### PR TITLE
janga: config: add janga dvt qsfp config file

### DIFF
--- a/fboss/platform/configs/janga800bic/qsfp.conf
+++ b/fboss/platform/configs/janga800bic/qsfp.conf
@@ -1,0 +1,127 @@
+{
+  "defaultCommandLineArgs": {
+    "mode": "janga800bic"
+  },
+  "transceiverConfigOverrides": [
+
+  ],
+  "qsfpTestConfig": {
+    "cabledPortPairs": [
+      {
+        "aPortName": "eth1/1/1",
+        "zPortName": "eth1/2/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "fab1/3/1",
+        "zPortName": "fab1/4/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/5/1",
+        "zPortName": "fab1/6/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/7/1",
+        "zPortName": "fab1/8/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/9/1",
+        "zPortName": "fab1/10/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/11/1",
+        "zPortName": "fab1/12/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/13/1",
+        "zPortName": "fab1/14/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/15/1",
+        "zPortName": "fab1/16/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/17/1",
+        "zPortName": "fab1/18/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/19/1",
+        "zPortName": "fab1/20/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/21/1",
+        "zPortName": "fab1/22/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/23/1",
+        "zPortName": "fab1/24/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/25/1",
+        "zPortName": "fab1/26/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/27/1",
+        "zPortName": "fab1/28/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/29/1",
+        "zPortName": "fab1/30/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/31/1",
+        "zPortName": "fab1/32/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/33/1",
+        "zPortName": "fab1/34/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/35/1",
+        "zPortName": "fab1/36/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/37/1",
+        "zPortName": "fab1/38/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/39/1",
+        "zPortName": "fab1/40/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "fab1/42/1",
+        "zPortName": "fab1/43/1",
+        "profileID": 42
+      },
+      {
+        "aPortName": "eth1/41/1",
+        "zPortName": "eth1/44/1",
+        "profileID": 22
+      },
+      {
+        "aPortName": "eth1/45/1",
+        "zPortName": "eth1/46/1",
+        "profileID": 38
+      }
+    ]
+  }
+}

--- a/fboss/platform/configs/janga800bic/qsfp.conf
+++ b/fboss/platform/configs/janga800bic/qsfp.conf
@@ -2,9 +2,7 @@
   "defaultCommandLineArgs": {
     "mode": "janga800bic"
   },
-  "transceiverConfigOverrides": [
-
-  ],
+  "transceiverConfigOverrides": [],
   "qsfpTestConfig": {
     "cabledPortPairs": [
       {


### PR DESCRIPTION
Description
This PR is for janga dvt qsfp config file.

Motivation
1.This is new added qsfp config file in janga dvt machine(note: this file is approved from https://github.com/facebookexternal/fboss.bsp.celestica/blob/master/janga/osfp/qsfp.conf) i just copy it here and then raise it again.
2.Test cmd:

Test cmd:
./bin/run_test.py qsfp --qsfp-config qsfp.conf --filter HwTest.i2cStressRead:HwTest.i2cStressWrite

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/
2.This PR has used "jq" cmd to pretty the format.
3.Test log as follow:
![image](https://github.com/user-attachments/assets/b92d8072-5ce0-455b-959a-b74e73fdb2ba)


[janga_E1-E2-E5-E6_test_ok.txt](https://github.com/user-attachments/files/16902091/janga_E1-E2-E5-E6_test_ok.txt)
[janga_E3_E4_i2c_stress_read_test_ok.txt](https://github.com/user-attachments/files/16902092/janga_E3_E4_i2c_stress_read_test_ok.txt)
[janga_F1.F22_test_ok.txt](https://github.com/user-attachments/files/16902093/janga_F1.F22_test_ok.txt)
[janga_F24.F39_test_ok.txt](https://github.com/user-attachments/files/16902094/janga_F24.F39_test_ok.txt)
[janga_F35.F40_test_ok.txt](https://github.com/user-attachments/files/16902096/janga_F35.F40_test_ok.txt)

