### PR TITLE
meru fw_util: config file changes

### DIFF
--- a/fboss/platform/configs/meru800bfa/fw_util.json
+++ b/fboss/platform/configs/meru800bfa/fw_util.json
@@ -11,63 +11,63 @@
     },
     "scm_cpld": {
       "preUpgradeCmd": "",
-      "getVersionCmd": "cpu_cpld_ver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_ver`));cpu_cpld_subver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_sub_ver`));echo $cpu_cpld_ver'.'$cpu_cpld_subver",
+      "getVersionCmd": "cpu_cpld_ver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_ver | sed '/^0[0-9]/s/^0*//'`));cpu_cpld_subver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $cpu_cpld_ver'.'$cpu_cpld_subver",
       "priority": 4,
       "upgradeCmd": "cpu_cpld_filename=$(head -n 1 /home/scm_cpld_filename.txt);jam -aprogram -fmeru_cpu_cpld -v $cpu_cpld_filename",
       "postUpgradeCmd": ""
     },
     "smb_cpld": {
       "preUpgradeCmd": "echo 1 > /run/devmap/fpgas/MERU_SCM_CPLD/switch_jtag_enable",
-      "getVersionCmd": "smb_cpld_ver=$((`head -1 /run/devmap/cplds/MERU800BFA_SMB_CPLD/cpld_ver`));smb_cpld_subver=$((`head -1 /run/devmap/cplds/MERU800BFA_SMB_CPLD/cpld_sub_ver`));echo $smb_cpld_ver'.'$smb_cpld_subver",
+      "getVersionCmd": "smb_cpld_ver=$((`head -1 /run/devmap/cplds/MERU800BFA_SMB_CPLD/cpld_ver | sed '/^0[0-9]/s/^0*//'`));smb_cpld_subver=$((`head -1 /run/devmap/cplds/MERU800BFA_SMB_CPLD/cpld_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_cpld_ver'.'$smb_cpld_subver",
       "priority": 3,
       "upgradeCmd": "smb_cpld_filename=$(head -n 1 /home/smb_cpld_filename.txt);jam -aprogram -fmeru_switch_cpld -v $smb_cpld_filename",
       "postUpgradeCmd": "sleep 30"
     },
     "smb_fpga0": {
-      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga0_layout;modprobe spidev;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);echo 'spidev' > /sys/bus/spi/devices/spi$fpga_spidev/driver_override;echo spi$fpga_spidev > /sys/bus/spi/drivers/spidev/bind;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
-      "getVersionCmd": "smb_fpga0_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/fpga_ver`));smb_fpga0_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/fpga_sub_ver`));echo $smb_fpga0_ver'.'$smb_fpga0_subver",
+      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga0_layout;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
+      "getVersionCmd": "smb_fpga0_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/fpga_ver | sed '/^0[0-9]/s/^0*//'`));smb_fpga0_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_fpga0_ver'.'$smb_fpga0_subver",
       "priority": 2,
-      "upgradeCmd": "smb_fpga0_binary_name=$(head -n 1 /home/smb_fpga0_filename.txt);fpga0_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga0_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga0_layout -i image -w $smb_fpga0_binary_name",
+      "upgradeCmd": "smb_fpga0_binary_name=$(head -n 1 /home/smb_fpga0_filename.txt);fpga0_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA0/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga0_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga0_layout -i image --noverify-all -w $smb_fpga0_binary_name",
       "postUpgradeCmd": "rm /home/smb_fpga0_layout;rm /home/flash_chip_name"
     },
     "smb_fpga1": {
-      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga1_layout;modprobe spidev;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);echo 'spidev' > /sys/bus/spi/devices/spi$fpga_spidev/driver_override;echo spi$fpga_spidev > /sys/bus/spi/drivers/spidev/bind;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
-      "getVersionCmd": "smb_fpga1_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/fpga_ver`));smb_fpga1_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/fpga_sub_ver`));echo $smb_fpga1_ver'.'$smb_fpga1_subver",
+      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga1_layout;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
+      "getVersionCmd": "smb_fpga1_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/fpga_ver | sed '/^0[0-9]/s/^0*//'`));smb_fpga1_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_fpga1_ver'.'$smb_fpga1_subver",
       "priority": 2,
