### PR TITLE
montblanc: config: Update sensor configuration for compatibility with 2nd source

### DIFF
--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -1,1894 +1,6356 @@
 {
-  "source": "sysfs",
-  "sensorMapList": {
-    "CPU_CARD": {
-      "CPU_UNCORE_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "MINIPACK3_MCB",
+      "sensors": [
+        {
+          "name": "CPU_UNCORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100,
+            "maxAlarmVal": 90
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
-        "type": 3
-      },
-      "CPU_CORE0_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
-        "type": 3
-      },
-      "CPU_CORE1_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
-        "type": 3
-      },
-      "CPU_CORE2_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
-        "type": 3
-      },
-      "CPU_CORE3_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
-        "type": 3
-      },
-      "CPU_CORE4_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
-        "type": 3
-      },
-      "CPU_CORE5_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
-        "type": 3
-      },
-      "CPU_CORE6_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
-        "type": 3
-      },
-      "CPU_CORE7_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 100,
-          "maxAlarmVal": 90
+        {
+          "name": "CPU_CORE7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
-        "type": 3
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15
+        {
+          "name": "FAN1_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
-        "type": 1
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.4,
-          "lowerCriticalVal": 0.6
+        {
+          "name": "FAN1_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
-        "type": 1
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 115,
-          "maxAlarmVal": 100
+        {
+          "name": "FAN2_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
-        "type": 3
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
-        "type": 0
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_POUT": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
-        "type": 0
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
-        "type": 2
-      },
-      "COMe_PU31_TDA38640_PVNN_PCH_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13
+        {
+          "name": "FAN2_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
-        "type": 2
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15
+        {
+          "name": "FAN3_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
-        "type": 1
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.46,
-          "lowerCriticalVal": 0.66
+        {
+          "name": "FAN3_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
-        "type": 1
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 115,
-          "maxAlarmVal": 100
+        {
+          "name": "FAN4_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
-        "type": 3
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
-        "type": 0
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_POUT": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
-        "type": 0
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
-        "type": 2
-      },
-      "COMe_PU32_TDA38640_P1V05_STBY_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 20
+        {
+          "name": "FAN4_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
-        "type": 2
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15
+        {
+          "name": "FAN5_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan9_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
-        "type": 1
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.4,
-          "lowerCriticalVal": 0.6
+        {
+          "name": "FAN5_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan10_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
-        "type": 1
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 150,
-          "maxAlarmVal": 100
+        {
+          "name": "FAN6_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan11_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
-        "type": 3
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
-        "type": 0
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
-        "type": 0
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
-        "type": 2
-      },
-      "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13
+        {
+          "name": "FAN6_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan12_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
-        "type": 2
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15
+        {
+          "name": "FAN7_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan13_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
-        "type": 1
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.4,
-          "lowerCriticalVal": 0.6
+        {
+          "name": "FAN7_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan14_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
-        "type": 1
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 115,
-          "maxAlarmVal": 100
+        {
+          "name": "FAN8_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan15_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 13200,
+            "maxAlarmVal": 12200,
+            "minAlarmVal": 3000,
+            "lowerCriticalVal": 1500
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
-        "type": 3
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
-        "type": 0
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_POUT": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
-        "type": 0
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
-        "type": 2
-      },
-      "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 5
+        {
+          "name": "FAN8_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan16_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12400,
+            "maxAlarmVal": 11400,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1400
+          }
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
-        "type": 2
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15,
-          "maxAlarmVal": 14,
-          "minAlarmVal": 9
+        {
+          "name": "MCB_U25_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75,
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
-        "type": 1
-      },
-      "COMe_PU4_XDPE15284_P1V8_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15,
-          "maxAlarmVal": 14,
-          "minAlarmVal": 9
+        {
+          "name": "XP1R0V_IOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in0_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.1,
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.95,
+            "lowerCriticalVal": 0.9
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-        "type": 1
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.2,
-          "maxAlarmVal": 2,
-          "lowerCriticalVal": 1.4
+        {
+          "name": "XP3R3V_MCB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-        "type": 1
-      },
-      "COMe_PU4_XDPE15284_P1V8_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.2,
-          "maxAlarmVal": 2,
-          "lowerCriticalVal": 1.4
+        {
+          "name": "XP3R3V_FCB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
-        "type": 1
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 115,
-          "maxAlarmVal": 100
+        {
+          "name": "XP1R8V_IOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.98,
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
-        "type": 3
-      },
-      "COMe_PU4_XDPE15284_P1V8_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 115,
-          "maxAlarmVal": 100
+        {
+          "name": "XP1R2V_IOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.32,
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.14,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
-        "type": 3
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "maxAlarmVal": 1024
+        {
+          "name": "XP3R3V_IOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
-        "type": 0
-      },
-      "COMe_PU4_XDPE15284_P1V8_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "maxAlarmVal": 4096
+        {
+          "name": "FAN_1_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-        "type": 0
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "maxAlarmVal": 1024
+        {
+          "name": "FAN_1_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-        "type": 0
-      },
-      "COMe_PU4_XDPE15284_P1V8_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "maxAlarmVal": 125
+        {
+          "name": "FAN_1_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
-        "type": 0
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_IIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15,
-          "maxAlarmVal": 12
+        {
+          "name": "FAN_3_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
-        "type": 2
-      },
-      "COMe_PU4_XDPE15284_P1V8_IIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.5,
-          "maxAlarmVal": 3
+        {
+          "name": "FAN_3_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-        "type": 2
-      },
-      "COMe_PU4_XDPE15284_PVCCIN_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 130,
-          "maxAlarmVal": 94
+        {
+          "name": "FAN_3_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-        "type": 2
-      },
-      "COMe_PU4_XDPE15284_P1V8_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 6,
-          "maxAlarmVal": 3
+        {
+          "name": "FAN_5_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
-        "type": 2
-      },
-      "COMe_U18_Inlet_Sensor_TMP75_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 65,
-          "maxAlarmVal": 60
+        {
+          "name": "FAN_5_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
         },
-        "path": "/run/devmap/sensors/COME_TSENSOR1/temp1_input",
-        "type": 3
-      },
-      "COMe_U39_Outlet_Sensor_TMP75_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 65,
-          "maxAlarmVal": 60
+        {
+          "name": "FAN_5_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
         },
-        "path": "/run/devmap/sensors/COME_TSENSOR2/temp1_input",
-        "type": 3
-      }
+        {
+          "name": "FAN_7_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FAN_7_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
+        },
+        {
+          "name": "FAN_7_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
+        },
+        {
+          "name": "FAN_2_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FAN_2_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
+        },
+        {
+          "name": "FAN_2_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
+        },
+        {
+          "name": "FAN_4_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FAN_4_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
+        },
+        {
+          "name": "FAN_4_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
+        },
+        {
+          "name": "FAN_6_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FAN_6_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
+        },
+        {
+          "name": "FAN_6_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
+        },
+        {
+          "name": "FAN_8_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FAN_8_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 30,
+            "maxAlarmVal": 15
+          },
+          "compute": "(1000/1780)*@/1000"
+        },
+        {
+          "name": "FAN_8_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "(1000/1780)*@/1000000"
+        }
+      ]
     },
-    "FCB_B_CARD": {
-      "FCB_B_U1_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 75,
-          "maxAlarmVal": 70
+    {
+      "slotPath": "/SCM_SLOT@0/COMESE_SLOT@0",
+      "pmUnitName": "NETLAKE",
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "lowerCriticalVal": 0.66
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.605,
+                "lowerCriticalVal": 0.805
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 150,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
+              "type": 0,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 150,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
+              "type": 0,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 4096
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 12
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 3.5,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 1
         },
-        "path": "/run/devmap/sensors/FCB_B_TSENSOR1/temp1_input",
-        "type": 3
-      },
-      "FCB_B_U5_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 75,
-          "maxAlarmVal": 70
-        },
-        "path": "/run/devmap/sensors/FCB_B_TSENSOR2/temp1_input",
-        "type": 3
-      },
-      "FCB_T_U1_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 75,
-          "maxAlarmVal": 70
-        },
-        "path": "/run/devmap/sensors/FCB_T_TSENSOR1/temp1_input",
-        "type": 3
-      },
-      "FCB_T_U5_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 75,
-          "maxAlarmVal": 70
-        },
-        "path": "/run/devmap/sensors/FCB_T_TSENSOR2/temp1_input",
-        "type": 3
-      }
+        {
+          "sensors": [
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "lowerCriticalVal": 0.66
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.605,
+                "lowerCriticalVal": 0.805
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 150,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
+              "type": 0,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 150,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
+              "type": 0,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 12
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 2
+        }
+      ]
     },
-    "MCB_CARD": {
-      "FAN 1_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
+    {
+      "slotPath": "/FCBBOTTOM_SLOT@0",
+      "pmUnitName": "MINIPACK3_FCB_B",
+      "sensors": [
+        {
+          "name": "FCB_B_U1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_B_TSENSOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75,
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
-        "type": 4
-      },
-      "FAN 1_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
-        "type": 4
-      },
-      "FAN 2_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
-        "type": 4
-      },
-      "FAN 2_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
-        "type": 4
-      },
-      "FAN 3_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
-        "type": 4
-      },
-      "FAN 3_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
-        "type": 4
-      },
-      "FAN 4_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
-        "type": 4
-      },
-      "FAN 4_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
-        "type": 4
-      },
-      "FAN 5_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan9_input",
-        "type": 4
-      },
-      "FAN 5_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan10_input",
-        "type": 4
-      },
-      "FAN 6_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan11_input",
-        "type": 4
-      },
-      "FAN 6_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan12_input",
-        "type": 4
-      },
-      "FAN 7_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan13_input",
-        "type": 4
-      },
-      "FAN 7_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan14_input",
-        "type": 4
-      },
-      "FAN 8_F_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 13200,
-          "maxAlarmVal": 12200,
-          "minAlarmVal": 3000,
-          "lowerCriticalVal": 1500
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan15_input",
-        "type": 4
-      },
-      "FAN 8_R_RPM": {
-        "thresholds": {
-          "upperCriticalVal": 12400,
-          "maxAlarmVal": 11400,
-          "minAlarmVal": 2900,
-          "lowerCriticalVal": 1400
-        },
-        "path": "/run/devmap/sensors/MCB_FAN_CPLD/fan16_input",
-        "type": 4
-      },
-      "MCB_U35_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 75,
-          "maxAlarmVal": 70
-        },
-        "path": "/run/devmap/sensors/MCB_TSENSOR/temp1_input",
-        "type": 4
-      },
-      "XP1R0V_IOB_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.1,
-          "maxAlarmVal": 1.05,
-          "minAlarmVal": 0.95,
-          "lowerCriticalVal": 0.9
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in0_input",
-        "type": 1
-      },
-      "XP3R3V_MCB_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in1_input",
-        "type": 1
-      },
-      "XP3R3V_FCB_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in2_input",
-        "type": 1
-      },
-      "XP1R8V_IOB_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.98,
-          "maxAlarmVal": 1.89,
-          "minAlarmVal": 1.71,
-          "lowerCriticalVal": 1.62
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in3_input",
-        "type": 1
-      },
-      "XP1R2V_IOB_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.32,
-          "maxAlarmVal": 1.26,
-          "minAlarmVal": 1.14,
-          "lowerCriticalVal": 1.08
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in4_input",
-        "type": 1
-      },
-      "XP3R3V_IOB_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR9/in5_input",
-        "type": 1
-      },
-      "FAN_1_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/in1_input",
-        "type": 1
-      },
-      "FAN_1_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/curr1_input",
-        "type": 2
-      },
-      "FAN_1_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1/power1_input",
-        "type": 0
-      },
-      "FAN_3_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/in1_input",
-        "type": 1
-      },
-      "FAN_3_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/curr1_input",
-        "type": 2
-      },
-      "FAN_3_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2/power1_input",
-        "type": 0
-      },
-      "FAN_5_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/in1_input",
-        "type": 1
-      },
-      "FAN_5_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/curr1_input",
-        "type": 2
-      },
-      "FAN_5_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3/power1_input",
-        "type": 0
-      },
-      "FAN_7_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/in1_input",
-        "type": 1
-      },
-      "FAN_7_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/curr1_input",
-        "type": 2
-      },
-      "FAN_7_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4/power1_input",
-        "type": 0
-      },
-      "FAN_2_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/in1_input",
-        "type": 1
-      },
-      "FAN_2_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/curr1_input",
-        "type": 1
-      },
-      "FAN_2_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR5/power1_input",
-        "type": 0
-      },
-      "FAN_4_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/in1_input",
-        "type": 1
-      },
-      "FAN_4_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/curr1_input",
-        "type": 2
-      },
-      "FAN_4_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR6/power1_input",
-        "type": 0
-      },
-      "FAN_6_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/in1_input",
-        "type": 1
-      },
-      "FAN_6_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/curr1_input",
-        "type": 2
-      },
-      "FAN_6_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR7/power1_input",
-        "type": 0
-      },
-      "FAN_8_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/in1_input",
-        "type": 1
-      },
-      "FAN_8_CURRENT": {
-        "compute": "(1000/1780)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 30,
-          "maxAlarmVal": 15
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/curr1_input",
-        "type": 2
-      },
-      "FAN_8_POWER": {
-        "compute": "(1000/1780)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
-        },
-        "path": "/run/devmap/sensors/MCB_VOLTAGE_MONITOR8/power1_input",
-        "type": 0
-      }
+        {
+          "name": "FCB_B_U5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_B_TSENSOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75,
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000"
+        }
+      ]
     },
