### PR TITLE
DARWIN: add initial platform_manager.json config

### DIFF
--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -435,7 +435,7 @@
     "/run/devmap/sensors/PEM_TEMP_MAX6658": "/PEM_SLOT@0/[PEM_TEMP_MAX6658]"
   },
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.3-1",
+  "bspKmodsRpmVersion": "0.7.4-1",
   "bspKmodsToReload": [
     "scd",
     "scd-leds",

--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -312,6 +312,10 @@
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
           "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        },
+        {
+          "pmUnitScopedName": "PCH_THERMAL",
+          "sysfsPath": "/sys/devices/virtual/thermal/thermal_zone0"
         }
       ]
     },
@@ -425,6 +429,7 @@
     "/run/devmap/sensors/SC_TH3_ANLG_IR35223": "/[SC_TH3_ANLG_IR35223]",
     "/run/devmap/sensors/SC_QSFPDD_IR35223": "/[SC_QSFPDD_IR35223]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/PCH_THERMAL": "/[PCH_THERMAL]",
     "/run/devmap/flashes/SCD_SPI_MASTER_DEVICE1": "/[SCD_SPI_MASTER_DEVICE1]",
     "/run/devmap/eeproms/RACKMON_EEPROM": "/RACKMON_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/FS_FAN_SLG4F4527": "/RACKMON_SLOT@0/[FS_FAN_SLG4F4527]",

