### PR TITLE
tahan: config: add tahan dvt qsfp config file

### DIFF
--- a/fboss/platform/configs/tahan800bc/qsfp.conf
+++ b/fboss/platform/configs/tahan800bc/qsfp.conf
@@ -2,9 +2,7 @@
   "defaultCommandLineArgs": {
     "mode": "tahan800bc"
   },
-  "transceiverConfigOverrides": [
-
-  ],
+  "transceiverConfigOverrides": [],
   "qsfpTestConfig": {
     "cabledPortPairs": [
       {

--- a/fboss/platform/configs/tahan800bc/qsfp.conf
+++ b/fboss/platform/configs/tahan800bc/qsfp.conf
@@ -1,0 +1,97 @@
+{
+  "defaultCommandLineArgs": {
+    "mode": "tahan800bc"
+  },
+  "transceiverConfigOverrides": [
+
+  ],
+  "qsfpTestConfig": {
+    "cabledPortPairs": [
+      {
+        "aPortName": "eth1/1/1",
+        "zPortName": "eth1/2/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/3/1",
+        "zPortName": "eth1/4/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/5/1",
+        "zPortName": "eth1/6/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/7/1",
+        "zPortName": "eth1/8/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/9/1",
+        "zPortName": "eth1/10/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/11/1",
+        "zPortName": "eth1/12/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/13/1",
+        "zPortName": "eth1/14/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/15/1",
+        "zPortName": "eth1/16/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/17/1",
+        "zPortName": "eth1/18/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/19/1",
+        "zPortName": "eth1/20/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/21/1",
+        "zPortName": "eth1/22/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/23/1",
+        "zPortName": "eth1/24/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/25/1",
+        "zPortName": "eth1/26/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/27/1",
+        "zPortName": "eth1/28/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/29/1",
+        "zPortName": "eth1/30/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/31/1",
+        "zPortName": "eth1/32/1",
+        "profileID": 38
+      },
+      {
+        "aPortName": "eth1/33/1",
+        "zPortName": "eth1/33/1",
+        "profileID": 23
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Description
This PR is for janga dvt qsfp config file.

Motivation
1.This is new added qsfp config file in tahan dvt machine(note: this file is approved from https://github.com/facebookexternal/fboss.bsp.celestica/blob/master/tahan/osfp/qsfp.conf) i just copy it here and then raise it again.
2.Test cmd:

Test cmd:
./bin/run_test.py qsfp --qsfp-config qsfp.conf --filter_file=./share/hw_sanity_tests/bsp_sanity_tests.conf

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/
2.This PR has used "jq" cmd to pretty the format.
3.The lint issue is not about the json file.
![image](https://github.com/user-attachments/assets/0ff7ed5c-436e-4274-a20f-e6896de7c49c)


4.Test log as follow:

![image](https://github.com/user-attachments/assets/669dfe40-d043-4bf5-be7c-c8577779ecf7)


[hwtest_results_2022_Aug_28-10_37_25_AM.csv](https://github.com/user-attachments/files/16902232/hwtest_results_2022_Aug_28-10_37_25_AM.csv)
[tahan_oss_test_log_12.18.txt](https://github.com/user-attachments/files/16902234/tahan_oss_test_log_12.18.txt)




