### PR TITLE
Meru800bia/bfa: updated fan_service configs

### DIFF
--- a/fboss/platform/configs/meru800bfa/fan_service.json
+++ b/fboss/platform/configs/meru800bfa/fan_service.json
@@ -1,13 +1,33 @@
 {
-  "pwmBoostOnNumDeadFan": 1,
-  "pwmBoostOnNumDeadSensor": 0,
-  "pwmBoostOnNoQsfpAfterInSec": 0,
-  "pwmBoostValue": 60,
-  "pwmTransitionValue": 50,
-  "pwmLowerThreshold": 24,
-  "pwmUpperThreshold": 100,
-  "optics": [],
-  "sensors": [
+  "pwmBoostOnNumDeadFan" : 1,
+  "pwmBoostOnNumDeadSensor" : 0,
+  "pwmBoostOnNoQsfpAfterInSec" : 0,
+  "pwmBoostValue" : 60,
+  "pwmTransitionValue" : 50,
+  "pwmLowerThreshold" : 7,
+  "pwmUpperThreshold" : 100,
+  "shutdownCmd" : "echo 0xdead > /run/devmap/fpgas/MERU_SCM_CPLD/chassis_power_cycle",
+  "optics" : [
+    {
+      "opticName" : "osfp_group_1",
+      "access" : {
+        "accessType" : "ACCESS_TYPE_QSFP"
+      },
+      "portList" : [],
+      "aggregationType" : "OPTIC_AGGREGATION_TYPE_MAX",
+      "tempToPwmMaps" : {
+        "OPTIC_TYPE_800_GENERIC" : {
+          "5" : 35,
+          "67": 41,
+          "68": 50,
+          "69": 67,
+          "70": 80,
+          "71": 100
+        }
+      }
+    }
+  ],
+  "sensors" : [
     {
       "sensorName": "SMB_INLET_TEMP",
       "access": {
@@ -16,20 +36,76 @@
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
       "scale": 1,
       "normalUpTable": {
-        "15": 30,
-        "110": 100
+        "15": 28,
+        "110": 80
       },
       "normalDownTable": {
-        "15": 30,
-        "110": 100
+        "15": 28,
+        "110": 80
       },
       "failUpTable": {
-        "15": 30,
-        "110": 100
+        "15": 28,
+        "110": 80
       },
       "failDownTable": {
-        "15": 30,
-        "110": 100
+        "15": 28,
+        "110": 80
+      }
+    },
+    {
+      "sensorName": "R3_0_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "scale": 1,
+      "normalUpTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "normalDownTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "failUpTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "failDownTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      }
+    },
+    {
+      "sensorName": "R3_1_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "scale": 1,
+      "normalUpTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "normalDownTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "failUpTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
+      },
+      "failDownTable": {
+        "15": 7,
+        "70": 10,
+        "80": 100
       }
     }
   ],
@@ -194,15 +270,27 @@
   "zones": [
     {
       "zoneType": "ZONE_TYPE_MAX",
-      "zoneName": "zone1",
+      "zoneName": "asic_zone",
       "sensorNames": [
-        "SMB_INLET_TEMP"
+        "R3_0_TEMP",
+        "R3_1_TEMP"
       ],
-      "fanNames": [
+      "fanNames":[
         "fan_1",
         "fan_2",
         "fan_3",
-        "fan_4",
+        "fan_4"
+      ],
+      "slope": 3
+    },
+    {
+      "zoneType": "ZONE_TYPE_MAX",
+      "zoneName": "system_zone",
+      "sensorNames": [
+        "SMB_INLET_TEMP",
+        "osfp_group_1"
+      ],
+      "fanNames": [
         "fan_5",
         "fan_6",
         "fan_7",

--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -745,6 +745,24 @@
         },
         "compute": "@/1000.0",
         "type": 3
+      },
+      "R3_0_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp2_input",
+        "thresholds": {
+          "upperCriticalVal": 125.0,
+          "maxAlarmVal": 110.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
+      },
+      "R3_1_TEMP": {
+        "path": "/run/devmap/sensors/SMB_MAX6581/temp3_input",
+        "thresholds": {
+          "upperCriticalVal": 125.0,
+          "maxAlarmVal": 110.0
+        },
+        "compute": "@/1000.0",
+        "type": 3
       }
     },
     "FAN1": {

--- a/fboss/platform/configs/meru800bia/fan_service.json
+++ b/fboss/platform/configs/meru800bia/fan_service.json
@@ -4,7 +4,7 @@
   "pwmBoostOnNoQsfpAfterInSec": 0,
   "pwmBoostValue": 60,
   "pwmTransitionValue": 50,
-  "pwmLowerThreshold": 50,
+  "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,
   "optics" : [
     {
@@ -16,15 +16,10 @@
       "aggregationType" : "OPTIC_AGGREGATION_TYPE_MAX",
       "tempToPwmMaps" : {
         "OPTIC_TYPE_800_GENERIC" : {
-          "5": 34,
-          "68": 35,
-          "69": 37,
-          "70": 40,
-          "71": 44,
-          "72": 57,
-          "73": 70,
-          "74": 83,
-          "75": 100
+          "5": 43,
+          "69": 56,
+          "70": 73,
+          "71": 100
         }
       }
     }


### PR DESCRIPTION
# Summary
Adds:
- Optic temp to PWM mapping for 800G optics for Meru800bia/bfa.
- Reduced optics target temps.
- Zones configuration for Meru800bfa (System and Asic Zones). The Asic zone relies on a sensor which is added to the sensor_service config by this PR.

# Testing
Verified on Meru800bia and Meru800bfa