### PR TITLE
montblanc: config: add port 65 in dvt qsfp config

### DIFF
--- a/fboss/platform/configs/montblanc/qsfp.conf
+++ b/fboss/platform/configs/montblanc/qsfp.conf
@@ -1,0 +1,177 @@
+{
+  "defaultCommandLineArgs": {
+    "mode": "montblanc"
+  },
+  "transceiverConfigOverrides": [
+
+  ],
+  "qsfpTestConfig": {
+    "cabledPortPairs": [
+      {
+        "aPortName": "eth1/1/1",
+        "zPortName": "eth1/2/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/3/1",
+        "zPortName": "eth1/4/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/5/1",
+        "zPortName": "eth1/6/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/7/1",
+        "zPortName": "eth1/8/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/9/1",
+        "zPortName": "eth1/10/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/11/1",
+        "zPortName": "eth1/12/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/13/1",
+        "zPortName": "eth1/14/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/15/1",
+        "zPortName": "eth1/16/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/17/1",
+        "zPortName": "eth1/18/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/19/1",
+        "zPortName": "eth1/20/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/21/1",
+        "zPortName": "eth1/22/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/23/1",
+        "zPortName": "eth1/24/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/25/1",
+        "zPortName": "eth1/26/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/27/1",
+        "zPortName": "eth1/28/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/29/1",
+        "zPortName": "eth1/30/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/31/1",
+        "zPortName": "eth1/32/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/33/1",
+        "zPortName": "eth1/34/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/35/1",
+        "zPortName": "eth1/36/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/37/1",
+        "zPortName": "eth1/38/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/39/1",
+        "zPortName": "eth1/40/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/41/1",
+        "zPortName": "eth1/42/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/43/1",
+        "zPortName": "eth1/44/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/45/1",
+        "zPortName": "eth1/46/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/47/1",
+        "zPortName": "eth1/48/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/49/1",
+        "zPortName": "eth1/50/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/51/1",
+        "zPortName": "eth1/52/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/53/1",
+        "zPortName": "eth1/54/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/55/1",
+        "zPortName": "eth1/56/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/57/1",
+        "zPortName": "eth1/58/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/59/1",
+        "zPortName": "eth1/60/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/61/1",
+        "zPortName": "eth1/62/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/63/1",
+        "zPortName": "eth1/64/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/65/1",
+        "zPortName": "eth1/65/1",
+        "profileID": 23
+      }
+    ]
+  }
+}

--- a/fboss/platform/configs/montblanc/qsfp.conf
+++ b/fboss/platform/configs/montblanc/qsfp.conf
@@ -2,9 +2,7 @@
   "defaultCommandLineArgs": {
     "mode": "montblanc"
   },
-  "transceiverConfigOverrides": [
-
-  ],
+  "transceiverConfigOverrides": [],
   "qsfpTestConfig": {
     "cabledPortPairs": [
       {


### PR DESCRIPTION
Description
This PR is for montblanc dvt qsfp config.

Motivation
1.In montblanc dvt machine has added port 65,so we need to add it in qsfp.conf file.
2.Test cmd:

test cmd:
[root@localhost main_137]# LD_LIBRARY_PATH=./fboss_lib/ ./qsfp_hw_test --qsfp-config qsfp_65.conf --gtest_filter=HwTest.i2cStressRead:HwTest.i2cStressWrite:HwTest.cmisPageChange:HwTest.i2cUniqueSerialNumbers --bsp_platform_mapping_override_path ./montblanc_bsp_mapping_dvt_all_port_65.json

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/
2.This PR has used "jq" cmd to pretty the format.
3.The lint issue is not about the json file.
![image](https://github.com/user-attachments/assets/912ac97d-ee7b-4f6a-80b6-928c994676c2)


4.Test log as follow:


![354143316-2db530f0-a48f-48b2-ae21-e336b2352c74](https://github.com/user-attachments/assets/c022c68d-6fdd-4fe1-9e0c-05a2606aa9dc)

[mp3_dvt_oss_test_qsfp_hw_test_all_65port_test_log_7_30.txt](https://github.com/user-attachments/files/16901905/mp3_dvt_oss_test_qsfp_hw_test_all_65port_test_log_7_30.txt)