-    "PDB_L_CARD": {
-      "PDB_L_U1_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 65,
-          "maxAlarmVal": 60
+    {
+      "slotPath": "/FCBTOP_SLOT@0",
+      "pmUnitName": "MINIPACK3_FCB_T",
+      "sensors": [
+        {
+          "name": "FCB_T_U1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_T_TSENSOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75,
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_TSENSOR/temp1_input",
-        "type": 3
-      }
+        {
+          "name": "FCB_T_U5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_T_TSENSOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75,
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000"
+        }
+      ]
     },
-    "PDB_R_CARD": {
-      "PDB_R_U1_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 65,
-          "maxAlarmVal": 60
+    {
+      "slotPath": "/PDBLEFT_SLOT@0",
+      "pmUnitName": "MINIPACK3_PDB_L",
+      "sensors": [
+        {
+          "name": "PDB_L_U1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 65,
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_TSENSOR/temp1_input",
-        "type": 3
-      }
+        {
+          "name": "PSU1_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 305,
+            "maxAlarmVal": 305,
+            "minAlarmVal": 90,
+            "lowerCriticalVal": 90
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_12V_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_12V_MAIN_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 250,
+            "maxAlarmVal": 250
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_12V_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 2.5,
+            "maxAlarmVal": 2.5
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 3300,
+            "maxAlarmVal": 2860
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU1_L_12V_MAIN_POUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 3000,
+            "maxAlarmVal": 2600
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU1_L_12V_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 28,
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU1_fan_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/fan1_input",
+          "type": 4
+        },
+        {
+          "name": "PSU1_fan_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/fan2_input",
+          "type": 4
+        },
+        {
+          "name": "PSU1_TEMP_1",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_TEMP_2",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_TEMP_3",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
+          "type": 3,
+          "compute": "@/1000"
+        }
+      ]
     },
-    "PSU1_CARD": {
-      "PSU1_L_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 305,
-          "maxAlarmVal": 305,
-          "minAlarmVal": 90,
-          "lowerCriticalVal": 90
+    {
+      "slotPath": "/PDBRIGHT_SLOT@0",
+      "pmUnitName": "MINIPACK3_PDB_R",
+      "sensors": [
+        {
+          "name": "PDB_R_U1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 65,
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/in1_input",
-        "type": 1
-      },
-      "PSU1_L_12V_MAIN_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "PSU2_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 305,
+            "maxAlarmVal": 305,
+            "minAlarmVal": 90,
+            "lowerCriticalVal": 90
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/in2_input",
-        "type": 1
-      },
-      "PSU1_L_12V_STBY_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "PSU2_R_12V_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/in3_input",
-        "type": 1
-      },
-      "PSU1_L_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/curr1_input",
-        "type": 2
-      },
-      "PSU1_L_12V_MAIN_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 250,
-          "maxAlarmVal": 250
+        {
+          "name": "PSU2_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/curr2_input",
-        "type": 2
-      },
-      "PSU1_L_12V_STBY_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.5,
-          "maxAlarmVal": 2.5
+        {
+          "name": "PSU2_R_12V_MAIN_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 250,
+            "maxAlarmVal": 250
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/curr3_input",
-        "type": 2
-      },
-      "PSU1_L_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 3300,
-          "maxAlarmVal": 2860
+        {
+          "name": "PSU2_R_12V_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 2.5,
+            "maxAlarmVal": 2.5
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/power1_input",
-        "type": 0
-      },
-      "PSU1_L_12V_MAIN_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 3000,
-          "maxAlarmVal": 2600
+        {
+          "name": "PSU2_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 3300,
+            "maxAlarmVal": 2860
+          },
+          "compute": "@/1000000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/power2_input",
-        "type": 0
-      },
-      "PSU1_L_12V_STBY_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 28,
-          "maxAlarmVal": 26
+        {
+          "name": "PSU2_R_12V_MAIN_POUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 3000,
+            "maxAlarmVal": 2600
+          },
+          "compute": "@/1000000"
         },
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/power3_input",
-        "type": 0
-      },
-      "PSU1_fan_F_RPM": {
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/fan1_input",
-        "type": 4
-      },
-      "PSU1_fan_R_RPM": {
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/fan2_input",
-        "type": 4
-      },
-      "PSU1_TEMP_1": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
-        "type": 3
-      },
-      "PSU1_TEMP_2": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
-        "type": 3
-      },
-      "PSU1_TEMP_3": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
-        "type": 3
-      }
+        {
+          "name": "PSU2_R_12V_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 28,
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU2_FAN_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/fan1_input",
+          "type": 4
+        },
+        {
+          "name": "PSU2_FAN_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/fan2_input",
+          "type": 4
+        },
+        {
+          "name": "PSU2_TEMP_1",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU2_TEMP_2",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU2_TEMP_3",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
+          "type": 3,
+          "compute": "@/1000"
+        }
+      ]
     },
