### PR TITLE
Meru800bia: populate LED/FRU configs in led_manager.json

### DIFF
--- a/fboss/platform/configs/meru800bia/led_manager.json
+++ b/fboss/platform/configs/meru800bia/led_manager.json
@@ -1,5 +1,54 @@
 {
-  "systemLedConfig": {},
-  "fruTypeLedConfigs": {},
-  "fruConfigs": []
+  "systemLedConfig": {
+    "presentLedColor": 1,
+    "presentLedSysfsPath": "/sys/class/leds/status_led1:green:status/brightness",
+    "absentLedColor": 2,
+    "absentLedSysfsPath": "/sys/class/leds/status_led1:red:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/status_led2:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/status_led2:red:status/brightness"
+    },
+    "PSU": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/status_led3:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/status_led3:red:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_present"
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_present"
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_present"
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_present"
+    },
+    {
+      "fruName": "PSU1",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu1_present"
+    },
+    {
+      "fruName": "PSU2",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu2_present"
+    }
+  ]
 }

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -1057,7 +1057,7 @@
                 "csrOffset": "0x6060"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 2
             },
             {
               "fpgaIpBlockConfig": {
@@ -1066,7 +1066,7 @@
                 "csrOffset": "0x6070"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 3
             },
             {
               "fpgaIpBlockConfig": {
@@ -1075,7 +1075,7 @@
                 "csrOffset": "0x6090"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 4
             }
           ],
           "xcvrCtrlConfigs": [


### PR DESCRIPTION
# Summary

For Meru800bia platform, adds LED/FRU configs in `led_manager.json`. Also updates `platform_manager.json` to provide a unique `ledId` to each status LED.

# Testing

Verified that `data_corral_service` loads correctly on Meru800bia:
```
# ./data_corral_service -config_file=/tmp/led_manager.json 
I0319 19:18:56.210022  5190 ConfigLib.cpp:48] Using config file: /tmp/led_manager.json
I0319 19:18:56.210656  5191 FruPresenceExplorer.cpp:20] Detecting presence of FRUs
I0319 19:18:56.212068  5191 FruPresenceExplorer.cpp:37] Detected that FAN1 is present
I0319 19:18:56.212985  5191 FruPresenceExplorer.cpp:37] Detected that FAN2 is present
I0319 19:18:56.213980  5191 FruPresenceExplorer.cpp:37] Detected that FAN3 is present
I0319 19:18:56.215024  5191 FruPresenceExplorer.cpp:37] Detected that FAN4 is present
I0319 19:18:56.215135  5191 FruPresenceExplorer.cpp:37] Detected that PSU1 is present
I0319 19:18:56.215180  5191 FruPresenceExplorer.cpp:37] Detected that PSU2 is present
I0319 19:18:56.215227  5191 LedManager.cpp:45] Programming PSU LED with true
I0319 19:18:56.215350  5191 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led3:green:status/brightness
I0319 19:18:56.215417  5191 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led3:red:status/brightness
I0319 19:18:56.215439  5191 LedManager.cpp:55] Programmed PSU LED with presence true
I0319 19:18:56.215462  5191 LedManager.cpp:45] Programming FAN LED with true
I0319 19:18:56.215520  5191 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led2:green:status/brightness
I0319 19:18:56.215576  5191 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led2:red:status/brightness
I0319 19:18:56.215596  5191 LedManager.cpp:55] Programmed FAN LED with presence true
I0319 19:18:56.215616  5191 LedManager.cpp:25] Programming system LED with true
I0319 19:18:56.215669  5191 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led1:green:status/brightness
I0319 19:18:56.215728  5191 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led1:red:status/brightness
I0319 19:18:56.215751  5191 LedManager.cpp:34] Programmed system LED with true
```