### PR TITLE
Change package-fboss.py to use system tar with zstd

### DIFF
--- a/.github/workflows/platform-services.yml
+++ b/.github/workflows/platform-services.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fboss
-          path: ${{ github.workspace }}/build-output/fboss_bins.tar.gz
+          path: ${{ github.workspace }}/build-output/fboss_bins.tar.zst
           # Explicitly set the retention at the object level
           retention-days: 14
   Platform-Services-Test:
@@ -59,4 +59,4 @@ jobs:
         run: >
           sudo
           ./fboss/oss/scripts/github_actions/docker-unittest.py
-          ${{ github.workspace }}/fboss_bins.tar.gz
+          ${{ github.workspace }}/fboss_bins.tar.zst

--- a/.github/workflows/qsfp-build.yml
+++ b/.github/workflows/qsfp-build.yml
@@ -38,6 +38,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fboss
-          path: ${{ github.workspace }}/build-output/fboss_bins.tar.gz
+          path: ${{ github.workspace }}/build-output/fboss_bins.tar.zst
           # Explicitly set the retention at the object level
           retention-days: 14

--- a/fboss/oss/scripts/github_actions/docker-unittest.py
+++ b/fboss/oss/scripts/github_actions/docker-unittest.py
@@ -49,7 +49,7 @@ def build_docker_image(docker_dir_path: str):
 def unpack_tarball(tarball_path: str) -> str:
     output_dir = tempfile.mkdtemp()
     print(f"Unpacking tarball to {output_dir}")
-    shutil.unpack_archive(tarball_path, output_dir, "gztar")
+    subprocess.run(["tar", "-xvf", tarball_path, "-C", output_dir])
     return output_dir
 
 

--- a/fboss/oss/scripts/package-fboss.py
+++ b/fboss/oss/scripts/package-fboss.py
@@ -32,7 +32,7 @@ def parse_args():
 
 class PackageFboss:
     FBOSS_BINS = "fboss_bins-1"
-    FBOSS_BIN_TAR_BASE_NAME = "fboss_bins"
+    FBOSS_BIN_TAR = "fboss_bins.tar.zst"
     FBOSS = "fboss"
 
     BIN = "bin"
@@ -225,9 +225,12 @@ class PackageFboss:
 
     def _compress_binaries(self):
         print("Compressing FBOSS Binaries...")
-        tar_path = os.path.join(args.scratch_path, PackageFboss.FBOSS_BIN_TAR_BASE_NAME)
+        tar_path = os.path.join(args.scratch_path, PackageFboss.FBOSS_BIN_TAR)
         compressed_file = shutil.make_archive(tar_path, "gztar", self.tmp_dir_name)
-        print(f"Compressed to {tar_path}: {compressed_file}")
+        subprocess.run(
+            ["tar", "-cvf", tar_path, "--zstd", "-C", self.tmp_dir_name, "."]
+        )
+        print(f"Compressed to {tar_path}")
 
     def run(self, args):
         self._copy_binaries(self.tmp_dir_name)


### PR DESCRIPTION
Summary:
The pythonic method of creating archives is incredibly slow compared to GNU tar. Going back to using GNU tar improves packaging time by >70%, and changing to use zstd as the compression method further improves this. Some benchmarks are listed below:

```
# Before
Compressed to /var/FBOSS/tmp_bld_dir/fboss_bins: /var/FBOSS/tmp_bld_dir/fboss_bins.tar.gz
real    26m9.177s
user    25m46.934s
sys     0m16.649s

# After (with zstd)
Compressed to /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst: /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst
real    0m51.466s
user    0m46.463s
sys     0m27.720s
[root@2e9a1903117b fboss]# ls -alh /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst
-rw-r--r-- 1 root root 2.7G Oct  3 17:44 /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst

# After (with gzip)
Compressed to /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst: /var/FBOSS/tmp_bld_dir/fboss_bins.tar.zst
real    7m8.505s
user    6m51.396s
sys     0m21.459s
[root@2e9a1903117b fboss]# ls -alh /var/FBOSS/tmp_bld_dir/fboss_bins.tar.gz
-rw-r--r-- 1 root root 3.3G Oct  3 17:42 /var/FBOSS/tmp_bld_dir/fboss_bins.tar.gz
``` 

It's worth noting that zstd improves on both compression speed and ratio.

Differential Revision: D63846303


