### PR TITLE
Meru800bia: adds P2 devices and sensors to PM/sensor_service

### DIFF
--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -144,6 +144,12 @@
           "pmUnitScopedName": "SMB_TMP75_REAR"
         },
         {
+          "busName": "INCOMING@1",
+          "address": "0x4d",
+          "kernelDeviceName": "max6581",
+          "pmUnitScopedName": "SMB_MAX6581"
+        },
+        {
           "busName": "INCOMING@2",
           "address": "0x48",
           "kernelDeviceName": "tmp75",
@@ -172,6 +178,12 @@
           "address": "0x55",
           "kernelDeviceName": "isl68226",
           "pmUnitScopedName": "SMB_ISL68226_OPTICS"
+        },
+        {
+          "busName": "SMB_I2C_MASTER0@2",
+          "address": "0x48",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "SMB_MGMT_TMP75"
         }
       ],
       "outgoingSlotConfigs": {
@@ -1496,9 +1508,11 @@
     "/run/devmap/gpiochips/SMB_PCA": "/SMB_SLOT@0/[SMB_PCA]",
     "/run/devmap/sensors/SMB_TMP75_FRONT": "/SMB_SLOT@0/[SMB_TMP75_FRONT]",
     "/run/devmap/sensors/SMB_TMP75_REAR": "/SMB_SLOT@0/[SMB_TMP75_REAR]",
+    "/run/devmap/sensors/SMB_MAX6581": "/SMB_SLOT@0/[SMB_MAX6581]",
     "/run/devmap/sensors/SMB_RAA228926_J3": "/SMB_SLOT@0/[SMB_RAA228926_J3]",
     "/run/devmap/sensors/SMB_ISL68226_J3": "/SMB_SLOT@0/[SMB_ISL68226_J3]",
     "/run/devmap/sensors/SMB_ISL68226_OPTICS": "/SMB_SLOT@0/[SMB_ISL68226_OPTICS]",
+    "/run/devmap/sensors/SMB_MGMT_TMP75": "/SMB_SLOT@0/[SMB_MGMT_TMP75]",
     "/run/devmap/sensors/FAN_TMP75": "/SMB_SLOT@0/[FAN_TMP75]",
     "/run/devmap/cplds/FAN_CPLD": "/SMB_SLOT@0/[FAN_CPLD]",
     "/run/devmap/sensors/FAN_CPLD": "/SMB_SLOT@0/[FAN_CPLD]",

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -135,25 +135,77 @@
           "busName": "INCOMING@1",
           "address": "0x49",
           "kernelDeviceName": "tmp75",
-          "pmUnitScopedName": "SMB_TMP75_FRONT"
+          "pmUnitScopedName": "SMB_TMP75_FRONT",
+          "initRegSettings": [
+            {
+              "regOffset": 3,
+              "ioBuf": [95]
+            }
+          ]
         },
         {
           "busName": "INCOMING@1",
           "address": "0x4a",
           "kernelDeviceName": "tmp75",
-          "pmUnitScopedName": "SMB_TMP75_REAR"
+          "pmUnitScopedName": "SMB_TMP75_REAR",
+          "initRegSettings": [
+            {
+              "regOffset": 3,
+              "ioBuf": [95]
+            }
+          ]
         },
         {
           "busName": "INCOMING@1",
           "address": "0x4d",
           "kernelDeviceName": "max6581",
-          "pmUnitScopedName": "SMB_MAX6581"
+          "pmUnitScopedName": "SMB_MAX6581",
+          "initRegSettings": [
+            {
+              "regOffset": 32,
+              "ioBuf": [110]
+            },
+            {
+              "regOffset": 33,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 34,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 35,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 36,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 37,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 38,
+              "ioBuf": [-121]
+            },
+            {
+              "regOffset": 39,
+              "ioBuf": [-121]
+            }
+          ]
         },
         {
           "busName": "INCOMING@2",
           "address": "0x48",
           "kernelDeviceName": "tmp75",
-          "pmUnitScopedName": "FAN_TMP75"
+          "pmUnitScopedName": "FAN_TMP75",
+          "initRegSettings": [
+            {
+              "regOffset": 3,
+              "ioBuf": [95]
+            }
+          ]
         },
         {
           "busName": "INCOMING@2",

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -269,6 +269,78 @@
         "compute": "@/1000.0",
         "type": 3
       },