-      "upgradeCmd": "smb_fpga1_binary_name=$(head -n 1 /home/smb_fpga1_filename.txt);fpga1_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga1_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga1_layout -i image -w $smb_fpga1_binary_name",
+      "upgradeCmd": "smb_fpga1_binary_name=$(head -n 1 /home/smb_fpga1_filename.txt);fpga1_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA1/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga1_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga1_layout -i image --noverify-all -w $smb_fpga1_binary_name",
       "postUpgradeCmd": "rm /home/smb_fpga1_layout;rm /home/flash_chip_name"
     },
     "smb_fpga2": {
-      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga2_layout;modprobe spidev;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);echo 'spidev' > /sys/bus/spi/devices/spi$fpga_spidev/driver_override;echo spi$fpga_spidev > /sys/bus/spi/drivers/spidev/bind;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
-      "getVersionCmd": "smb_fpga2_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/fpga_ver`));smb_fpga2_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/fpga_sub_ver`));echo $smb_fpga2_ver'.'$smb_fpga2_subver",
+      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga2_layout;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
+      "getVersionCmd": "smb_fpga2_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/fpga_ver | sed '/^0[0-9]/s/^0*//'`));smb_fpga2_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_fpga2_ver'.'$smb_fpga2_subver",
       "priority": 2,
-      "upgradeCmd": "smb_fpga2_binary_name=$(head -n 1 /home/smb_fpga2_filename.txt);fpga2_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga2_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga2_layout -i image -w $smb_fpga2_binary_name",
+      "upgradeCmd": "smb_fpga2_binary_name=$(head -n 1 /home/smb_fpga2_filename.txt);fpga2_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA2/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga2_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga2_layout -i image --noverify-all -w $smb_fpga2_binary_name",
       "postUpgradeCmd": "rm /home/smb_fpga2_layout;rm /home/flash_chip_name"
     },
     "smb_fpga3": {
-      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga3_layout;modprobe spidev;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);echo 'spidev' > /sys/bus/spi/devices/spi$fpga_spidev/driver_override;echo spi$fpga_spidev > /sys/bus/spi/drivers/spidev/bind;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
-      "getVersionCmd": "smb_fpga3_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/fpga_ver`));smb_fpga3_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/fpga_sub_ver`));echo $smb_fpga3_ver'.'$smb_fpga3_subver",
+      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga3_layout;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MX25U25635F' /home/flashrom_output && echo 'MX25U25635F' > /home/flash_chip_name) || (grep 'GD25LQ256D' /home/flashrom_output && echo 'GD25LQ256D' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
+      "getVersionCmd": "smb_fpga3_ver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/fpga_ver | sed '/^0[0-9]/s/^0*//'`));smb_fpga3_subver=$((`cat /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_fpga3_ver'.'$smb_fpga3_subver",
       "priority": 2,
