### PR TITLE
janga800bic : added COME_FRU EEPROM entry in the  weutil.json file.

### DIFF
--- a/fboss/platform/configs/janga800bic/weutil.json
+++ b/fboss/platform/configs/janga800bic/weutil.json
@@ -9,6 +9,9 @@
     },
     "RUNBMC" : {
       "path" : "/run/devmap/eeproms/RUNBMC_EEPROM"
+    },
+    "COME_FRU" : {
+      "path" : "/run/devmap/eeproms/COME_FRU"
     }
   }
 }


### PR DESCRIPTION
# Description

Janga platform has the following EEPROMs available:

```
[root@localhost 211_47]# ls /run/devmap/eeproms/
COME_EEPROM  COME_FRU  RUNBMC_EEPROM  SMB_EEPROM
[root@localhost 211_47]#
```

Entry for the EEPROM `COME_FRU` is missing in the `weutil.json` file, PR is raised to add this entry.

# Motivation

Aim is to have all the EEPROMs entries available in the `weutil.json` file to be tested by `weutil` FBOSS service.

# Testing

[janga800bic_weutil_logs.txt](https://github.com/user-attachments/files/16929429/janga800bic_weutil_logs.txt)