--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -1,0 +1,458 @@
+{
+  "platformName": "darwin",
+  "rootPmUnitName": "SMB",
+  "rootSlotType": "SMB_SLOT",
+  "slotTypeConfigs": {
+    "SMB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "pmUnitName": "SMB"
+    },
+    "FAN_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "pmUnitName": "FAN"
+    },
+    "RACKMON_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x52",
+        "kernelDeviceName": "24c512",
+        "offset": 0
+      },
+      "pmUnitName": "RACKMON"
+    },
+    "PEM_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c512",
+        "offset": 0
+      },
+      "pmUnitName": "PEM"
+    }
+  },
+  "pmUnitConfigs": {
+    "SMB": {
+      "pluggedInSlotType": "SMB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "ROOK_SMBUS0@0",
+          "address": "0x4c",
+          "kernelDeviceName": "bp4a_max6658",
+          "pmUnitScopedName": "CPU_BOARD_TEMP_MAX6658"
+        },
+        {
+          "busName": "ROOK_SMBUS3@2",
+          "address": "0x48",
+          "kernelDeviceName": "lm73",
+          "pmUnitScopedName": "CPU_FP_TEMP_LM73"
+        },
+        {
+          "busName": "ROOK_SMBUS0@1",
+          "address": "0x4e",
+          "kernelDeviceName": "ucd90160",
+          "pmUnitScopedName": "CPU_POS_UCD90160"
+        },
+        {
+          "busName": "ROOK_SMBUS0@2",
+          "address": "0x21",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "CPU_MPS1_PMBUS"
+        },
+        {
+          "busName": "ROOK_SMBUS0@2",
+          "address": "0x27",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "CPU_MPS2_PMBUS"
+        },
+        {
+          "busName": "ROOK_SMBUS3@0",
+          "address": "0x60",
+          "kernelDeviceName": "tehama_cpld",
+          "pmUnitScopedName": "FAN_CPLD"
+        },
+        {
+          "busName": "ROOK_SMBUS2@0",
+          "address": "0x23",
+          "kernelDeviceName": "blackhawk_cpld",
+          "pmUnitScopedName": "BLACKHAWK_CPLD"
+        },
+        {
+          "busName": "SCD_SMBUS1@0",
+          "address": "0x4d",
+          "kernelDeviceName": "max6581",
+          "pmUnitScopedName": "SC_BOARD_TEMP_MAX6581"
+        },
+        {
+          "busName": "ROOK_SMBUS2@2",
+          "address": "0x11",
+          "kernelDeviceName": "ucd90320",
+          "pmUnitScopedName": "SC_POS_UCD90320"
+        },
+        {
+          "busName": "SCD_SMBUS1@5",
+          "address": "0x40",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_TH3_CORE_IR35223"
+        },
+        {
+          "busName": "SCD_SMBUS1@6",
+          "address": "0x41",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_TH3_ANLG_IR35223"
+        },
+        {
+          "busName": "SCD_SMBUS1@7",
+          "address": "0x42",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_QSFPDD_IR35223"
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RACKMON_SLOT@0": {
+          "slotType": "RACKMON_SLOT",
+          "outgoingI2cBusNames": [
+            "SCD_SMBUS1@4"
+          ]
+        },
+        "FAN_SLOT@0": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan1_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@1": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan2_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@2": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan3_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@3": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan4_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@4": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan5_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "PEM_SLOT@0": {
+          "slotType": "PEM_SLOT",
+          "outgoingI2cBusNames": [
+            "SCD_SMBUS1@3"
+          ]
+        }
+      },
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "ROOK_CPU_CPLD",
+          "vendorId": "0x8086",
+          "deviceId": "0x6f76",
+          "subSystemVendorId": "0x0000",
+          "subSystemDeviceId": "0x0000",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS0",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8000"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS1",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8080"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS2",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8100"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS3",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8180"
+              },
+              "numberOfAdapters": 4
+            }
+          ],
+          "spiMasterConfigs": [],
+          "ledCtrlConfigs": [],
+          "xcvrCtrlConfigs": []
+        },
+        {
+          "pmUnitScopedName": "SCD_FPGA",
+          "vendorId": "0x3475",
+          "deviceId": "0x0001",
+          "subSystemVendorId": "0x3475",
+          "subSystemDeviceId": "0x0002",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS0",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8000"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS1",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8080"
+              },
+              "numberOfAdapters": 8
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SPI_MASTER",
+                "deviceName": "spi_master",
+                "csrOffset": "0x7900"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "SCD_SPI_MASTER_DEVICE1",
+                  "chipSelect": 0,
+                  "modalias": "spidev",
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "ledCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SYSTEM_STATUS_LED",
+                "deviceName": "sys_led",
+                "csrOffset": "0x6050"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "FAN_STATUS_LED",
+                "deviceName": "fan_led",
+                "csrOffset": "0x6060"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PSU_STATUS_LED",
+                "deviceName": "psu_led",
+                "csrOffset": "0x6070"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            }
+          ],
+          "xcvrCtrlConfigs": [],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SCD_WDT1",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x120"
+            },
+            {
+              "pmUnitScopedName": "SCD_WDT2",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x304"
+            }
+          ]
+        }
+      ],
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        }
+      ]
+    },
+    "FAN": {
+      "pluggedInSlotType": "FAN_SLOT",
+      "i2cDeviceConfigs": [],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    },
+    "RACKMON": {
+      "pluggedInSlotType": "RACKMON_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x08",
+          "kernelDeviceName": "aslg4f4527",
+          "pmUnitScopedName": "FS_FAN_SLG4F4527"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x74",
+          "kernelDeviceName": "pca9539",
+          "pmUnitScopedName": "RACKMON_PLS",
+          "isGpioChip": true
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x50",
+          "kernelDeviceName": "24c512",
+          "pmUnitScopedName": "FANSPINNER_EEPROM"
+        }
+      ],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    },
+    "PEM": {
+      "pluggedInSlotType": "PEM_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x3a",
+          "kernelDeviceName": "amax5970",
+          "pmUnitScopedName": "PEM_ECB_MAX5970"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x36",
+          "kernelDeviceName": "bp4a_max11645",
+          "pmUnitScopedName": "PEM_ADC_MAX11645"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4c",
+          "kernelDeviceName": "bp4a_max6658",
+          "pmUnitScopedName": "PEM_TEMP_MAX6658"
+        }
+      ],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "SMBus I801 adapter at 1020"
+  ],
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/cplds/ROOK_CPU_CPLD": "/[ROOK_CPU_CPLD]",
+    "/run/devmap/fpgas/SCD_FPGA": "/[SCD_FPGA]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH0": "/[ROOK_SMBUS0@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH1": "/[ROOK_SMBUS0@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH2": "/[ROOK_SMBUS0@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH3": "/[ROOK_SMBUS0@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH0": "/[ROOK_SMBUS1@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH1": "/[ROOK_SMBUS1@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH2": "/[ROOK_SMBUS1@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH3": "/[ROOK_SMBUS1@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH0": "/[ROOK_SMBUS2@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH1": "/[ROOK_SMBUS2@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH2": "/[ROOK_SMBUS2@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH3": "/[ROOK_SMBUS2@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH0": "/[ROOK_SMBUS3@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH1": "/[ROOK_SMBUS3@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH2": "/[ROOK_SMBUS3@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH3": "/[ROOK_SMBUS3@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH0": "/[SCD_SMBUS0@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH1": "/[SCD_SMBUS0@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH2": "/[SCD_SMBUS0@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH3": "/[SCD_SMBUS0@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH4": "/[SCD_SMBUS0@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH5": "/[SCD_SMBUS0@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH6": "/[SCD_SMBUS0@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH7": "/[SCD_SMBUS0@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH0": "/[SCD_SMBUS1@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH1": "/[SCD_SMBUS1@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH2": "/[SCD_SMBUS1@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH3": "/[SCD_SMBUS1@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH4": "/[SCD_SMBUS1@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH5": "/[SCD_SMBUS1@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH6": "/[SCD_SMBUS1@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH7": "/[SCD_SMBUS1@7]",
+    "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658": "/[CPU_BOARD_TEMP_MAX6658]",
+    "/run/devmap/sensors/CPU_FP_TEMP_LM73": "/[CPU_FP_TEMP_LM73]",
+    "/run/devmap/sensors/CPU_POS_UCD90160": "/[CPU_POS_UCD90160]",
+    "/run/devmap/sensors/CPU_MPS1_PMBUS": "/[CPU_MPS1_PMBUS]",
+    "/run/devmap/sensors/CPU_MPS2_PMBUS": "/[CPU_MPS2_PMBUS]",
+    "/run/devmap/cplds/FAN_CPLD": "/[FAN_CPLD]",
+    "/run/devmap/sensors/FAN_CPLD": "/[FAN_CPLD]",
+    "/run/devmap/cplds/BLACKHAWK_CPLD": "/[BLACKHAWK_CPLD]",
+    "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581": "/[SC_BOARD_TEMP_MAX6581]",
+    "/run/devmap/sensors/SC_POS_UCD90320": "/[SC_POS_UCD90320]",
+    "/run/devmap/sensors/SC_TH3_CORE_IR35223": "/[SC_TH3_CORE_IR35223]",
+    "/run/devmap/sensors/SC_TH3_ANLG_IR35223": "/[SC_TH3_ANLG_IR35223]",
+    "/run/devmap/sensors/SC_QSFPDD_IR35223": "/[SC_QSFPDD_IR35223]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/flashes/SCD_SPI_MASTER_DEVICE1": "/[SCD_SPI_MASTER_DEVICE1]",
+    "/run/devmap/eeproms/RACKMON_EEPROM": "/RACKMON_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/FS_FAN_SLG4F4527": "/RACKMON_SLOT@0/[FS_FAN_SLG4F4527]",
+    "/run/devmap/gpiochips/RACKMON_PLS": "/RACKMON_SLOT@0/[RACKMON_PLS]",
+    "/run/devmap/eeproms/FANSPINNER_EEPROM": "/RACKMON_SLOT@0/[FANSPINNER_EEPROM]",
+    "/run/devmap/sensors/PEM_ECB_MAX5970": "/PEM_SLOT@0/[PEM_ECB_MAX5970]",
+    "/run/devmap/sensors/PEM_ADC_MAX11645": "/PEM_SLOT@0/[PEM_ADC_MAX11645]",
+    "/run/devmap/sensors/PEM_TEMP_MAX6658": "/PEM_SLOT@0/[PEM_TEMP_MAX6658]"
+  },
+  "bspKmodsRpmName": "arista_bsp_kmods",
+  "bspKmodsRpmVersion": "0.7.3-1",
+  "bspKmodsToReload": [
+    "scd",
+    "scd-leds",
+    "scd-smbus",
+    "scd-spi",
+    "scd-watchdog-darwin",
+    "rook-fan-cpld",
+    "blackhawk-cpld",
+    "aslg4f4527",
+    "bp4a_lm90",
+    "amax5970",
+    "bp4a_max1363"
+  ],
+  "sharedKmodsToReload": [
+    "scd"
+  ],
+  "upstreamKmodsToLoad": [
+    "i2c-i801"
+  ]
+}