-    "PSU2_CARD": {
-      "PSU2_L_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 305,
-          "maxAlarmVal": 305,
-          "minAlarmVal": 90,
-          "lowerCriticalVal": 90
+    {
+      "slotPath": "/SCM_SLOT@0",
+      "pmUnitName": "MINIPACK3_SCM",
+      "sensors": [
+        {
+          "name": "SCM_M2_SSD_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SCM_M2_SSD_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/in1_input",
-        "type": 1
-      },
-      "PSU2_L_12V_MAIN_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "SCM_INLET_U36_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SCM_TSENSOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 60,
+            "maxAlarmVal": 55
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/in2_input",
-        "type": 1
-      },
-      "PSU2_L_12V_STBY_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "SCM_OUTLET_U37_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SCM_TSENSOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 65,
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/in3_input",
-        "type": 1
-      },
-      "PSU2_L_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/curr1_input",
-        "type": 2
-      },
-      "PSU2_L_12V_MAIN_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 250,
-          "maxAlarmVal": 250
+        {
+          "name": "XP1R5V_OOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in0_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.65,
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.425,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/curr2_input",
-        "type": 2
-      },
-      "PSU2_L_12V_STBY_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.5,
-          "maxAlarmVal": 2.5
+        {
+          "name": "XP3R3V_BMC_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/curr3_input",
-        "type": 2
-      },
-      "PSU2_L_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 3300,
-          "maxAlarmVal": 2860
+        {
+          "name": "XP3R3V_SSD_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/power1_input",
-        "type": 0
-      },
-      "PSU2_L_12V_MAIN_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 3000,
-          "maxAlarmVal": 2600
+        {
+          "name": "XP2R5V_OOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.75,
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/power2_input",
-        "type": 0
-      },
-      "PSU2_L_12V_STBY_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 28,
-          "maxAlarmVal": 26
+        {
+          "name": "XP1R1V_OOB_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.21,
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/power3_input",
-        "type": 0
-      },
-      "PSU2_fan_F_RPM": {
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/fan1_input",
-        "type": 4
-      },
-      "PSU2_fan_R_RPM": {
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/fan2_input",
-        "type": 4
-      },
-      "PSU2_TEMP_1": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
-        "type": 3
-      },
-      "PSU2_TEMP_2": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
-        "type": 3
-      },
-      "PSU2_TEMP_3": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
-        "type": 3
-      }
+        {
+          "name": "XP3R3V_I210_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
+        },
+        {
+          "name": "XP12R0V_COME_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in6_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "(100/9)*@/1000"
+        },
+        {
+          "name": "XP5R0V_COME_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in7_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.5,
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000"
+        },
+        {
+          "name": "12V_COME_VOLTAGE",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "12V_COME_CURRENT",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 15,
+            "maxAlarmVal": 10
+          },
+          "compute": "0.274*@/1000"
+        },
+        {
+          "name": "12V_COME_POWER",
+          "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 200,
+            "maxAlarmVal": 180
+          },
+          "compute": "0.238*@/1000000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_IIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 9,
+                "maxAlarmVal": 8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_IIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 9,
+                "maxAlarmVal": 8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_IIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 9,
+                "maxAlarmVal": 8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_IIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 9,
+                "maxAlarmVal": 8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_IIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 9,
+                "maxAlarmVal": 8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SCM_12V_HSC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 60,
+                "maxAlarmVal": 55
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_VIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SCM_12V_HSC_PIN",
+              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 108,
+                "maxAlarmVal": 96
+              },
+              "compute": "@/1000000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 20
+        }
+      ]
     },
