### PR TITLE
Meru800bfa: fix SMB_VRM_R3R1_ANLG1_VOUT_1V8 threshold

### DIFF
--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -671,8 +671,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.44,
-            "lowerCriticalVal": 0.96
+            "upperCriticalVal": 2.16,
+            "lowerCriticalVal": 1.44
           },
           "compute": "@/1000.0"
         },


### PR DESCRIPTION
# Description

Corrects sensor threshold for `SMB_VRM_R3R1_ANLG1_VOUT_1V8` sensor in `sensor_service.json` config.

# Test Plan

Verified on Meru800bfa.