### PR DESCRIPTION
# Description

Adds initial `platform_manager` support for DARWIN platform.

All sysfs file names are the same as the current udev-based approach, with the following exception:
- No watchdog sysfs file is created anymore, now that the kernel driver no longer exposes an endpoint. In the config, `miscCtrlConfigs` is used for watchdogs so that `platform_manager` doesn't enforce that a device be created in `/dev/`.
- `SC_QSFPDD_IR35223`, `SC_TH3_ANLG_IR35223`, and `SC_TH3_CORE_IR35223` devices are added for additional monitoring. These were previously shared but had not been incorporated.
- SCD SPI device is added.

# Caveats

1. `platform_manager` currently reports two failures because it does not read Darwin's EEPROM format correctly; `platform_manager` support needs to be added for this:
```
platform_manager[1434]: I1015 00:50:40.059080  1434 PlatformExplorer.cpp:656] Concluding darwin exploration...
platform_manager[1434]: I1015 00:50:40.059091  1434 PlatformExplorer.cpp:660] Unexpected Failures in Device IDPROM for PmUnit RACKMON at SlotPath /RACKMON_SLOT@0
platform_manager[1434]: I1015 00:50:40.059096  1434 PlatformExplorer.cpp:670] 1. Could not fetch contents of IDPROM /sys/bus/i2c/devices/29-0052/eeprom in /RACKMON_SLOT@0. EEPROM version 48 is not supported. Only ver 4+ is supported.
platform_manager[1434]: I1015 00:50:40.059103  1434 PlatformExplorer.cpp:660] Unexpected Failures in Device IDPROM for PmUnit PEM at SlotPath /PEM_SLOT@0
platform_manager[1434]: I1015 00:50:40.059108  1434 PlatformExplorer.cpp:670] 1. Could not fetch contents of IDPROM /sys/bus/i2c/devices/28-0050/eeprom in /PEM_SLOT@0. EEPROM version 48 is not supported. Only ver 4+ is supported.
```

