### PR TITLE
Meru800bia: adds initial fw_util config file

### DIFF
--- a/fboss/platform/configs/meru800bia/fw_util.json
+++ b/fboss/platform/configs/meru800bia/fw_util.json
@@ -1,0 +1,19 @@
+{
+  "fwConfigs" : {
+    "bios" : {
+      "preUpgradeCmd" : "printf '3000000:3FFFFFF image\n2FF0000:2FF7FFF aboot_conf' > /tmp/bios_spi_layout",
+      "priority" : 1,
+      "upgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -w $bios_filename",
+      "postUpgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -v $bios_filename",
+      "verifyFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -v $bios_filename",
+      "readFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -r $bios_filename"
+    },
+    "meru_scm_cpld" : {
+      "preUpgradeCmd" : "",
+      "getVersionCmd" : "cpu_cpld_ver=$((`cat /sys/bus/pci/drivers/scd/0000:07:00.0/fpga_ver`));cpu_cpld_subver=$((`cat /sys/bus/pci/drivers/scd/0000:07:00.0/fpga_sub_ver`));echo $cpu_cpld_ver'.'$cpu_cpld_subver",
+      "priority" : 2,
+      "upgradeCmd" : "cpu_cpld_filename=$(head -n 1 /tmp/meru_scm_cpld_filename.txt);/usr/bin/jam -aprogram -fmeru_cpu_cpld -v $cpu_cpld_filename",
+      "postUpgradeCmd" : ""
+    }
+  }
+}


### PR DESCRIPTION
Adds initial fw_util config file for Meru800bia platform. This config file supports programming of BIOS and SCM CPLD.