### PR TITLE
fan_service: Adapt to fan LED is controlled by hardware

### DIFF
--- a/fboss/platform/fan_service/ControlLogic.cpp
+++ b/fboss/platform/fan_service/ControlLogic.cpp
@@ -433,14 +433,21 @@ std::pair<bool, int16_t> ControlLogic::programFan(
 }
 
 void ControlLogic::programLed(const Fan& fan, bool fanFailed) {
-  unsigned int valueToWrite =
-      (fanFailed ? *fan.fanFailLedVal() : *fan.fanGoodLedVal());
-  pBsp_->setFanLedSysfs(*fan.ledSysfsPath(), valueToWrite);
-  XLOG(INFO) << fmt::format(
-      "{}: Setting LED to {} (value: {})",
-      *fan.fanName(),
-      (fanFailed ? "Fail" : "Good"),
-      valueToWrite);
+  if (!fan.ledSysfsPath()->empty())
+  {
+    unsigned int valueToWrite =
+        (fanFailed ? *fan.fanFailLedVal() : *fan.fanGoodLedVal());
+    pBsp_->setFanLedSysfs(*fan.ledSysfsPath(), valueToWrite);
+    XLOG(INFO) << fmt::format(
+        "{}: Setting LED to {} (value: {})",
+        *fan.fanName(),
+        (fanFailed ? "Fail" : "Good"),
+        valueToWrite);
+  } else {
+    XLOG(INFO) << fmt::format(
+        "{}: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.",
+        *fan.fanName());
+  }
 }
 
 int16_t ControlLogic::calculateZonePwm(const Zone& zone, bool boostMode) {

--- a/fboss/platform/fan_service/Utils.cpp
+++ b/fboss/platform/fan_service/Utils.cpp
@@ -90,10 +90,6 @@ bool Utils::isValidConfig(const FanServiceConfig& config) {
       XLOG(ERR) << "presenceSysfsPath cannot be empty";
       return false;
     }
-    if (fan.ledSysfsPath()->empty()) {
-      XLOG(ERR) << "ledSysfsPath cannot be empty";
-      return false;
-    }
     if ((!fan.presenceSysfsPath()) && (!fan.presenceGpio())) {
       XLOG(ERR) << "either presenceSysfsPath or presenceGpio must be set";
       return false;


### PR DESCRIPTION
**Description:**
For Minerva project, the FAN LEDs are controlled by FAN CPLD and compute blades do not participate in the control of the FAN LEDs. 

**Test log:**
I0908 19:49:03.912449  6958 ControlLogic.cpp:483] zone1: Components: SMB_U77_INLET_LEFT_BOT_LM75_TEMP,CPU_UNCORE_TEMP,qsfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 75.
I0908 19:49:03.912872  6958 ControlLogic.cpp:419] FANTRAY1_FAN1: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.913288  6958 ControlLogic.cpp:419] FANTRAY1_FAN2: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.913704  6958 ControlLogic.cpp:419] FANTRAY1_FAN3: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.914120  6958 ControlLogic.cpp:419] FANTRAY1_FAN4: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.914535  6958 ControlLogic.cpp:419] FANTRAY1_FAN5: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.914952  6958 ControlLogic.cpp:419] FANTRAY1_FAN6: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.915368  6958 ControlLogic.cpp:419] FANTRAY1_FAN7: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.915784  6958 ControlLogic.cpp:419] FANTRAY1_FAN8: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.916200  6958 ControlLogic.cpp:419] FANTRAY2_FAN1: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.916616  6958 ControlLogic.cpp:419] FANTRAY2_FAN2: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.917033  6958 ControlLogic.cpp:419] FANTRAY2_FAN3: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.917449  6958 ControlLogic.cpp:419] FANTRAY2_FAN4: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.917866  6958 ControlLogic.cpp:419] FANTRAY2_FAN5: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.918282  6958 ControlLogic.cpp:419] FANTRAY2_FAN6: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.918698  6958 ControlLogic.cpp:419] FANTRAY2_FAN7: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.919114  6958 ControlLogic.cpp:419] FANTRAY2_FAN8: Programmed with PWM 59 (raw value 150)
I0908 19:49:03.919119  6958 ControlLogic.cpp:447] FANTRAY1_FAN1: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919124  6958 ControlLogic.cpp:447] FANTRAY1_FAN2: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919129  6958 ControlLogic.cpp:447] FANTRAY1_FAN3: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919133  6958 ControlLogic.cpp:447] FANTRAY1_FAN4: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919138  6958 ControlLogic.cpp:447] FANTRAY1_FAN5: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919142  6958 ControlLogic.cpp:447] FANTRAY1_FAN6: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919146  6958 ControlLogic.cpp:447] FANTRAY1_FAN7: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919151  6958 ControlLogic.cpp:447] FANTRAY1_FAN8: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919156  6958 ControlLogic.cpp:447] FANTRAY2_FAN1: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919160  6958 ControlLogic.cpp:447] FANTRAY2_FAN2: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919164  6958 ControlLogic.cpp:447] FANTRAY2_FAN3: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919169  6958 ControlLogic.cpp:447] FANTRAY2_FAN4: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919173  6958 ControlLogic.cpp:447] FANTRAY2_FAN5: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919177  6958 ControlLogic.cpp:447] FANTRAY2_FAN6: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919182  6958 ControlLogic.cpp:447] FANTRAY2_FAN7: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
I0908 19:49:03.919186  6958 ControlLogic.cpp:447] FANTRAY2_FAN8: FAN LED path is empty. It's normal when FAN LED is controlled by hardware.
