### PR TITLE
Meru800bfa: update sensor_service.json thresholds

### DIFF
--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -4,7 +4,8 @@
       "CPU_PACKAGE_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -12,7 +13,8 @@
       "CPU_CORE0_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -20,7 +22,8 @@
       "CPU_CORE1_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -28,7 +31,8 @@
       "CPU_CORE2_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -36,7 +40,8 @@
       "CPU_CORE3_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -44,7 +49,8 @@
       "CPU_CORE4_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -52,7 +58,8 @@
       "CPU_CORE5_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -60,7 +67,8 @@
       "CPU_CORE6_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -68,18 +76,27 @@
       "CPU_CORE7_TEMP": {
         "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
         "thresholds": {
-          "upperCriticalVal": 105
+          "upperCriticalVal": 100.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
       },
       "SCM_ECB_VIN": {
         "path": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
         "compute": "@/32000.0",
         "type": 1
       },
       "SCM_ECB_VOUT": {
         "path": "/run/devmap/sensors/CPU_MPS_PMBUS/in2_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/32000.0",
         "type": 1
       },
@@ -90,23 +107,36 @@
       },
       "SCM_VRM1_VIN": {
         "path": "/run/devmap/sensors/CPU_PXM1310_1/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM1_VOUT_VCCIN": {
         "path": "/run/devmap/sensors/CPU_PXM1310_1/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 2.16,
+          "lowerCriticalVal": 1.44
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM1_VOUT_1V8_CPU": {
         "path": "/run/devmap/sensors/CPU_PXM1310_1/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 2.16,
+          "lowerCriticalVal": 1.44
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM1_TEMP1": {
         "path": "/run/devmap/sensors/CPU_PXM1310_1/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -114,35 +144,53 @@
       "SCM_VRM1_TEMP2": {
         "path": "/run/devmap/sensors/CPU_PXM1310_1/temp2_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
       },
       "SCM_VRM2_VIN": {
         "path": "/run/devmap/sensors/CPU_PXE1211/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM2_VOUT_1V2_VDDQ": {
         "path": "/run/devmap/sensors/CPU_PXE1211/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.96
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM2_VOUT_VNN_NAC": {
         "path": "/run/devmap/sensors/CPU_PXE1211/in5_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.48
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM2_VOUT_1V0_CPU": {
         "path": "/run/devmap/sensors/CPU_PXE1211/in6_input",
+        "thresholds": {
+          "upperCriticalVal": 1.2,
+          "lowerCriticalVal": 0.8
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM2_TEMP1": {
         "path": "/run/devmap/sensors/CPU_PXE1211/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -150,30 +198,44 @@
       "SCM_VRM2_TEMP2": {
         "path": "/run/devmap/sensors/CPU_PXE1211/temp2_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
       },
       "SCM_VRM3_VIN": {
         "path": "/run/devmap/sensors/CPU_PXM1310_2/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM3_VOUT_1V05_CPU": {
         "path": "/run/devmap/sensors/CPU_PXM1310_2/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.272,
+          "lowerCriticalVal": 0.848
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM3_VOUT_VNN_PCH": {
         "path": "/run/devmap/sensors/CPU_PXM1310_2/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.48
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SCM_VRM3_TEMP1": {
         "path": "/run/devmap/sensors/CPU_PXM1310_2/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -181,7 +243,8 @@
       "SCM_VRM3_TEMP2": {
         "path": "/run/devmap/sensors/CPU_PXM1310_2/temp2_input",
         "thresholds": {
-          "upperCriticalVal": 110
+          "upperCriticalVal": 110.0,
+          "maxAlarmVal": 105.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -191,7 +254,8 @@
       "SMB_BOARD_TOP_CENTER_TEMP": {
         "path": "/run/devmap/sensors/SMB_MAX6581/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -199,7 +263,8 @@
       "SMB_BOARD_REAR_RIGHT_TEMP": {
         "path": "/run/devmap/sensors/SMB_MAX6581/temp5_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -207,7 +272,8 @@
       "SMB_BOARD_FRONT_RIGHT_TEMP": {
         "path": "/run/devmap/sensors/SMB_MAX6581/temp6_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -215,7 +281,8 @@
       "SMB_BOARD_REAR_LEFT_TEMP": {
         "path": "/run/devmap/sensors/SMB_MAX6581/temp7_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -223,7 +290,8 @@
       "SMB_BOARD_FRONT_LEFT_TEMP": {
         "path": "/run/devmap/sensors/SMB_MAX6581/temp8_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 90.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -231,155 +299,431 @@
       "SMB_INLET_TEMP": {
         "path": "/run/devmap/sensors/SMB_TMP75/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 85.0
         },
         "compute": "@/1000.0",
         "type": 3
       },
       "SMB_VRM_R3R0_CORE_VIN": {
         "path": "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
-      "SMB_VRM_R3R0_CORE_VOUT": {
+      "SMB_VRM_R3R0_CORE_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.008,
+          "lowerCriticalVal": 0.504
+        },
         "compute": "@/1000.0",
         "type": 1
+      },
+      "SMB_VRM_R3R0_CORE_TEMP": {
+        "path": "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       },
       "SMB_VRM_R3R0_ANLG0_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R0_ANLG0_VOUT_0V9": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.08,
+          "lowerCriticalVal": 0.72
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R0_ANLG0_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 0.9,
+          "lowerCriticalVal": 0.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R0_ANLG0_VOUT_1V2": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in5_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.96
+        },
         "compute": "@/1000.0",
         "type": 1
       },
+      "SMB_VRM_R3R0_ANLG0_TEMP_0V9": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R0_ANLG0_TEMP_0V75": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R0_ANLG0_TEMP_1V2": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "SMB_VRM_R3R0_ANLG1_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R0_ANLG1_VOUT_0V9": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.08,
+          "lowerCriticalVal": 0.72
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R0_ANLG1_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 0.9,
+          "lowerCriticalVal": 0.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
-      "SMB_VRM_R3R0_ANLG1_VOUT_1V2": {
+      "SMB_VRM_R3R0_ANLG1_VOUT_1V8": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in5_input",
+        "thresholds": {
+          "upperCriticalVal": 2.16,
+          "lowerCriticalVal": 1.44
+        },
         "compute": "@/1000.0",
         "type": 1
+      },
+      "SMB_VRM_R3R0_ANLG1_TEMP_0V9": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R0_ANLG1_TEMP_0V75": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R0_ANLG1_TEMP_1V8": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       },
       "SMB_VRM_R3R1_CORE_VIN": {
         "path": "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
-      "SMB_VRM_R3R1_CORE_VOUT": {
+      "SMB_VRM_R3R1_CORE_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.008,
+          "lowerCriticalVal": 0.504
+        },
         "compute": "@/1000.0",
         "type": 1
+      },
+      "SMB_VRM_R3R1_CORE_TEMP": {
+        "path": "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       },
       "SMB_VRM_R3R1_ANLG0_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R1_ANLG0_VOUT_0V9": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.08,
+          "lowerCriticalVal": 0.72
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R1_ANLG0_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 0.9,
+          "lowerCriticalVal": 0.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R1_ANLG0_VOUT_1V2": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in5_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.96
+        },
         "compute": "@/1000.0",
         "type": 1
       },
+      "SMB_VRM_R3R1_ANLG0_TEMP_0V9": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R1_ANLG0_TEMP0V75": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R1_ANLG0_TEMP_1V2": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "SMB_VRM_R3R1_ANLG1_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R1_ANLG1_VOUT_0V9": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 1.08,
+          "lowerCriticalVal": 0.72
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_R3R1_ANLG1_VOUT_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 0.9,
+          "lowerCriticalVal": 0.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
-      "SMB_VRM_R3R1_ANLG1_VOUT_1V2": {
+      "SMB_VRM_R3R1_ANLG1_VOUT_1V8": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in5_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.96
+        },
         "compute": "@/1000.0",
         "type": 1
+      },
+      "SMB_VRM_R3R1_ANLG1_TEMP_0V9": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R1_ANLG1_TEMP0V75": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_VRM_R3R1_ANLG1_TEMP_1V8": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       },
       "SMB_VRM_OSFP_TL_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TL/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_OSFP_TL_VOUT_3V3": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TL/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
         "compute": "@/1000.0",
         "type": 1
       },
+      "SMB_VRM_OSFP_TL_TEMP_3V3": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TL/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "SMB_VRM_OSFP_TR_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TR/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_OSFP_TR_VOUT_3V3": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TR/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
         "compute": "@/1000.0",
         "type": 1
       },
+      "SMB_VRM_OSFP_TR_TEMP_3V3": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_TR/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "SMB_VRM_OSFP_BL_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BL/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_OSFP_BL_VOUT_3V3": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BL/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
         "compute": "@/1000.0",
         "type": 1
       },
+      "SMB_VRM_OSFP_BL_TEMP_3V3": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BL/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "SMB_VRM_OSFP_BR_VIN": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BR/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "SMB_VRM_OSFP_BR_VOUT_3V3": {
         "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BR/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
         "compute": "@/1000.0",
         "type": 1
+      },
+      "SMB_VRM_OSFP_BR_TEMP_3V3": {
+        "path": "/run/devmap/sensors/SMB_ISL68226_OSFP_BR/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       },
       "FAN_BOARD0_TEMP": {
         "path": "/run/devmap/sensors/FAN0_TMP75/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 85.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -387,7 +731,8 @@
       "FAN_BOARD1_TEMP": {
         "path": "/run/devmap/sensors/FAN1_TMP75/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 85.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -395,7 +740,8 @@
       "FAN_BOARD2_TEMP": {
         "path": "/run/devmap/sensors/FAN2_TMP75/temp1_input",
         "thresholds": {
-          "upperCriticalVal": 95
+          "upperCriticalVal": 95.0,
+          "maxAlarmVal": 85.0
         },
         "compute": "@/1000.0",
         "type": 3
@@ -405,8 +751,8 @@
       "FAN1_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD0/fan1_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -415,8 +761,8 @@
       "FAN2_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD0/fan2_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -425,8 +771,8 @@
       "FAN3_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD0/fan3_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -435,8 +781,8 @@
       "FAN4_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD0/fan4_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -445,8 +791,8 @@
       "FAN5_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD1/fan1_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -455,8 +801,8 @@
       "FAN6_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD1/fan2_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -465,8 +811,8 @@
       "FAN7_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD1/fan3_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -475,8 +821,8 @@
       "FAN8_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD1/fan4_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -485,8 +831,8 @@
       "FAN9_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD2/fan1_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -495,8 +841,8 @@
       "FAN10_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD2/fan2_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -505,8 +851,8 @@
       "FAN11_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD2/fan3_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -515,8 +861,8 @@
       "FAN12_RPM": {
         "path": "/run/devmap/sensors/FAN_CPLD2/fan4_input",
         "thresholds": {
-          "upperCriticalVal": 14900,
-          "lowerCriticalVal": 1100
+          "upperCriticalVal": 14900.0,
+          "lowerCriticalVal": 1100.0
         },
         "type": 4
       }
@@ -529,29 +875,53 @@
       },
       "PSU1_VOUT": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "PSU1_FAN1_RPM": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/fan1_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU1_FAN2_RPM": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/fan2_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU1_TEMP1": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 70.0,
+          "maxAlarmVal": 65.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU1_TEMP2": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 130.0,
+          "maxAlarmVal": 120.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU1_TEMP3": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 112.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
@@ -568,12 +938,12 @@
       "PSU1_PIN": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/power1_input",
         "compute": "@/1000000.0",
-        "type": 0
+        "type": 4
       },
       "PSU1_POUT": {
         "path": "/run/devmap/sensors/PSU1_PMBUS/power2_input",
         "compute": "@/1000000.0",
-        "type": 0
+        "type": 4
       }
     },
     "PSU2": {
@@ -584,29 +954,53 @@
       },
       "PSU2_VOUT": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "PSU2_FAN1_RPM": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/fan1_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU2_FAN2_RPM": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/fan2_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU2_TEMP1": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 70.0,
+          "maxAlarmVal": 65.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU2_TEMP2": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 130.0,
+          "maxAlarmVal": 120.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU2_TEMP3": {
         "path": "/run/devmap/sensors/PSU2_PMBUS/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 112.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
@@ -639,29 +1033,53 @@
       },
       "PSU3_VOUT": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "PSU3_FAN1_RPM": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/fan1_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU3_FAN2_RPM": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/fan2_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU3_TEMP1": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 70.0,
+          "maxAlarmVal": 65.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU3_TEMP2": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 130.0,
+          "maxAlarmVal": 120.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU3_TEMP3": {
         "path": "/run/devmap/sensors/PSU3_PMBUS/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 112.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
@@ -694,29 +1112,53 @@
       },
       "PSU4_VOUT": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
         "compute": "@/1000.0",
         "type": 1
       },
       "PSU4_FAN1_RPM": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/fan1_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU4_FAN2_RPM": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/fan2_input",
+        "thresholds": {
+          "upperCriticalVal": 25500.0,
+          "lowerCriticalVal": 0.0
+        },
         "type": 4
       },
       "PSU4_TEMP1": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 70.0,
+          "maxAlarmVal": 65.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU4_TEMP2": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 130.0,
+          "maxAlarmVal": 120.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },
       "PSU4_TEMP3": {
         "path": "/run/devmap/sensors/PSU4_PMBUS/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 120.0,
+          "maxAlarmVal": 112.0
+        },
         "compute": "@/1000.0",
         "type": 3
       },


### PR DESCRIPTION
# Summary

Updates `sensor_service.json` for platform Meru800bfa.

Changes:
- Adds upper/lower thresholds for voltage sensors
- Adjusts upper thresholds for some temperature sensors
- Adds previously missing temperature sensors on the SMB FRU

# Testing

Ran `sensor_service` on Meru800bfa and verified that all sensors are accessible.