### PR TITLE
janga: config: changed SMB_U337_PMBUS_1, SMB_U177_PMBUS_2 addresses

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -147,13 +147,13 @@
             },
             {
               "busName": "INCOMING@3",
-              "address": "0x21",
+              "address": "0x2f",
               "kernelDeviceName": "bp4f_mp2891",
               "pmUnitScopedName": "SMB_U337_PMBUS_1"
             },
             {
               "busName": "INCOMING@3",
-              "address": "0x2f",
+              "address": "0x21",
               "kernelDeviceName": "bp4f_mp2891",
               "pmUnitScopedName": "SMB_U177_PMBUS_2"
             },


### PR DESCRIPTION
Description

Description
This PR is for janga dvt platform config.

Motivation
1.According to i2c topology SMB_U337_PMBUS_1 address is 0x2f, SMB_U177_PMBUS_2 address is 0x21,so fix the previous bug.

![image](https://github.com/user-attachments/assets/b9c9e8f9-d59a-41f1-8c27-cff888dfb790)

![image](https://github.com/user-attachments/assets/29605f8c-b5bb-4699-8234-0ab156dd9706)


Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:
Tested both in janga dvt main source & janga dvt 2nd source machine.


[janga_dvt_2nd_source_sensor_hw_test_log.txt](https://github.com/user-attachments/files/17514762/janga_dvt_2nd_source_sensor_hw_test_log.txt)
[janga_dvt_2nd_source_sensor_test_log.txt](https://github.com/user-attachments/files/17514763/janga_dvt_2nd_source_sensor_test_log.txt)
[janga_dvt_main_source_platform_test_log.txt](https://github.com/user-attachments/files/17514765/janga_dvt_main_source_platform_test_log.txt)
[janga_dvt_main_source_sensor_hw_test_log.txt](https://github.com/user-attachments/files/17514766/janga_dvt_main_source_sensor_hw_test_log.txt)
[janga_dvt_main_source_sensor_test_log.txt](https://github.com/user-attachments/files/17514767/janga_dvt_main_source_sensor_test_log.txt)
[janga_dvt_2nd_source_platform_test_log.txt](https://github.com/user-attachments/files/17514768/janga_dvt_2nd_source_platform_test_log.txt)