-    "SCM_CARD": {
-      "SCM_M2_SSD_TEMP": {
-        "path": "/run/devmap/sensors/SCM_M2_SSD_TEMP/temp1_input",
-        "compute": "@/1000.0",
-        "thresholds": {
-          "maxAlarmVal": 75,
-          "upperCriticalVal": 85
+    {
+      "slotPath": "/SMB_SLOT@0",
+      "pmUnitName": "MINIPACK3_SMB",
+      "sensors": [
+        {
+          "name": "SMB_LEFT_U51_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
+          "compute": "@/1000"
         },
-        "type": 3
-      },
-      "SCM_12V_HSC_IIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 9,
-          "maxAlarmVal": 8
+        {
+          "name": "SMB_OUTLET_U57_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95,
+            "maxAlarmVal": 90
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-        "type": 2
-      },
-      "SCM_12V_HSC_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "SMB_BEHIND_TH5_U39_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95,
+            "maxAlarmVal": 90
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-        "type": 1
-      },
-      "SCM_12V_HSC_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 108,
-          "maxAlarmVal": 96
+        {
+          "name": "SMB_RIGHT_U182_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-        "type": 0
-      },
-      "SCM_12V_HSC_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 60,
-          "maxAlarmVal": 55
+        {
+          "name": "XP3R3V_CLK",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in0_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-        "type": 3
-      },
-      "SCM_INLET_U36_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 60,
-          "maxAlarmVal": 55
+        {
+          "name": "XP0R9V_TH5_TSC_PLL_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.99,
+            "maxAlarmVal": 0.945,
+            "minAlarmVal": 0.855,
+            "lowerCriticalVal": 0.81
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_TSENSOR1/temp1_input",
-        "type": 3
-      },
-      "SCM_OUTLET_U37_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 65,
-          "maxAlarmVal": 60
+        {
+          "name": "XP1R8V_TH5",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.98,
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_TSENSOR2/temp1_input",
-        "type": 3
-      },
-      "XP1R5V_OOB_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.65,
-          "maxAlarmVal": 1.575,
-          "minAlarmVal": 1.425,
-          "lowerCriticalVal": 1.35
+        {
+          "name": "XP0R9V_TH5_TSC_PLL_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.99,
+            "maxAlarmVal": 0.945,
+            "minAlarmVal": 0.855,
+            "lowerCriticalVal": 0.81
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in0_input",
-        "type": 1
-      },
-      "XP3R3V_BMC_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
+        {
+          "name": "XP1R5V_TH5_VDDH",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.65,
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.425,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in1_input",
-        "type": 1
-      },
-      "XP3R3V_SSD_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
+        {
+          "name": "XP1R1V_DOM_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.21,
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in2_input",
-        "type": 1
-      },
-      "XP2R5V_OOB_VOLTAGE": {
-        "compute": "2*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.75,
-          "maxAlarmVal": 2.625,
-          "minAlarmVal": 2.375,
-          "lowerCriticalVal": 2.25
+        {
+          "name": "XP2R5V_DOM_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in6_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.75,
+            "maxAlarmVal": 2.635,
+            "minAlarmVal": 2.375,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in3_input",
-        "type": 1
-      },
-      "XP1R1V_OOB_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.21,
-          "maxAlarmVal": 1.155,
-          "minAlarmVal": 1.045,
-          "lowerCriticalVal": 0.99
+        {
+          "name": "XP3R3V",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in7_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(8/5)*@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in4_input",
-        "type": 1
-      },
-      "XP3R3V_I210_VOLTAGE": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
+        {
+          "name": "XP1R8V_CLK",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in0_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.98,
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.7955,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in5_input",
-        "type": 1
-      },
-      "XP12R0V_COME_VOLTAGE": {
-        "compute": "(100/9)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "name": "XP1R1V_DOM_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.21,
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.09725,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in6_input",
-        "type": 1
-      },
-      "XP5R0V_COME_VOLTAGE": {
-        "compute": "5.7*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 5.5,
-          "maxAlarmVal": 5.25,
-          "minAlarmVal": 4.75,
-          "lowerCriticalVal": 4.5
+        {
+          "name": "XP0R9V_TH5_TSC_PLL_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.99,
+            "maxAlarmVal": 0.945,
+            "minAlarmVal": 0.89775,
+            "lowerCriticalVal": 0.81
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR1/in7_input",
-        "type": 1
-      },
-      "12V_COME_VOLTAGE": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6
+        {
+          "name": "XP2R5V_DOM_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.75,
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.49375,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/in1_input",
-        "type": 1
-      },
-      "12V_COME_CURRENT": {
-        "compute": "(1000/3650)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 15,
-          "maxAlarmVal": 10
+        {
+          "name": "XP0R8V_TH5_VDDA",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.88,
+            "maxAlarmVal": 0.84,
+            "minAlarmVal": 0.798,
+            "lowerCriticalVal": 0.72
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/curr1_input",
-        "type": 2
-      },
-      "12V_COME_POWER": {
-        "compute": "(1000/3650)*@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 200,
-          "maxAlarmVal": 180
+        {
+          "name": "XP1R5V_TH5_ANLG",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.65,
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.49625,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000"
         },
-        "path": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/power1_input",
-        "type": 0
-      }
+        {
+          "name": "XP1R2V_TH5",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in6_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.32,
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.197,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "XP0R9V_TH5_TSC_PLL_3",
+          "sysfsPath": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in7_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.99,
+            "maxAlarmVal": 0.945,
+            "minAlarmVal": 0.89775,
+            "lowerCriticalVal": 0.81
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_TH5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105,
+            "maxAlarmVal": 102
+          },
+          "compute": "@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.811,
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "lowerCriticalVal": 0.679
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 750,
+                "maxAlarmVal": 675
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_VDDC_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_R_VRM1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+              "type": 2,
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 63
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 36,
+                "maxAlarmVal": 32.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.945,
+                "maxAlarmVal": 0.927,
+                "minAlarmVal": 0.873,
+                "lowerCriticalVal": 0.855
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.7875,
+                "maxAlarmVal": 0.7725,
+                "minAlarmVal": 0.7275,
+                "lowerCriticalVal": 0.7125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+              "type": 0,
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V9_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 63,
+                "maxAlarmVal": 56.7
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_L_VRM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 27,
+                "maxAlarmVal": 24.3
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 20
+        }
+      ]
     },
-    "SMB_CARD": {
-      "SMB_LEFT_U51_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 85,
-          "maxAlarmVal": 80
+    {
+      "slotPath": "/SMB_SLOT@0/OPTICL_SLOT@0",
+      "pmUnitName": "3_V_3_L_CARD",
+      "sensors": [
+        {
+          "name": "3V3_L_U8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR5/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
+          "compute": "@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR1/temp1_input",
-        "type": 3
-      },
-      "SMB_OUTLET_U57_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 95,
-          "maxAlarmVal": 90
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR2/temp1_input",
-        "type": 3
-      },
-      "SMB_BEHIND_TH5_U39_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 95,
-          "maxAlarmVal": 90
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR3/temp1_input",
-        "type": 3
-      },
-      "SMB_RIGHT_U182_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 85,
-          "maxAlarmVal": 80
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR4/temp1_input",
-        "type": 3
-      },
-      "XP3R3V_CLK": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in0_input",
-        "type": 1
-      },
-      "XP0R9V_TH5_TSC_PLL_0": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.99,
-          "maxAlarmVal": 0.945,
-          "minAlarmVal": 0.855,
-          "lowerCriticalVal": 0.81
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in1_input",
-        "type": 1
-      },
-      "XP1R8V_TH5": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.98,
-          "maxAlarmVal": 1.89,
-          "minAlarmVal": 1.71,
-          "lowerCriticalVal": 1.62
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in2_input",
-        "type": 1
-      },
-      "XP0R9V_TH5_TSC_PLL_1": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.99,
-          "maxAlarmVal": 0.945,
-          "minAlarmVal": 0.855,
-          "lowerCriticalVal": 0.81
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in3_input",
-        "type": 1
-      },
-      "XP1R5V_TH5_VDDH": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.65,
-          "maxAlarmVal": 1.575,
-          "minAlarmVal": 1.425,
-          "lowerCriticalVal": 1.35
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in4_input",
-        "type": 1
-      },
-      "XP1R1V_DOM_1": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.21,
-          "maxAlarmVal": 1.155,
-          "minAlarmVal": 1.045,
-          "lowerCriticalVal": 0.99
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in5_input",
-        "type": 1
-      },
-      "XP2R5V_DOM_1": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.75,
-          "maxAlarmVal": 2.635,
-          "minAlarmVal": 2.375,
-          "lowerCriticalVal": 2.25
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in6_input",
-        "type": 1
-      },
-      "XP3R3V": {
-        "compute": "(8/5)*@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1/in7_input",
-        "type": 1
-      },
-      "XP1R8V_CLK": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.98,
-          "maxAlarmVal": 1.89,
-          "minAlarmVal": 1.7955,
-          "lowerCriticalVal": 1.62
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in0_input",
-        "type": 1
-      },
-      "XP1R1V_DOM_2": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.21,
-          "maxAlarmVal": 1.155,
-          "minAlarmVal": 1.09725,
-          "lowerCriticalVal": 0.99
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in1_input",
-        "type": 1
-      },
-      "XP0R9V_TH5_TSC_PLL_2": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.99,
-          "maxAlarmVal": 0.945,
-          "minAlarmVal": 0.89775,
-          "lowerCriticalVal": 0.81
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in2_input",
-        "type": 1
-      },
-      "XP2R5V_DOM_2": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 2.75,
-          "maxAlarmVal": 2.625,
-          "minAlarmVal": 2.49375,
-          "lowerCriticalVal": 2.25
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in3_input",
-        "type": 1
-      },
-      "XP0R8V_TH5_VDDA": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.88,
-          "maxAlarmVal": 0.84,
-          "minAlarmVal": 0.798,
-          "lowerCriticalVal": 0.72
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in4_input",
-        "type": 1
-      },
-      "XP1R5V_TH5_ANLG": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.65,
-          "maxAlarmVal": 1.575,
-          "minAlarmVal": 1.49625,
-          "lowerCriticalVal": 1.35
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in5_input",
-        "type": 1
-      },
-      "XP1R2V_TH5": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 1.32,
-          "maxAlarmVal": 1.26,
-          "minAlarmVal": 1.197,
-          "lowerCriticalVal": 1.08
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in6_input",
-        "type": 1
-      },
-      "XP0R9V_TH5_TSC_PLL_3": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.99,
-          "maxAlarmVal": 0.945,
-          "minAlarmVal": 0.89775,
-          "lowerCriticalVal": 0.81
-        },
-        "path": "/run/devmap/sensors/SMB_VOLTAGE_MONITOR2/in7_input",
-        "type": 1
-      },
-      "SMB_VDDC_VRM_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 827,
-          "maxAlarmVal": 661.6
-        },
-        "path": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-        "type": 2
-      },
-      "SMB_VDDC_VRM_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
-        },
-        "path": "/run/devmap/sensors/SMB_VRM1/in1_input",
-        "type": 1
-      },
-      "SMB_VDDC_VRM_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.811,
-          "maxAlarmVal": 0.8,
-          "minAlarmVal": 0.7,
-          "lowerCriticalVal": 0.679
-        },
-        "path": "/run/devmap/sensors/SMB_VRM1/in2_input",
-        "type": 1
-      },
-      "SMB_VDDC_VRM_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/SMB_VRM1/power1_input",
-        "type": 0
-      },
-      "SMB_VDDC_VRM_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 750,
-          "maxAlarmVal": 675
-        },
-        "path": "/run/devmap/sensors/SMB_VRM1/power2_input",
-        "type": 0
-      },
-      "SMB_VDDC_VRM1_TEMP": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-        "type": 3
-      },
-      "SMB_0V75_0V9_R_VRM1_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/SMB_VRM2/curr1_input",
-        "type": 2
-      },
-      "SMB_0V9_R_VRM1_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 70,
-          "maxAlarmVal": 63
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-        "type": 2
-      },
-      "SMB_0V75_0V9_R_VRM1_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/in1_input",
-        "type": 1
-      },
-      "SMB_0V9_R_VRM1_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.945,
-          "maxAlarmVal": 0.927,
-          "minAlarmVal": 0.873,
-          "lowerCriticalVal": 0.855
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/in2_input",
-        "type": 1
-      },
-      "SMB_0V75_R_VRM1_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.7875,
-          "maxAlarmVal": 0.7725,
-          "minAlarmVal": 0.7275,
-          "lowerCriticalVal": 0.7125
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/in3_input",
-        "type": 1
-      },
-      "SMB_0V75_0V9_R_VRM1_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/SMB_VRM2/power1_input",
-        "type": 0
-      },
-      "SMB_0V9_R_VRM1_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 63,
-          "maxAlarmVal": 56.7
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/power2_input",
-        "type": 0
-      },
-      "SMB_0V75_R_VRM1_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 27,
-          "maxAlarmVal": 24.3
-        },
-        "path": "/run/devmap/sensors/SMB_VRM2/power3_input",
-        "type": 0
-      },
-      "SMB_0V75_0V9_R_VRM1_TEMP": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-        "type": 3
-      },
-      "SMB_0V75_0V9_L_VRM0_IIN": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-        "type": 2
-      },
-      "SMB_0V9_L_VRM0_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 70,
-          "maxAlarmVal": 63
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-        "type": 2
-      },
-      "SMB_0V75_0V9_L_VRM0_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/in1_input",
-        "type": 1
-      },
-      "SMB_0V9_L_VRM0_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.945,
-          "maxAlarmVal": 0.927,
-          "minAlarmVal": 0.873,
-          "lowerCriticalVal": 0.855
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/in2_input",
-        "type": 1
-      },
-      "SMB_0V75_L_VRM0_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 0.7875,
-          "maxAlarmVal": 0.7725,
-          "minAlarmVal": 0.7275,
-          "lowerCriticalVal": 0.7125
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/in3_input",
-        "type": 1
-      },
-      "SMB_0V75_0V9_L_VRM0_PIN": {
-        "compute": "@/1000000",
-        "path": "/run/devmap/sensors/SMB_VRM3/power1_input",
-        "type": 0
-      },
-      "SMB_0V9_L_VRM0_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 63,
-          "maxAlarmVal": 56.7
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/power2_input",
-        "type": 0
-      },
-      "SMB_0V75_L_VRM0_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 27,
-          "maxAlarmVal": 24.3
-        },
-        "path": "/run/devmap/sensors/SMB_VRM3/power3_input",
-        "type": 0
-      },
-      "SMB_0V75_0V9_L_VRM0_TEMP": {
-        "compute": "@/1000",
-        "path": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-        "type": 3
-      },
-      "SMB_TH5_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 105,
-          "maxAlarmVal": 102
-        },
-        "path": "/run/devmap/sensors/SMB_CPLD/temp1_input",
-        "type": 3
-      }
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 20
+        }
+      ]
     },
