### PR TITLE
Meru800bia: adds initial weutil config file

### DIFF
--- a/fboss/platform/configs/meru800bia/weutil.json
+++ b/fboss/platform/configs/meru800bia/weutil.json
@@ -1,0 +1,8 @@
+{
+  "chassisEepromName" : "CHASSIS" ,
+  "fruEepromList" : {
+    "SCM" : {
+      "path" : "/run/devmap/eeproms/MERU_SCM_EEPROM"
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Adds initial weutil config file for Meru800bia platform. This config file supports reading SCM EEPROM.

### Testing
**weutil --eeprom SCM --config_file weutil.json**

