### PR TITLE
weutil : Changes to support Meru800bia

### DIFF
--- a/fboss/platform/weutil/WeutilImpl.h
+++ b/fboss/platform/weutil/WeutilImpl.h
@@ -37,7 +37,6 @@ class WeutilImpl : public WeutilInterface {
   int loadEeprom(
       const std::string& eeprom,
       unsigned char* output,
-      int offset,
       int max);
   std::unordered_map<int, std::string> parseEepromBlobV3(
       const unsigned char* buffer);


### PR DESCRIPTION
### Summary

- Update the type of checksum field in EEPROM version 4+ to uint
- Start parsing at an offset of 15K when the EEPROM file starts with Arista Prefdl

### Testing 
weutil --eeprom SCM --config_file weutil.json
