### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+
 ## Pull Requests
 We actively welcome your pull requests.
 1. Fork the repo and create your branch from `master`. 


### PR DESCRIPTION
In the past Facebook didn't promote including a Code of Conduct when creating new projects, and many projects skipped this important document. Let's fix it. :)

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the FBOSS community profile](https://github.com/facebook/fboss/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1033" alt="screen shot 2017-12-03 at 5 29 16 pm" src="https://user-images.githubusercontent.com/1114467/33532568-951bdf36-d84f-11e7-95e3-6e4fe53caa28.png">
<img width="1010" alt="screen shot 2017-12-03 at 5 29 31 pm" src="https://user-images.githubusercontent.com/1114467/33532570-9533f5bc-d84f-11e7-929a-e2caf1f0022b.png">

**issue:**
internal task t23481323