-    "3V3_L_CARD": {
-      "3V3_L_U8_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 85,
-          "maxAlarmVal": 80
+    {
+      "slotPath": "/SMB_SLOT@0/OPTICR_SLOT@0",
+      "pmUnitName": "3_V_3_R_CARD",
+      "sensors": [
+        {
+          "name": "3V3_R_U8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
+          "compute": "@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR5/temp1_input",
-        "type": 3
-      },
-      "3V3_L_VRM_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 250,
-          "maxAlarmVal": 214
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-        "type": 2
-      },
-      "3V3_L_VRM_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-        "type": 1
-      },
-      "3V3_L_VRM_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-        "type": 1
-      },
-      "3V3_L_VRM_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 887,
-          "maxAlarmVal": 760
+        {
+          "sensors": [
+            {
+              "name": "3V3_L_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_L_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_L_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 10
         },
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-        "type": 0
-      },
-      "3V3_L_VRM_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 825,
-          "maxAlarmVal": 706.2
+        {
+          "sensors": [
+            {
+              "name": "3V3_R_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-        "type": 0
-      },
-      "3V3_L_VRM_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {},
-        "path": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-        "type": 3
-      }
-    },
-    "3V3_R_CARD": {
-      "3V3_R_U8_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 85,
-          "maxAlarmVal": 80
+        {
+          "sensors": [
+            {
+              "name": "3V3_R_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/SMB_TSENSOR6/temp1_input",
-        "type": 3
-      },
-      "3V3_R_VRM_IOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 250,
-          "maxAlarmVal": 214
+        {
+          "sensors": [
+            {
+              "name": "3V3_R_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-        "type": 2
-      },
-      "3V3_R_VRM_VIN": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 13.2,
-          "maxAlarmVal": 12.6,
-          "minAlarmVal": 11.4,
-          "lowerCriticalVal": 10.8
+        {
+          "sensors": [
+            {
+              "name": "3V3_R_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 20
         },
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-        "type": 1
-      },
-      "3V3_R_VRM_VOUT": {
-        "compute": "@/1000",
-        "thresholds": {
-          "upperCriticalVal": 3.63,
-          "maxAlarmVal": 3.465,
-          "minAlarmVal": 3.135,
-          "lowerCriticalVal": 2.97
-        },
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-        "type": 1
-      },
-      "3V3_R_VRM_PIN": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 887,
-          "maxAlarmVal": 760
-        },
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-        "type": 0
-      },
-      "3V3_R_VRM_POUT": {
-        "compute": "@/1000000",
-        "thresholds": {
-          "upperCriticalVal": 825,
-          "maxAlarmVal": 706.2
-        },
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-        "type": 0
-      },
-      "3V3_R_VRM_TEMP": {
-        "compute": "@/1000",
-        "thresholds": {},
-        "path": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-        "type": 3
-      }
+        {
+          "sensors": [
+            {
+              "name": "3V3_R_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 250,
+                "maxAlarmVal": 214
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 13.2,
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_VOUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "3V3_R_VRM_PIN",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 887,
+                "maxAlarmVal": 760
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_POUT",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 825,
+                "maxAlarmVal": 706.2
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "3V3_R_VRM_TEMP",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+              "type": 3,
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 20
+        }
+      ]
     }
-  }
+  ]
 }

--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -597,244 +597,285 @@
     {
       "slotPath": "/SCM_SLOT@0/COMESE_SLOT@0",
       "pmUnitName": "NETLAKE",
+      "sensors": [
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.4,
+            "lowerCriticalVal": 0.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 13
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.46,
+            "lowerCriticalVal": 0.66
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 20
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.605,
+            "lowerCriticalVal": 0.805
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 150,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
+          "type": 0,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 20
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.4,
+            "lowerCriticalVal": 0.6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 150,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
+          "type": 0,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 20
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15,
+            "maxAlarmVal": 14,
+            "minAlarmVal": 9
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115,
+            "maxAlarmVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 1024
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 15,
+            "maxAlarmVal": 12
+          },
+          "compute": "@/1000"
+        }
+      ],
       "versionedSensors": [
         {
           "sensors": [
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 13
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.46,
-                "lowerCriticalVal": 0.66
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.605,
-                "lowerCriticalVal": 0.805
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 150,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
-              "type": 0,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 150,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
-              "type": 0,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9
-              },
-              "compute": "@/1000"
-            },
             {
               "name": "COMe_PU4_XDPE15284_P1V8_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
@@ -869,35 +910,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "COMe_PU4_XDPE15284_P1V8_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
               "type": 0,
@@ -923,16 +935,6 @@
                 "maxAlarmVal": 125
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 12
-              },
-              "compute": "@/1000"
             },
             {
               "name": "COMe_PU4_XDPE15284_P1V8_IIN",
@@ -972,241 +974,6 @@
         {
           "sensors": [
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 13
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.46,
-                "lowerCriticalVal": 0.66
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.605,
-                "lowerCriticalVal": 0.805
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 150,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
-              "type": 0,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 150,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
-              "type": 0,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 20
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9
-              },
-              "compute": "@/1000"
-            },
-            {
               "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
               "type": 1,
@@ -1229,35 +996,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 100
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
               "type": 0,
@@ -1276,17 +1014,7 @@
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 12
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
               "type": 2,
               "thresholds": {
@@ -1296,7 +1024,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
               "type": 2,
               "thresholds": {
@@ -1771,6 +1499,38 @@
             "maxAlarmVal": 180
           },
           "compute": "0.238*@/1000000"
+        },
+        {
+          "name": "SCM_12V_HSC_PIN",
+          "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 108,
+            "maxAlarmVal": 96
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SCM_12V_HSC_VIN",
+          "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SCM_12V_HSC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 60,
+            "maxAlarmVal": 55
+          },
+          "compute": "@/1000"
         }
       ],
       "versionedSensors": [
@@ -1785,38 +1545,6 @@
                 "maxAlarmVal": 8
               },
               "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -1832,38 +1560,6 @@
               "thresholds": {
                 "upperCriticalVal": 9,
                 "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
               },
               "compute": "@/1000"
             }