2. `platform_manager` fails to read the version and subversion of the CPU_CPLD because the symlink is in `/run/devmap/cplds/`; this is where the symlink is located in the existing udev rule-based implementation, so the behavior is maintained here.
```
platform_manager[1434]: E1015 00:50:40.058992  1434 PlatformFsUtils.cpp:128] Received error code 2 from reading from path /run/devmap/cplds/ROOK_CPU_CPLD/cpld_ver: No such file or directory
platform_manager[1434]: E1015 00:50:40.059000  1434 PlatformExplorer.cpp:123] Failed to open firmware version file /run/devmap/cplds/ROOK_CPU_CPLD/cpld_ver: No such file or directory
platform_manager[1434]: E1015 00:50:40.059011  1434 PlatformFsUtils.cpp:128] Received error code 2 from reading from path /run/devmap/cplds/ROOK_CPU_CPLD/cpld_sub_ver: No such file or directory
platform_manager[1434]: E1015 00:50:40.059016  1434 PlatformExplorer.cpp:123] Failed to open firmware version file /run/devmap/cplds/ROOK_CPU_CPLD/cpld_sub_ver: No such file or directory
platform_manager[1434]: I1015 00:50:40.059021  1434 PlatformExplorer.cpp:733] Reporting firmware version for ROOK_CPU_CPLD - version string:0.0 ODS value:0
```

3. A udev rule is still required in order for the kernel driver to manage the CPU_CPLD correctly; this is because that device uses LPC rather than PCIe and `platform_manager` does not currently support it natively.

# Test Plan

Tested on Darwin with Linux kernel 6.4 and CentOS 9.

`platform_manager` service is running:
```
[root@rkd326 sys]# systemctl status platform_manager
● platform_manager.service - FBOSS Platform Manager
     Loaded: loaded (/etc/systemd/system/platform_manager.service; enabled; preset: disabled)
     Active: active (running) since Tue 2024-10-15 00:50:40 UTC; 25min ago
    Process: 1432 ExecStartPre=/bin/bash -c [[ -f /opt/fboss/share/platform_configs/platform_manager.json ]] (code=exited, status=0/SUCCESS)
   Main PID: 1434 (platform_manage)
      Tasks: 32 (limit: 200901)
     Memory: 4.6M
        CPU: 1.880s
     CGroup: /system.slice/platform_manager.service
             └─1434 /opt/fboss/bin/platform_manager -config-file /opt/fboss/share/platform_configs/platform_manager.json -noenable_pkg_mgmnt --run_once=false -reload_kmods=true
```

