### PR TITLE
DARWIN: update led_manager.json

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,22 +1,22 @@
 {
   "systemLedConfig": {
     "presentLedColor": 1,
-    "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
     "absentLedColor": 2,
-    "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PEM": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },
   "fruConfigs": [

--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -71,6 +71,16 @@
       }
     },
     {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/SCD_FPGA/rackmon_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
       "fruName": "PEM1",
       "fruType": "PEM",
       "presenceDetection": {


### PR DESCRIPTION
# Description

Updates `led_manager.json` config for DARWIN platform with two changes:

1. Updates LED sysfs files to account for refactored kernel driver.
2. Adds Rackmon fan as `fan6`.

# Test Plan

Tested on Darwin with Linux kernel 6.4 and CentOS 9.

`data_corral_service` initializes LEDs correctly:
```
I1015 02:00:45.049965 10377 PlatformNameLib.cpp:71] Platform name read from cache: DARWIN
I1015 02:00:45.050030 10377 ConfigLib.cpp:48] Using config file: /opt/fboss/share/platform_configs/led_manager.json
I1015 02:00:45.050233 10378 FruPresenceExplorer.cpp:25] Detecting presence of FRUs
I1015 02:00:45.051052 10377 ThriftServer.cpp:836] Using thread manager (resource pools not enabled) on address/port 5971: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable g>
I1015 02:00:45.051445 10378 FruPresenceExplorer.cpp:40] Detected that FAN1 is present
I1015 02:00:45.052593 10378 FruPresenceExplorer.cpp:40] Detected that FAN2 is present
I1015 02:00:45.053579 10378 FruPresenceExplorer.cpp:40] Detected that FAN3 is present
I1015 02:00:45.054590 10378 FruPresenceExplorer.cpp:40] Detected that FAN4 is present
I1015 02:00:45.055589 10378 FruPresenceExplorer.cpp:40] Detected that FAN5 is present
I1015 02:00:45.055612 10378 FruPresenceExplorer.cpp:40] Detected that FAN6 is present
I1015 02:00:45.055628 10378 FruPresenceExplorer.cpp:40] Detected that PEM1 is present
I1015 02:00:45.055646 10378 LedManager.cpp:45] Programming PEM LED with true
I1015 02:00:45.055697 10378 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I1015 02:00:45.055727 10378 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I1015 02:00:45.055735 10378 LedManager.cpp:55] Programmed PEM LED with presence true
I1015 02:00:45.055741 10378 LedManager.cpp:45] Programming FAN LED with true
I1015 02:00:45.055766 10378 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I1015 02:00:45.055790 10378 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I1015 02:00:45.055797 10378 LedManager.cpp:55] Programmed FAN LED with presence true
I1015 02:00:45.055803 10378 LedManager.cpp:25] Programming system LED with true
I1015 02:00:45.055826 10378 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I1015 02:00:45.055865 10378 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I1015 02:00:45.055871 10378 LedManager.cpp:34] Programmed system LED with true
```