### PR TITLE
Initial attempt to move open source FBOSS to OpenNSL 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,7 +244,7 @@ find_library(THRIFTCORE thrift-core
 find_library(THRIFTFROZEN thriftfrozen2
              PATHS ${CMAKE_SOURCE_DIR}/external/fbthrift/build/lib)
 find_library(OPENNSL opennsl
-             PATHS ${CMAKE_SOURCE_DIR}/external/OpenNSL/bin/wedge-trident)
+             PATHS ${CMAKE_SOURCE_DIR}/external/OpenNSL/bin/wedge)
 find_library(IPROUTE2 netlink PATHS ${CMAKE_SOURCE_DIR}/external/iproute2/lib)
 find_library(ZSTD zstd PATHS ${CMAKE_SOURCE_DIR}/external/zstd/lib)
 

--- a/fboss/agent/hw/bcm/oss/BcmUnit.cpp
+++ b/fboss/agent/hw/bcm/oss/BcmUnit.cpp
@@ -77,7 +77,17 @@ void BcmUnit::attach(std::string warmBootDir) {
     setenv(wbEnvVar, wbFlag, 1);
   }
 
-  opennsl_driver_init();
+  /*
+   * By passing NULL here instead of a opennsl_init_t, we fall back
+   * to configation via environmental variable, e.g.,:
+   * - OPENNSL_CONFIG_FILE to point to the config.bcm
+   * - OPENNSL_BOOT_FLAGS for bootflags
+   * - OPENNSL_POST_INIT_CONFIG_FILE for post-init bcm shell cmds
+   *
+   * this also forces(?) the resource monitor to not start
+   */
+
+  opennsl_driver_init(NULL);
 
   attached_.store(true, std::memory_order_release);
 }

--- a/getdeps.sh
+++ b/getdeps.sh
@@ -103,7 +103,7 @@ NPROC=$(grep -c processor /proc/cpuinfo)
     if [ $GET_OPENNSL == 1 ] ; then
       # We hard code OpenNSL to OpenNSL-6.4.6.6 release, later releases seem to
       # SIGSEV in opennsl_pkt_alloc()
-      update https://github.com/Broadcom-Switch/OpenNSL.git 8e0b499f02dcef751a3703c9a18600901374b28a
+      update https://github.com/Broadcom-Switch/OpenNSL.git v3.5.0.1
     fi
     # iproute2 v4.4.0
     update https://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git 7ca63aef7d1b0c808da0040c6b366ef7a61f38c1


### PR DESCRIPTION
Configuration is now set via environmental variables instead
of baked into the libopennsl.so.  Specifically:

- OPENNSL_CONFIG_FILE to point to the config.bcm
- OPENNSL_BOOT_FLAGS for bootflags
- OPENNSL_POST_INIT_CONFIG_FILE for post-init bcm shell cmds

The documentation for these files can be found in the OpenNSL
Platform documentation.  Examples ship with OpenNSL, e.g.,

OPENNSL_CONFIG_FILE=OpenNSL/bin/wedge/config.wedge100