### PR TITLE
airstore next: bundle V4: thrift working in OSS build

### DIFF
--- a/build/fbcode_builder/manifests/airstore
+++ b/build/fbcode_builder/manifests/airstore
@@ -18,6 +18,7 @@ builder = nop
 libcurl
 fizz
 fmt
+fbthrift
 folly
 googletest
 libsodium


### PR DESCRIPTION
Summary: this diff adds support for thrift in the OSS client build. it changes the `getdeps` airstore manifest to gain access to the thrift cpp2 compiler, then uses a rule similar to other projects to generate the cpp type headers. It changes the OSS `libbundle` library to depend on the thrift types introduced in D56578073 (and, through a lot of pain, get generated in the OSS build stack) which will then be used to ser/de bundles in the OSS build later in the stack!

Differential Revision: D56578071
