### PR TITLE
tahan800bc : added led_manager.json

### DIFF
--- a/fboss/platform/configs/tahan800bc/led_manager.json
+++ b/fboss/platform/configs/tahan800bc/led_manager.json
@@ -1,10 +1,4 @@
 {
-  "chassisEepromName" : "CHASSIS" ,
-  "fruEepromList" : {
-    "CHASSIS" : {
-      "path" : "/run/devmap/eeproms/COME_EEPROM"
-    }
-  },
   "systemLedConfig": {
     "presentLedColor": 3,
     "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",

--- a/fboss/platform/configs/tahan800bc/led_manager.json
+++ b/fboss/platform/configs/tahan800bc/led_manager.json
@@ -1,0 +1,16 @@
+{
+  "chassisEepromName" : "CHASSIS" ,
+  "fruEepromList" : {
+    "CHASSIS" : {
+      "path" : "/run/devmap/eeproms/COME_EEPROM"
+    }
+  },
+  "systemLedConfig": {
+    "presentLedColor": 3,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",
+    "absentLedColor": 4,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:amber:status/brightness"
+  },
+  "fruTypeLedConfigs": {},
+  "fruConfigs": []
+}


### PR DESCRIPTION
# Description

Added `led_manager.json` file to verify the `data_corral_service` and the `data_corral_service_hw_test`.

# Motivation

Aim is to verify the `data_corral_service` and the `data_corral_service_hw_test`.

# Testing 

1. `jq` command output is clean.

2. **Data Corral Service Logs :** [th5_data_corral_service_logs.txt](https://github.com/user-attachments/files/17038224/th5_data_corral_service_logs.txt)

3. **Data Corral Service HW Test Logs :** [th5_data_corral_service_hw_test_logs.txt](https://github.com/user-attachments/files/17038237/th5_data_corral_service_hw_test_logs.txt)

