### PR TITLE
migrate from FOLLY_FALLTHROUGH to [[fallthrough]] (assorted)

### DIFF
--- a/fboss/agent/platforms/sai/SaiBcmPlatform.cpp
+++ b/fboss/agent/platforms/sai/SaiBcmPlatform.cpp
@@ -164,57 +164,57 @@ phy::VCOFrequency SaiBcmPlatform::getPortVcoFrequency(
     phy::FecMode fec) const {
   switch (speed) {
     case cfg::PortSpeed::FOURHUNDREDG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::TWOHUNDREDG:
       return phy::VCOFrequency::VCO_26_5625GHZ;
     case cfg::PortSpeed::HUNDREDG:
       switch (fec) {
         case phy::FecMode::RS544:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS544_2N:
           return phy::VCOFrequency::VCO_26_5625GHZ;
         case phy::FecMode::NONE:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::CL74:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::CL91:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS545:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS528:
           return phy::VCOFrequency::VCO_25_78125GHZ;
       }
     case cfg::PortSpeed::FIFTYG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::FIFTYTHREEPOINTONETWOFIVEG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::HUNDREDANDSIXPOINTTWOFIVEG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::TWENTYFIVEG:
       switch (fec) {
         case phy::FecMode::RS544:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS544_2N:
           return phy::VCOFrequency::VCO_26_5625GHZ;
         case phy::FecMode::NONE:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::CL74:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::CL91:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS545:
-          FOLLY_FALLTHROUGH;
+          [[fallthrough]];
         case phy::FecMode::RS528:
           return phy::VCOFrequency::VCO_25_78125GHZ;
       }
     case cfg::PortSpeed::FORTYG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::TWENTYG:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::XG:
       return phy::VCOFrequency::VCO_20_625GHZ;
     case cfg::PortSpeed::GIGE:
-      FOLLY_FALLTHROUGH;
+      [[fallthrough]];
     case cfg::PortSpeed::EIGHTHUNDREDG:
     case cfg::PortSpeed::DEFAULT:
       return phy::VCOFrequency::UNKNOWN;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/velox/pull/8555

The attribute `[[fallthrough]]` is standard C++17. We no longer need to wrap it.

Reviewed By: Orvid

Differential Revision: D53034072


