### PR TITLE
Enable Invariant tests for Yuba/Morgan

### DIFF
--- a/fboss/agent/hw/test/ProdConfigFactory.cpp
+++ b/fboss/agent/hw/test/ProdConfigFactory.cpp
@@ -101,6 +101,7 @@ uint16_t uplinksCountFromSwitch(PlatformType mode) {
     case PM::PLATFORM_WEDGE400C:
     case PM::PLATFORM_WEDGE400:
     case PM::PLATFORM_YAMP:
+    case PM::PLATFORM_MORGAN800CC:
     case PM::PLATFORM_MINIPACK:
     case PM::PLATFORM_ELBERT:
     case PM::PLATFORM_FUJI:


### PR DESCRIPTION
The changes make the following tests passed for Yuba Asic:
HwProdInvariantsFswStrictPriorityTest.verifyInvariants                                       
HwProdInvariantsFswTest.verifyInvariants                                                     
HwProdInvariantsRswMhnicTest.verifyInvariants                                                
HwProdInvariantsRswStrictPriorityTest.verifyInvariants                                       
HwProdInvariantsRswTest.verifyInvariants






























