### PR TITLE
Meru800bia: Initial weutil config file

### DIFF
--- a/fboss/platform/configs/meru800bia/weutil.json
+++ b/fboss/platform/configs/meru800bia/weutil.json
@@ -5,6 +5,11 @@
       "path" : "/run/devmap/eeproms/MERU_SCM_EEPROM",
       "offset" : 15360,
       "idEepromFormatVer" : 4
+    },
+    "CHASSIS" : {
+      "path" : "/run/devmap/eeproms/MERU800BIA_SMB_EEPROM",
+      "offset" : 15360,
+      "idEepromFormatVer" : 4
     }
   }
 }

--- a/fboss/platform/configs/meru800bia/weutil.json
+++ b/fboss/platform/configs/meru800bia/weutil.json
@@ -1,0 +1,10 @@
+{
+  "chassisEepromName" : "CHASSIS" ,
+  "fruEepromList" : {
+    "SCM" : {
+      "path" : "/run/devmap/eeproms/MERU_SCM_EEPROM",
+      "offset" : 15360,
+      "idEepromFormatVer" : 4
+    }
+  }
+}


### PR DESCRIPTION
### Summary
Added initial weutil config file for Meru800bia platform. This config file supports reading SCM EEPROM and CHASSIS EEPROM.

### Testing
Read EEPROM with the commands `weutil --eeprom SCM --config_file weutil.json` and `weutil --eeprom CHASSIS --config_file weutil.json`