### PR TITLE
Meru800: fix SCM_ECB_VIN sensor thresholds

### DIFF
--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -99,8 +99,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
-            "lowerCriticalVal": 2.64
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 10.5
           },
           "compute": "@/32000.0"
         },

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -99,8 +99,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
-            "lowerCriticalVal": 2.64
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 10.5
           },
           "compute": "@/32000.0"
         },


### PR DESCRIPTION
# Description

 SCM_ECB_VIN is reporting thersholds exceeded. The thresholds are not correct:
```
SCM_ECB_VIN 11.906250 2024-10-16 11:45:51.0 PDT 3.960000 2.640000 VOLTAGE Critical
```

This PR updates the thresholds to the following (ECB is a 12V device):
```
        "thresholds": {
          "upperCriticalVal": 14.4,
          "lowerCriticalVal": 10.5
        },
```