-      "upgradeCmd": "smb_fpga3_binary_name=$(head -n 1 /home/smb_fpga3_filename.txt);fpga3_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga3_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga3_layout -i image -w $smb_fpga3_binary_name",
+      "upgradeCmd": "smb_fpga3_binary_name=$(head -n 1 /home/smb_fpga3_filename.txt);fpga3_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BFA_SMB_FPGA3/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga3_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga3_layout -i image --noverify-all -w $smb_fpga3_binary_name",
       "postUpgradeCmd": "rm /home/smb_fpga3_layout;rm /home/flash_chip_name"
     },
     "fan_cpld0": {
       "preUpgradeCmd": "echo 1 > /run/devmap/fpgas/MERU_SCM_CPLD/switch_jtag_enable && echo 5 > /run/devmap/cplds/MERU800BFA_SMB_CPLD/jtag_mux_sel",
-      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon*/cpld_ver`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon*/cpld_sub_ver`));echo $fan_cpld_ver'.'$fan_cpld_subver",
+      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon*/cpld_ver | sed '/^0[0-9]/s/^0*//'`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon*/cpld_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $fan_cpld_ver'.'$fan_cpld_subver",
       "priority": 1,
       "upgradeCmd": "fan_cpld_filename=$(head -n 1 /home/fan_cpld0_filename.txt);jam -aprogram -fmeru_fan_cpld -v $fan_cpld_filename",
       "postUpgradeCmd": ""
     },
     "fan_cpld1": {
       "preUpgradeCmd": "echo 1 > /run/devmap/fpgas/MERU_SCM_CPLD/switch_jtag_enable && echo 6 > /run/devmap/cplds/MERU800BFA_SMB_CPLD/jtag_mux_sel",
-      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN1_CPLD/hwmon/hwmon*/cpld_ver`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN1_CPLD/hwmon/hwmon*/cpld_sub_ver`));echo $fan_cpld_ver'.'$fan_cpld_subver",
+      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN1_CPLD/hwmon/hwmon*/cpld_ver | sed '/^0[0-9]/s/^0*//'`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN1_CPLD/hwmon/hwmon*/cpld_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $fan_cpld_ver'.'$fan_cpld_subver",
       "priority": 1,
       "upgradeCmd": "fan_cpld_filename=$(head -n 1 /home/fan_cpld1_filename.txt);jam -aprogram -fmeru_fan_cpld -v $fan_cpld_filename",
       "postUpgradeCmd": ""
     },
     "fan_cpld2": {
       "preUpgradeCmd": "echo 1 > /run/devmap/fpgas/MERU_SCM_CPLD/switch_jtag_enable && echo 7 > /run/devmap/cplds/MERU800BFA_SMB_CPLD/jtag_mux_sel",
-      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN2_CPLD/hwmon/hwmon*/cpld_ver`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN2_CPLD/hwmon/hwmon*/cpld_sub_ver`));echo $fan_cpld_ver'.'$fan_cpld_subver",
+      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN2_CPLD/hwmon/hwmon*/cpld_ver | sed '/^0[0-9]/s/^0*//'`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN2_CPLD/hwmon/hwmon*/cpld_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $fan_cpld_ver'.'$fan_cpld_subver",
       "priority": 1,
       "upgradeCmd": "fan_cpld_filename=$(head -n 1 /home/fan_cpld2_filename.txt);jam -aprogram -fmeru_fan_cpld -v $fan_cpld_filename",
       "postUpgradeCmd": ""

--- a/fboss/platform/configs/meru800bia/fw_util.json
+++ b/fboss/platform/configs/meru800bia/fw_util.json
@@ -11,21 +11,21 @@
     },
     "scm_cpld": {
       "preUpgradeCmd": "",
-      "getVersionCmd": "cpu_cpld_ver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_ver`));cpu_cpld_subver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_sub_ver`));echo $cpu_cpld_ver'.'$cpu_cpld_subver",
+      "getVersionCmd": "cpu_cpld_ver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_ver | sed '/^0[0-9]/s/^0*//'`));cpu_cpld_subver=$((`cat /run/devmap/fpgas/MERU_SCM_CPLD/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $cpu_cpld_ver'.'$cpu_cpld_subver",
       "priority": 3,
       "upgradeCmd": "cpu_cpld_filename=$(head -n 1 /home/scm_cpld_filename.txt);jam -aprogram -fmeru_cpu_cpld -v $cpu_cpld_filename",
       "postUpgradeCmd": ""
     },
     "smb_fpga": {
-      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga_layout;modprobe spidev;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BIA_SMB_FPGA/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);echo 'spidev' > /sys/bus/spi/devices/spi$fpga_spidev/driver_override;echo spi$fpga_spidev > /sys/bus/spi/drivers/spidev/bind;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MT25QL256' /home/flashrom_output && echo 'MT25QL256' > /home/flash_chip_name) || (grep 'MX25L25635F' /home/flashrom_output && echo 'MX25L25635F/MX25L25645G' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
-      "getVersionCmd": "smb_fpga_ver=$((`cat /run/devmap/fpgas/MERU800BIA_SMB_FPGA/fpga_ver`));smb_fpga_subver=$((`cat /run/devmap/fpgas/MERU800BIA_SMB_FPGA/fpga_sub_ver`));echo $smb_fpga_ver'.'$smb_fpga_subver",
+      "preUpgradeCmd": "printf '0:3FFFFF image' > /home/smb_fpga_layout;fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BIA_SMB_FPGA/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev > /home/flashrom_output;(grep 'MT25QL256' /home/flashrom_output && echo 'MT25QL256' > /home/flash_chip_name) || (grep 'MX25L25635F' /home/flashrom_output && echo 'MX25L25635F/MX25L25645G' > /home/flash_chip_name) || echo 'NONE' > /home/flash_chip_name",
+      "getVersionCmd": "smb_fpga_ver=$((`cat /run/devmap/fpgas/MERU800BIA_SMB_FPGA/fpga_ver | sed '/^0[0-9]/s/^0*//'`));smb_fpga_subver=$((`cat /run/devmap/fpgas/MERU800BIA_SMB_FPGA/fpga_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $smb_fpga_ver'.'$smb_fpga_subver",
       "priority": 2,
-      "upgradeCmd": "smb_fpga_binary_name=$(head -n 1 /home/smb_fpga_filename.txt);fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BIA_SMB_FPGA/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga_layout -i image -w $smb_fpga_binary_name",
+      "upgradeCmd": "smb_fpga_binary_name=$(head -n 1 /home/smb_fpga_filename.txt);fpga_spidev=$(echo $(ls /run/devmap/fpgas/MERU800BIA_SMB_FPGA/*spi*/spi_master/spi* | grep spi*.*) | cut -c 4-);chip=$(head -n 1 /home/flash_chip_name);if [ $chip = 'NONE' ];then cmd_chip_option='' cmd_chip_name='';else cmd_chip_option='-c' cmd_chip_name=$chip;fi;flashrom -p linux_spi:dev=/dev/spidev$fpga_spidev $cmd_chip_option $cmd_chip_name -l /home/smb_fpga_layout -i image --noverify-all -w $smb_fpga_binary_name",
       "postUpgradeCmd": "rm /home/smb_fpga_layout; rm /home/flash_chip_name"
     },
     "fan_cpld": {
       "preUpgradeCmd": "echo 1 > /run/devmap/fpgas/MERU_SCM_CPLD/switch_jtag_enable",
-      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN_CPLD/hwmon/hwmon*/cpld_ver`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN_CPLD/hwmon/hwmon*/cpld_sub_ver`));echo $fan_cpld_ver'.'$fan_cpld_subver",
+      "getVersionCmd": "fan_cpld_ver=$((`cat /run/devmap/cplds/FAN_CPLD/hwmon/hwmon*/cpld_ver | sed '/^0[0-9]/s/^0*//'`));fan_cpld_subver=$((`cat /run/devmap/cplds/FAN_CPLD/hwmon/hwmon*/cpld_sub_ver | sed '/^0[0-9]/s/^0*//'`));echo $fan_cpld_ver'.'$fan_cpld_subver",
       "priority": 1,
       "upgradeCmd": "fan_cpld_filename=$(head -n 1 /home/fan_cpld_filename.txt);jam -aprogram -fmeru_fan_cpld -v $fan_cpld_filename",
       "postUpgradeCmd": ""


### PR DESCRIPTION
### Summary of Changes
1. Use –noverify-all option with flashrom write.
This would skip verification of regions not included in the layout file to improve performance.

2. Leading zeros in the FW version numbers read through sysfs can cause them to be interpreted as octal numbers by shell. This change removes leading 0’s from the version numbers except when there is a ‘0x’ prefix. The sed commands to search and replace are written in a way that the leading 0’s are replaced only if the version number starts with a 0 followed by another digit.

3. Remove spidev binding since it is no longer necessary as the spi driver already binds to spidev as specified by platform_manager

### Testing
Verified fw upgrade/downgrade with fw_util

```
Change in programming time:
meru800bia smb_fpga:
real    4m55.654s => 0m55.890s
user    0m9.705s  => 0m9.748s
sys     2m55.965s => 0m26.562s

meru800bfa smb_fpga0:
real    4m57.611s => 0m58.643s
user    0m13.195s => 0m13.162s
sys     2m54.678s => 0m26.260s
```
