### PR TITLE
fix range for race

### DIFF
--- a/fboss/agent/ResolvedNexthopMonitor.h
+++ b/fboss/agent/ResolvedNexthopMonitor.h
@@ -94,10 +94,13 @@ class ResolvedNexthopMonitor : public StateObserver {
   }
 
   bool isClientMonitored(ClientID clientId) const {
-    for (auto client : *kMonitoredClients.rlock()) {
-      if (clientId == client) {
-        /* route is programmed by client and it's next hops are preferred */
-        return true;
+    {
+      auto monitoredClientsLocked = kMonitoredClients.rlock();
+      for (auto client : *monitoredClientsLocked) {
+        if (clientId == client) {
+          /* route is programmed by client and it's next hops are preferred */
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
Summary: acquiring the lock of folly::Synchronized<T> in a range-for will drop the lock.  This is racy on the container / iterator.

Reviewed By: jasmeetbagga

Differential Revision: D39390783

