### PR TITLE
weutil_test : enabled weutil_test compilation.

### DIFF
--- a/cmake/PlatformWeutil.cmake
+++ b/cmake/PlatformWeutil.cmake
@@ -61,4 +61,14 @@ target_link_libraries(weutil
   weutil_lib
 )
 
+add_executable(weutil_test
+  fboss/platform/weutil/hw_test/WeutilTest.cpp
+)
+
+target_link_libraries(weutil_test
+  weutil_lib
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+)
+
 install(TARGETS weutil)


### PR DESCRIPTION
# Description

Enabled the compilation of `weutil_test` OSS test suite.

# Motivation

Aim is to test `weutil` configuration using the `weutil_test` suite.

# Testing

1. Compilation is successful and binary is available in the <scratch_path>/build/fboss/ area.
2. Test Log:
```
[root@dhcp-10-208-85-223 185_32]# ./weutil_test --config_file meta_bsp_configs/montblanc/configs/weutil.json
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from WeutilTest
[ RUN      ] WeutilTest.getWedgeInfo
I0829 01:21:37.726519  6569 ConfigLib.cpp:48] Using config file: meta_bsp_configs/montblanc/configs/weutil.json
[       OK ] WeutilTest.getWedgeInfo (395 ms)
[ RUN      ] WeutilTest.getEepromPaths
I0829 01:21:38.122342  6569 ConfigLib.cpp:48] Using config file: meta_bsp_configs/montblanc/configs/weutil.json
I0829 01:21:38.122366  6569 ConfigLib.cpp:48] Using config file: meta_bsp_configs/montblanc/configs/weutil.json
[       OK ] WeutilTest.getEepromPaths (0 ms)
[----------] 2 tests from WeutilTest (395 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (395 ms total)
[  PASSED  ] 2 tests.
[root@dhcp-10-208-85-223 185_32]#
```
