### PR TITLE
Meru800bia: update BIOS commands in fw_util config file

### DIFF
--- a/fboss/platform/configs/meru800bia/fw_util.json
+++ b/fboss/platform/configs/meru800bia/fw_util.json
@@ -1,12 +1,12 @@
 {
   "fwConfigs" : {
     "bios" : {
-      "preUpgradeCmd" : "printf '3000000:3FFFFFF image\n2FF0000:2FF7FFF aboot_conf' > /tmp/bios_spi_layout",
+      "preUpgradeCmd" : "printf '3000000:3FFFFFF image' > /tmp/bios_spi_layout",
       "priority" : 1,
-      "upgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -w $bios_filename",
-      "postUpgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -v $bios_filename",
-      "verifyFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -v $bios_filename",
-      "readFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image -i aboot_conf --noverify-all -r $bios_filename"
+      "upgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image --noverify-all -w $bios_filename",
+      "postUpgradeCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image --noverify-all -v $bios_filename",
+      "verifyFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image --noverify-all -v $bios_filename",
+      "readFwCmd" : "bios_filename=$(head -n 1 /tmp/bios_filename.txt); flashrom -p internal -l /tmp/bios_spi_layout -i image --noverify-all -r $bios_filename"
     },
     "scm_cpld" : {
       "preUpgradeCmd" : "",


### PR DESCRIPTION
### Summary
`-i aboot_conf` option in the BIOS commands would result in updating the configuration section in the BIOS layout. However, the configurations are programmed by BMC and they should remain persistent during BIOS updates. Removed the `-i aboot_conf` option from the commands to fix this issue.

### Testing
Updated BIOS using `fw_util` and made sure the configurations remain unchanged
Read the BIOS using `fw_util` with two different sets of BIOS configurations and made sure the output of read operations are the same