### PR TITLE
platformmanager: update publish firmware version

### DIFF
--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -625,18 +625,11 @@ void PlatformExplorer::publishFirmwareVersions() {
     CHECK(!linkPathParts.empty());
     const auto deviceName = linkPathParts.back();
     std::string verDirPath = linkPath;
-    // Check for and handle hwmon case. e.g.
-    // /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon20/
-    auto hwmonSubdirPath = std::filesystem::path(linkPath) / "hwmon";
-    if (platformFsUtils_->exists(hwmonSubdirPath)) {
-      for (const auto& entry : platformFsUtils_->ls(hwmonSubdirPath)) {
-        if (entry.is_directory() &&
-            entry.path().filename().string().starts_with("hwmon")) {
-          verDirPath = hwmonSubdirPath / entry.path().filename();
-          break;
-        }
-      }
-    }
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(linkPath)) {  
+        if (entry.is_regular_file() && entry.path().filename().string().find(fmt::format("{}_ver", deviceType)) != std::string::npos) {  
+            verDirPath = entry.path().parent_path();  
+        }  
+    } 
     const auto version = readVersionNumber(
         fmt::format("{}/{}_ver", verDirPath, deviceType),
         platformFsUtils_.get());


### PR DESCRIPTION
### **Description**
Fix platform manager issue as below:
![image](https://github.com/user-attachments/assets/0aa484de-d7de-4f62-bd34-8d4b30187ddd)
When one CPLD has hwmon sensor, but the cpld_ver/cpld_sub_ver file isn't at hwnon folder path. It will fail to find the cpld_ver/cpld_sub_ver file.

### **Test log**
![image](https://github.com/user-attachments/assets/c27e657e-f469-4122-8a36-78013d8a0183)
 