### PR TITLE
airserver: remove local/shared bundle cleaners and loadgen from OSS/client build

### DIFF
--- a/build/fbcode_builder/manifests/airstore
+++ b/build/fbcode_builder/manifests/airstore
@@ -15,7 +15,6 @@ builder = cmake
 builder = nop
 
 [dependencies]
-boost
 libcurl
 fizz
 fmt


### PR DESCRIPTION
Summary: some cleanup: remove loadgen and bundle cleaners from client build and OSS build - hopefully will let us move faster in these codebases and avoid needing to upkeep the OSS side

Reviewed By: DevSatpathy

Differential Revision:
D50094943

Privacy Context Container: L1091835


