### PR TITLE
Route scale for Yuba asic and other yuba changes

### DIFF
--- a/fboss/agent/hw/switch_asics/YubaAsic.cpp
+++ b/fboss/agent/hw/switch_asics/YubaAsic.cpp
@@ -37,6 +37,11 @@ bool YubaAsic::isSupportedNonFabric(Feature feature) const {
     case HwAsic::Feature::L2_LEARNING:
     case HwAsic::Feature::CPU_PORT:
     case HwAsic::Feature::ACL_COPY_TO_CPU:
+    case HwAsic::Feature::SWITCH_ATTR_INGRESS_ACL:
+    case HwAsic::Feature::MULTIPLE_ACL_TABLES:
+    case HwAsic::Feature::ACL_TABLE_GROUP:
+    case HwAsic::Feature::SAI_ACL_TABLE_UPDATE:
+    case HwAsic::Feature::SAI_ACL_ENTRY_SRC_PORT_QUALIFIER:
     case HwAsic::Feature::VRF:
     case HwAsic::Feature::SAI_PORT_SERDES_FIELDS_RESET:
     case HwAsic::Feature::PTP_TC:
@@ -52,7 +57,6 @@ bool YubaAsic::isSupportedNonFabric(Feature feature) const {
     case HwAsic::Feature::FABRIC_PORTS:
     case HwAsic::Feature::SAI_PORT_SPEED_CHANGE:
     case HwAsic::Feature::ROUTE_METADATA:
-    case HwAsic::Feature::P4_WARMBOOT:
     case HwAsic::Feature::PMD_RX_LOCK_STATUS:
     case HwAsic::Feature::PMD_RX_SIGNAL_DETECT:
     case HwAsic::Feature::FEC_AM_LOCK_STATUS:
@@ -66,6 +70,7 @@ bool YubaAsic::isSupportedNonFabric(Feature feature) const {
     case HwAsic::Feature::SAI_CONFIGURE_SEVEN_TAP:
     case HwAsic::Feature::SAI_CONFIGURE_SIX_TAP:
     case HwAsic::Feature::SEPARATE_BYTE_AND_PACKET_ACL_COUNTER:
+    case HwAsic::Feature::L3_QOS:
       return true;
     // VOQ vs NPU mode dependent features
     case HwAsic::Feature::BRIDGE_PORT_8021Q:
@@ -129,14 +134,8 @@ bool YubaAsic::isSupportedNonFabric(Feature feature) const {
     case HwAsic::Feature::PACKET_INTEGRITY_DROP_STATS:
     case HwAsic::Feature::SAI_UDF_HASH:
     case HwAsic::Feature::TRAFFIC_HASHING:
-    case HwAsic::Feature::SWITCH_ATTR_INGRESS_ACL:
-    case HwAsic::Feature::MULTIPLE_ACL_TABLES:
-    case HwAsic::Feature::ACL_TABLE_GROUP:
-    case HwAsic::Feature::SAI_ACL_TABLE_UPDATE:
-    case HwAsic::Feature::SAI_ACL_ENTRY_SRC_PORT_QUALIFIER:
     case HwAsic::Feature::RESOURCE_USAGE_STATS:
     case HwAsic::Feature::SAI_MPLS_QOS:
-    case HwAsic::Feature::L3_QOS:
     case HwAsic::Feature::IN_PAUSE_INCREMENTS_DISCARDS:
     case HwAsic::Feature::SAI_FEC_COUNTERS:
     case HwAsic::Feature::MPLS:
@@ -149,6 +148,7 @@ bool YubaAsic::isSupportedNonFabric(Feature feature) const {
     case HwAsic::Feature::VOQ_DELETE_COUNTER:
     case HwAsic::Feature::DRAM_ENQUEUE_DEQUEUE_STATS:
     case HwAsic::Feature::FLOWLET_PORT_ATTRIBUTES:
+    case HwAsic::Feature::P4_WARMBOOT:
       return false;
   }
   return false;

--- a/fboss/agent/hw/test/HwRouteScaleTest.cpp
+++ b/fboss/agent/hw/test/HwRouteScaleTest.cpp
@@ -62,6 +62,7 @@ TEST_F(HwRouteScaleTest, rswRouteScale) {
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_WEDGE400,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER,
        PlatformType::PLATFORM_ELBERT,
        PlatformType::PLATFORM_FUJI});
@@ -76,6 +77,7 @@ TEST_F(HwRouteScaleTest, fswRouteScale) {
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_WEDGE400,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER,
        PlatformType::PLATFORM_ELBERT,
        PlatformType::PLATFORM_FUJI});
@@ -87,6 +89,7 @@ TEST_F(HwRouteScaleTest, thAlpmScale) {
        PlatformType::PLATFORM_GALAXY_LC,
        PlatformType::PLATFORM_GALAXY_FC,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER});
 }
 