+      "SMB_J3_BOARD_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 90.0,
+          "maxAlarmVal": 85.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_CORE_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_FAB0_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_FAB1_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp4_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_NIF0_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp5_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_NIF1_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp6_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_HBM0_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp7_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_J3_DIODE_HBM1_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp8_input",
+        "thresholds": {
+          "upperCriticalVal": 135.0,
+          "maxAlarmVal": 120.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
       "FAN_BOARD_TEMP": {
         "path": "/run/devmap/sensors/FAN_TMP75/temp1_input",
         "thresholds": {
@@ -391,6 +463,15 @@
         "thresholds": {
           "upperCriticalVal": 120.0,
           "maxAlarmVal": 115.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "SMB_MGMT_INLET_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MGMT_TMP75/temp1_input",
+        "thresholds": {
+          "upperCriticalVal": 75.0,
+          "maxAlarmVal": 70.0
         },
         "compute": "@/1000.0",
         "type": 3


### PR DESCRIPTION
# Summary

Adds two devices (new to P2) to platform_manager.json then updates sensor_service.json to track the new sensors.
Also adds `initRegSettings` for temperature sensor devices to override default hardware thresholds.

# Testing

Verified on Meru800bia.

Started `platform_manager`, which succeeds and creates the correct new symlinks. From the service log:
```
Creating symlink from /run/devmap/sensors/SMB_MAX6581 to /sys/bus/i2c/devices/12-004d/hwmon/hwmon8. DevicePath: /SMB_SLOT@0/[SMB_MAX6581]
Creating symlink from /run/devmap/sensors/SMB_MGMT_TMP75 to /sys/bus/i2c/devices/20-0048/hwmon/hwmon14. DevicePath: /SMB_SLOT@0/[SMB_MGMT_TMP75]
```

Started `sensor_service` and verified that the new devices are being polled and are correctly reading sensors. From the service log:
```
SMB_J3_BOARD_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp1_input, Compute=@/1000.0, FRU=SMB
SMB_J3_DIODE_CORE_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp2_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_FAB0_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp3_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_FAB1_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp4_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_HBM0_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp7_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_HBM1_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp8_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_NIF0_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp5_input, Compute=@/1000.0, FRU=SMB                                                                                                      
SMB_J3_DIODE_NIF1_TEMP: Path=/run/devmap/sensors/SMB_MAX6581/temp6_input, Compute=@/1000.0, FRU=SMB
SMB_MGMT_INLET_TEMP: Path=/run/devmap/sensors/SMB_MGMT_TMP75/temp1_input, Compute=@/1000.0, FRU=SMB
...
SMB_J3_BOARD_TEMP (/run/devmap/sensors/SMB_MAX6581/temp1_input) : 36.25
SMB_J3_DIODE_CORE_TEMP (/run/devmap/sensors/SMB_MAX6581/temp2_input) : 60.125
SMB_J3_DIODE_FAB0_TEMP (/run/devmap/sensors/SMB_MAX6581/temp3_input) : 58.625
SMB_J3_DIODE_FAB1_TEMP (/run/devmap/sensors/SMB_MAX6581/temp4_input) : 59.125
SMB_J3_DIODE_HBM0_TEMP (/run/devmap/sensors/SMB_MAX6581/temp7_input) : 55.375
SMB_J3_DIODE_HBM1_TEMP (/run/devmap/sensors/SMB_MAX6581/temp8_input) : 55
SMB_J3_DIODE_NIF0_TEMP (/run/devmap/sensors/SMB_MAX6581/temp5_input) : 61
SMB_J3_DIODE_NIF1_TEMP (/run/devmap/sensors/SMB_MAX6581/temp6_input) : 60.5
```
Registers are initialized correctly:
```
I0520 20:22:02.897955  2311 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:22:02.897962  2311 I2cExplorer.cpp:116] Setting up i2c device 12-0049. Writing 1 bytes at register 3
I0520 20:22:02.898873  2311 I2cExplorer.cpp:132] Creating i2c device SMB_TMP75_FRONT (tmp75) at i2c-12
V0520 20:22:02.898889  2311 PlatformUtils.cpp:15] Executing command: echo tmp75 0x49 > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:22:03.004415  2311 I2cExplorer.cpp:174] Created i2c device SMB_TMP75_FRONT (tmp75) at /sys/bus/i2c/devices/12-0049
I0520 20:22:03.004444  2311 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:22:03.004450  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004a. Writing 1 bytes at register 3
I0520 20:22:03.005340  2311 I2cExplorer.cpp:132] Creating i2c device SMB_TMP75_REAR (tmp75) at i2c-12
V0520 20:22:03.005354  2311 PlatformUtils.cpp:15] Executing command: echo tmp75 0x4a > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:22:03.110370  2311 I2cExplorer.cpp:174] Created i2c device SMB_TMP75_REAR (tmp75) at /sys/bus/i2c/devices/12-004a
I0520 20:22:03.110399  2311 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:22:03.110406  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 32
I0520 20:22:03.111308  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 33
I0520 20:22:03.112212  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 34
I0520 20:22:03.113115  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 35
I0520 20:22:03.114017  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 36
I0520 20:22:03.114919  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 37
I0520 20:22:03.115829  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 38
I0520 20:22:03.116330  2311 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 39
I0520 20:22:03.117245  2311 I2cExplorer.cpp:132] Creating i2c device SMB_MAX6581 (max6581) at i2c-12
V0520 20:22:03.117258  2311 PlatformUtils.cpp:15] Executing command: echo max6581 0x4d > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:22:03.181843  2311 I2cExplorer.cpp:174] Created i2c device SMB_MAX6581 (max6581) at /sys/bus/i2c/devices/12-004d
I0520 20:22:03.181867  2311 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-13
I0520 20:22:03.181873  2311 I2cExplorer.cpp:116] Setting up i2c device 13-0048. Writing 1 bytes at register 3
I0520 20:22:03.182794  2311 I2cExplorer.cpp:132] Creating i2c device FAN_TMP75 (tmp75) at i2c-13
V0520 20:22:03.182806  2311 PlatformUtils.cpp:15] Executing command: echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-13/new_device
I0520 20:22:03.288357  2311 I2cExplorer.cpp:174] Created i2c device FAN_TMP75 (tmp75) at /sys/bus/i2c/devices/13-0048
```

Also verified on P1:

PM will log failure in setting up P2 devices:
```
Failures in PmUnit SMB at /SMB_SLOT@0
1. Failed to create i2c device for SMB_MAX6581 (max6581) at bus: 12, addr: 0x4d with exit status 0
2. Failed to create i2c device for SMB_MGMT_TMP75 (tmp75) at bus: 20, addr: 0x48 with exit status 0
3. Failed to create a symlink /run/devmap/sensors/SMB_MAX6581 for DevicePath /SMB_SLOT@0/[SMB_MAX6581]. Reason: SMB_MAX6581 is not plugged-in to the platform
4. Failed to create a symlink /run/devmap/sensors/SMB_MGMT_TMP75 for DevicePath /SMB_SLOT@0/[SMB_MGMT_TMP75]. Reason: SMB_MGMT_TMP75 is not plugged-in to the platform
```

Registers for present devices are initialized correctly:
```
I0520 20:27:45.681740  7595 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:27:45.681749  7595 I2cExplorer.cpp:116] Setting up i2c device 12-0049. Writing 1 bytes at register 3
I0520 20:27:45.682672  7595 I2cExplorer.cpp:132] Creating i2c device SMB_TMP75_FRONT (tmp75) at i2c-12
V0520 20:27:45.682691  7595 PlatformUtils.cpp:15] Executing command: echo tmp75 0x49 > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:27:45.788043  7595 I2cExplorer.cpp:174] Created i2c device SMB_TMP75_FRONT (tmp75) at /sys/bus/i2c/devices/12-0049
I0520 20:27:45.788078  7595 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:27:45.788086  7595 I2cExplorer.cpp:116] Setting up i2c device 12-004a. Writing 1 bytes at register 3
I0520 20:27:45.789017  7595 I2cExplorer.cpp:132] Creating i2c device SMB_TMP75_REAR (tmp75) at i2c-12
V0520 20:27:45.789033  7595 PlatformUtils.cpp:15] Executing command: echo tmp75 0x4a > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:27:45.894108  7595 I2cExplorer.cpp:174] Created i2c device SMB_TMP75_REAR (tmp75) at /sys/bus/i2c/devices/12-004a
I0520 20:27:45.894130  7595 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-12
I0520 20:27:45.894135  7595 I2cExplorer.cpp:116] Setting up i2c device 12-004d. Writing 1 bytes at register 32
E0520 20:27:45.895047  7595 PlatformExplorer.cpp:565] write() failed to write to /dev/i2c-12, errno = Input/output error
I0520 20:27:45.895066  7595 I2cExplorer.cpp:132] Creating i2c device SMB_MAX6581 (max6581) at i2c-12
V0520 20:27:45.895086  7595 PlatformUtils.cpp:15] Executing command: echo max6581 0x4d > /sys/bus/i2c/devices/i2c-12/new_device
I0520 20:27:45.999155  7595 I2cExplorer.cpp:227] I2cDevice at busNum: 12 and addr: 004d is not yet created. Waiting for 5s
E0520 20:27:50.999283  7595 PlatformExplorer.cpp:580] Failed to create i2c device for SMB_MAX6581 (max6581) at bus: 12, addr: 0x4d with exit status 0
I0520 20:27:50.999335  7595 I2cDevIo.cpp:85] Creating I2cRdWrIo for /dev/i2c-13
I0520 20:27:50.999342  7595 I2cExplorer.cpp:116] Setting up i2c device 13-0048. Writing 1 bytes at register 3
I0520 20:27:51.000044  7595 I2cExplorer.cpp:132] Creating i2c device FAN_TMP75 (tmp75) at i2c-13
V0520 20:27:51.000063  7595 PlatformUtils.cpp:15] Executing command: echo tmp75 0x48 > /sys/bus/i2c/devices/i2c-13/new_device
I0520 20:27:51.085118  7595 I2cExplorer.cpp:174] Created i2c device FAN_TMP75 (tmp75) at /sys/bus/i2c/devices/13-0048
```

sensor_service logs missing sensors:
```
Could not read data for SMB_J3_BOARD_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp1_input, error:File does not exist
Could not read data for SMB_J3_DIODE_CORE_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp2_input, error:File does not exist
Could not read data for SMB_J3_DIODE_FAB0_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp3_input, error:File does not exist
Could not read data for SMB_J3_DIODE_FAB1_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp4_input, error:File does not exist
Could not read data for SMB_J3_DIODE_HBM0_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp7_input, error:File does not exist
Could not read data for SMB_J3_DIODE_HBM1_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp8_input, error:File does not exist
Could not read data for SMB_J3_DIODE_NIF0_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp5_input, error:File does not exist
Could not read data for SMB_J3_DIODE_NIF1_TEMP from path:/run/devmap/sensors/SMB_MAX6581/temp6_input, error:File does not exist
Could not read data for SMB_MGMT_INLET_TEMP from path:/run/devmap/sensors/SMB_MGMT_TMP75/temp1_input, error:File does not exist
```