### PR TITLE
platformmanager: fix publish firmware version issue

### DIFF
--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -700,16 +700,13 @@ void PlatformExplorer::publishFirmwareVersions() {
     std::string versionString;
     int odsValue = 0;
     std::string verDirPath = linkPath;
-    // Check for and handle hwmon case. e.g.
-    // /run/devmap/cplds/FAN0_CPLD/hwmon/hwmon20/
-    auto hwmonSubdirPath = std::filesystem::path(linkPath) / "hwmon";
-    if (platformFsUtils_->exists(hwmonSubdirPath)) {
-      for (const auto& entry : platformFsUtils_->ls(hwmonSubdirPath)) {
-        if (entry.is_directory() &&
-            entry.path().filename().string().starts_with("hwmon")) {
-          verDirPath = hwmonSubdirPath / entry.path().filename();
-          break;
-        }
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator(linkPath)) {
+      if (entry.is_regular_file() &&
+          entry.path().filename().string().find(
+              fmt::format("{}_ver", deviceType)) != std::string::npos) {
+        verDirPath = entry.path().parent_path();
+        break;
       }
     }
     // New-style fw_ver


### PR DESCRIPTION
### Description
On Montblanc & Tahan & Janga device, running platform_manager will report firmware version read failed log as below 
![image](https://github.com/user-attachments/assets/6eb8ef4f-1fbf-46b1-bfae-ce0475645f94)

When one CPLD has hwmon sensor path, but the cpld_ver/cpld_sub_ver file isn't at hwnon folder path. It will fail to find the cpld_ver/cpld_sub_ver file. Fix this issue, it's also suitable for "/run/devmap/cplds/FAN0_CPLD/hwmon/hwmon20/" case.

### Test log
![image](https://github.com/user-attachments/assets/f753ef53-e282-4ff2-8be1-baf9a91bfdeb)