`platform_manager` loads all devices correctly:
```
# tree /run/devmap/
/run/devmap/
├── cplds
│   ├── BLACKHAWK_CPLD -> /sys/bus/i2c/devices/9-0023
│   ├── FAN_CPLD -> /sys/bus/i2c/devices/13-0060
│   └── ROOK_CPU_CPLD -> /sys/bus/pci/devices/0000:ff:0b.3
├── eeproms
│   ├── FANSPINNER_EEPROM -> /sys/bus/i2c/devices/29-0050/eeprom
│   └── RACKMON_EEPROM -> /sys/bus/i2c/devices/29-0052/eeprom
├── flashes
│   └── SCD_SPI_MASTER_DEVICE1 -> /dev/spidev2002.0
├── fpgas
│   └── SCD_FPGA -> /sys/bus/pci/devices/0000:07:00.0
├── gpiochips
│   └── RACKMON_PLS -> /dev/gpiochip2
├── i2c-busses
│   ├── ROOK_SMBUS0_CH0 -> /dev/i2c-1
│   ├── ROOK_SMBUS0_CH1 -> /dev/i2c-2
│   ├── ROOK_SMBUS0_CH2 -> /dev/i2c-3
│   ├── ROOK_SMBUS0_CH3 -> /dev/i2c-4
│   ├── ROOK_SMBUS1_CH0 -> /dev/i2c-5
│   ├── ROOK_SMBUS1_CH1 -> /dev/i2c-6
│   ├── ROOK_SMBUS1_CH2 -> /dev/i2c-7
│   ├── ROOK_SMBUS1_CH3 -> /dev/i2c-8
│   ├── ROOK_SMBUS2_CH0 -> /dev/i2c-9
│   ├── ROOK_SMBUS2_CH1 -> /dev/i2c-10
│   ├── ROOK_SMBUS2_CH2 -> /dev/i2c-11
│   ├── ROOK_SMBUS2_CH3 -> /dev/i2c-12
│   ├── ROOK_SMBUS3_CH0 -> /dev/i2c-13
│   ├── ROOK_SMBUS3_CH1 -> /dev/i2c-14
│   ├── ROOK_SMBUS3_CH2 -> /dev/i2c-15
│   ├── ROOK_SMBUS3_CH3 -> /dev/i2c-16
│   ├── SCD_SMBUS0_CH0 -> /dev/i2c-17
│   ├── SCD_SMBUS0_CH1 -> /dev/i2c-18
│   ├── SCD_SMBUS0_CH2 -> /dev/i2c-19
│   ├── SCD_SMBUS0_CH3 -> /dev/i2c-20
│   ├── SCD_SMBUS0_CH4 -> /dev/i2c-21
│   ├── SCD_SMBUS0_CH5 -> /dev/i2c-22
│   ├── SCD_SMBUS0_CH6 -> /dev/i2c-23
│   ├── SCD_SMBUS0_CH7 -> /dev/i2c-24
│   ├── SCD_SMBUS1_CH0 -> /dev/i2c-25
│   ├── SCD_SMBUS1_CH1 -> /dev/i2c-26
│   ├── SCD_SMBUS1_CH2 -> /dev/i2c-27
│   ├── SCD_SMBUS1_CH3 -> /dev/i2c-28
│   ├── SCD_SMBUS1_CH4 -> /dev/i2c-29
│   ├── SCD_SMBUS1_CH5 -> /dev/i2c-30
│   ├── SCD_SMBUS1_CH6 -> /dev/i2c-31
│   └── SCD_SMBUS1_CH7 -> /dev/i2c-32
└── sensors
    ├── CPU_BOARD_TEMP_MAX6658 -> /sys/bus/i2c/devices/1-004c/hwmon/hwmon2
    ├── CPU_CORE_TEMP -> /sys/bus/platform/devices/coretemp.0/hwmon/hwmon1
    ├── CPU_FP_TEMP_LM73 -> /sys/bus/i2c/devices/15-0048/hwmon/hwmon3
    ├── CPU_MPS1_PMBUS -> /sys/bus/i2c/devices/3-0021/hwmon/hwmon5
    ├── CPU_MPS2_PMBUS -> /sys/bus/i2c/devices/3-0027/hwmon/hwmon6
    ├── CPU_POS_UCD90160 -> /sys/bus/i2c/devices/2-004e/hwmon/hwmon4
    ├── FAN_CPLD -> /sys/bus/i2c/devices/13-0060/hwmon/hwmon7
    ├── FS_FAN_SLG4F4527 -> /sys/bus/i2c/devices/29-0008/hwmon/hwmon15
    ├── PCH_THERMAL -> /sys/devices/virtual/thermal/thermal_zone0/hwmon0
    ├── PEM_ADC_MAX11645 -> /sys/bus/i2c/devices/28-0036/iio:device0
    ├── PEM_ECB_MAX5970 -> /sys/bus/i2c/devices/28-003a/hwmon/hwmon13
    ├── PEM_TEMP_MAX6658 -> /sys/bus/i2c/devices/28-004c/hwmon/hwmon14
    ├── SC_BOARD_TEMP_MAX6581 -> /sys/bus/i2c/devices/25-004d/hwmon/hwmon8
    ├── SC_POS_UCD90320 -> /sys/bus/i2c/devices/11-0011/hwmon/hwmon9
    ├── SC_QSFPDD_IR35223 -> /sys/bus/i2c/devices/32-0042/hwmon/hwmon12
    ├── SC_TH3_ANLG_IR35223 -> /sys/bus/i2c/devices/31-0041/hwmon/hwmon11
    └── SC_TH3_CORE_IR35223 -> /sys/bus/i2c/devices/30-0040/hwmon/hwmon10
```
