### PR TITLE
meru400bia: adds BSP platform mapping and qsfp_service

### DIFF
--- a/fboss/lib/bsp/BspGenericSystemContainer.cpp
+++ b/fboss/lib/bsp/BspGenericSystemContainer.cpp
@@ -3,6 +3,7 @@
 #include "fboss/lib/bsp/BspGenericSystemContainer.h"
 #include <folly/Singleton.h>
 #include "fboss/lib/bsp/meru400bfu/Meru400bfuBspPlatformMapping.h"
+#include "fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru400biu/Meru400biuBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru800bia/Meru800biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/montblanc/MontblancBspPlatformMapping.h"
@@ -17,6 +18,15 @@ template <>
 std::shared_ptr<Meru400bfuSystemContainer>
 Meru400bfuSystemContainer::getInstance() {
   return _meru400bfuSystemContainer.try_get();
+}
+
+using Meru400biaSystemContainer =
+    BspGenericSystemContainer<Meru400biaBspPlatformMapping>;
+folly::Singleton<Meru400biaSystemContainer> _meru400biaSystemContainer;
+template <>
+std::shared_ptr<Meru400biaSystemContainer>
+Meru400biaSystemContainer::getInstance() {
+  return _meru400biaSystemContainer.try_get();
 }
 
 using Meru400biuSystemContainer =

