### PR TITLE
Add recycle port to Yangra platform mapping

### DIFF
--- a/fboss/agent/platforms/common/yangra/YangraPlatformMapping.cpp
+++ b/fboss/agent/platforms/common/yangra/YangraPlatformMapping.cpp
@@ -15,6 +15,41 @@ namespace {
 constexpr auto kJsonPlatformMappingStr = R"(
 {
   "ports": {
+    "1": {
+        "mapping": {
+          "id": 1,
+          "name": "rcy1/1/1",
+          "controllingPort": 1,
+          "pins": [
+            {
+              "a": {
+                "chip": "rcy1",
+                "lane": 0
+              }
+            }
+          ],
+          "portType": 3,
+          "attachedCoreId": 0,
+          "attachedCorePortIndex": 1
+        },
+        "supportedProfiles": {
+          "11": {
+              "subsumedPorts": [
+
+              ],
+              "pins": {
+                "iphy": [
+                  {
+                    "id": {
+                      "chip": "rcy1",
+                      "lane": 0
+                    }
+                  }
+                ]
+              }
+          }
+        }
+    },
     "2": {
         "mapping": {
           "id": 2,
@@ -380,6 +415,11 @@ constexpr auto kJsonPlatformMappingStr = R"(
       "name": "eth1/18",
       "type": 3,
       "physicalID": 17
+    },
+    {
+      "name": "rcy1",
+      "type": 1,
+      "physicalID": 55
     }
   ],
   "platformSettings": {
@@ -400,6 +440,22 @@ constexpr auto kJsonPlatformMappingStr = R"(
           "medium": 1,
           "interfaceMode": 12,
           "interfaceType": 12
+        }
+      }
+    },
+    {
+      "factor": {
+        "profileID": 11
+      },
+      "profile": {
+        "speed": 10000,
+        "iphy": {
+          "numLanes": 1,
+          "modulation": 1,
+          "fec": 1,
+          "medium": 1,
+          "interfaceMode": 10,
+          "interfaceType": 10
         }
       }
     }

--- a/fboss/bcm_sai_configs/yangra.agent.materialized_JSON
+++ b/fboss/bcm_sai_configs/yangra.agent.materialized_JSON
@@ -328,6 +328,7 @@
           "tm_port_header_type_out_240.BCM8885X": "ETH",
           "tm_port_header_type_in_1.BCM8885X": "ETH",
           "tm_port_header_type_out_1.BCM8885X": "ETH",
+          "ucode_port_1.BCM8885X": "RCY.21:core_0.1",
           "ucode_port_2.BCM8885X": "CGE32:core_1.2",
           "ucode_port_3.BCM8885X": "CGE34:core_1.3",
           "lane_to_serdes_map_nif_lane128": "rx135:tx132",


### PR DESCRIPTION
- Recycle port is required for HwVoqSwitchTests to pass.
- Setup RCY port in bcm config.