### PR TITLE
Meru800bfa: add UCD90320 sensors

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -4297,6 +4297,7 @@
     "/run/devmap/sensors/SMB_ISL68226_OSFP_TR": "/SMB_SLOT@0/[SMB_ISL68226_OSFP_TR]",
     "/run/devmap/sensors/SMB_ISL68226_OSFP_BL": "/SMB_SLOT@0/[SMB_ISL68226_OSFP_BL]",
     "/run/devmap/sensors/SMB_ISL68226_OSFP_BR": "/SMB_SLOT@0/[SMB_ISL68226_OSFP_BR]",
+    "/run/devmap/sensors/SMB_UCD90320": "/SMB_SLOT@0/[SMB_UCD90320]",
     "/run/devmap/sensors/FAN0_TMP75": "/SMB_SLOT@0/[FAN0_TMP75]",
     "/run/devmap/cplds/FAN0_CPLD": "/SMB_SLOT@0/[FAN0_CPLD]",
     "/run/devmap/sensors/FAN_CPLD0": "/SMB_SLOT@0/[FAN0_CPLD]",

--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -530,7 +530,7 @@
         "compute": "@/1000.0",
         "type": 3
       },
-      "SMB_VRM_R3R1_ANLG0_TEMP0V75": {
+      "SMB_VRM_R3R1_ANLG0_TEMP_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/temp2_input",
         "thresholds": {
           "upperCriticalVal": 120.0,
@@ -593,7 +593,7 @@
         "compute": "@/1000.0",
         "type": 3
       },
-      "SMB_VRM_R3R1_ANLG1_TEMP0V75": {
+      "SMB_VRM_R3R1_ANLG1_TEMP_0V75": {
         "path": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/temp2_input",
         "thresholds": {
           "upperCriticalVal": 120.0,
@@ -718,6 +718,60 @@
         },
         "compute": "@/1000.0",
         "type": 3
+      },
+      "SMB_DPM_12V": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in1_input",
+        "thresholds": {
+          "upperCriticalVal": 14.4,
+          "lowerCriticalVal": 9.6
+        },
+        "compute": "@/1000.0",
+        "type": 1
+      },
+      "SMB_DPM_3V3_DKR": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in2_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
+        "compute": "@/1000.0",
+        "type": 1
+      },
+      "SMB_DPM_1V9_DKR": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in3_input",
+        "thresholds": {
+          "upperCriticalVal": 2.16,
+          "lowerCriticalVal": 1.44
+        },
+        "compute": "@/1000.0",
+        "type": 1
+      },
+      "SMB_DPM_1V2_DKR": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in4_input",
+        "thresholds": {
+          "upperCriticalVal": 1.44,
+          "lowerCriticalVal": 0.96
+        },
+        "compute": "@/1000.0",
+        "type": 1
+      },
+      "SMB_DPM_3V3": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in7_input",
+        "thresholds": {
+          "upperCriticalVal": 3.96,
+          "lowerCriticalVal": 2.64
+        },
+        "compute": "@/1000.0",
+        "type": 1
+      },
+      "SMB_DPM_5V0": {
+        "path": "/run/devmap/sensors/SMB_UCD90320/in8_input",
+        "thresholds": {
+          "upperCriticalVal": 6.0,
+          "lowerCriticalVal": 4.0
+        },
+        "compute": "@/1000.0",
+        "type": 1
       },
       "FAN_BOARD0_TEMP": {
         "path": "/run/devmap/sensors/FAN0_TMP75/temp1_input",


### PR DESCRIPTION
# Summary

Adds sensor support for UCD90320 and corrects the names of two existing temp sensors to follow the convention used by the other temp sensors. Note that this is supported on P2 only currently.

# Testing

Tested on Meru800bfa.

ucd90320 is correctly initialized:
```
[ 5416.277630] ucd9000 12-0011: Device ID UCD90320U|3.0.0.3323|211011
[ 5417.830854] i2c i2c-12: new_device: Instantiated device ucd90320 at 0x11
```

`platform_manager` creates the symlink for the UCD90320 sensors. From the service log:
```
Creating symlink from /run/devmap/sensors/SMB_UCD90320 to /sys/bus/i2c/devices/12-0011/hwmon/hwmon19. DevicePath: /SMB_SLOT@0/[SMB_UCD90320]
```

Ran `sensor_service` and ensured that the new sensors are being polled correctly. From the service log:
```
SMB_DPM_12V: Path=/run/devmap/sensors/SMB_UCD90320/in1_input, Compute=@/1000.0, FRU=SMB
SMB_DPM_1V2_DKR: Path=/run/devmap/sensors/SMB_UCD90320/in4_input, Compute=@/1000.0, FRU=SMB
SMB_DPM_1V9_DKR: Path=/run/devmap/sensors/SMB_UCD90320/in3_input, Compute=@/1000.0, FRU=SMB
SMB_DPM_3V3: Path=/run/devmap/sensors/SMB_UCD90320/in7_input, Compute=@/1000.0, FRU=SMB
SMB_DPM_3V3_DKR: Path=/run/devmap/sensors/SMB_UCD90320/in2_input, Compute=@/1000.0, FRU=SMB
SMB_DPM_5V0: Path=/run/devmap/sensors/SMB_UCD90320/in8_input, Compute=@/1000.0, FRU=SMB
...
SMB_DPM_5V0 (/run/devmap/sensors/SMB_UCD90320/in8_input) : 4.928                                                                                                                                        
SMB_DPM_3V3_DKR (/run/devmap/sensors/SMB_UCD90320/in2_input) : 3.305                                                                                                                                    
SMB_DPM_3V3 (/run/devmap/sensors/SMB_UCD90320/in7_input) : 3.311                                                                                                                                        
SMB_DPM_1V2_DKR (/run/devmap/sensors/SMB_UCD90320/in4_input) : 1.197                                                                                                                                    
SMB_DPM_12V (/run/devmap/sensors/SMB_UCD90320/in1_input) : 12.089
```

On P1, platform_manager logs the failures:
```
Failures in PmUnit SMB at /SMB_SLOT@0
1. Failed to create i2c device for SMB_UCD90320 (ucd90320) at bus: 12, addr: 0x11 with exit status 0
2. Failed to create a symlink /run/devmap/sensors/SMB_UCD90320 for DevicePath /SMB_SLOT@0/[SMB_UCD90320]. Reason: SMB_UCD90320 is not plugged-in to the platform
```

sensor_service logs the failures also:
```
Could not read data for SMB_DPM_12V from path:/run/devmap/sensors/SMB_UCD90320/in1_input, error:File does not exist
Could not read data for SMB_DPM_1V2_DKR from path:/run/devmap/sensors/SMB_UCD90320/in4_input, error:File does not exist
Could not read data for SMB_DPM_1V9_DKR from path:/run/devmap/sensors/SMB_UCD90320/in3_input, error:File does not exist
Could not read data for SMB_DPM_3V3 from path:/run/devmap/sensors/SMB_UCD90320/in7_input, error:File does not exist
Could not read data for SMB_DPM_3V3_DKR from path:/run/devmap/sensors/SMB_UCD90320/in2_input, error:File does not exist
Could not read data for SMB_DPM_5V0 from path:/run/devmap/sensors/SMB_UCD90320/in8_input, error:File does not exist
Processed 145 Sensors. 6 Failures.
```


