### PR TITLE
move sai fake to sai 1.12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,11 @@ if (SAI_BRCM_IMPL)
   # Build for BCM DNX by default. For XGS, set the ENV variable SAI_SDK_VERSION
   # to build for BCM XGS.
   set(SAI_SDK_VERSION "SAI_VERSION_10_0_EA_DNX_ODP")
-  set(SAI_VER_MAJOR "1")
-  set(SAI_VER_MINOR "12")
-  set(SAI_VER_RELEASE "0")
-else()
-  set(SAI_VER_MAJOR "1")
-  set(SAI_VER_MINOR "7")
-  set(SAI_VER_RELEASE "1")
 endif()
+
+set(SAI_VER_MAJOR "1")
+set(SAI_VER_MINOR "12")
+set(SAI_VER_RELEASE "0")
 
 if (NOT "$ENV{SAI_SDK_VERSION}" STREQUAL "")
   message(STATUS "ENV SAI_SDK_VERSION is set to $ENV{SAI_SDK_VERSION}")
@@ -180,6 +177,18 @@ include_directories(${Python3_INCLUDE_DIR})
 
 find_path(SAI_INCLUDE_DIR NAMES sai.h)
 include_directories(${SAI_INCLUDE_DIR})
+
+if (SAI_BRCM_IMPL)
+  find_path(SAI_EXPERIMENTAL_INCLUDE_DIR NAMES saiswitchextensions.h)
+  include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR})
+  message(STATUS, "Experimental dir: ${SAI_EXPERIMENTAL_INCLUDE_DIR}")
+else()
+  find_path(SAI_EXPERIMENTAL_INCLUDE_DIR
+    NAMES
+    experimental/saiswitchextensions.h)
+  include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR}/experimental)
+  message(STATUS, "Experimental Dir: ${SAI_EXPERIMENTAL_INCLUDE_DIR}")
+endif()
 
 message(STATUS "Found SAI_INCLUDE_DIR: ${SAI_INCLUDE_DIR}")
 

--- a/build/fbcode_builder/manifests/libsai
+++ b/build/fbcode_builder/manifests/libsai
@@ -2,12 +2,13 @@
 name = libsai
 
 [download]
-url = https://github.com/opencomputeproject/SAI/archive/v1.7.1.tar.gz
-sha256 = e18eb1a2a6e5dd286d97e13569d8b78cc1f8229030beed0db4775b9a50ab6a83
+url = https://github.com/opencomputeproject/SAI/archive/v1.12.0.tar.gz
+sha256 = 1e7f43599baf1dcca122bbbb2baaeb9b20e5632d2ca6aaa61a568d1d58afaa97
 
 [build]
 builder = nop
-subdir = SAI-1.7.1
+subdir = SAI-1.12.0
 
 [install.files]
 inc = include
+experimental = experimental

--- a/cmake/AgentHwSaiHwTest.cmake
+++ b/cmake/AgentHwSaiHwTest.cmake
@@ -230,12 +230,6 @@ endif()
 find_library(SAI_IMPL sai_impl)
 message(STATUS "SAI_IMPL: ${SAI_IMPL}")
 
-if (SAI_BRCM_IMPL)
-  find_path(SAI_EXPERIMENTAL_INCLUDE_DIR NAMES saiswitchextensions.h)
-  include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR})
-  message(STATUS, "SAI_EXPERIMENTAL_INCLUDE_DIR: ${SAI_EXPERIMENTAL_INCLUDE_DIR}")
-endif()
-
 if(SAI_IMPL)
   BUILD_SAI_TEST("sai_impl" ${SAI_IMPL})
   install(

--- a/fboss/agent/hw/sai/api/SaiVersion.h
+++ b/fboss/agent/hw/sai/api/SaiVersion.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#ifndef IS_OSS_BRCM_SAI
+#ifndef IS_OSS
 
 #if !defined(SAI_VERSION)
 #define SAI_VERSION(major, minor, micro) \


### PR DESCRIPTION
Summary:
As titled, move sai fake sai to 1.12.0. BCM and TAJO P4 WB SDK already moved to 1.12.0 and its good to move fake also to the same version.

This diff addresses:

- Moving SAI version for fake from sai version 1.7 to 1.12
- Update sandcastle job to build the fake sai 1.12
- saiobject.h includes experimental header files as part of SAI 1.12 and hence the include path has to contain both sai/include and sai/experimental. Currently, vendors leverage the experimental header files differently (by placing include and experimental in the same include dir) than SAI spec but eventually we will have vendors also converge to the same model. Changing it now will break BCM builds.
- Ignore including Saiversion.h in OSS since 1.12 contains saiversion.h already and defines SAI_VERSION and SAI_API_VERSION macros.

NOTE that this should not alter BCM OSS builds.

Reviewed By: shri-khare

Differential Revision: D47779384

