### PR TITLE
montblanc: config: Update sensor config based on the latest sensors list

### DIFF
--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -3598,7 +3598,7 @@
             "minAlarmVal": 11.4,
             "lowerCriticalVal": 10.8
           },
-          "compute": "3*@/1000"
+          "compute": "@/1000"
         },
         {
           "name": "SMB_3V3_L_VRM_VOUT",
@@ -3610,7 +3610,7 @@
             "minAlarmVal": 3.135,
             "lowerCriticalVal": 2.97
           },
-          "compute": "@/1000"
+          "compute": "3*@/1000"
         },
         {
           "name": "SMB_3V3_L_VRM_TEMP",
@@ -3926,7 +3926,7 @@
             "minAlarmVal": 11.4,
             "lowerCriticalVal": 10.8
           },
-          "compute": "3*@/1000"
+          "compute": "@/1000"
         },
         {
           "name": "SMB_3V3_R_VRM_VOUT",
@@ -3938,7 +3938,7 @@
             "minAlarmVal": 3.135,
             "lowerCriticalVal": 2.97
           },
-          "compute": "@/1000"
+          "compute": "3*@/1000"
         },
         {
           "name": "SMB_3V3_R_VRM_TEMP",

--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -599,7 +599,27 @@
       "pmUnitName": "NETLAKE",
       "sensors": [
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+          "name": "COME_U18_INLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_TSENSOR1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_U39_OUTLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_TSENSOR2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU31_TDA38640_PVNN_PCH_VIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
           "type": 1,
           "thresholds": {
@@ -608,7 +628,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_VOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
           "type": 1,
           "thresholds": {
@@ -618,7 +638,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
           "type": 3,
           "thresholds": {
@@ -628,25 +648,25 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_PIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power1_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr1_input",
           "type": 2,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+          "name": "COME_PU31_TDA38640_PVNN_PCH_IOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
           "type": 2,
           "thresholds": {
@@ -655,7 +675,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_VIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
           "type": 1,
           "thresholds": {
@@ -664,7 +684,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_VOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
           "type": 1,
           "thresholds": {
@@ -674,7 +694,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
           "type": 3,
           "thresholds": {
@@ -684,25 +704,25 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_PIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power1_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr1_input",
           "type": 2,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+          "name": "COME_PU32_TDA38640_P1V05_STBY_IOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
           "type": 2,
           "thresholds": {
@@ -711,7 +731,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+          "name": "COME_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in1_input",
           "type": 1,
           "thresholds": {
@@ -720,7 +740,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+          "name": "COME_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/in2_input",
           "type": 1,
           "thresholds": {
@@ -730,7 +750,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+          "name": "COME_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/temp1_input",
           "type": 3,
           "thresholds": {
@@ -740,25 +760,25 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+          "name": "COME_PU41_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power1_input",
           "type": 0,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_P1V05_STBY_POUT",
+          "name": "COME_PU41_TDA38640_P1V05_STBY_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU41_TDA38640_P1V05_STBY_IIN",
+          "name": "COME_PU41_TDA38640_P1V05_STBY_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr1_input",
           "type": 2,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU41_TDA38640_P1V05_STBY_IOUT",
+          "name": "COME_PU41_TDA38640_P1V05_STBY_IOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/curr2_input",
           "type": 2,
           "thresholds": {
@@ -767,7 +787,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
+          "name": "COME_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in1_input",
           "type": 1,
           "thresholds": {
@@ -776,7 +796,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
+          "name": "COME_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_VOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/in2_input",
           "type": 1,
           "thresholds": {
@@ -786,7 +806,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
+          "name": "COME_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/temp1_input",
           "type": 3,
           "thresholds": {
@@ -796,25 +816,25 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
+          "name": "COME_PU42_TDA38640_1V2_PVDDQ_ABC_CPU_PIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power1_input",
           "type": 0,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_P1V05_STBY_POUT",
+          "name": "COME_PU42_TDA38640_P1V05_STBY_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
           "type": 0,
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU42_TDA38640_P1V05_STBY_IIN",
+          "name": "COME_PU42_TDA38640_P1V05_STBY_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr1_input",
           "type": 2,
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU42_TDA38640_P1V05_STBY_IOUT",
+          "name": "COME_PU42_TDA38640_P1V05_STBY_IOUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/curr2_input",
           "type": 2,
           "thresholds": {
@@ -823,7 +843,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+          "name": "COME_PU4_XDPE15284_PVCCIN_VIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in1_input",
           "type": 1,
           "thresholds": {
@@ -834,7 +854,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+          "name": "COME_PU4_XDPE15284_PVCCIN_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
           "type": 3,
           "thresholds": {
@@ -844,7 +864,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+          "name": "COME_PU4_XDPE15284_P1V8_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp2_input",
           "type": 3,
           "thresholds": {
@@ -854,16 +874,16 @@
           "compute": "@/1000"
         },
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+          "name": "COME_PU4_XDPE15284_PVCCIN_PIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power1_input",
           "type": 0,
           "thresholds": {
-            "maxAlarmVal": 1024
+            "maxAlarmVal": 225
           },
           "compute": "@/1000000"
         },
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+          "name": "COME_PU4_XDPE15284_PVCCIN_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
           "type": 2,
           "thresholds": {
@@ -877,7 +897,7 @@
         {
           "sensors": [
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_VIN",
+              "name": "COME_PU4_XDPE15284_P1V8_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
               "type": 1,
               "thresholds": {
@@ -888,7 +908,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
               "type": 1,
               "thresholds": {
@@ -899,7 +919,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
               "type": 1,
               "thresholds": {
@@ -910,34 +930,34 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_PIN",
+              "name": "COME_PU4_XDPE15284_P1V8_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 4096
+                "maxAlarmVal": 52.5
               },
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 318.5
               },
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "name": "COME_PU4_XDPE15284_P1V8_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 125
+                "maxAlarmVal": 15
               },
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "name": "COME_PU4_XDPE15284_P1V8_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
               "type": 2,
               "thresholds": {
@@ -947,7 +967,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
               "type": 2,
               "thresholds": {
@@ -957,7 +977,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
+              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
               "type": 2,
               "thresholds": {
@@ -974,7 +994,7 @@
         {
           "sensors": [
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
               "type": 1,
               "thresholds": {
@@ -985,7 +1005,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
               "type": 1,
               "thresholds": {
@@ -996,7 +1016,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
               "type": 0,
               "thresholds": {
@@ -1005,7 +1025,7 @@
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "name": "COME_PU4_XDPE15284_P1V8_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
               "type": 0,
               "thresholds": {
@@ -1014,7 +1034,7 @@
               "compute": "@/1000000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
               "type": 2,
               "thresholds": {
@@ -1024,7 +1044,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
+              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
               "type": 2,
               "thresholds": {
@@ -1119,8 +1139,20 @@
           "compute": "@/1000"
         },
         {
-          "name": "PSU1_L_12V_VOUT",
+          "name": "PSU1_L_12V_MAIN_VOUT",
           "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU1_L_12V_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
             "upperCriticalVal": 13.2,
@@ -1243,8 +1275,20 @@
           "compute": "@/1000"
         },
         {
-          "name": "PSU2_R_12V_VOUT",
+          "name": "PSU2_R_12V_MAIN_VOUT",
           "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.2,
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PSU2_L_12V_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
             "upperCriticalVal": 13.2,
@@ -1627,7 +1671,7 @@
       "sensors": [
         {
           "name": "SMB_LEFT_U51_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR1/temp1_input",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR5/temp1_input",
           "type": 3,
           "thresholds": {
             "upperCriticalVal": 85,
@@ -1657,7 +1701,7 @@
         },
         {
           "name": "SMB_RIGHT_U182_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR4/temp1_input",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR6/temp1_input",
           "type": 3,
           "thresholds": {
             "upperCriticalVal": 85,
@@ -1768,7 +1812,7 @@
           "thresholds": {
             "upperCriticalVal": 1.98,
             "maxAlarmVal": 1.89,
-            "minAlarmVal": 1.7955,
+            "minAlarmVal": 1.71,
             "lowerCriticalVal": 1.62
           },
           "compute": "@/1000"
@@ -1780,7 +1824,7 @@
           "thresholds": {
             "upperCriticalVal": 1.21,
             "maxAlarmVal": 1.155,
-            "minAlarmVal": 1.09725,
+            "minAlarmVal": 1.045,
             "lowerCriticalVal": 0.99
           },
           "compute": "@/1000"
@@ -1792,7 +1836,7 @@
           "thresholds": {
             "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
-            "minAlarmVal": 0.89775,
+            "minAlarmVal": 0.855,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000"
@@ -1804,7 +1848,7 @@
           "thresholds": {
             "upperCriticalVal": 2.75,
             "maxAlarmVal": 2.625,
-            "minAlarmVal": 2.49375,
+            "minAlarmVal": 2.375,
             "lowerCriticalVal": 2.25
           },
           "compute": "@/1000"
@@ -1816,7 +1860,7 @@
           "thresholds": {
             "upperCriticalVal": 0.88,
             "maxAlarmVal": 0.84,
-            "minAlarmVal": 0.798,
+            "minAlarmVal": 0.76,
             "lowerCriticalVal": 0.72
           },
           "compute": "@/1000"
@@ -1828,7 +1872,7 @@
           "thresholds": {
             "upperCriticalVal": 1.65,
             "maxAlarmVal": 1.575,
-            "minAlarmVal": 1.49625,
+            "minAlarmVal": 1.425,
             "lowerCriticalVal": 1.35
           },
           "compute": "@/1000"
@@ -1840,7 +1884,7 @@
           "thresholds": {
             "upperCriticalVal": 1.32,
             "maxAlarmVal": 1.26,
-            "minAlarmVal": 1.197,
+            "minAlarmVal": 1.14,
             "lowerCriticalVal": 1.08
           },
           "compute": "@/1000"
@@ -1852,7 +1896,7 @@
           "thresholds": {
             "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
-            "minAlarmVal": 0.89775,
+            "minAlarmVal": 0.855,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000"
@@ -3526,7 +3570,7 @@
       "sensors": [
         {
           "name": "SMB_3V3_L_U8_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR5/temp1_input",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
             "upperCriticalVal": 85,
@@ -3554,7 +3598,7 @@
             "minAlarmVal": 11.4,
             "lowerCriticalVal": 10.8
           },
-          "compute": "@/1000"
+          "compute": "3*@/1000"
         },
         {
           "name": "SMB_3V3_L_VRM_VOUT",
@@ -3854,7 +3898,7 @@
       "sensors": [
         {
           "name": "SMB_3V3_R_U8_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR6/temp1_input",
+          "sysfsPath": "/run/devmap/sensors/SMB_TSENSOR4/temp1_input",
           "type": 3,
           "thresholds": {
             "upperCriticalVal": 85,
@@ -3863,7 +3907,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "SMB_3V3_L_VRM_PIN",
+          "name": "SMB_3V3_R_VRM_PIN",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power1_input",
           "type": 0,
           "thresholds": {
@@ -3873,7 +3917,7 @@
           "compute": "@/1000000"
         },
         {
-          "name": "SMB_3V3_L_VRM_VIN",
+          "name": "SMB_3V3_R_VRM_VIN",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in1_input",
           "type": 1,
           "thresholds": {
@@ -3882,10 +3926,10 @@
             "minAlarmVal": 11.4,
             "lowerCriticalVal": 10.8
           },
-          "compute": "@/1000"
+          "compute": "3*@/1000"
         },
         {
-          "name": "SMB_3V3_L_VRM_VOUT",
+          "name": "SMB_3V3_R_VRM_VOUT",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/in2_input",
           "type": 1,
           "thresholds": {
@@ -3897,7 +3941,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "SMB_3V3_L_VRM_TEMP",
+          "name": "SMB_3V3_R_VRM_TEMP",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
           "type": 3,
           "compute": "@/1000"
@@ -3907,7 +3951,7 @@
         {
           "sensors": [
             {
-              "name": "SMB_3V3_L_VRM_IOUT",
+              "name": "SMB_3V3_R_VRM_IOUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
               "type": 2,
               "thresholds": {
@@ -3917,7 +3961,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_3V3_L_VRM_POUT",
+              "name": "SMB_3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
@@ -3934,7 +3978,7 @@
         {
           "sensors": [
             {
-              "name": "SMB_3V3_L_VRM_IOUT",
+              "name": "SMB_3V3_R_VRM_IOUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
               "type": 2,
               "thresholds": {
@@ -3944,7 +3988,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_3V3_L_VRM_POUT",
+              "name": "SMB_3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
@@ -3961,7 +4005,7 @@
         {
           "sensors": [
             {
-              "name": "SMB_3V3_L_VRM_IOUT",
+              "name": "SMB_3V3_R_VRM_IOUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
               "type": 2,
               "thresholds": {
@@ -3971,7 +4015,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_3V3_L_VRM_POUT",
+              "name": "SMB_3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
@@ -3988,7 +4032,7 @@
         {
           "sensors": [
             {
-              "name": "SMB_3V3_L_VRM_IOUT",
+              "name": "SMB_3V3_R_VRM_IOUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
               "type": 2,
               "thresholds": {
@@ -3998,7 +4042,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_3V3_L_VRM_POUT",
+              "name": "SMB_3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {
@@ -4015,7 +4059,7 @@
         {
           "sensors": [
             {
-              "name": "SMB_3V3_L_VRM_IOUT",
+              "name": "SMB_3V3_R_VRM_IOUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
               "type": 2,
               "thresholds": {
@@ -4025,7 +4069,7 @@
               "compute": "@/1000"
             },
             {
-              "name": "SMB_3V3_L_VRM_POUT",
+              "name": "SMB_3V3_R_VRM_POUT",
               "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
               "type": 0,
               "thresholds": {


### PR DESCRIPTION
**Description**
Updated sensors config files based on the latest sensors list.

**Motivation**

1. Sync up sensor config from fboss repo.
2. Updated sensor config file based on the latest sensors list.
-  Added two PSU standby voltage sesnors.
- Added two COMe temp sesnors.
- Updated some COMe sensors threshold date with list data.
https://docs.google.com/spreadsheets/d/1V_JFLw2m0Zu1DUgVeVPKSGsQrPkRYgCh/edit?gid=1703809973#gid=1703809973

**Test Plan**

- Run the jq to format json file.
- build the latest fboss bsp kmod.
- build the latest fboss platform manager binary.
- Run the platform manager with the changed config files on DVT and 2nd source DVT device normally: LD_LIBRARY_PATH=./lib/ ./bin/platform_manager --config_file ./platform_manager.json --run_once=false --noenable_pkg_mgmnt
- Run sensor_service with the new config file: LD_LIBRARY_PATH=./lib/ ./bin/sensor_service --config_file ./sensor_service.json --logging=DBG1

Current tested the new config file on two tpye board normal.
[montblanc_sensor_config_IFX_test_log_20241015.txt](https://github.com/user-attachments/files/17374775/montblanc_sensor_config_IFX_test_log_20241015.txt)
[montblanc_sensor_config_MP_test_log_20241015.txt](https://github.com/user-attachments/files/17374776/montblanc_sensor_config_MP_test_log_20241015.txt)

_Limitation:_
Due to the firmware problem of the PSU, the standby voltage cannot be found, so it is necessary to upgrade to the latest firmware.
![image](https://github.com/user-attachments/assets/c3490528-2bdc-48ee-b78d-8b597022a205)

