### PR TITLE
Meru800bfa: populate LED/FRU configs in led_manager.json

### DIFF
--- a/fboss/platform/configs/meru800bfa/led_manager.json
+++ b/fboss/platform/configs/meru800bfa/led_manager.json
@@ -1,5 +1,104 @@
 {
-  "systemLedConfig": {},
-  "fruTypeLedConfigs": {},
-  "fruConfigs": []
+  "systemLedConfig": {
+    "presentLedColor": 1,
+    "presentLedSysfsPath": "/sys/class/leds/status_led1:green:status/brightness",
+    "absentLedColor": 2,
+    "absentLedSysfsPath": "/sys/class/leds/status_led1:red:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/status_led2:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/status_led2:red:status/brightness"
+    },
+    "PSU": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/status_led3:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/status_led3:red:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD0/fan1_present"
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD0/fan2_present"
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD0/fan3_present"
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD0/fan4_present"
+    },
+    {
+      "fruName": "FAN5",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD1/fan1_present"
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD1/fan2_present"
+    },
+    {
+      "fruName": "FAN7",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD1/fan3_present"
+    },
+    {
+      "fruName": "FAN8",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD1/fan4_present"
+    },
+    {
+      "fruName": "FAN9",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD2/fan1_present"
+    },
+    {
+      "fruName": "FAN10",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD2/fan2_present"
+    },
+    {
+      "fruName": "FAN11",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD2/fan3_present"
+    },
+    {
+      "fruName": "FAN12",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD2/fan4_present"
+    },
+    {
+      "fruName": "PSU1",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu1_prsnt"
+    },
+    {
+      "fruName": "PSU2",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu2_prsnt"
+    },
+    {
+      "fruName": "PSU3",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu3_prsnt"
+    },
+    {
+      "fruName": "PSU4",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu4_prsnt"
+    }
+  ]
 }

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -2894,7 +2894,7 @@
                 "csrOffset": "0x6060"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 2
             },
             {
               "fpgaIpBlockConfig": {
@@ -2903,7 +2903,7 @@
                 "csrOffset": "0x6070"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 3
             },
             {
               "fpgaIpBlockConfig": {
@@ -2912,7 +2912,7 @@
                 "csrOffset": "0x60a0"
               },
               "portNumber": -1,
-              "ledId": 1
+              "ledId": 4
             }
           ],
           "xcvrCtrlConfigs": [


### PR DESCRIPTION
# Summary

For Meru800bfa platform, adds LED/FRU configs in `led_manager.json`. Also updates `platform_manager.json` to provide a unique `ledId` to each status LED.

# Testing

Verified that `data_corral_service` loads correctly on Meru800bfa:
```
# ./data_corral_service -config_file=/tmp/led_manager.json
I0319 19:28:42.661546  3450 ConfigLib.cpp:48] Using config file: /tmp/led_manager.json
I0319 19:28:42.662206  3451 FruPresenceExplorer.cpp:25] Detecting presence of FRUs
I0319 19:28:42.663044  3451 FruPresenceExplorer.cpp:41] Detected that FAN1 is present
I0319 19:28:42.664000  3451 FruPresenceExplorer.cpp:41] Detected that FAN2 is present
I0319 19:28:42.665001  3451 FruPresenceExplorer.cpp:41] Detected that FAN3 is present
I0319 19:28:42.666000  3451 FruPresenceExplorer.cpp:41] Detected that FAN4 is present
I0319 19:28:42.667106  3451 FruPresenceExplorer.cpp:41] Detected that FAN5 is present
I0319 19:28:42.668005  3451 FruPresenceExplorer.cpp:41] Detected that FAN6 is present
I0319 19:28:42.669065  3451 FruPresenceExplorer.cpp:41] Detected that FAN7 is present
I0319 19:28:42.670005  3451 FruPresenceExplorer.cpp:41] Detected that FAN8 is present
I0319 19:28:42.671059  3451 FruPresenceExplorer.cpp:41] Detected that FAN9 is present
I0319 19:28:42.671997  3451 FruPresenceExplorer.cpp:41] Detected that FAN10 is present
I0319 19:28:42.673059  3451 FruPresenceExplorer.cpp:41] Detected that FAN11 is present
I0319 19:28:42.674004  3451 FruPresenceExplorer.cpp:41] Detected that FAN12 is present
I0319 19:28:42.674075  3451 FruPresenceExplorer.cpp:41] Detected that PSU1 is present
I0319 19:28:42.674117  3451 FruPresenceExplorer.cpp:41] Detected that PSU2 is present
I0319 19:28:42.674155  3451 FruPresenceExplorer.cpp:41] Detected that PSU3 is present
I0319 19:28:42.674191  3451 FruPresenceExplorer.cpp:41] Detected that PSU4 is present
I0319 19:28:42.674236  3451 LedManager.cpp:45] Programming PSU LED with true
I0319 19:28:42.674343  3451 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led3:green:status/brightness
I0319 19:28:42.674406  3451 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led3:red:status/brightness
I0319 19:28:42.674427  3451 LedManager.cpp:55] Programmed PSU LED with presence true
I0319 19:28:42.674447  3451 LedManager.cpp:45] Programming FAN LED with true
I0319 19:28:42.674501  3451 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led2:green:status/brightness
I0319 19:28:42.674556  3451 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led2:red:status/brightness
I0319 19:28:42.674575  3451 LedManager.cpp:55] Programmed FAN LED with presence true
I0319 19:28:42.674596  3451 LedManager.cpp:25] Programming system LED with true
I0319 19:28:42.674649  3451 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/status_led1:green:status/brightness
I0319 19:28:42.674706  3451 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/status_led1:red:status/brightness
I0319 19:28:42.674726  3451 LedManager.cpp:34] Programmed system LED with true
```