### PR TITLE
Allow zero interface multiple vlan configuration

### DIFF
--- a/fboss/agent/ApplyThriftConfig.cpp
+++ b/fboss/agent/ApplyThriftConfig.cpp
@@ -361,7 +361,7 @@ shared_ptr<SwitchState> ThriftConfigApplier::run() {
     // Make sure there is a one-to-one map between vlan and interface
     // Remove this sanity check if multiple interfaces are allowed per vlans
     auto& entry = vlanInterfaces_[vlanInfo.first];
-    if (entry.interfaces.size() != 1) {
+    if (entry.interfaces.size() > 1) {
       auto cpu_vlan = new_->getDefaultVlan();
       if (vlanInfo.first != cpu_vlan) {
         throw FbossError("Vlan ", vlanInfo.first, " refers to ",


### PR DESCRIPTION
Summary:
Currently when applying a configuration with multiple vlans and no L3 interfaces the message "Vlan 552 refers to 0 interfaces" is displayed and configuration is rejected.
Most likely this was an accident in the original code as having no L3 interfaces is quite rare.