### PR TITLE
Added HW test suites to be compile in the hourly build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -795,5 +795,8 @@ if (GITHUB_ACTIONS_BUILD)
     sensor_service_utils_tests
     rackmon_test
     fan_service_sw_test
+    data_corral_service_hw_test
+    fan_service_hw_test
+    sensor_service_hw_test
   )
 endif()


### PR DESCRIPTION
# Description 

"Build & Test Platform Services" hourly build doesn't include the following FBOSS HW test suites, PR is raised to include these also:
1. `data_corral_service_hw_test`
2. `fan_service_hw_test`
3. `sensor_service_hw_test`

# Motivation
Aim is to generate all the FBOSS binaries using a common build environment to avoid any issue arising due to the build environment difference.

# Testing

Compiled the FBOSS binaries using the following command which is taken from the `platform-services.yml`
https://github.com/facebook/fboss/blob/main/.github/workflows/platform-services.yml#L23-L32 :
```
./fboss/oss/scripts/docker-build.py --scratch-path build-output --target github_actions_fboss_platform_services --no-docker-output --no-system-deps --env-var GITHUB_ACTIONS_BUILD
```

Compiled binaries are available in the scratch path folder `build-output`:
```
[ggarg@AZUHPS25 fboss]$ ls -lh build-output/build/fboss/*hw_test
-rwxr-xr-x. 1 root root 72M Sep 24 05:17 build-output/build/fboss/data_corral_service_hw_test
-rwxr-xr-x. 1 root root 85M Sep 24 05:16 build-output/build/fboss/fan_service_hw_test
-rwxr-xr-x. 1 root root 89M Sep 24 05:16 build-output/build/fboss/sensor_service_hw_test
[ggarg@AZUHPS25 fboss]$
```
