### PR TITLE
led_service: add DARWIN48V platform support

### DIFF
--- a/fboss/led_service/LedManagerInit.cpp
+++ b/fboss/led_service/LedManagerInit.cpp
@@ -36,7 +36,9 @@ std::unique_ptr<LedManager> createLedManager() {
     return std::make_unique<YampLedManager>();
   } else if (mode == PlatformType::PLATFORM_ELBERT) {
     return std::make_unique<ElbertLedManager>();
-  } else if (mode == PlatformType::PLATFORM_DARWIN) {
+  } else if (
+      mode == PlatformType::PLATFORM_DARWIN ||
+      mode == PlatformType::PLATFORM_DARWIN48V) {
     return std::make_unique<DarwinLedManager>();
   } else if (mode == PlatformType::PLATFORM_WEDGE400) {
     return std::make_unique<Wedge400LedManager>();

--- a/fboss/platform/configs/darwin48v/led_manager.json
+++ b/fboss/platform/configs/darwin48v/led_manager.json
@@ -46,6 +46,11 @@
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_present"
     },
     {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present"
+    },
+    {
       "fruName": "PSU1",
       "fruType": "PSU",
       "presenceSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_present"

--- a/fboss/platform/configs/darwin48v/led_manager.json
+++ b/fboss/platform/configs/darwin48v/led_manager.json
@@ -1,0 +1,54 @@
+{
+  "systemLedConfig": {
+    "presentLedColor": 1,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
+    "absentLedColor": 2,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
+    },
+    "PSU": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_present"
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_present"
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_present"
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_present"
+    },
+    {
+      "fruName": "FAN5",
+      "fruType": "FAN",
+      "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_present"
+    },
+    {
+      "fruName": "PSU1",
+      "fruType": "PSU",
+      "presenceSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_present"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds initial `led_service` support for `DARWIN48V` platform.

Note that this depends on the changes in #257.

# Test Plan

FBOSS OSS build passes with CentOS 9 and Linux kernel 6.4.

Validated on DARWIN48V hardware.

`data_corral_service` loads correctly:
```
# systemctl status data_corral_service
● data_corral_service.service - Start data_corral_service
     Loaded: loaded (/etc/systemd/system/data_corral_service.service; enabled; preset: disabled)
     Active: active (running) since Tue 2024-10-08 00:39:22 UTC; 2h 9min ago
   Main PID: 4893 (run_data_corral)
      Tasks: 34 (limit: 200901)
     Memory: 4.5M
        CPU: 773ms
     CGroup: /system.slice/data_corral_service.service
             ├─4893 /bin/bash /opt/fboss/bin/run_data_corral_service.sh
             └─4895 /opt/fboss/bin/data_corral_service -config_file /opt/fboss/share/platform_configs/led_manager.json
```
LEDs are initialized correctly:
```
I1008 02:54:29.428475  5242 PlatformNameLib.cpp:71] Platform name read from cache: DARWIN48V
I1008 02:54:29.428544  5242 ConfigLib.cpp:48] Using config file: /opt/fboss/share/platform_configs/led_manager.json
I1008 02:54:29.428772  5243 FruPresenceExplorer.cpp:25] Detecting presence of FRUs
I1008 02:54:29.429607  5242 ThriftServer.cpp:836] Using thread manager (resource pools not enabled) on address/port 5971: runtime: thriftFlagNotSet, >
I1008 02:54:29.429641  5243 FruPresenceExplorer.cpp:40] Detected that FAN1 is present
I1008 02:54:29.430628  5243 FruPresenceExplorer.cpp:40] Detected that FAN2 is present
I1008 02:54:29.431602  5243 FruPresenceExplorer.cpp:40] Detected that FAN3 is present
I1008 02:54:29.432599  5243 FruPresenceExplorer.cpp:40] Detected that FAN4 is present
I1008 02:54:29.433598  5243 FruPresenceExplorer.cpp:40] Detected that FAN5 is present
I1008 02:54:29.433636  5243 FruPresenceExplorer.cpp:40] Detected that FAN6 is present
I1008 02:54:29.433667  5243 FruPresenceExplorer.cpp:40] Detected that PSU1 is present
I1008 02:54:29.433696  5243 LedManager.cpp:45] Programming PSU LED with true
I1008 02:54:29.433760  5243 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I1008 02:54:29.433803  5243 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I1008 02:54:29.433817  5243 LedManager.cpp:55] Programmed PSU LED with presence true
I1008 02:54:29.433829  5243 LedManager.cpp:45] Programming FAN LED with true
I1008 02:54:29.433868  5243 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I1008 02:54:29.433908  5243 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I1008 02:54:29.433921  5243 LedManager.cpp:55] Programmed FAN LED with presence true
I1008 02:54:29.433931  5243 LedManager.cpp:25] Programming system LED with true
I1008 02:54:29.433967  5243 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I1008 02:54:29.434007  5243 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I1008 02:54:29.434019  5243 LedManager.cpp:34] Programmed system LED with true
```
