### PR TITLE
tahan800bc : added RUNBMC & COME_FRU EEPROMs entry in the weutil.json file.

### DIFF
--- a/fboss/platform/configs/tahan800bc/weutil.json
+++ b/fboss/platform/configs/tahan800bc/weutil.json
@@ -2,14 +2,16 @@
   "chassisEepromName" : "SMB" ,
   "fruEepromList" : {
     "SMB" : {
-      "path" : "/run/devmap/eeproms/SMB_EEPROM",
-      "offset" : 0,
-      "idEepromFormatVer" : 4
+      "path" : "/run/devmap/eeproms/SMB_EEPROM"
     },
     "COME" : {
-      "path" : "/run/devmap/eeproms/COME_EEPROM",
-      "offset" : 0,
-      "idEepromFormatVer" : 4
+      "path" : "/run/devmap/eeproms/COME_EEPROM"
+    },
+    "COME_FRU" : {
+      "path" : "/run/devmap/eeproms/COME_FRU"
+    },
+    "RUNBMC" : {
+      "path" : "/run/devmap/eeproms/RUNBMC_EEPROM"
     }
   }
 }


### PR DESCRIPTION
# Description

Tahan platform has the following EEPROMs available:

```
[root@localhost 211_47]# ls /run/devmap/eeproms/
COME_EEPROM  COME_FRU  RUNBMC_EEPROM  SMB_EEPROM
[root@localhost 211_47]#
```

Entry for the EEPROMs `RUNBMC` &  `COME_FRU` is missing in the `weutil.json` file, PR is raised to add this entry.

Also, cleaned up the `weutil.json` file for the following:
In `weutil` FBOSS service, the default implicit values of `idEepromFormatVer` is `v4` and for `offset` it is `0`.
Hence passing the same values in the configuration is redundant.

https://github.com/facebook/fboss/blob/a374fbf363af163950e3c4e851723f62ec8daf90/fboss/platform/weutil/if/weutil_config.thrift#L18-L26 

# Motivation

Aim is to have all the proper EEPROMs entries available in the `weutil.json` file to be tested by `weutil` FBOSS service.

# Testing

[tahan800bc_weutil_logs.txt](https://github.com/user-attachments/files/16929628/tahan800bc_weutil_logs.txt)
