### PR TITLE
Do not read bytes ACL stat for Yuba Asic

### DIFF
--- a/fboss/agent/hw/test/dataplane_tests/HwAclCounterTests.cpp
+++ b/fboss/agent/hw/test/dataplane_tests/HwAclCounterTests.cpp
@@ -167,17 +167,23 @@ class HwAclCounterTest : public HwLinkStateDependentTest {
           EXPECT_EVENTUALLY_GE(aclPktCountAfter, aclPktCountBefore + 1);
           // At most we should get a pkt bump of 2
           EXPECT_EVENTUALLY_LE(aclPktCountAfter, aclPktCountBefore + 2);
-          EXPECT_EVENTUALLY_GE(
-              aclBytesCountAfter, aclBytesCountBefore + sizeOfPacketSent);
+          if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
+              EXPECT_EVENTUALLY_GE(
+                  aclBytesCountAfter, aclBytesCountBefore + sizeOfPacketSent);
+          }
           // On native BCM we see 4 extra bytes in the acl counter. This is
           // likely due to ingress vlan getting imposed and getting counted
           // when packet hits acl in ingress pipeline
-          EXPECT_EVENTUALLY_LE(
-              aclBytesCountAfter,
-              aclBytesCountBefore + (2 * sizeOfPacketSent) + 4);
+          if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
+            EXPECT_EVENTUALLY_LE(
+                aclBytesCountAfter,
+                aclBytesCountBefore + (2 * sizeOfPacketSent) + 4);
+          }
         } else {
           EXPECT_EVENTUALLY_EQ(aclPktCountBefore, aclPktCountAfter);
-          EXPECT_EVENTUALLY_EQ(aclBytesCountBefore, aclBytesCountAfter);
+          if (getAsic()->getAsicType() != cfg::AsicType::ASIC_TYPE_YUBA) {
+              EXPECT_EVENTUALLY_EQ(aclBytesCountBefore, aclBytesCountAfter);
+          }
         }
       });
     };


### PR DESCRIPTION
Read only pakcet stats in  HwAclCounterTest for Yuba Asic