### PR TITLE
re-added python interpreter to fboss_route.py

### DIFF
--- a/fboss/agent/tools/fboss_route.py
+++ b/fboss/agent/tools/fboss_route.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Copyright (C) 2004-present Facebook. All Rights Reserved
 
 from __future__ import division


### PR DESCRIPTION
Removed in https://github.com/facebook/fboss/commit/1ba41dd6efc2184d7ce6e691f60db7a26cec8901 causing it to fail on local machines.