### PR TITLE
Netlink manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(${CMAKE_BINARY_DIR}/gen)
 include_directories(${CMAKE_BINARY_DIR}/gen/fboss/agent/if/gen-cpp2)
 include_directories(${CMAKE_BINARY_DIR}/gen/common/fb303/if/gen-cpp2)
 include_directories(${CMAKE_BINARY_DIR}/gen/common/network/if/gen-cpp2)
+include_directories(/usr/include/libnl3)
 
 # System libraries
 find_library(GLOG glog)
@@ -40,16 +41,26 @@ find_library(SSL ssl)
 find_library(CRYPTO crypto)
 find_library(DL dl)
 find_library(EVENT event)
+find_library(NETLINK nl-3)
+find_library(NETLINKGENL nl-genl-3)
+find_library(NETLINKROUTE nl-route-3)
 
 # External libraries that are not generally available. Look in external/
 # for these. This is where getdeps.sh will toss them.
-find_library(FOLLY folly PATHS ${CMAKE_SOURCE_DIR}/external/folly/folly/.libs)
-find_library(WANGLE wangle PATHS ${CMAKE_SOURCE_DIR}/external/wangle/wangle/build/lib)
-find_library(THRIFT thrift PATHS ${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp/.libs)
-find_library(THRIFTPROTO thriftprotocol PATHS ${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp2/.libs)
-find_library(THRIFTCPP2 thriftcpp2 PATHS ${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp2/.libs)
-find_library(OPENNSL opennsl PATHS ${CMAKE_SOURCE_DIR}/external/OpenNSL/bin/wedge-trident)
-find_library(IPROUTE2 netlink PATHS ${CMAKE_SOURCE_DIR}/external/iproute2/lib)
+find_library(FOLLY folly PATHS ${CMAKE_SOURCE_DIR}/external/folly/folly/.libs
+	NO_DEFAULT_PATH)
+find_library(WANGLE wangle PATHS
+	${CMAKE_SOURCE_DIR}/external/wangle/wangle/build/lib NO_DEFAULT_PATH)
+find_library(THRIFT thrift PATHS
+	${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp/.libs NO_DEFAULT_PATH)
+find_library(THRIFTPROTO thriftprotocol PATHS
+	${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp2/.libs NO_DEFAULT_PATH)
+find_library(THRIFTCPP2 thriftcpp2 PATHS
+	${CMAKE_SOURCE_DIR}/external/fbthrift/thrift/lib/cpp2/.libs NO_DEFAULT_PATH)
+find_library(OPENNSL opennsl PATHS
+	${CMAKE_SOURCE_DIR}/external/OpenNSL/bin/wedge-trident NO_DEFAULT_PATH)
+find_library(IPROUTE2 netlink PATHS
+	${CMAKE_SOURCE_DIR}/external/iproute2/lib NO_DEFAULT_PATH)
 
 include_directories(${CMAKE_SOURCE_DIR}/external/OpenNSL/include)
 include_directories(${CMAKE_SOURCE_DIR}/external/iproute2/include)
@@ -58,6 +69,7 @@ include_directories(${CMAKE_SOURCE_DIR}/external/fbthrift)
 include_directories(${CMAKE_SOURCE_DIR}/external/wangle)
 
 add_executable(wedge_agent
+		fboss/agent/platforms/wedge/Wedge100Platform.cpp
     fboss/agent/platforms/wedge/WedgePlatform.cpp
     fboss/agent/platforms/wedge/WedgeProductInfo.cpp
     fboss/agent/platforms/wedge/WedgePort.cpp
@@ -133,7 +145,9 @@ add_library(fboss_agent STATIC
     fboss/agent/Main.cpp
     fboss/agent/ndp/IPv6RouteAdvertiser.cpp
     fboss/agent/NeighborListenerClient.cpp
-    fboss/agent/NeighborUpdater.cpp
+		fboss/agent/ArpCache.cpp
+		fboss/agent/NdpCache.cpp
+		fboss/agent/NeighborUpdater.cpp
     fboss/agent/NexthopToRouteCount.cpp
     fboss/agent/oss/ApplyThriftConfig.cpp
     fboss/agent/oss/Main.cpp
@@ -150,6 +164,7 @@ add_library(fboss_agent STATIC
     fboss/agent/packet/PktUtil.cpp
     fboss/agent/Platform.cpp
     fboss/agent/platforms/wedge/oss/WedgePlatform.cpp
+		fboss/agent/platforms/wedge/oss/Wedge100Platform.cpp
     fboss/agent/platforms/wedge/oss/WedgePort.cpp
     fboss/agent/platforms/wedge/oss/WedgeProductInfo.cpp
     fboss/agent/platforms/wedge/wedge_ctrl.cpp
@@ -198,6 +213,8 @@ add_library(fboss_agent STATIC
     fboss/agent/TunManager.cpp
     fboss/agent/UDPHeader.cpp
     fboss/agent/Utils.cpp
+		fboss/agent/NetlinkManager.cpp
+		fboss/agent/TapIntf.cpp
 
     fboss/lib/usb/BaseWedgeI2CBus.cpp
     fboss/lib/usb/BaseWedgeI2CBus.h
@@ -264,6 +281,9 @@ target_link_libraries(fboss_agent
     ${DOUBLECONV}
     ${DL}
     ${EVENT}
+		${NETLINK}
+		${NETLINKGENL}
+		${NETLINKROUTE}
 )
 
 find_program(THRIFT1 thrift1)

--- a/fboss/agent/ArpHandler.cpp
+++ b/fboss/agent/ArpHandler.cpp
@@ -60,6 +60,35 @@ void ArpHandler::handlePacket(unique_ptr<RxPacket> pkt,
   PortID port = pkt->getSrcPort();
   auto stats = sw_->stats();
   stats->port(port)->arpPkt();
+
+  // Look up the Vlan state.
+  auto state = sw_->getState();
+  auto vlan = state->getVlans()->getVlanIf(pkt->getSrcVlan());
+  if (!vlan) {
+    // Hmm, we don't actually have this VLAN configured.
+    // Perhaps the state has changed since we received the packet.
+    stats->port(port)->pktDropped();
+    return;
+  }
+
+	const uint32_t l2Len = pkt->getLength();
+	/*
+	 * Short circuit remaining logic if we're letting the host OS handle
+	 * the packet. TODO Should probably filter by MAC address here first:
+	 * -- if Interface's MAC
+	 * -- if broadcast MAC
+	 * -- if multicast MAC
+	 */
+	if (sw_->runningInNetlinkMode()) {
+		if (sw_->sendPacketToHost(std::move(pkt))) {
+			stats->port(port)->pktToHost(l2Len);
+		} else {
+			stats->port(port)->pktDropped();
+		}
+		VLOG(2) << "Sent ARP packet to host";
+		return;
+	}
+
   // Read htype, ptype, hlen, and plen
   auto htype = cursor.readBE<uint16_t>();
   if (htype != ARP_HTYPE_ETHERNET) {
@@ -79,16 +108,6 @@ void ArpHandler::handlePacket(unique_ptr<RxPacket> pkt,
   auto plen = cursor.readBE<uint8_t>();
   if (plen != ARP_PLEN_IPV4) {
     stats->port(port)->arpUnsupported();
-    return;
-  }
-
-  // Look up the Vlan state.
-  auto state = sw_->getState();
-  auto vlan = state->getVlans()->getVlanIf(pkt->getSrcVlan());
-  if (!vlan) {
-    // Hmm, we don't actually have this VLAN configured.
-    // Perhaps the state has changed since we received the packet.
-    stats->port(port)->pktDropped();
     return;
   }
 

--- a/fboss/agent/NetlinkManager.cpp
+++ b/fboss/agent/NetlinkManager.cpp
@@ -1,0 +1,899 @@
+#include "fboss/agent/NetlinkManager.h"
+
+namespace facebook { namespace fboss {
+
+using folly::EventBase;
+using folly::make_unique;
+
+NetlinkManager::NetlinkManager(SwSwitch * sw, EventBase * evb, std::string &iface_prefix): 
+	sock_(0), link_cache_(0), route_cache_(0), manager_(0), prefix_(iface_prefix),
+	netlink_listener_thread_(NULL), host_packet_rx_thread_(NULL),
+	sw_(sw), evb_(evb) {
+	VLOG(4) << "Constructor of NetlinkManager";
+	register_w_netlink();
+}
+
+NetlinkManager::~NetlinkManager() {
+	stopNetlinkManager();
+	delete_ifaces();
+}
+
+void NetlinkManager::init_dump_params() {
+	/* globals should be 0ed out, but just in case we want to call this w/different params in future */
+	memset(&dump_params_, 0, sizeof(dump_params_));
+	dump_params_.dp_type = NL_DUMP_STATS;
+	dump_params_.dp_fd = stdout;
+}
+
+struct nl_dump_params * NetlinkManager::get_dump_params() {
+	return &dump_params_;
+}
+
+void NetlinkManager::log_and_die_rc(const char * msg, const int rc) {
+	VLOG(0) << std::string(msg) << ". RC=" << std::to_string(rc);
+ 	exit(1);
+}
+
+void NetlinkManager::log_and_die(const char * msg) {
+	VLOG(0) << std::string(msg);
+	exit(1);
+}
+
+#define MAC_ADDRSTRLEN 18
+void NetlinkManager::netlink_link_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data) {
+	struct rtnl_link * link = (struct rtnl_link *) obj;
+	NetlinkManager * nlm = (NetlinkManager *) data;
+	const std::string name(rtnl_link_get_name(link));
+	VLOG(3) << "Link cache callback was triggered for link: " << name;
+
+  //nl_cache_dump(cache, nlm->get_dump_params());
+
+	/* Is this update for one of our tap interfaces? */
+	const int ifindex = rtnl_link_get_ifindex(link);
+	const std::map<int, TapIntf *>::const_iterator itr = nlm->getInterfacesByIfindex().find(ifindex);
+	if (itr == nlm->getInterfacesByIfindex().end()) {
+		VLOG(1) << "Ignoring netlink Link update for interface " << name << ", ifindex=" << std::to_string(ifindex);
+		return;
+	}
+	TapIntf * tapIface = itr->second;
+
+	/* 
+	 * Things we need to consider when updating: 
+	 * (1) MAC
+	 * (2) MTU
+	 * (3) State (UP/DOWN)
+	 *
+	 * We really don't care about the state, since any packets
+	 * to be transmitted by the host will have no route and any
+	 * packets to be received will have no active IP to go to.
+	 */
+
+	/* 
+	 * We'll handle add and change for updates. del for our 
+	 * taps will/should only occur when we're exiting.
+	 */
+	if (nl_operation == NL_ACT_DEL) {
+		VLOG(1) << "Ignoring netlink link remove for interface " << name << ", ifindex" << std::to_string(ifindex);
+		return;
+	}
+
+	const std::shared_ptr<SwitchState> state = nlm->sw_->getState();
+	const std::shared_ptr<Interface> interface = state->getInterfaces()->getInterface(tapIface->getInterfaceID());
+	
+	/* Did the MAC get updated? */
+	bool updateMac = false;
+	char macStr[MAC_ADDRSTRLEN];
+	const MacAddress nlMac(nl_addr2str(rtnl_link_get_addr(link), macStr, MAC_ADDRSTRLEN));
+	if (nlMac != interface->getMac()) {
+		VLOG(0) << "Updating interface " << name << " MAC from " << interface->getMac() << " to " << nlMac;
+		updateMac = true;
+	}
+
+	/* Did the MTU get updated? */
+	bool updateMtu = false;
+	const unsigned int nlMtu = rtnl_link_get_mtu(link);
+	if (nlMtu != interface->getMtu()) { /* unsigned vs signed comparison...shouldn't be an issue though since MTU typically < ~9000 */ 
+		VLOG(0) << "Updating interface " << name << " MTU from " << std::to_string(interface->getMtu()) << " to " << std::to_string(nlMtu);
+		updateMtu = true;
+	}
+	
+	if (updateMac || updateMtu) {
+		auto updateLinkFn = [=](const std::shared_ptr<SwitchState>& state) {
+			std::shared_ptr<SwitchState> newState = state->clone();
+			Interface * newInterface = state->getInterfaces()->getInterface(tapIface->getInterfaceID())->modify(&newState);	
+
+		  if (updateMac) {
+				newInterface->setMac(MacAddress::fromNBO(nlMac.u64NBO()));
+			}
+			if (updateMtu) {
+				newInterface->setMtu(nlMtu);
+			}
+			return newState;
+		};
+
+		nlm->sw_->updateStateBlocking("NetlinkManager update Interface " + name, updateLinkFn);
+	}
+	return;
+}
+
+void NetlinkManager::netlink_route_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data) {
+	struct rtnl_route * route = (struct rtnl_route *) obj;
+	NetlinkManager * nlm = (NetlinkManager *) data;
+	VLOG(3) << "Route cache callback was triggered";
+	//nl_cache_dump(cache, nlm->get_dump_params());
+	
+	const uint8_t family = rtnl_route_get_family(route);
+	bool is_ipv4 = true;
+	switch (family) {
+		case AF_INET:
+			is_ipv4 = true;
+			break;
+		case AF_INET6:
+			is_ipv4 = false;
+			break;
+		default:
+			VLOG(0) << "Unknown address family " << std::to_string(family);
+			return;
+	}
+
+	if (rtnl_route_get_type(route) != RTN_UNICAST) {
+		VLOG(1) << "Ignoring non-unicast route update";
+		return;
+	}
+
+	const uint8_t ipLen = is_ipv4 ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+	char ipBuf[ipLen];
+	folly::IPAddress network;
+	nl_addr2str(rtnl_route_get_dst(route), ipBuf, ipLen);
+	try {
+		network = folly::IPAddress::createNetwork(ipBuf, -1, false).first;
+		//network = folly::IPAddress(ipBuf);
+	} catch (const std::exception& ex) {
+		VLOG(2) << "Exception caught: " << ex.what();
+		VLOG(0) << "Could not parse IP '" << ipBuf << "' in route update";
+		return;
+	}
+
+	const uint8_t mask = nl_addr_get_prefixlen(rtnl_route_get_dst(route));
+	VLOG(3) << "Got route update of (buf= " << std::string(ipBuf) << ") " << network.str() << "/" << std::to_string(mask);
+
+	RouteNextHops fbossNextHops;
+	fbossNextHops.reserve(1); // TODO
+
+	RouterID routerId;
+
+	if (!rtnl_route_get_nnexthops(route)) {
+		VLOG(0) << "Could not find next hop for route: ";
+		nl_object_dump((nl_object *) route, nlm->get_dump_params());
+		return;
+	} else {
+		struct rtnl_nexthop * nh = rtnl_route_nexthop_n(route, 0); /* assume single next hop */
+		const int ifindex = rtnl_route_nh_get_ifindex(nh); 
+		std::map<int, TapIntf *>::const_iterator itr = nlm->getInterfacesByIfindex().find(ifindex);
+		if (itr == nlm->getInterfacesByIfindex().end()) { /* shallow ptr cmp */
+			VLOG(1) << "Interface index " << std::to_string(ifindex) << " not found";
+			return;
+		}
+		
+		routerId = itr->second->getIfaceRouterID();
+		VLOG(1) << "Interface index " << std::to_string(ifindex) << " located on RouterID " 
+			<< std::to_string(routerId) << ", iface name " << itr->second->getIfaceName();
+
+		folly::IPAddress nextHopIp;
+		nl_addr2str(rtnl_route_nh_get_gateway(nh), ipBuf, ipLen);
+		try {
+			nextHopIp = folly::IPAddress(ipBuf);
+			fbossNextHops.emplace(nextHopIp);
+		} catch (const std::exception& ex) {
+			if (strcmp("none", ipBuf) == 0) {
+				VLOG(2) << "Exception caught: " << ex.what();
+				VLOG(1) << "Got IP of 'none' in route update for " << itr->second->getIfaceName()
+					<< ". Assigning LAN route " 
+					<< network.str() << "/" << std::to_string(mask);
+			} else {
+				VLOG(0) << "Could not parse IP '" << ipBuf << "' in route update for " 
+					<< itr->second->getIfaceName();
+				return;
+			}
+		}
+	}
+	
+	switch (nl_operation) {
+		case NL_ACT_NEW:
+			{
+			is_ipv4 ? nlm->sw_->stats()->addRouteV4() : nlm->sw_->stats()->addRouteV6();
+
+			/* Perform the update */
+			auto addFn = [=](const std::shared_ptr<SwitchState>& state) {
+				RouteUpdater updater(state->getRouteTables());
+				if (fbossNextHops.size()) {
+					updater.addRoute(routerId, network, mask, std::move(fbossNextHops));
+				} else {
+					updater.addRoute(routerId, network, mask, RouteForwardAction::TO_CPU);
+				}
+				auto newRt = updater.updateDone();
+				if (!newRt) {
+					return std::shared_ptr<SwitchState>();
+				}
+				auto newState = state->clone();
+				newState->resetRouteTables(std::move(newRt));
+				return newState;
+			};
+
+			nlm->sw_->updateStateBlocking("add route", addFn);
+			}
+			break; /* NL_ACT_NEW */
+		case NL_ACT_DEL:
+			{
+			is_ipv4 ? nlm->sw_->stats()->delRouteV4() : nlm->sw_->stats()->delRouteV6();
+			
+			/* Perform the update */
+			auto delFn = [=](const std::shared_ptr<SwitchState>& state) {
+				RouteUpdater updater(state->getRouteTables());
+				updater.delRoute(routerId, network, mask);
+				auto newRt = updater.updateDone();
+				if (!newRt) {
+					return std::shared_ptr<SwitchState>();
+				}
+				auto newState = state->clone();
+				newState->resetRouteTables(std::move(newRt));
+				return newState;
+			};
+
+			nlm->sw_->updateStateBlocking("delete route", delFn);
+			}
+			break; /* NL_ACT_DEL */
+		case NL_ACT_CHANGE:
+			VLOG(2) << "Not updating state due to unimplemented NL_ACT_CHANGE netlink operation";
+			break; /* NL_ACT_CHANGE */
+		default:
+			VLOG(0) << "Not updating state due to unknown netlink operation " << std::to_string(nl_operation);
+			break; /* NL_ACT_??? */
+	}
+	return;
+}
+
+void NetlinkManager::netlink_neighbor_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data) {
+	struct rtnl_neigh * neigh = (struct rtnl_neigh *) obj;
+	NetlinkManager * nlm = (NetlinkManager *) data;
+	//nl_cache_dump(cache, nlm->get_dump_params());
+
+	const int ifindex = rtnl_neigh_get_ifindex(neigh);
+	char nameTmp[IFNAMSIZ];
+	rtnl_link_i2name(nlm->link_cache_, ifindex, nameTmp, IFNAMSIZ); /* must explicitly use link cache */
+	const std::string name(nameTmp);
+	VLOG(1) << "Neighbor cache callback was triggered for link " << name;
+
+	const std::map<int, TapIntf *>::const_iterator itr = nlm->getInterfacesByIfindex().find(ifindex);
+	if (itr == nlm->getInterfacesByIfindex().end()) { /* shallow ptr cmp */ 
+		VLOG(1) << "Not updating neighbor entry for interface " << name << ", ifindex=" << std::to_string(ifindex);
+		return;
+	}
+	TapIntf * tapIface = itr->second;
+	const std::shared_ptr<SwitchState> state = nlm->sw_->getState();
+	const std::shared_ptr<Interface> interface = state->getInterfaces()->getInterface(tapIface->getInterfaceID());
+
+	bool is_ipv4 = true;
+	const int family = rtnl_neigh_get_family(neigh);
+	switch (family) {
+		case AF_INET:
+			is_ipv4 = true;
+			break;
+		case AF_INET6:
+			is_ipv4 = false;
+			break;
+		default:
+			VLOG(0) << "Unknown address family " << std::to_string(family);
+			return;
+	}
+
+	const uint8_t ipLen = is_ipv4 ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+	char ipBuf[ipLen];
+	char macBuf[MAC_ADDRSTRLEN];
+	folly::IPAddress nlIpAddress;
+	folly::MacAddress nlMacAddress;
+	nl_addr2str(rtnl_neigh_get_dst(neigh), ipBuf, ipLen);
+	nl_addr2str(rtnl_neigh_get_lladdr(neigh), macBuf, MAC_ADDRSTRLEN);
+	try {
+		nlIpAddress = folly::IPAddress(ipBuf);
+		nlMacAddress = folly::MacAddress(macBuf);
+	} catch (const std::invalid_argument& ex) {
+		VLOG(0) << "Could not parse MAC '" << macBuf << "' or IP '" << ipBuf << "' in neighbor update for ifindex " << ifindex;
+		return;
+	}
+
+	switch (nl_operation) {
+		case NL_ACT_NEW:
+		{
+			if (is_ipv4) {
+				/* Perform the update */
+				auto addFn = [=](const std::shared_ptr<SwitchState>& state) {
+					std::shared_ptr<SwitchState> newState = state->clone();
+					Vlan * vlan = newState->getVlans()->getVlan(interface->getVlanID()).get();
+					const PortID port = vlan->getPorts().begin()->first; /* TODO what if we have multiple ports? */
+					ArpTable * arpTable = vlan->getArpTable().get();
+					std::shared_ptr<ArpEntry> arpEntry = arpTable->getNodeIf(nlIpAddress.asV4());
+					if (!arpEntry) {
+						arpTable = arpTable->modify(&vlan, &newState);
+						arpTable->addEntry(nlIpAddress.asV4(), nlMacAddress, port, interface->getID());
+					} else {
+						if (arpEntry->getMac() == nlMacAddress &&
+							arpEntry->getPort() == port &&
+							arpEntry->getIntfID() == interface->getID() &&
+							!arpEntry->isPending()) {
+							return std::shared_ptr<SwitchState>(); /* already there */
+						}
+						arpTable = arpTable->modify(&vlan, &newState);
+						arpTable->addEntry(nlIpAddress.asV4(), nlMacAddress, port, interface->getID());
+					}
+
+					return newState;
+				};
+
+				nlm->sw_->updateStateBlocking("Adding new ARP entry", addFn);
+			} else {
+				auto addFn = [=](const std::shared_ptr<SwitchState>& state) {
+					std::shared_ptr<SwitchState> newState = state->clone();
+					Vlan * vlan = newState->getVlans()->getVlan(interface->getVlanID()).get();
+					const PortID port = vlan->getPorts().begin()->first; /* TODO what if we have multiple ports? */
+					NdpTable * ndpTable = vlan->getNdpTable().get();
+					std::shared_ptr<NdpEntry> ndpEntry = ndpTable->getNodeIf(nlIpAddress.asV6());
+					if (!ndpEntry) {
+						ndpTable = ndpTable->modify(&vlan, &newState);
+						ndpTable->addEntry(nlIpAddress.asV6(), nlMacAddress, port, interface->getID());
+					} else {
+						if (ndpEntry->getMac() == nlMacAddress &&
+							ndpEntry->getPort() == port &&
+							ndpEntry->getIntfID() == interface->getID() &&
+							!ndpEntry->isPending()) {
+							return std::shared_ptr<SwitchState>(); /* already there */
+						}
+						ndpTable = ndpTable->modify(&vlan, &newState);
+						ndpTable->addEntry(nlIpAddress.asV6(), nlMacAddress, port, interface->getID());
+					}
+
+					return newState;
+				};
+
+				nlm->sw_->updateStateBlocking("Adding new NDP entry", addFn);
+			}
+			break; /* NL_ACL_NEW */
+		}
+		case NL_ACT_DEL:
+		{
+			if (is_ipv4) {
+				/* Perform the update */
+				auto delFn = [=](const std::shared_ptr<SwitchState>& state) {
+					std::shared_ptr<SwitchState> newState = state->clone();
+					Vlan * vlan = newState->getVlans()->getVlan(interface->getVlanID()).get();
+					ArpTable * arpTable = vlan->getArpTable().get();
+					std::shared_ptr<ArpEntry> arpEntry = arpTable->getNodeIf(nlIpAddress.asV4());
+					if (arpEntry) {
+						arpTable = arpTable->modify(&vlan, &newState);
+						arpTable->removeNode(arpEntry);
+					} else {
+						return std::shared_ptr<SwitchState>();
+					}
+
+					return newState;
+				};
+
+				nlm->sw_->updateStateBlocking("Removing expired ARP entry", delFn);
+			} else {
+				/* Perform the update */
+				auto delFn = [=](const std::shared_ptr<SwitchState>& state) {
+					std::shared_ptr<SwitchState> newState = state->clone();
+					Vlan * vlan = newState->getVlans()->getVlan(interface->getVlanID()).get();
+					NdpTable * ndpTable = vlan->getNdpTable().get();
+					std::shared_ptr<NdpEntry> ndpEntry = ndpTable->getNodeIf(nlIpAddress.asV6());
+					if (ndpEntry) {
+						ndpTable = ndpTable->modify(&vlan, &newState);
+						ndpTable->removeNode(ndpEntry);
+					} else {
+						return std::shared_ptr<SwitchState>();
+					}
+
+					return newState;
+				};
+
+				nlm->sw_->updateStateBlocking("Removing expired NDP entry", delFn);
+			}
+			break; /* NL_ACT_DEL */
+		}
+		case NL_ACT_CHANGE:
+			VLOG(1) << "Not updating state due to unimplemented NL_ACT_CHANGE netlink operation";
+			break; /* NL_ACT_CHANGE */
+		default:
+			VLOG(0) << "Not updating state due to unknown netlink operation " << std::to_string(nl_operation);
+			break; /* NL_ACT_??? */
+	}
+	return;
+}
+
+void NetlinkManager::netlink_address_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data) {
+	struct rtnl_addr * addr = (struct rtnl_addr *) obj;
+	struct rtnl_link * link = rtnl_addr_get_link(addr);
+	NetlinkManager * nlm = (NetlinkManager *) data;
+	//nl_cache_dump(cache, nlm->get_dump_params());
+
+	const std::string name(rtnl_link_get_name(link));
+	VLOG(1) << "Address cache callback was triggered for link " << name;
+
+	/* Verify this update is for one of our taps */
+	const int ifindex = rtnl_addr_get_ifindex(addr);
+	const std::map<int, TapIntf *>::const_iterator itr = nlm->getInterfacesByIfindex().find(ifindex);
+	if (itr == nlm->getInterfacesByIfindex().end()) { /* shallow ptr cmp */
+		VLOG(1) << "Not changing IP for interface " << name << ", ifindex=" << std::to_string(ifindex);
+		return;
+	}
+	TapIntf * tapIface = itr->second;
+	const std::shared_ptr<SwitchState> state = nlm->sw_->getState();
+	const std::shared_ptr<Interface> interface = state->getInterfaces()->getInterface(tapIface->getInterfaceID());
+
+	bool is_ipv4 = true;
+	const int family = rtnl_addr_get_family(addr);
+	switch (family) {
+		case AF_INET:
+			is_ipv4 = true;
+			break;
+		case AF_INET6:
+			is_ipv4 = false;
+			break;
+		default:
+			VLOG(0)	<< "Unknown address family " << std::to_string(family);
+			return;
+	}
+
+	const uint8_t str_len = is_ipv4 ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN;
+	char tmp[str_len];
+	nl_addr2str(rtnl_addr_get_local(addr), tmp, str_len);
+	const folly::IPAddress nlAddress = folly::IPAddress::createNetwork(tmp, -1, false).first; /* libnl3 puts IPv4 and IPv6 addresses in local */
+	VLOG(3) << "Got IP address update of " << nlAddress.str() << " for interface " << name;
+
+	switch (nl_operation) {
+		case NL_ACT_NEW:
+		{
+			/* Ignore if we have this IP address already */
+			if (interface->hasAddress(nlAddress)) {
+				VLOG(0) << "Ignoring duplicate address add of " << nlAddress.str() << " on interface " << name;
+				break;
+			}
+
+			/* Perform the update */
+			auto addFn = [=](const std::shared_ptr<SwitchState>& state) {
+				std::shared_ptr<SwitchState> newState = state->clone();
+				Interface * newInterface = state->getInterfaces()->getInterface(tapIface->getInterfaceID())->modify(&newState);	
+				const Interface::Addresses oldAddresses = state->getInterfaces()->getInterface(tapIface->getInterfaceID())->getAddresses();
+				Interface::Addresses newAddresses; /* boost::flat_map<IPAddress, uint8_t */
+				for (auto itr = oldAddresses.begin();
+					       	itr != oldAddresses.end();
+						itr++) {
+					newAddresses.insert(folly::IPAddress::createNetwork(itr->first.str(), -1, false)); /* std::pair<IPAddress, uint8_t> */
+				}
+				/* Now add our new one */
+				VLOG(0) << "Adding address " << nlAddress.str() << " to interface " << name;
+				newAddresses.insert(folly::IPAddress::createNetwork(nlAddress.str(), -1, false));
+				newInterface->setAddresses(newAddresses);
+
+				return newState;
+			};
+			
+			nlm->sw_->updateStateBlocking("Adding new IP address " + nlAddress.str(), addFn);
+			break; /* NL_ACT_NEW */
+		}
+		case NL_ACT_DEL:
+		{
+			/* Ignore if we don't have this IP address already */
+			if (!interface->hasAddress(nlAddress)) {
+				VLOG(1) << "Ignoring address delete for unknown address " << nlAddress.str() << " on interface " << name;
+				break;
+			}
+			auto delFn = [=](const std::shared_ptr<SwitchState>& state) {
+				std::shared_ptr<SwitchState> newState = state->clone();
+				Interface * newInterface = state->getInterfaces()->getInterface(tapIface->getInterfaceID())->modify(&newState);	
+				const Interface::Addresses oldAddresses = state->getInterfaces()->getInterface(tapIface->getInterfaceID())->getAddresses();
+				Interface::Addresses newAddresses; /* boost::flat_map<IPAddress, uint8_t */
+				for (auto itr = oldAddresses.begin();
+					       	itr != oldAddresses.end();
+						itr++) {
+					if (itr->first != nlAddress) {
+						newAddresses.insert(*itr);
+					} else {
+						VLOG(0) << "Deleting address " << nlAddress.str() << " on interface " << name;
+					}
+				}
+				/* Replace with -1 addresses */
+				newInterface->setAddresses(newAddresses);
+
+				return newState;
+			};
+
+			nlm->sw_->updateStateBlocking("Deleting old IP address " + nlAddress.str(), delFn);
+			break; /* NL_ACT_DEL */
+		}
+		case NL_ACT_CHANGE:
+			VLOG(1) << "Not updating state due to unimplemented NL_ACT_CHANGE netlink operation";
+			break; /* NL_ACT_CHANGE */
+		default:
+			VLOG(0) << "Not updating state due to unknown netlink operation " << std::to_string(nl_operation);
+			break; /* NL_ACT_??? */
+	}
+	return;
+}
+
+void NetlinkManager::register_w_netlink() {
+	int rc = 0; /* track errors; defined in libnl3/netlinks/errno.h */
+
+	init_dump_params();
+
+	if ((sock_ = nl_socket_alloc()) == NULL) {
+		log_and_die("Opening netlink socket failed");
+  } else {
+		VLOG(1) << "Opened netlink socket";
+  }
+    
+  if ((rc = nl_connect(sock_, NETLINK_ROUTE)) < 0) {
+   	unregister_w_netlink();
+    log_and_die_rc("Connecting to netlink socket failed", rc);
+  } else{
+		VLOG(1) << "Connected to netlink socket";
+  }
+
+  if ((rc = rtnl_link_alloc_cache(sock_, AF_UNSPEC, &link_cache_)) < 0) {
+    unregister_w_netlink();
+    log_and_die_rc("Allocating link cache failed", rc);
+  } else {
+		VLOG(1) << "Allocated link cache";
+  }
+
+  if ((rc = rtnl_route_alloc_cache(sock_, AF_UNSPEC, 0, &route_cache_)) < 0) {
+    unregister_w_netlink();
+		log_and_die_rc("Allocating route cache failed", rc);
+  } else {
+		VLOG(1) << "Allocated route cache";
+  }
+	
+  if ((rc = rtnl_neigh_alloc_cache(sock_, &neigh_cache_)) < 0) {
+    unregister_w_netlink();
+		log_and_die_rc("Allocating neighbor cache failed", rc);
+  } else {
+		VLOG(1) << "Allocated neighbor cache";
+  }
+  	
+	if ((rc = rtnl_addr_alloc_cache(sock_, &addr_cache_)) < 0) {
+    unregister_w_netlink();
+		log_and_die_rc("Allocating address cache failed", rc);
+  } else {
+		VLOG(1) << "Allocated address cache";
+  }
+	
+  if ((rc = nl_cache_mngr_alloc(NULL, AF_UNSPEC, 0, &manager_)) < 0) {
+    unregister_w_netlink();
+		log_and_die_rc("Failed to allocate cache manager", rc);
+  } else{
+		VLOG(1) << "Allocated cache manager";
+  }
+
+  nl_cache_mngt_provide(link_cache_);
+	nl_cache_mngt_provide(route_cache_);
+	nl_cache_mngt_provide(neigh_cache_);
+	nl_cache_mngt_provide(addr_cache_);
+
+	/*
+	printf("Initial Cache Manager:\r\n");
+  	nl_cache_mngr_info(manager_, get_dump_params());
+  	printf("\r\nInitial Link Cache:\r\n");
+  	nl_cache_dump(link_cache_, get_dump_params());
+  	printf("\r\nInitial Route Cache:\r\n");
+  	nl_cache_dump(route_cache_, get_dump_params());
+	*/
+
+  if ((rc = nl_cache_mngr_add_cache(manager_, route_cache_, netlink_route_updated, this)) < 0) {
+    unregister_w_netlink();
+		log_and_die_rc("Failed to add route cache to cache manager", rc);
+  } else {
+		VLOG(1) << "Added route cache to cache manager";
+  }
+
+  if ((rc = nl_cache_mngr_add_cache(manager_, link_cache_, netlink_link_updated, this)) < 0) {
+    unregister_w_netlink();
+    log_and_die_rc("Failed to add link cache to cache manager", rc);
+  } else {	
+		VLOG(1) << "Added link cache to cache manager";
+  }
+
+  if ((rc = nl_cache_mngr_add_cache(manager_, neigh_cache_, netlink_neighbor_updated, this)) < 0) {
+    unregister_w_netlink();
+    log_and_die_rc("Failed to add neighbor cache to cache manager", rc);
+  } else {	
+		VLOG(1) << "Added neighbor cache to cache manager";
+  }
+
+  if ((rc = nl_cache_mngr_add_cache(manager_, addr_cache_, netlink_address_updated, this)) < 0) {
+    unregister_w_netlink();
+    log_and_die_rc("Failed to add address cache to cache manager", rc);
+  } else {	
+		VLOG(1) << "Added address cache to cache manager";
+  }
+}
+
+void NetlinkManager::unregister_w_netlink() {
+	/* these will fail silently/will log error (which is okay) if it's not allocated in the first place */
+	nl_cache_mngr_free(manager_);
+	nl_cache_free(link_cache_);
+    	nl_cache_free(route_cache_);
+    	nl_cache_free(neigh_cache_);
+	nl_cache_free(addr_cache_);
+	nl_socket_free(sock_);
+	sock_ = 0;
+	VLOG(0) << "Unregistered with netlink";
+}
+
+void NetlinkManager::add_ifaces(const std::string &prefix, std::shared_ptr<SwitchState> state) {
+	if (sock_ == 0) {
+		register_w_netlink();
+	}
+
+	/* 
+	 * Must update both Interfaces and Vlans, since they "reference" each other
+	 * by keeping track of each others' VlanID and InterfaceID, respectively.
+	 */
+	std::shared_ptr<InterfaceMap> interfaces = std::make_shared<InterfaceMap>();
+	std::shared_ptr<VlanMap> newVlans = std::make_shared<VlanMap>();
+	
+	/* Get default VLAN to use temporarily */
+	std::shared_ptr<Vlan> defaultVlan = state->getVlans()->getVlan(state->getDefaultVlan());
+
+	VLOG(0) << "Adding " << state->getVlans()->size() << " Interfaces to FBOSS";
+	for (const auto& oldVlan : state->getVlans()->getAllNodes()) { /* const VlanMap::NodeContainer& vlans */
+		std::string interfaceName = prefix + std::to_string((int) oldVlan.second->getID()); /* stick with the original VlanIDs as given in JSON config */
+		std::string vlanName = "vlan" + std::to_string((int) oldVlan.second->getID());
+
+		std::shared_ptr<Interface> interface = std::make_shared<Interface>(
+			(InterfaceID) oldVlan.second->getID(), /* TODO why not? */
+			(RouterID) 0, /* TODO assume single router */
+			oldVlan.second->getID(),
+			interfaceName,
+			sw_->getPlatform()->getLocalMac(), /* Temporarily use CPU MAC until netlink tells us our MAC */
+			/* TODO why static_cast here? It works in ApplyThriftConfig and is static const and already initialized to 1500 in the declaration */
+			static_cast<int>(Interface::kDefaultMtu) 
+			);
+		interfaces->addInterface(std::move(interface));
+
+		/*
+		 * Swap out the Vlan purposefully omitting any DHCP or other config.
+		 * All that's needed is the VlanID, its name, and the Ports that are
+		 * on that Vlan.
+		 */
+		std::shared_ptr<Vlan> newVlan = std::make_shared<Vlan>(
+				oldVlan.second->getID(),
+				vlanName
+				);
+		newVlan->setInterfaceID((InterfaceID) oldVlan.second->getID());	/* TODO why not? */
+		newVlan->setPorts(oldVlan.second->getPorts());
+		newVlans->addVlan(std::move(newVlan));
+		VLOG(4) << "Updating VLAN " << newVlan->getID() << " with new Interface ID";
+	}
+
+	/* Update the SwitchState with the new Interfaces and Vlans */
+	auto addIfacesAndVlansFn = [=](const std::shared_ptr<SwitchState>& state) {
+		std::shared_ptr<SwitchState> newState = state->clone();	
+		newState->resetIntfs(std::move(interfaces));
+		newState->resetVlans(std::move(newVlans));
+		return newState;
+	};
+
+	auto clearIfacesAndVlansFn = [=](const std::shared_ptr<SwitchState>& state) {
+		std::shared_ptr<SwitchState> newState = state->clone();
+		std::shared_ptr<InterfaceMap> delIfaces = std::make_shared<InterfaceMap>();
+		std::shared_ptr<VlanMap> delVlans = std::make_shared<VlanMap>();
+		delVlans->addVlan(std::move(defaultVlan));	
+		newState->resetIntfs(std::move(delIfaces));
+		newState->resetVlans(std::move(delVlans));
+		return newState;
+	};
+	
+	VLOG(3) << "About to update state blocking with new VLANs";
+	sw_->updateStateBlocking("Purge existing Interfaces and Vlans", clearIfacesAndVlansFn);
+	sw_->updateStateBlocking("Add NetlinkManager initial Interfaces and Vlans", addIfacesAndVlansFn);
+
+	/* 
+	 * Now add the tap interfaces. This will trigger lots of netlink
+	 * messages that we'll handle and update our Interfaces with based on
+	 * the MAC address, MTU, and (eventually) the IP address(es) detected.
+	 */
+
+	/* It's okay if we use the stale SwitchState here; only getting VlanID */
+	VLOG(0) << "Adding " << state->getVlans()->size() << " tap interfaces to host";
+	for (const auto& vlan : state->getVlans()->getAllNodes()) {
+		std::string name = prefix + std::to_string((int) vlan.second->getID()); /* name w/same VLAN ID for transparency */
+
+		TapIntf * tapiface = new TapIntf(
+				name, 
+				(RouterID) 0, /* TODO assume single router */
+				(InterfaceID) vlan.second->getID() /* TODO why not? */
+				); 
+		interfaces_by_ifindex_[tapiface->getIfaceIndex()] = tapiface;
+		interfaces_by_vlan_[vlan.second->getID()] = tapiface;
+		VLOG(4) << "Tap interface " << name << " added";
+	}
+}
+
+void NetlinkManager::delete_ifaces() {
+
+	while (!interfaces_by_ifindex_.empty()) {
+		TapIntf * iface = interfaces_by_ifindex_.end()->second; 
+		VLOG(4) << "Deleting interface " << iface->getIfaceName();
+		interfaces_by_ifindex_.erase(iface->getIfaceIndex());
+		delete iface;
+	}
+	if (!interfaces_by_ifindex_.empty()) {
+		VLOG(0) << "Should have no interfaces left. Bug? Clearing...";
+		interfaces_by_ifindex_.clear();
+	}
+	interfaces_by_vlan_.clear();
+	VLOG(0) << "Deleted all interfaces";
+}
+
+void NetlinkManager::addInterfacesAndUpdateState(std::shared_ptr<SwitchState> state) {
+	if (interfaces_by_ifindex_.size() == 0) {
+		add_ifaces(prefix_.c_str(), state);
+	} else {
+		VLOG(0) << "Not creating tap interfaces upon possible netlink manager restart";
+	}
+}
+
+void NetlinkManager::startNetlinkManager(const int pollIntervalMillis) {
+	if (netlink_listener_thread_ == NULL) {
+		netlink_listener_thread_ = new boost::thread(netlink_listener, pollIntervalMillis /* args to function ptr */, this);
+		if (netlink_listener_thread_ == NULL) {
+			log_and_die("Netlink listener thread creation failed");
+		}
+		VLOG(0) << "Started netlink listener thread";
+	} else {
+		VLOG(0) << "Tried to start netlink listener thread, but thread was already started" << std::endl;
+	}
+
+	if (host_packet_rx_thread_ == NULL) {
+		host_packet_rx_thread_ = new boost::thread(host_packet_rx_listener, this);
+		if (host_packet_rx_thread_ == NULL) {
+			log_and_die("Host packet RX thread creation failed");
+		}
+		VLOG(0) << "Started host packet RX thread";
+	} else {
+		VLOG(0) << "Tried to start host packet RX thread, but thread was already started";
+	}
+}
+
+void NetlinkManager::stopNetlinkManager() {
+	netlink_listener_thread_->interrupt();
+	delete netlink_listener_thread_;
+	netlink_listener_thread_ = NULL;
+	VLOG(0) << "Stopped netlink listener thread";
+
+	host_packet_rx_thread_->interrupt();
+	delete host_packet_rx_thread_;
+	host_packet_rx_thread_ = NULL;
+	VLOG(0) << "Stopped packet RX thread";
+
+	delete_ifaces();
+	unregister_w_netlink();
+}
+
+void NetlinkManager::netlink_listener(const int pollIntervalMillis, NetlinkManager * nlm) {
+	int rc;
+  while(1) {
+		boost::this_thread::interruption_point();
+    if ((rc = nl_cache_mngr_poll(nlm->manager_, pollIntervalMillis)) < 0) {
+    	nl_cache_mngr_free(nlm->manager_);
+      nl_cache_free(nlm->link_cache_);
+      nl_cache_free(nlm->route_cache_);
+      nl_socket_free(nlm->sock_);
+      nlm->log_and_die_rc("Failed to set poll for cache manager", rc);
+    } else {
+      if (rc > 0) {
+				VLOG(1) << "Processed " << std::to_string(rc) << " updates from netlink";	
+      } else {
+				VLOG(2) << "No news from netlink (" << std::to_string(rc) << " updates to process). Polling...";
+			}
+    }
+  }
+}
+
+int NetlinkManager::read_packet_from_port(NetlinkManager * nlm, TapIntf * iface) {
+	/* Parse into TxPacket */
+	int len;
+	std::unique_ptr<TxPacket> pkt;
+	
+	std::shared_ptr<Interface> interface = nlm->sw_->getState()->getInterfaces()->getInterfaceIf(iface->getInterfaceID());
+	if (!interface) {
+		VLOG(0) << "Could not find FBOSS interface ID for " << iface->getIfaceName() << ". Dropping packet from host";
+		return 0; /* silently fail */
+	}
+
+	pkt = nlm->sw_->allocateL2TxPacket(interface->getMtu());
+	auto buf = pkt->buf();
+
+	/* read one packet per call; assumes level-triggered epoll() */
+	if ((len = read(iface->getIfaceFD(), buf->writableTail(), buf->tailroom())) < 0) {
+		if ((errno == EWOULDBLOCK) || (errno == EAGAIN)) {
+			return 0;
+		} else {
+			VLOG(0) << "read() failed on iface " << iface->getIfaceName() << ", " << strerror(errno);
+			return -1;
+		}
+	} else if (len > 0 && len > buf->tailroom()) {
+		VLOG(0) << "Too large packet (" << std::to_string(len) << " > " << buf->tailroom() << ") received from host. Dropping packet";
+	} else if (len > 0) {
+		/* Send packet to FBOSS for output on port */
+		VLOG(2) << "Got packet of " << std::to_string(len) << " bytes on iface " << iface->getIfaceName() << ". Sending to FBOSS...";
+		buf->append(len);
+		nlm->sw_->sendL2Packet(interface->getID(), std::move(pkt));
+	} else { /* len == 0 */
+		VLOG(0) << "Read from iface " << iface->getIfaceName() << " returned EOF (!?) -- ignoring";
+	}
+	return 0;
+}
+
+void NetlinkManager::host_packet_rx_listener(NetlinkManager * nlm) {
+	int epoll_fd;
+	struct epoll_event * events;
+	struct epoll_event ev;
+	int num_ifaces;
+
+	num_ifaces = nlm->getInterfacesByIfindex().size();
+
+	if ((epoll_fd = epoll_create(num_ifaces)) < 0) {
+		VLOG(0) << "epoll_create() failed: " << strerror(errno);
+		exit(-1);
+	}
+
+	if ((events = (struct epoll_event *) malloc(num_ifaces * sizeof(struct epoll_event))) == NULL) {
+		VLOG(0) << "malloc() failed: " << strerror(errno);
+		exit(-1);
+	}
+
+	for (std::map<int, TapIntf *>::const_iterator itr = nlm->getInterfacesByIfindex().begin(), 
+			end = nlm->getInterfacesByIfindex().end();
+			itr != end; itr++) {
+		ev.events = EPOLLIN;
+		ev.data.ptr = itr->second; /* itr points to a TapIntf */
+		if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, (itr->second)->getIfaceFD(), &ev) < 0) {
+			VLOG(0) << "epoll_ctl() failed: " << strerror(errno);
+			exit(-1);
+		}
+	}
+
+	VLOG(0) << "Going into epoll() loop";
+
+	int err = 0;
+	int nfds;
+	while (!err) {
+		if ((nfds = epoll_wait(epoll_fd, events, num_ifaces, -1)) < 0) {
+			if (errno == EINTR || errno == EAGAIN) {
+				continue;
+			} else {
+				VLOG(0) << "epoll_wait() failed: " << strerror(errno);
+				exit(-1);
+			}
+		}
+		for (int i = 0; i < nfds; i++) {
+			TapIntf * iface = (TapIntf *) events[i].data.ptr;
+			VLOG(2) << "Got packet on iface " << iface->getIfaceName();
+			err = nlm->read_packet_from_port(nlm, iface);
+		}
+	}
+
+	VLOG(0) << "Exiting epoll() loop";
+}
+
+bool NetlinkManager::sendPacketToHost(std::unique_ptr<RxPacket> pkt) {
+	const VlanID vlan = pkt->getSrcVlan();
+	std::map<VlanID, TapIntf *>::const_iterator itr = interfaces_by_vlan_.find(vlan);
+	if (itr == interfaces_by_vlan_.end()) {
+		VLOG(4) << "Dropping packet for unknown tap interface on VLAN " << std::to_string(vlan);
+		return false;
+	}
+	return itr->second->sendPacketToHost(std::move(pkt));
+}
+}} /* facebook::fboss */

--- a/fboss/agent/NetlinkManager.h
+++ b/fboss/agent/NetlinkManager.h
@@ -1,0 +1,152 @@
+#pragma once
+
+/* C headers */
+extern "C" {
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <string.h>
+#include <linux/if_tun.h>
+#include <linux/rtnetlink.h>
+#include <libnl3/netlink/types.h>
+#include <libnl3/netlink/route/addr.h>
+#include <libnl3/netlink/route/route.h>
+#include <libnl3/netlink/route/neighbour.h>
+#include <sys/epoll.h>
+}
+/* C++ headers */
+#include <string>
+#include <iostream>
+#include <memory> /* std::unique_ptr */
+#include <boost/thread.hpp>
+#include <boost/ptr_container/ptr_map.hpp>
+#include "TapIntf.h"
+
+#include <folly/io/async/EventBase.h>
+#include <folly/IPAddress.h>
+
+#include "fboss/agent/types.h"
+#include "fboss/agent/SwSwitch.h"
+#include "fboss/agent/Platform.h"
+#include "fboss/agent/state/SwitchState.h"
+#include "fboss/agent/state/PortMap.h"
+#include "fboss/agent/state/Route.h"
+#include "fboss/agent/state/RouteTable.h"
+#include "fboss/agent/state/RouteTableRib.h"
+#include "fboss/agent/state/RouteUpdater.h"
+#include "fboss/agent/SwitchStats.h"
+#include "fboss/agent/state/Interface.h"
+#include "fboss/agent/state/InterfaceMap.h"
+#include "fboss/agent/state/Vlan.h"
+#include "fboss/agent/state/VlanMap.h"
+#include "fboss/agent/RxPacket.h"
+#include "fboss/agent/TxPacket.h"
+
+/* Buffer used to read in packets from host */
+#define BUFLEN 65536
+
+namespace facebook { namespace fboss {
+
+class SwSwitch;
+
+class NetlinkManager {
+	public:
+	NetlinkManager(SwSwitch * sw, folly::EventBase * evb, std::string &iface_prefix);
+	~NetlinkManager();
+
+	/* Call first to add Interfaces to the SwitchState */
+	void addInterfacesAndUpdateState(std::shared_ptr<SwitchState> swState);
+	/* Call second to add TapIntf tap interfaces to host */
+	void startNetlinkManager(const int pollIntervalMillis);
+	/* Kill listener thread and remove tap interfaces*/
+	void stopNetlinkManager();
+
+	inline const std::map<int, TapIntf *>& getInterfacesByIfindex() {
+		return interfaces_by_ifindex_;
+	};
+
+	inline const std::map<VlanID, TapIntf *>& getInterfacesByVlanID() {
+		return interfaces_by_vlan_;
+	};
+
+	bool sendPacketToHost(std::unique_ptr<RxPacket> pkt);
+
+	private:
+
+	/* Our variables */
+	struct nl_dump_params dump_params_;		/* format and verbosity of netlink cache dumps */
+	struct nl_sock * sock_; 			/* pipe to RX/TX netlink messages */
+	struct nl_cache * link_cache_;			/* our copy of the system link state */
+	struct nl_cache * route_cache_;			/* our copy of the system route state */
+	struct nl_cache * neigh_cache_;			/* our copy of the system ARP table */
+	struct nl_cache * addr_cache_;			/* our copy of the system L3 addresses */
+	struct nl_cache_mngr * manager_;		/* wraps caches and notifies us upon a change */
+	std::string prefix_;				/* name we'll use for our host tap interfaces */
+	std::map<int, TapIntf *> interfaces_by_ifindex_;
+	std::map<VlanID, TapIntf *> interfaces_by_vlan_;
+	boost::thread * netlink_listener_thread_;	/* polls cache manager for updates */
+	boost::thread * host_packet_rx_thread_;		/* polls host iface FDs for packets en route to the dataplane */
+	SwSwitch * sw_;					/* use to update state and (TODO) receive updates */
+	folly::EventBase * evb_;			/* TODO consider removing this. I don't think we need it */
+
+	/* No copy or assign */
+	NetlinkManager(const NetlinkManager &);
+	NetlinkManager& operator=(const NetlinkManager &);
+
+	/* Logging -- TODO not necessary with FBOSS's logging */
+	void log_and_die(const char * msg);
+	void log_and_die_rc(const char * msg, const int rc);
+
+	/* Netlink logging verbosity in object dumps */
+	void init_dump_params();
+
+	/* Used internally when dumping Netlink nl_object types */
+	struct nl_dump_params * get_dump_params();
+	
+	/* Monitor what the host is doing (network-wise) using netlink */
+	void register_w_netlink();
+	void unregister_w_netlink();
+	
+	/* 
+	 * interfaces:
+	 *
+	 * The term "interface" is thrown around a lot but means different
+	 * things and refers to different types in different places. Internally,
+	 * we use TapIntf to represent the FBOSS-to-host-OS information that
+	 * enables a tap interface. FBOSS uses Interface to track a host OS
+	 * interface the FBOSS agent is supposed to be emulating. In non-netlink
+	 * mode, this emulation will occur (e.g. ARP handling, etc.), but in 
+	 * netlink mode, we delegate this to the host OS. Still, FBOSS tracks
+	 * the SwitchState using Interfaces. Thus, we need to map between the
+	 * FBOSS Interface and our TapIntf.
+	 *
+	 * These functions are responsible for handling both TapIntf and
+	 * Interface interfaces.
+	 */
+	void add_ifaces(const std::string &prefix, std::shared_ptr<SwitchState> state);
+	void delete_ifaces();
+
+	/* 
+	 * Netlink callbacks:
+	 *
+	 * nl_operation can be one of NL_ACT_NEW, NL_ACT_CHANGE, or NL_ACT_DEL for add, modify, and remove operations
+	 * data is used to pass in 'this' NetlinkManager
+	 */
+	static void netlink_link_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data);
+	static void netlink_route_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data);
+	static void netlink_neighbor_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data);
+	static void netlink_address_updated(struct nl_cache * cache, struct nl_object * obj, int nl_operation, void * data);
+
+	/* Cache manager polling thread */
+	static void netlink_listener(const int pollIntervalMillis, NetlinkManager * nlm);
+
+	/* Get ready to receive packets from the host on a tap interface */
+	void init_host_packet_rx();
+
+	/* Handle packets received from host on a tap interface */
+	static void host_packet_rx_listener(NetlinkManager * nlm);
+	int read_packet_from_port(NetlinkManager * nlm, TapIntf * iface);
+
+};
+
+}} /* facebook::fboss */

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -59,6 +59,8 @@ using std::unique_lock;
 using std::unique_ptr;
 
 DEFINE_string(config, "", "The path to the local JSON configuration file");
+DEFINE_int32(netlink_manager_poll_seconds, 5, "How often the netlink listener thread will poll for updates");
+DEFINE_string(netlink_manager_tap_prefix, "fboss", "The name to give tap interfaces. VLAN will be appended");
 
 namespace {
 constexpr auto kSwSwitch = "swSwitch";
@@ -116,17 +118,20 @@ inline void updatePortStatusCounters(const facebook::fboss::StateDelta& delta) {
 
 namespace facebook { namespace fboss {
 
-SwSwitch::SwSwitch(std::unique_ptr<Platform> platform)
+SwSwitch::SwSwitch(std::unique_ptr<Platform> platform, bool netlinkManaged)
   : hw_(platform->getHwSwitch()),
     platform_(std::move(platform)),
     arp_(new ArpHandler(this)),
     ipv4_(new IPv4Handler(this)),
     ipv6_(new IPv6Handler(this)),
-    nUpdater_(new NeighborUpdater(this)),
     pcapMgr_(new PktCaptureManager(this)),
     transceiverMap_(new TransceiverMap()) {
   // Create the platform-specific state directories if they
   // don't exist already.
+	if (!netlinkManaged) {
+		VLOG(3) << "Creating NeighborUpdater";
+		nUpdater_.reset(new NeighborUpdater(this));
+	}
   utilCreateDir(platform_->getVolatileStateDir());
   utilCreateDir(platform_->getPersistentStateDir());
 }
@@ -213,8 +218,10 @@ void SwSwitch::gracefulExit() {
   if (isFullyInitialized()) {
     folly::dynamic switchState = folly::dynamic::object;
     switchState[kSwSwitch] =  getState()->toFollyDynamic();
-    ipv6_->floodNeighborAdvertisements();
-    arp_->floodGratuituousArp();
+		if (!runningInNetlinkMode()) {
+    	ipv6_->floodNeighborAdvertisements();
+    	arp_->floodGratuituousArp();
+		}
     // Stop handlers and threads before uninitializing h/w
     stop();
     // Cleanup if we ever initialized
@@ -306,10 +313,21 @@ void SwSwitch::init(SwitchFlags flags) {
                                       initialState));
   });
 
+	if ((flags & SwitchFlags::ENABLE_TUN) && (flags & SwitchFlags::ENABLE_NETLINK_MANAGER)) {
+		VLOG(0) << "Both tun interfaces and netlink listener cannot be enabled simultaneously. Using tunnel interfaces";
+	}
   if (flags & SwitchFlags::ENABLE_TUN) {
     tunMgr_ = folly::make_unique<TunManager>(this, &backgroundEventBase_);
     tunMgr_->startProbe();
-  }
+	} else if (flags & SwitchFlags::ENABLE_NETLINK_MANAGER) { 
+		VLOG(1) << "Enabling netlink listener";
+		netlinkManager_ = folly::make_unique<NetlinkManager>(this, &backgroundEventBase_, FLAGS_netlink_manager_tap_prefix);
+	  if (nUpdater_) { /* disable; unique_ptr cleans everything up */
+			VLOG(0) << "Netlink listener initialized. Disabling neighbor updater";
+			nUpdater_.reset();
+			VLOG(0) << "Neighbor updater disabled";
+		}
+	}
 
   startThreads();
 
@@ -324,6 +342,17 @@ void SwSwitch::init(SwitchFlags flags) {
 }
 
 void SwSwitch::initialConfigApplied() {
+	/* First create the interfaces (before notifying anyone) */
+	if (netlinkManager_) {
+		/* This will cause the NetlinkManager to get a copy of
+		 * the current state, examine the VLANs, and install a
+		 * single Interface per VLAN. Any existing Interfaces
+		 * will be removed (invalidating any prior JSON config).
+		 */
+		VLOG(1) << "Creating tap interfaces for netlink";
+		netlinkManager_->addInterfacesAndUpdateState(getState());
+	}
+
   // notify the hw
   hw_->initialConfigApplied();
   setSwitchRunState(SwitchRunState::CONFIGURED);
@@ -346,6 +375,12 @@ void SwSwitch::initialConfigApplied() {
     // secondaries as well leading to errors, t4746261 is tracking this.
     tunMgr_->startObservingUpdates();
   }
+
+	if (netlinkManager_) {
+		VLOG(0) << "Starting manager listener";
+		netlinkManager_->startNetlinkManager(FLAGS_netlink_manager_poll_seconds * 1000); /* need sec --> ms */
+		VLOG(0) << "Netlink manager started";
+	} 
 
   if (lldpManager_) {
       lldpManager_->start();
@@ -905,6 +940,20 @@ std::unique_ptr<TxPacket> SwSwitch::allocateL3TxPacket(uint32_t l3Len) {
   return pkt;
 }
 
+std::unique_ptr<TxPacket> SwSwitch::allocateL2TxPacket(uint32_t l2Len) {
+	const uint32_t minLen = 68;
+	const uint32_t vlanLen = 4;
+	const uint32_t pktLen = l2Len + vlanLen; /* add in VLAN */
+	auto len = std::max(pktLen, minLen);
+	auto pkt = hw_->allocatePacket(len);
+	auto buf = pkt->buf();
+	// make sure the whole buffer is available
+	buf->clear();
+	// reserve 4 bytes for the VLAN tag if we need it
+	buf->advance(vlanLen);
+	return pkt;
+}
+
 void SwSwitch::sendPacketOutOfPort(std::unique_ptr<TxPacket> pkt,
                                    PortID portID) noexcept {
   pcapMgr_->packetSent(pkt.get());
@@ -990,11 +1039,73 @@ void SwSwitch::sendL3Packet(
   }
 }
 
+/*
+ * We have reserved 4 bytes of space for a VLAN tag in the headroom in alloateL2TxPacket.
+ * Although we might have to shift the dst and src MAC addresses to use it, we'll take
+ * this approach for now. If it turns out to be a performance issue, we can skip the 4
+ * bytes when the raw bytes are read into the folly::IOBuf in the first place in NetlinkManager.
+ */
+void SwSwitch::sendL2Packet(InterfaceID iid, std::unique_ptr<TxPacket> pkt) noexcept {
+	folly::IOBuf * buf = pkt->buf();
+	CHECK(!buf->isShared());
+	const uint32_t dstSrcMacLen = 12;
+	const uint32_t vlanLen = 4;
+	if (buf->headroom() != vlanLen) {
+		LOG(ERROR) << "Packet does not have the correct headroom to insert VLAN tag. "
+						   << "headroom=" << buf->headroom()
+							 << ", required=" << vlanLen;
+		return;
+	}
+				 
+	/* Figure out what VLAN to use */
+	std::shared_ptr<Interface> interface = getState()->getInterfaces()->getInterfaceIf(iid);
+	if (!interface) {
+		LOG(ERROR) << "Could not lookup Interface for InterfaceID " << iid 
+							 << " when sending L2 packet. Dropping packet";
+		return;
+	} else {
+		VLOG(2) << "Packet will be sent out Interface " << interface->getName() 
+						<< "on VLAN " << std::to_string(interface->getVlanID());
+	}
+					 
+	/* 
+	 * Now just need to figure out how to chain three IOBufs together:
+	 * [ dst MAC (6)]+[src MAC (6)]+[ethtype (2=0x8100)]+[vlan (2)]+[ethtype (2)]+[rest of packet (X)]
+	 *
+	 * IOBuf chaining would be cool, but a simple memcpy of the dst and src MAC -4 bytes to the head
+	 * of the buffer (guaranteed -4 bytes away) will do the trick.
+	 */
+	memcpy(buf->writableBuffer(), buf->data(), dstSrcMacLen);	
+	buf->prepend(vlanLen); /* adjust data to point to new start of -4 bytes and add +4 to length */
+						 	
+	/* Now, add in the VLAN ethtype and the tag, which is 12 bytes in */
+	RWPrivateCursor cursor(buf);
+	TxPacket::writeEthHeaderVlanTag(&cursor, interface->getVlanID());
+							 
+	const uint32_t pktLenWithVlan = buf->length() + vlanLen; /* need to record, since we're forfeiting our TxPacket */
+	sendPacketOutOfPort(std::move(pkt), getState()->getVlans()->getVlan(interface->getVlanID())->getPorts().begin()->first);
+	stats()->pktFromHost(pktLenWithVlan);
+}
+
 bool SwSwitch::sendPacketToHost(std::unique_ptr<RxPacket> pkt) {
   pcapMgr_->packetSentToHost(pkt.get());
+
+	/* Only one or the other (XOR) is used to handle to host packets */
   if (tunMgr_) {
     return tunMgr_->sendPacketToHost(std::move(pkt));
-  } else {
+	} else if (netlinkManager_) {
+		/* pop VLAN tag; will (err...should) always be present */
+	  folly::IOBuf * buf = pkt->buf();
+	  CHECK(!buf->isShared());
+	  const uint32_t dstSrcMacLen = 12;
+	  const uint32_t vlanLen = 4;
+	 
+	  /* Remove VLAN tag and shift prior L2 header towards payload */
+	  memmove(buf->writableData() + vlanLen, buf->data(), dstSrcMacLen);
+	  buf->trimStart(vlanLen); /* +4 bytes to start of buffer */
+	 		 
+	  return netlinkManager_->sendPacketToHost(std::move(pkt));
+	} else {
     return false;
   }
 }

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -59,7 +59,7 @@ using std::unique_lock;
 using std::unique_ptr;
 
 DEFINE_string(config, "", "The path to the local JSON configuration file");
-DEFINE_int32(netlink_manager_poll_seconds, 5, "How often the netlink listener thread will poll for updates");
+DEFINE_int32(netlink_manager_wait_ms, 300, "How long (in ms) the netlink listener thread will wait to fetch updates after an update occurs");
 DEFINE_string(netlink_manager_tap_prefix, "fboss", "The name to give tap interfaces. VLAN will be appended");
 
 namespace {
@@ -378,7 +378,7 @@ void SwSwitch::initialConfigApplied() {
 
 	if (netlinkManager_) {
 		VLOG(0) << "Starting manager listener";
-		netlinkManager_->startNetlinkManager(FLAGS_netlink_manager_poll_seconds * 1000); /* need sec --> ms */
+		netlinkManager_->startNetlinkManager(FLAGS_netlink_manager_wait_ms);
 		VLOG(0) << "Netlink manager started";
 	} 
 

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -1072,10 +1072,10 @@ void SwSwitch::sendL2Packet(InterfaceID iid, std::unique_ptr<TxPacket> pkt) noex
 	 * Now just need to figure out how to chain three IOBufs together:
 	 * [ dst MAC (6)]+[src MAC (6)]+[ethtype (2=0x8100)]+[vlan (2)]+[ethtype (2)]+[rest of packet (X)]
 	 *
-	 * IOBuf chaining would be cool, but a simple memcpy of the dst and src MAC -4 bytes to the head
+	 * IOBuf chaining would be cool, but a simple *memmove* of the dst and src MAC -4 bytes to the head
 	 * of the buffer (guaranteed -4 bytes away) will do the trick.
 	 */
-	memcpy(buf->writableBuffer(), buf->data(), dstSrcMacLen);	
+	memmove(buf->writableBuffer(), buf->data(), dstSrcMacLen);	
 	buf->prepend(vlanLen); /* adjust data to point to new start of -4 bytes and add +4 to length */
 						 	
 	/* Now, add in the VLAN ethtype and the tag, which is 12 bytes in */

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -1080,6 +1080,7 @@ void SwSwitch::sendL2Packet(InterfaceID iid, std::unique_ptr<TxPacket> pkt) noex
 						 	
 	/* Now, add in the VLAN ethtype and the tag, which is 12 bytes in */
 	RWPrivateCursor cursor(buf);
+	cursor.skip(dstSrcMacLen);
 	TxPacket::writeEthHeaderVlanTag(&cursor, interface->getVlanID());
 							 
 	const uint32_t pktLenWithVlan = buf->length() + vlanLen; /* need to record, since we're forfeiting our TxPacket */

--- a/fboss/agent/TapIntf.cpp
+++ b/fboss/agent/TapIntf.cpp
@@ -1,0 +1,136 @@
+#include "TapIntf.h"
+
+namespace facebook { namespace fboss {
+
+TapIntf::TapIntf(const std::string &iface_name, RouterID rid, InterfaceID iid) : 
+	name_(iface_name), fd_(0), index_(0), rid_(rid), iid_(iid) {
+	bring_up_iface();
+}
+
+TapIntf::~TapIntf() {
+	take_down_iface();
+}
+
+int TapIntf::bring_up_iface() {
+	int rc;
+	int flags;
+	struct ifreq ifr;
+
+	/* Check if we're already running */
+	if (fd_ != 0) {
+		VLOG(0) << "Tried to initialize " << name_ << ", but it was already running";
+		return -1;
+	}
+
+	if ((fd_ = open("/dev/net/tun", O_RDWR)) < 0) {
+		VLOG(0) << "Could not open file descriptor for " << name_ << ". open() returned " << fd_;
+		rc = fd_;
+		fd_ = 0;
+		return rc;
+	}
+
+	memset(&ifr, 0, sizeof(ifr));
+	ifr.ifr_flags = IFF_TAP | IFF_NO_PI;
+	size_t len = std::min(name_.size(), sizeof(ifr.ifr_name));
+	memmove(ifr.ifr_name, name_.c_str(), len);
+
+	if ((rc = ioctl(fd_, TUNSETIFF, (void *) &ifr)) < 0) {
+		std::string err;
+		if (errno == EBADF) {
+			err = std::string("Invalid file descriptor, errno=") + std::to_string(errno);	
+		} else if (errno == EFAULT) {
+			err = std::string("Argument references inaccessible memory area, errno=") + std::to_string(errno);
+		} else if (errno == EINVAL) {
+			err = std::string("File descriptor not associated with a character special device, errno=") + std::to_string(errno);
+		} else if (errno == ENOTTY) {
+			err = std::string("Request invalid for object type referenced by file descriptor, errno=") + std::to_string(errno);
+		} else if (errno == EPERM) {
+			err = std::string("Insufficient permissions to create tap interface, errno=") + std::to_string(errno);
+		} else if (errno == EBUSY) {
+			err = std::string("Device is busy, errno=") + std::to_string(errno);
+		} else {
+			err = std::string("Unknown errno=") + std::to_string(errno);
+		}
+		VLOG(0) << "Could not open interface " << std::string(ifr.ifr_name) << " for packet RX/TX. ioctl() returned " << rc << ". " << err;
+		close(fd_);
+		fd_ = 0;
+		return rc;
+	}
+
+	int sock = socket(AF_INET, SOCK_DGRAM, 0);
+	if ((rc = ioctl(sock, SIOCGIFINDEX, &ifr)) < 0) {
+		VLOG(0) << "Could not fetch index of interface " << name_ << ", errno=" << std::to_string(errno) << ", " << strerror(errno);
+		close(fd_);
+		fd_ = 0;
+		return rc;
+	}
+	index_ = ifr.ifr_ifindex;
+	close(sock);
+
+	if ((flags = fcntl(fd_, F_GETFL, 0)) < 0) {
+		VLOG(0) << "Could not get flags for interface " << name_ << ". fcntl() returned " << flags;
+		close(fd_);
+		fd_ = 0;
+		return flags;
+	}
+
+	flags |= O_NONBLOCK;
+	
+	if ((rc = fcntl(fd_, F_SETFL, flags)) < 0) {
+		VLOG(0) << "Could not set flags (nonblocking) for interface " << name_ << ". fcntl() returned " << rc;
+		close(fd_);
+		fd_ = 0;
+		return rc;
+	}
+
+	VLOG(1) << "Created interface " << name_ << " (index=" << std::to_string(index_) << ")"; 
+
+	return 0;
+}
+
+void TapIntf::take_down_iface() {
+	int rc;
+	if (fd_ == 0) {
+		VLOG(0) << "Interface " << name_ << " already removed";
+	} else if ((rc = close(fd_)) < 0) {
+		VLOG(0) << "Error closing file descriptor for interface " << name_ << ", " << strerror(errno);
+	} else {
+		VLOG(1) << "Removed interface " << name_;
+		fd_ = 0;
+	}
+}
+
+bool TapIntf::sendPacketToHost(std::unique_ptr<RxPacket> pkt) {
+	const int l2len = EthHdr::SIZE;
+
+	if (pkt->buf()->length() <= l2len) {
+		VLOG(0) << "Received too small packet (size of " << std::to_string(pkt->buf()->length()) << " bytes) from FBOSS to host. Dropping packet";
+		return false;
+	}
+
+	/* Sanity check */
+	if (!fd_) {
+		VLOG(0) << "File descriptor for interface " << name_ << " was not set (?!). Exiting now";
+		exit(1);
+	}
+
+	int rc = 0;
+	do {
+		rc = write(fd_, pkt->buf()->data(), pkt->buf()->length());
+	} while (rc == -1 && errno == EINTR);
+
+	if (rc < 0) {
+		VLOG(0) << "Failed to send packet to interface " << name_;
+		return false;
+	} else if (rc < pkt->buf()->length()) {
+		VLOG(0) << "Failed to send full packet to interface " << name_ << ". Sent " << std::to_string(rc) << " bytes instead of " 
+			<< std::to_string(pkt->buf()->length()) << " bytes";
+		return false;
+	} else {
+		VLOG(1) << "Sent packet of size " << std::to_string(rc) << " bytes to interface " << name_;
+		return true;
+	}
+	return false;
+}
+
+}} /* facebook::fboss */

--- a/fboss/agent/TapIntf.h
+++ b/fboss/agent/TapIntf.h
@@ -1,0 +1,68 @@
+/* C headers */
+extern "C" {
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <fcntl.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+#include <string.h>
+#include <errno.h>
+}
+/* C++ headers */
+#include <string>
+#include <sstream>
+#include <iostream>
+
+#include "fboss/agent/types.h"
+#include "fboss/agent/RxPacket.h"
+#include "fboss/agent/TxPacket.h"
+#include "fboss/agent/packet/EthHdr.h"
+
+namespace facebook { namespace fboss {
+
+class TapIntf {
+	public:
+	TapIntf(const std::string &name, RouterID rid, InterfaceID iid);
+	~TapIntf();
+
+	inline std::string& getIfaceName() {
+		return name_;
+	};
+	inline int getIfaceFD() {
+		return fd_;
+	};
+	inline unsigned short getIfaceIndex() {
+		return index_;
+	};
+	inline RouterID getIfaceRouterID() {
+		return rid_;
+	};
+	inline InterfaceID getInterfaceID() {
+		return iid_;
+	};
+
+	bool sendPacketToHost(std::unique_ptr<RxPacket> pkt);
+
+	private:
+	/* class-local variables */
+	std::string name_;
+	int fd_;
+	unsigned short index_;
+	RouterID rid_;
+	InterfaceID iid_;
+	//TODO std::mutex mutex_;
+
+	int bring_up_iface();
+	void take_down_iface();
+
+	/* Disallow copy */
+	TapIntf(const TapIntf &);
+	TapIntf& operator=(const TapIntf &);
+};
+
+}} /* facebook::fboss */

--- a/fboss/agent/TxPacket.h
+++ b/fboss/agent/TxPacket.h
@@ -51,6 +51,9 @@ class TxPacket : public Packet {
                              folly::MacAddress dst,
                              folly::MacAddress src,
                              uint16_t protocol);
+	template<typename CursorType>
+	static void writeEthHeaderVlanTag(CursorType* cursor, 
+														 VlanID vlan);
 
  protected:
   TxPacket() {}
@@ -69,8 +72,7 @@ void TxPacket::writeEthHeader(CursorType* cursor,
                               uint16_t protocol) {
   cursor->push(dst.bytes(), folly::MacAddress::SIZE);
   cursor->push(src.bytes(), folly::MacAddress::SIZE);
-  cursor->template writeBE<uint16_t>(0x8100); // 802.1Q
-  cursor->template writeBE<uint16_t>(vlan);
+	TxPacket::writeEthHeaderVlanTag(cursor, vlan);
   cursor->template writeBE<uint16_t>(protocol);
 }
 
@@ -82,6 +84,13 @@ void TxPacket::writeEthHeader(CursorType* cursor,
   cursor->push(dst.bytes(), folly::MacAddress::SIZE);
   cursor->push(src.bytes(), folly::MacAddress::SIZE);
   cursor->template writeBE<uint16_t>(protocol);
+}
+
+template<typename CursorType>
+void TxPacket::writeEthHeaderVlanTag(CursorType* cursor,
+		                          VlanID vlan) {
+	cursor->template writeBE<uint16_t>(0x8100); // 802.1Q
+	cursor->template writeBE<uint16_t>(vlan);
 }
 
 }} // facebook::fboss

--- a/fboss/agent/state/Interface.cpp
+++ b/fboss/agent/state/Interface.cpp
@@ -33,6 +33,19 @@ constexpr auto kMtu = "mtu";
 
 namespace facebook { namespace fboss {
 
+Interface * Interface::modify(std::shared_ptr<SwitchState> * state) {
+	if (!isPublished()) {
+		CHECK(!(*state)->isPublished());
+		return this;
+	}
+
+	InterfaceMap * interfaces = (*state)->getInterfaces()->modify(state);
+	std::shared_ptr<Interface> newInterface = clone();
+	Interface * ptr = newInterface.get();
+	interfaces->updateInterface(std::move(newInterface));
+	return ptr;
+}
+
 InterfaceFields InterfaceFields::fromFollyDynamic(const folly::dynamic& json) {
   auto intfFields =
     InterfaceFields(

--- a/fboss/agent/state/Interface.h
+++ b/fboss/agent/state/Interface.h
@@ -135,6 +135,8 @@ class Interface : public NodeBaseT<Interface, InterfaceFields> {
     return addrs.find(ip) != addrs.end();
   }
 
+	Interface * modify(std::shared_ptr<SwitchState> * state);
+
   /**
    * Find the interface IP address to reach the given destination
    */

--- a/fboss/agent/state/InterfaceMap.cpp
+++ b/fboss/agent/state/InterfaceMap.cpp
@@ -24,6 +24,19 @@ InterfaceMap::InterfaceMap() {
 InterfaceMap::~InterfaceMap() {
 }
 
+InterfaceMap * InterfaceMap::modify(std::shared_ptr<SwitchState> * state) {
+	if (!isPublished()) {
+		CHECK(!(*state)->isPublished());
+		return this;
+	}
+	  
+	SwitchState::modify(state);
+	std::shared_ptr<InterfaceMap> newInterfaces = clone();
+	InterfaceMap * ptr = newInterfaces.get();
+	(*state)->resetIntfs(std::move(newInterfaces));
+	return ptr;
+}
+
 std::shared_ptr<Interface>
 InterfaceMap::getInterfaceIf(RouterID router, const IPAddress& ip) const {
   for (auto itr = begin(); itr != end(); ++itr) {

--- a/fboss/agent/state/InterfaceMap.h
+++ b/fboss/agent/state/InterfaceMap.h
@@ -10,6 +10,7 @@
 #pragma once
 #include <vector>
 #include <folly/IPAddress.h>
+#include "fboss/agent/state/SwitchState.h"
 #include "fboss/agent/types.h"
 #include "fboss/agent/state/NodeMap.h"
 namespace facebook { namespace fboss {
@@ -98,6 +99,16 @@ class InterfaceMap : public NodeMapT<InterfaceMap, InterfaceMapTraits> {
   void addInterface(const std::shared_ptr<Interface>& interface) {
     addNode(interface);
   }
+
+	void removeInterface(const std::shared_ptr<Interface>& interface) {
+		removeNode(interface);
+	}
+ 
+	void updateInterface(const std::shared_ptr<Interface>& interface) {
+		updateNode(interface);
+	}
+ 
+	InterfaceMap * modify(std::shared_ptr<SwitchState> * state);
 
   /*
    * Serialize to a folly::dynamic object

--- a/getdeps.sh
+++ b/getdeps.sh
@@ -43,7 +43,8 @@ sudo apt-get install -yq autoconf automake libdouble-conversion-dev \
     libssl-dev make zip git autoconf libtool g++ libboost-all-dev \
     libevent-dev flex bison libgoogle-glog-dev scons libkrb5-dev \
     libsnappy-dev libsasl2-dev libnuma-dev libi2c-dev libcurl4-nss-dev \
-    libusb-1.0-0-dev libpcap-dev libdb5.3-dev cmake
+    libusb-1.0-0-dev libpcap-dev libdb5.3-dev cmake \
+		libnl-3-200 libnl-genl-3-200 libnl-route-3-200
 
 echo "creating external..."
 mkdir -p external

--- a/getdeps.sh
+++ b/getdeps.sh
@@ -44,7 +44,8 @@ sudo apt-get install -yq autoconf automake libdouble-conversion-dev \
     libevent-dev flex bison libgoogle-glog-dev scons libkrb5-dev \
     libsnappy-dev libsasl2-dev libnuma-dev libi2c-dev libcurl4-nss-dev \
     libusb-1.0-0-dev libpcap-dev libdb5.3-dev cmake \
-		libnl-3-200 libnl-genl-3-200 libnl-route-3-200
+		libnl-3-200 libnl-genl-3-200 libnl-route-3-200 \
+		libnl-3-dev libnl-genl-3-dev libnl-route-3-dev
 
 echo "creating external..."
 mkdir -p external


### PR DESCRIPTION
Add tap interfaces to switch host OS. There is a 1:1 mapping between a tap interface and an FBOSS Interface. Use netlink to monitor these tap interfaces for state changes, such as add/del/mod IPv4, IPv6, MAC addresses, MTU, ARP and NDP entries, and routes. Upon an observed change, notify FBOSS of the event. For example, if an IPv4 address is added to a tap interface, say tap01, FBOSS's corresponding Interface will be updated with the IP address. This and other updates received by the netlink manager are applied as a state change through the SwSwitch.

Notes:
-- The netlink manger and the existing TunManager are mutually exclusive
-- Limitation of one tap interface per VLAN at present
-- Work in progress (95% complete as of 03/29/16)

Changes to FBOSS:
-- Addition of libnl3 libraries
-- New GFLAGS for toggling b/t netlink and FBOSS managed modes
-- Addition of new NetlinkListener (soon to be renamed NetlinkManager)
-- Incorporation of netlink code into SwSwitch
-- Addition of L2 packet handling/forwarding to/from tap interfaces in SwSwitch
-- Minor changes to IPv4Handler, IPv6Handler, and ArpHandler for punting packets to CPU if in netlink managed mode
-- Modification of switch state types (e.g. state/Interface) for ease of performing state updates
-- Modification of BCM OpenNSL code to allow for interface updates outside of a warm boot scenario
