### PR TITLE
Re-sync with internal repository

### DIFF
--- a/fboss/agent/hw/bcm/BcmQosPolicy.h
+++ b/fboss/agent/hw/bcm/BcmQosPolicy.h
@@ -26,7 +26,7 @@ class BcmQosPolicy {
   void update(
       const std::shared_ptr<QosPolicy>& oldQosPolicy,
       const std::shared_ptr<QosPolicy>& newQosPolicy);
-  BcmQosPolicyHandle getHandle() const;
+  BcmQosPolicyHandle getHandle(BcmQosMap::Type type) const;
   bool policyMatches(const std::shared_ptr<QosPolicy>& qosPolicy) const;
 
  private:
@@ -34,11 +34,11 @@ class BcmQosPolicy {
       BcmSwitch* hw,
       const std::shared_ptr<QosPolicy>& qosPolicy);
   void programIngressExpQosMap(
-      BcmSwitch* /*hw*/,
-      const std::shared_ptr<QosPolicy>& /*qosPolicy*/) {}
+      BcmSwitch* hw,
+      const std::shared_ptr<QosPolicy>& qosPolicy);
   void programEgressExpQosMap(
-      BcmSwitch* /*hw*/,
-      const std::shared_ptr<QosPolicy>& /*qosPolicy*/) {}
+      BcmSwitch* hw,
+      const std::shared_ptr<QosPolicy>& qosPolicy);
 
   std::unique_ptr<BcmQosMap> ingressDscpQosMap_;
   std::unique_ptr<BcmQosMap> ingressExpQosMap_;


### PR DESCRIPTION
The internal and external repositories are out of sync. This attempts to brings them back in sync by patching the GitHub repository. Please carefully review this patch. You must disable ShipIt for your project in order to merge this pull request. DO NOT IMPORT this pull request. Instead, merge it directly on GitHub using the MERGE BUTTON. Re-enable ShipIt after merging.