@@ -1883,38 +1579,6 @@
                 "maxAlarmVal": 8
               },
               "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -1930,38 +1594,6 @@
               "thresholds": {
                 "upperCriticalVal": 9,
                 "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
               },
               "compute": "@/1000"
             }
@@ -1981,238 +1613,11 @@
                 "maxAlarmVal": 8
               },
               "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
           "productVersion": 4,
           "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 60,
-                "maxAlarmVal": 55
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_VIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SCM_12V_HSC_PIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 108,
-                "maxAlarmVal": 96
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 20
         }
       ]
     },
@@ -2461,51 +1866,110 @@
             "maxAlarmVal": 102
           },
           "compute": "@/1000"
+        },
+        {
+          "name": "SMB_VDDC_VRM_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_VDDC_VRM_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_VDDC_VRM_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.811,
+            "maxAlarmVal": 0.8,
+            "minAlarmVal": 0.7,
+            "lowerCriticalVal": 0.679
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_VDDC_VRM_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_R_VRM1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_0V75_0V9_R_VRM1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_R_VRM1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_R_VRM1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_L_VRM0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_0V75_0V9_L_VRM0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_L_VRM0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V75_0V9_L_VRM0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
         }
       ],
       "versionedSensors": [
         {
           "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
             {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
@@ -2517,15 +1981,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -2545,18 +2007,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -2585,12 +2035,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
               "type": 0,
@@ -2611,18 +2055,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
               "type": 2,
@@ -2639,18 +2071,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -2679,12 +2099,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
               "type": 0,
@@ -2703,12 +2117,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -2718,46 +2126,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
               "type": 0,
@@ -2768,15 +2136,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -2796,18 +2162,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -2836,12 +2190,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
               "type": 0,
@@ -2862,18 +2210,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
               "type": 2,
@@ -2890,18 +2226,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -2930,12 +2254,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
               "type": 0,
@@ -2954,12 +2272,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -2969,46 +2281,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
               "type": 0,
@@ -3019,15 +2291,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -3047,18 +2317,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3087,12 +2345,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
               "type": 0,
@@ -3113,18 +2365,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
               "type": 2,
@@ -3141,18 +2381,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3181,12 +2409,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
               "type": 0,
@@ -3205,12 +2427,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -3220,46 +2436,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
               "type": 0,
@@ -3270,15 +2446,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -3298,18 +2472,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3338,12 +2500,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
               "type": 0,
@@ -3364,18 +2520,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
               "type": 2,
@@ -3392,18 +2536,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3432,12 +2564,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
               "type": 0,
@@ -3456,12 +2582,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -3471,46 +2591,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
               "type": 0,
@@ -3521,15 +2601,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -3549,18 +2627,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3589,12 +2655,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
               "type": 0,
@@ -3615,18 +2675,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
               "type": 2,
@@ -3643,18 +2691,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3683,12 +2719,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
               "type": 0,
@@ -3707,12 +2737,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -3722,46 +2746,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
               "type": 0,
@@ -3772,15 +2756,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -3800,18 +2782,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3840,12 +2810,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
               "type": 0,
@@ -3866,18 +2830,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
               "type": 2,
@@ -3894,18 +2846,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -3934,12 +2874,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
               "type": 0,
@@ -3958,12 +2892,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -3973,46 +2901,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
               "type": 0,
@@ -4023,15 +2911,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -4051,18 +2937,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4091,12 +2965,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
               "type": 0,
@@ -4117,18 +2985,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
               "type": 2,
@@ -4145,18 +3001,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4185,12 +3029,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
               "type": 0,
@@ -4209,12 +3047,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -4224,46 +3056,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
               "type": 0,
@@ -4274,15 +3066,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -4302,18 +3092,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4342,12 +3120,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
               "type": 0,
@@ -4368,18 +3140,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
               "type": 2,
@@ -4396,18 +3156,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4436,12 +3184,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
               "type": 0,
@@ -4460,12 +3202,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -4475,46 +3211,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
               "type": 0,
@@ -4525,15 +3221,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -4553,18 +3247,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4593,12 +3275,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
               "type": 0,
@@ -4619,18 +3295,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
               "type": 2,
@@ -4647,18 +3311,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4687,12 +3339,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
               "type": 0,
@@ -4711,12 +3357,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -4726,46 +3366,6 @@
         {
           "sensors": [
             {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.811,
-                "maxAlarmVal": 0.8,
-                "minAlarmVal": 0.7,
-                "lowerCriticalVal": 0.679
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_VDDC_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
               "type": 0,
@@ -4776,15 +3376,13 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_VDDC_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
+              "name": "SMB_VDDC_VRM_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
               "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 827,
+                "maxAlarmVal": 661.6
+              },
               "compute": "@/1000"
             },
             {
@@ -4804,18 +3402,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_R_VRM1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4844,12 +3430,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_R_VRM1_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
               "type": 0,
@@ -4870,18 +3450,6 @@
               "compute": "@/1000000"
             },
             {
-              "name": "SMB_0V75_0V9_R_VRM1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
-              "type": 2,
-              "compute": "@/1000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_IOUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
               "type": 2,
@@ -4898,18 +3466,6 @@
               "thresholds": {
                 "upperCriticalVal": 36,
                 "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
               },
               "compute": "@/1000"
             },
@@ -4938,12 +3494,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_0V75_0V9_L_VRM0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
-              "type": 0,
-              "compute": "@/1000000"
-            },
-            {
               "name": "SMB_0V9_L_VRM0_POUT",
               "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
               "type": 0,
@@ -4962,12 +3512,6 @@
                 "maxAlarmVal": 24.3
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_0V9_L_VRM0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -4989,6 +3533,46 @@
             "maxAlarmVal": 80
           },
           "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_PIN",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 887,
+            "maxAlarmVal": 760
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "3V3_L_VRM_VIN",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_VOUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_TEMP",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
         }
       ],
       "versionedSensors": [
@@ -5005,54 +3589,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5072,54 +3616,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5139,54 +3643,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5206,54 +3670,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5273,54 +3697,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5340,40 +3724,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
               "type": 0,
@@ -5382,12 +3732,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5407,40 +3751,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
               "type": 0,
@@ -5449,12 +3759,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5474,40 +3778,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
               "type": 0,
@@ -5516,12 +3786,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5541,40 +3805,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
               "type": 0,
@@ -5583,12 +3813,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5608,40 +3832,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
               "type": 0,
@@ -5650,12 +3840,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5677,6 +3861,46 @@
             "maxAlarmVal": 80
           },
           "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_PIN",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 887,
+            "maxAlarmVal": 760
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "3V3_L_VRM_VIN",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_VOUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.63,
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "3V3_L_VRM_TEMP",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
         }
       ],
       "versionedSensors": [
@@ -5693,54 +3917,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5760,54 +3944,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5827,54 +3971,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5894,54 +3998,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -5961,54 +4025,14 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_L_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_L_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
                 "upperCriticalVal": 825,
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_L_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -6028,40 +4052,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_R_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
               "type": 0,
@@ -6070,12 +4060,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_R_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -6095,40 +4079,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_R_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
               "type": 0,
@@ -6137,12 +4087,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_R_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -6162,40 +4106,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_R_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
               "type": 0,
@@ -6204,12 +4114,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_R_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -6229,40 +4133,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_R_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
               "type": 0,
@@ -6271,12 +4141,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_R_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,
@@ -6296,40 +4160,6 @@
               "compute": "@/1000"
             },
             {
-              "name": "3V3_R_VRM_VIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 13.2,
-                "maxAlarmVal": 12.6,
-                "minAlarmVal": 11.4,
-                "lowerCriticalVal": 10.8
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_VOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "3V3_R_VRM_PIN",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 887,
-                "maxAlarmVal": 760
-              },
-              "compute": "@/1000000"
-            },
-            {
               "name": "3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
               "type": 0,
@@ -6338,12 +4168,6 @@
                 "maxAlarmVal": 706.2
               },
               "compute": "@/1000000"
