### PR TITLE
meru800bfa: Use lm75 driver for tmp75 devices

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -4446,7 +4446,7 @@
     "/run/devmap/sensors/PSU4_PMBUS": "/SMB_SLOT@0/PSU_SLOT@3/[PSU_PMBUS]"
   },
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.3-1",
+  "bspKmodsRpmVersion": "0.7.4-1",
   "bspKmodsToReload": [
     "scd-xcvr",
     "scd-spi",

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -134,7 +134,7 @@
         {
           "busName": "INCOMING@0",
           "address": "0x48",
-          "kernelDeviceName": "tmp75",
+          "kernelDeviceName": "lm75",
           "pmUnitScopedName": "SMB_TMP75"
         },
         {
@@ -206,7 +206,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x48",
-          "kernelDeviceName": "tmp75",
+          "kernelDeviceName": "lm75",
           "pmUnitScopedName": "FAN0_TMP75"
         },
         {
@@ -218,7 +218,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x49",
-          "kernelDeviceName": "tmp75",
+          "kernelDeviceName": "lm75",
           "pmUnitScopedName": "FAN1_TMP75"
         },
         {
@@ -230,7 +230,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x4a",
-          "kernelDeviceName": "tmp75",
+          "kernelDeviceName": "lm75",
           "pmUnitScopedName": "FAN2_TMP75"
         },
         {
@@ -4446,7 +4446,7 @@
     "/run/devmap/sensors/PSU4_PMBUS": "/SMB_SLOT@0/PSU_SLOT@3/[PSU_PMBUS]"
   },
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.4-1",
+  "bspKmodsRpmVersion": "0.7.3-1",
   "bspKmodsToReload": [
     "scd-xcvr",
     "scd-spi",


### PR DESCRIPTION
# Description
Meru800BFA now uses the lm75 driver instead of tmp75. The tmp75 driver is not compatible with some of the parts sourced from some vendors which can cause unexpected behavior. The lm75 is a more general driver and avoids any part specific configurations.

Similar changes were added to Meru800bia in #208 

# Test
sensor_service
```
========================================================
Processed 147 Sensors. 0 Failures.
Using thread manager (resource pools not enabled) on address/port 5970: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
Processed 147 Sensors. 0 Failures.
Processed 147 Sensors. 0 Failures.
Processed 147 Sensors. 0 Failures.
```