@@ -96,6 +99,7 @@ TEST_F(HwRouteScaleTest, hgridDuScaleTest) {
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_WEDGE400,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER,
        PlatformType::PLATFORM_ELBERT,
        PlatformType::PLATFORM_FUJI});
@@ -107,6 +111,7 @@ TEST_F(HwRouteScaleTest, hgridUuScaleTest) {
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_WEDGE400,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER,
        PlatformType::PLATFORM_ELBERT,
        PlatformType::PLATFORM_FUJI});
@@ -117,6 +122,7 @@ TEST_F(HwRouteScaleTest, turboFabricScaleTest) {
       {PlatformType::PLATFORM_MINIPACK,
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_ELBERT,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_FUJI});
 }
 
@@ -126,6 +132,7 @@ TEST_F(HwRouteScaleTest, anticipatedRouteScaleGenerator) {
        PlatformType::PLATFORM_YAMP,
        PlatformType::PLATFORM_WEDGE400,
        PlatformType::PLATFORM_WEDGE400C,
+       PlatformType::PLATFORM_MORGAN800CC,
        PlatformType::PLATFORM_CLOUDRIPPER,
        PlatformType::PLATFORM_ELBERT,
        PlatformType::PLATFORM_FUJI});

--- a/fboss/agent/hw/test/dataplane_tests/HwPacketSendTests.cpp
+++ b/fboss/agent/hw/test/dataplane_tests/HwPacketSendTests.cpp
@@ -168,7 +168,8 @@ class HwPacketFloodTest : public HwLinkStateDependentTest {
           *portStatsBefore[portId].outBytes_()) {
         return false;
       }
-      if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO) {
+      if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO &&
+       getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
         if (packetsAfter <= packetsBefore) {
           return false;
         }
@@ -208,7 +209,7 @@ TEST_F(HwPacketSendTest, LldpToFrontPanelOutOfPort) {
     EXPECT_EQ(
         pktLengthSent,
         *portStatsAfter.outBytes_() - *portStatsBefore.outBytes_());
-    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO) {
+    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO && getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
       EXPECT_EQ(
           1,
           *portStatsAfter.outMulticastPkts_() -
@@ -261,7 +262,7 @@ TEST_F(HwPacketSendTest, LldpToFrontPanelWithBufClone) {
     EXPECT_EQ(
         pktLengthSent,
         *portStatsAfter.outBytes_() - *portStatsBefore.outBytes_());
-    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO) {
+    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO && getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
       EXPECT_EQ(
           numPkts,
           *portStatsAfter.outMulticastPkts_() -
@@ -298,7 +299,7 @@ TEST_F(HwPacketSendTest, ArpRequestToFrontPanelPortSwitched) {
                << ", before bytes:" << *portStatsBefore.outBytes_()
                << ", after bytes:" << *portStatsAfter.outBytes_();
     EXPECT_NE(0, *portStatsAfter.outBytes_() - *portStatsBefore.outBytes_());
-    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO) {
+    if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_EBRO && getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
       EXPECT_EQ(
           1,
           *portStatsAfter.outBroadcastPkts_() -


### PR DESCRIPTION
1. Adding Morgan Platform to route scale tests
2. Enable ACL feature for Yuba
3. Disable P4_WARMBOOT to avoid  have ISSU capable device
4. Do not check some broadcast counter on HW Packet send for Yuba as for Ebro