-            },
-            {
-              "name": "3V3_R_VRM_TEMP",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
-              "type": 3,
-              "compute": "@/1000"
             }
           ],
           "productProductionState": 2,


### PR DESCRIPTION
**Description**
Updated the sensors service config to support 2nd source in fboss with latest source code with the latest platform manager config file: https://github.com/facebook/fboss/pull/216 

There lint issue with below detial info:
![image](https://github.com/user-attachments/assets/2cef6f10-09f9-4502-8b9f-5d5d31db5162)


**Motivation**
Added 2nd source config with two interchangeable chips based on the field "versionedSensors".
![image](https://github.com/user-attachments/assets/b36322d8-fd99-48ff-b59d-57f730e7a206)
Montblanc sensor config lists:
https://docs.google.com/spreadsheets/d/1V_JFLw2m0Zu1DUgVeVPKSGsQrPkRYgCh/edit?gid=1703809973#gid=1703809973 

Removed the V2 folder to ensure compatibility with the second source using a single configuration file.

**Test Plan**

- Use the jq command to format the JSON file for improved readability.
- build the latest fboss bsp kmod.
- build the latest fboss platform manager binary.
- Run the platform manager with the changed config files on DVT and 2nd source DVT device normally: LD_LIBRARY_PATH=./fboss_lib/ ./platform_manager --config_file platform_manager.json --run_once=false --noenable_pkg_mgmnt
- Run sensor_service with the new config file: LD_LIBRARY_PATH=./fboss_lib/ ./sensor_service --config_file sensor_service.json

Current tested the new config file on two tpye board normal.
[montblanc_sensor_config_MP_test_log_20240924.txt](https://github.com/user-attachments/files/17112137/montblanc_sensor_config_MP_test_log_20240924.txt)
[montblanc_sensor_config_IFX_test_log_20240924.txt](https://github.com/user-attachments/files/17112138/montblanc_sensor_config_IFX_test_log_20240924.txt)
