### PR TITLE
montblanc:config: update fan service config

### DIFF
--- a/fboss/platform/configs/montblanc/fan_service.json
+++ b/fboss/platform/configs/montblanc/fan_service.json
@@ -6,6 +6,13 @@
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 70,
+  "watchdog": {
+    "access": {
+      "accessType": "ACCESS_TYPE_SYSFS",
+      "path": "/run/devmap/watchdogs/FAN_WATCHDOG"
+    },
+    "value": 0
+  },
   "controlInterval": {
     "sensorReadInterval": 5,
     "pwmUpdateInterval": 5
@@ -82,25 +89,29 @@
         "24": 30,
         "27": 30,
         "32": 35,
-        "37": 40
+        "37": 40,
+        "42": 60
       },
       "normalDownTable": {
         "22": 30,
         "25": 30,
         "30": 35,
-        "35": 40
+        "35": 40,
+        "40": 60
       },
       "failUpTable": {
         "24": 35,
         "27": 35,
         "32": 40,
-        "37": 45
+        "37": 45,
+        "42": 65
       },
       "failDownTable": {
         "22": 35,
         "25": 35,
         "30": 40,
-        "35": 45
+        "35": 45,
+        "40": 65
       }
     },
     {


### PR DESCRIPTION
**Motivation**
1. Update Montblanc fan service config for temp sensor overheat safety case. For inlet temp sensor, add entries to the linear table to cover the temp sensor overheat safety case. For those sensors calculate PWM with PID algorithm, as aligned with Meta thermal, the PID algorithm already have appropriate overheat safety. We can ignore additional sensor overheat safety for those sensors.
2. Add fan watchdog in fanservice config.

**Test plan**
1. For temp sensor overheat safety case, thermal team has tested it, the test result is as expected.
2. For fan watchdog, Firstly, run fan service, check the fan speed; Then stop fan service, when the fan service is stopped for more than 30 seconds, check the fan speed changes. (For testing purposes, the fan watchdog timeout is temporarily set to 30 seconds).
Fan speed log is as below. From the log, after fan service was stopped for more than 30 seconds, the FAN PWM changed to 24. It's as expected.
[root@localhost hwmon3]# date +"%T"; cat ./pwm1; cat ./pwm2; cat ./pwm3; cat ./pwm4; cat ./pwm5; cat ./pwm6; cat ./pwm7; cat ./pwm8; cat ./fan*_input
16:21:07
20
20
20
20
20
20
20
20
7200
7650
7200
7650
7350
7650
7200
7650
7200
7500
7200
7650
7200
7500
7200
7500
[root@localhost hwmon3]# date +"%T"; cat ./pwm1; cat ./pwm2; cat ./pwm3; cat ./pwm4; cat ./pwm5; cat ./pwm6; cat ./pwm7; cat ./pwm8; cat ./fan*_input
16:21:29
20
20
20
20
20
20
20
20
7200
7650
7200
7500
7200
7650
7200
7650
7200
7500
7200
7650
7050
7650
7200
7650
[root@localhost hwmon3]# date +"%T"; cat ./pwm1; cat ./pwm2; cat ./pwm3; cat ./pwm4; cat ./pwm5; cat ./pwm6; cat ./pwm7; cat ./pwm8; cat ./fan*_input
16:21:34
20
20
20
20
20
20
20
20
7200
7650
7200
7650
7200
7500
7200
7650
7200
7650
7200
7650
7200
7500
7200
7650
[root@localhost hwmon3]# date +"%T"; cat ./pwm1; cat ./pwm2; cat ./pwm3; cat ./pwm4; cat ./pwm5; cat ./pwm6; cat ./pwm7; cat ./pwm8; cat ./fan*_input
16:21:37
24
24
24
24
24
24
24
24
7800
8400
7650
8400
7800
8400
7650
8250
7650
8250
7650
8250
7650
8250
7650
8400
[root@localhost hwmon3]# date +"%T"; cat ./pwm1; cat ./pwm2; cat ./pwm3; cat ./pwm4; cat ./pwm5; cat ./pwm6; cat ./pwm7; cat ./pwm8; cat ./fan*_input
16:21:42
24
24
24
24
24
24
24
24
8400
9000
8400
9000
8400
9000
8400
9000
8400
9000
8250
9000
8400
9000
8250
9000