--- a/fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.cpp
+++ b/fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.cpp
@@ -1,0 +1,516 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h"
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+#include "fboss/lib/bsp/BspPlatformMapping.h"
+#include "fboss/lib/bsp/gen-cpp2/bsp_platform_mapping_types.h"
+
+using namespace facebook::fboss;
+using namespace apache::thrift;
+
+namespace {
+constexpr auto kJsonBspPlatformMappingStr = R"(
+{
+  "pimMapping": {
+    "1": {
+        "pimID": 1,
+        "tcvrMapping": {
+          "1": {
+              "tcvrId": 1,
+              "accessControl": {
+                "controllerId": "accessController-1",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp1_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp1_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-1",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH0"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "2": {
+              "tcvrId": 2,
+              "accessControl": {
+                "controllerId": "accessController-2",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp2_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp2_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-2",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH1"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "3": {
+              "tcvrId": 3,
+              "accessControl": {
+                "controllerId": "accessController-3",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp3_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp3_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-3",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH2"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "4": {
+              "tcvrId": 4,
+              "accessControl": {
+                "controllerId": "accessController-4",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp4_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp4_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-4",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH3"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "5": {
+              "tcvrId": 5,
+              "accessControl": {
+                "controllerId": "accessController-5",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp5_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp5_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-5",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH4"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "6": {
+              "tcvrId": 6,
+              "accessControl": {
+                "controllerId": "accessController-6",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp6_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp6_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-6",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH5"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "7": {
+              "tcvrId": 7,
+              "accessControl": {
+                "controllerId": "accessController-7",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp7_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp7_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-7",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH6"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "8": {
+              "tcvrId": 8,
+              "accessControl": {
+                "controllerId": "accessController-8",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp8_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp8_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-8",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS0_CH7"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "9": {
+              "tcvrId": 9,
+              "accessControl": {
+                "controllerId": "accessController-9",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp9_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp9_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-9",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH0"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "10": {
+              "tcvrId": 10,
+              "accessControl": {
+                "controllerId": "accessController-10",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp10_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp10_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-10",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH1"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "11": {
+              "tcvrId": 11,
+              "accessControl": {
+                "controllerId": "accessController-11",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp11_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp11_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-11",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH2"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "12": {
+              "tcvrId": 12,
+              "accessControl": {
+                "controllerId": "accessController-12",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp12_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp12_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-12",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH3"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "13": {
+              "tcvrId": 13,
+              "accessControl": {
+                "controllerId": "accessController-13",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp13_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp13_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-13",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH4"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "14": {
+              "tcvrId": 14,
+              "accessControl": {
+                "controllerId": "accessController-14",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp14_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp14_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-14",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH5"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "15": {
+              "tcvrId": 15,
+              "accessControl": {
+                "controllerId": "accessController-15",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp15_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp15_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-15",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH6"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "16": {
+              "tcvrId": 16,
+              "accessControl": {
+                "controllerId": "accessController-16",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp16_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp16_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-16",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS1_CH7"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "17": {
+              "tcvrId": 17,
+              "accessControl": {
+                "controllerId": "accessController-17",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp17_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp17_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-17",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS2_CH0"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          },
+          "18": {
+              "tcvrId": 18,
+              "accessControl": {
+                "controllerId": "accessController-18",
+                "type": 1,
+                "reset": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp18_reset",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "presence": {
+                  "sysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-xcvr.0/qsfp18_present",
+                  "mask": 1,
+                  "gpioOffset": 0
+                },
+                "gpioChip": ""
+              },
+              "io": {
+                "controllerId": "ioController-18",
+                "type": 1,
+                "devicePath": "/run/devmap/i2c-busses/SCD_SMBUS2_CH1"
+              },
+              "tcvrLaneToLedId": {
+
+              }
+          }
+        },
+        "phyMapping": {
+
+        },
+        "phyIOControllers": {
+
+        },
+        "ledMapping": {
+
+        }
+    }
+  }
+}
+)";
+
+static BspPlatformMappingThrift buildMeru400biaPlatformMapping() {
+  return apache::thrift::SimpleJSONSerializer::deserialize<
+      BspPlatformMappingThrift>(kJsonBspPlatformMappingStr);
+}
+
+} // namespace
+
+namespace facebook {
+namespace fboss {
+
+// TODO: Use pre generated bsp platform mapping from cfgr
+Meru400biaBspPlatformMapping::Meru400biaBspPlatformMapping()
+    : BspPlatformMapping(buildMeru400biaPlatformMapping()) {}
+
+} // namespace fboss
+} // namespace facebook

--- a/fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h
+++ b/fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "fboss/lib/bsp/BspPlatformMapping.h"
+
+namespace facebook {
+namespace fboss {
+
+class Meru400biaBspPlatformMapping : public BspPlatformMapping {
+ public:
+  Meru400biaBspPlatformMapping();
+};
+
+} // namespace fboss
+} // namespace facebook

--- a/fboss/oss/qsfp_test_configs/meru400bia.materialized_JSON
+++ b/fboss/oss/qsfp_test_configs/meru400bia.materialized_JSON
@@ -1,0 +1,22 @@
+{
+  "defaultCommandLineArgs": {
+    "mode": "meru400bia"
+  },
+  "transceiverConfigOverrides": [
+
+  ],
+  "qsfpTestConfig": {
+    "cabledPortPairs": [
+      {
+        "aPortName": "eth1/8/1",
+        "zPortName": "eth1/9/1",
+        "profileID": 23
+      },
+      {
+        "aPortName": "eth1/11/1",
+        "zPortName": "eth1/12/1",
+        "profileID": 22
+      }
+    ]
+  }
+}

--- a/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
+++ b/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
@@ -10,11 +10,13 @@
 #include "fboss/qsfp_service/platforms/wedge/WedgeManagerInit.h"
 
 #include "fboss/agent/platforms/common/meru400bfu/Meru400bfuPlatformMapping.h"
+#include "fboss/agent/platforms/common/meru400bia/Meru400biaPlatformMapping.h"
 #include "fboss/agent/platforms/common/meru400biu/Meru400biuPlatformMapping.h"
 #include "fboss/agent/platforms/common/meru800bia/Meru800biaPlatformMapping.h"
 #include "fboss/agent/platforms/common/montblanc/MontblancPlatformMapping.h"
 #include "fboss/lib/bsp/BspGenericSystemContainer.h"
 #include "fboss/lib/bsp/meru400bfu/Meru400bfuBspPlatformMapping.h"
+#include "fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru400biu/Meru400biuBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru800bia/Meru800biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/montblanc/MontblancBspPlatformMapping.h"
@@ -54,6 +56,8 @@ std::unique_ptr<WedgeManager> createWedgeManager() {
     return createSandiaWedgeManager();
   } else if (mode == PlatformType::PLATFORM_MERU400BFU) {
     return createMeru400bfuWedgeManager();
+  } else if (mode == PlatformType::PLATFORM_MERU400BIA) {
+    return createMeru400biaWedgeManager();
   } else if (mode == PlatformType::PLATFORM_MERU400BIU) {
     return createMeru400biuWedgeManager();
   } else if (mode == PlatformType::PLATFORM_MERU800BIA) {
@@ -80,6 +84,17 @@ std::unique_ptr<WedgeManager> createMeru400bfuWedgeManager() {
       std::make_unique<BspTransceiverApi>(systemContainer),
       std::make_unique<Meru400bfuPlatformMapping>(),
       PlatformType::PLATFORM_MERU400BFU);
+}
+
+std::unique_ptr<WedgeManager> createMeru400biaWedgeManager() {
+  auto systemContainer =
+      BspGenericSystemContainer<Meru400biaBspPlatformMapping>::getInstance()
+          .get();
+  return std::make_unique<BspWedgeManager>(
+      systemContainer,
+      std::make_unique<BspTransceiverApi>(systemContainer),
+      std::make_unique<Meru400biaPlatformMapping>(),
+      PlatformType::PLATFORM_MERU400BIA);
 }
 
 std::unique_ptr<WedgeManager> createMeru400biuWedgeManager() {

--- a/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.h
+++ b/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.h
@@ -43,6 +43,7 @@ std::unique_ptr<WedgeManager> createSandiaWedgeManager();
 
 std::unique_ptr<WedgeManager> createMeru400bfuWedgeManager();
 
+std::unique_ptr<WedgeManager> createMeru400biaWedgeManager();
 std::unique_ptr<WedgeManager> createMeru400biuWedgeManager();
 std::unique_ptr<WedgeManager> createMeru800biaWedgeManager();
 

--- a/fboss/qsfp_service/test/BspPlatformMapTest.cpp
+++ b/fboss/qsfp_service/test/BspPlatformMapTest.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include "fboss/lib/CommonFileUtils.h"
 #include "fboss/lib/bsp/meru400bfu/Meru400bfuBspPlatformMapping.h"
+#include "fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru400biu/Meru400biuBspPlatformMapping.h"
 #include "fboss/lib/bsp/montblanc/MontblancBspPlatformMapping.h"
 #include "fboss/qsfp_service/platforms/wedge/tests/MockWedgeManager.h"
@@ -23,6 +24,10 @@ TEST_F(BspPlatformMapTest, checkNumPimTransceivers) {
   auto m400bfuBspPlatformMap = Meru400bfuBspPlatformMapping();
   EXPECT_EQ(m400bfuBspPlatformMap.numPims(), 1);
   EXPECT_EQ(m400bfuBspPlatformMap.numTransceivers(), 48);
+  // Check Meru400bia
+  auto m400biaBspPlatformMap = Meru400biaBspPlatformMapping();
+  EXPECT_EQ(m400biaBspPlatformMap.numPims(), 1);
+  EXPECT_EQ(m400biaBspPlatformMap.numTransceivers(), 18);
   // Check Makalu
   auto m400biuBspPlatformMap = Meru400biuBspPlatformMapping();
   EXPECT_EQ(m400biuBspPlatformMap.numPims(), 1);

--- a/fboss/util/oss/wedge_qsfp_util.cpp
+++ b/fboss/util/oss/wedge_qsfp_util.cpp
@@ -4,6 +4,7 @@
 #include "fboss/lib/bsp/BspIOBus.h"
 #include "fboss/lib/bsp/BspTransceiverApi.h"
 #include "fboss/lib/bsp/meru400bfu/Meru400bfuBspPlatformMapping.h"
+#include "fboss/lib/bsp/meru400bia/Meru400biaBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru400biu/Meru400biuBspPlatformMapping.h"
 #include "fboss/lib/bsp/meru800bia/Meru800biaBspPlatformMapping.h"
 #include "fboss/lib/platforms/PlatformMode.h"
@@ -37,6 +38,12 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
               .get();
       auto ioBus = std::make_unique<BspIOBus>(systemContainer);
       return std::make_pair(std::move(ioBus), 0);
+    } else if (FLAGS_platform == "meru400bia") {
+      auto systemContainer =
+          BspGenericSystemContainer<Meru400biaBspPlatformMapping>::getInstance()
+              .get();
+      auto ioBus = std::make_unique<BspIOBus>(systemContainer);
+      return std::make_pair(std::move(ioBus), 0);
     } else if (FLAGS_platform == "meru400biu") {
       auto systemContainer =
           BspGenericSystemContainer<Meru400biuBspPlatformMapping>::getInstance()
@@ -63,6 +70,12 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
   if (mode == PlatformType::PLATFORM_MERU400BFU) {
     auto systemContainer =
         BspGenericSystemContainer<Meru400bfuBspPlatformMapping>::getInstance()
+            .get();
+    auto ioBus = std::make_unique<BspIOBus>(systemContainer);
+    return std::make_pair(std::move(ioBus), 0);
+  } else if (mode == PlatformType::PLATFORM_MERU400BIA) {
+    auto systemContainer =
+        BspGenericSystemContainer<Meru400biaBspPlatformMapping>::getInstance()
             .get();
     auto ioBus = std::make_unique<BspIOBus>(systemContainer);
     return std::make_pair(std::move(ioBus), 0);
@@ -100,6 +113,8 @@ getTransceiverPlatformAPI(TransceiverI2CApi* i2cBus) {
     // Fpga object
     if (FLAGS_platform == "meru400bfu") {
       mode = PlatformType::PLATFORM_MERU400BFU;
+    } else if (FLAGS_platform == "meru400bia") {
+      mode = PlatformType::PLATFORM_MERU400BIA;
     } else if (FLAGS_platform == "meru400biu") {
       mode = PlatformType::PLATFORM_MERU400BIU;
     }
@@ -116,6 +131,12 @@ getTransceiverPlatformAPI(TransceiverI2CApi* i2cBus) {
   if (mode == PlatformType::PLATFORM_MERU400BFU) {
     auto systemContainer =
         BspGenericSystemContainer<Meru400bfuBspPlatformMapping>::getInstance()
+            .get();
+    return std::make_pair(
+        std::make_unique<BspTransceiverApi>(systemContainer), 0);
+  } else if (mode == PlatformType::PLATFORM_MERU400BIA) {
+    auto systemContainer =
+        BspGenericSystemContainer<Meru400biaBspPlatformMapping>::getInstance()
             .get();
     return std::make_pair(
         std::make_unique<BspTransceiverApi>(systemContainer), 0);


### PR DESCRIPTION
## Summary

- Adds BSP platform mapping for Meru400bia platform including all ports.
- Adds qsfp_service support for Meru400bia
- Adds wedge_qsfp_util support for Meru400bia
- Adds qsfp_test_config for Meru400bia

## Testing

qsfp_service runs successfully on Meru400bia and wedge_qsfp_service works.
The following qsfp_hw_tests pass on Meru400bia:
```
HwTest.i2cStressRead
HwTest.i2cStressWrite
HwTest.i2cUniqueSerialNumbers
HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.TestProfile
HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile
HwStateMachineTest.CheckAgentConfigChanged
HwStateMachineTest.CheckPortStatusUpdated
HwStateMachineTest.CheckPortsProgrammed
HwStateMachineTest.CheckTransceiverRemediated
HwStateMachineTest.CheckTransceiverRemoved
HwStateMachineTestWithoutIphyProgramming.CheckOpticsDetection
HwTest.publishStats
HwTransceiverConfigTest.moduleConfigVerification
```