### PR TITLE
tahan: config: adjusted sensor config to support 2nd source

### DIFF
--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -19,7 +19,7 @@
         "address": "0x56",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "SMB"
+      "pmUnitName": "SMB_FRU"
     },
     "RUNBMC_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -104,7 +104,7 @@
         "productSubVersion": 2
       }
     ],
-    "SMB": [
+    "SMB_FRU": [
       {
         "pmUnitConfig": {
           "pluggedInSlotType": "SMB_FRU_SLOT",
@@ -1748,7 +1748,7 @@
         }
       }
     },
-    "SMB": {
+    "SMB_FRU": {
       "pluggedInSlotType": "SMB_FRU_SLOT",
       "i2cDeviceConfigs": [
         {

--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -1,9 +1,9 @@
 {
   "platformName": "tahan800bc",
   "rootPmUnitName": "TAHAN",
-  "rootSlotType": "SMB_SLOT",
+  "rootSlotType": "TAHAN_SLOT",
   "slotTypeConfigs": {
-    "SMB_SLOT": {
+    "TAHAN_SLOT": {
       "numOutgoingI2cBuses": 0,
       "idpromConfig": {
         "busName": "SMBus I801 adapter at 5000",
@@ -11,6 +11,15 @@
         "kernelDeviceName": "24c02"
       },
       "pmUnitName": "TAHAN"
+    },
+    "SMB_FRU_SLOT": {
+      "numOutgoingI2cBuses": 4,
+      "idpromConfig": {
+        "busName": "INCOMING@1",
+        "address": "0x56",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "SMB"
     },
     "RUNBMC_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -33,6 +42,10 @@
     "PDB_SLOT": {
       "numOutgoingI2cBuses": 1,
       "pmUnitName": "PDB"
+    },
+    "BCB_SLOT": {
+      "numOutgoingI2cBuses": 2,
+      "pmUnitName": "BCB"
     }
   },
   "i2cAdaptersFromCpu": [
@@ -90,11 +103,51 @@
         },
         "productSubVersion": 2
       }
+    ],
+    "SMB": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "SMB_FRU_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "bp4f_mp2891",
+              "pmUnitScopedName": "SMB_U122_PMBUS_1"
+            },
+            {
+              "busName": "INCOMING@2",
+              "address": "0x7e",
+              "kernelDeviceName": "mp2975",
+              "pmUnitScopedName": "SMB_U20_XDPE12284_1"
+            },
+            {
+              "busName": "INCOMING@2",
+              "address": "0x7d",
+              "kernelDeviceName": "mp2975",
+              "pmUnitScopedName": "SMB_U86_XDPE12284_2"
+            },
+            {
+              "busName": "INCOMING@3",
+              "address": "0x7a",
+              "kernelDeviceName": "mp2975",
+              "pmUnitScopedName": "SMB_U229_XDPE12284_1"
+            },
+            {
+              "busName": "INCOMING@3",
+              "address": "0x7b",
+              "kernelDeviceName": "mp2975",
+              "pmUnitScopedName": "SMB_U92_XDPE12284_2"
+            }
+          ]
+        },
+        "productSubVersion": 10
+      }
     ]
   },
   "pmUnitConfigs": {
     "TAHAN": {
-      "pluggedInSlotType": "SMB_SLOT",
+      "pluggedInSlotType": "TAHAN_SLOT",
       "embeddedSensorConfigs": [
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
@@ -1533,49 +1586,6 @@
       ],
       "i2cDeviceConfigs": [
         {
-          "busName": "SMB_IOB_I2C_MASTER_1",
-          "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
-          "pmUnitScopedName": "SMB_BCB_FAN_CPLD"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_1",
-          "address": "0x16",
-          "kernelDeviceName": "mtia_fan_watchdog",
-          "pmUnitScopedName": "BCB_FAN_WATCHDOG",
-          "isWatchdog": true
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_4",
-          "address": "0x76",
-          "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "SMB_U122_PMBUS_1"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_11",
-          "address": "0x68",
-          "kernelDeviceName": "bp4f_xdpe12284",
-          "pmUnitScopedName": "SMB_U20_XDPE12284_1"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_11",
-          "address": "0x6a",
-          "kernelDeviceName": "bp4f_xdpe12284",
-          "pmUnitScopedName": "SMB_U86_XDPE12284_2"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_12",
-          "address": "0x72",
-          "kernelDeviceName": "bp4f_xdpe12284",
-          "pmUnitScopedName": "SMB_U229_XDPE12284_1"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_12",
-          "address": "0x70",
-          "kernelDeviceName": "bp4f_xdpe12284",
-          "pmUnitScopedName": "SMB_U92_XDPE12284_2"
-        },
-        {
           "busName": "SMB_IOB_I2C_MASTER_13",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
@@ -1604,12 +1614,6 @@
           "address": "0x49",
           "kernelDeviceName": "lm75b",
           "pmUnitScopedName": "SMB_U57_LM75B_2"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_19",
-          "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
-          "pmUnitScopedName": "SMB_BCB_FAN_CPLD_2"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_21",
@@ -1649,7 +1653,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -1661,7 +1667,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -1700,12 +1708,6 @@
           "address": "0x60",
           "kernelDeviceName": "mtia_pwrcpld",
           "pmUnitScopedName": "PWR_CPLD"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_9",
-          "address": "0x56",
-          "kernelDeviceName": "24c64",
-          "pmUnitScopedName": "SMB_EEPROM"
         }
       ],
       "outgoingSlotConfigs": {
@@ -1722,13 +1724,64 @@
             "SMB_IOB_I2C_MASTER_24"
           ]
         },
+        "BCB_SLOT@0": {
+          "slotType": "BCB_SLOT",
+          "outgoingI2cBusNames": [
+            "SMB_IOB_I2C_MASTER_1",
+            "SMB_IOB_I2C_MASTER_19"
+          ]
+        },
         "PDB_SLOT@0": {
           "slotType": "PDB_SLOT",
           "outgoingI2cBusNames": [
             "SMB_IOB_I2C_MASTER_22"
           ]
+        },
+        "SMB_FRU_SLOT@0": {
+          "slotType": "SMB_FRU_SLOT",
+          "outgoingI2cBusNames": [
+            "SMB_IOB_I2C_MASTER_4",
+            "SMB_IOB_I2C_MASTER_9",
+            "SMB_IOB_I2C_MASTER_11",
+            "SMB_IOB_I2C_MASTER_12"
+          ]
         }
       }
+    },
+    "SMB": {
+      "pluggedInSlotType": "SMB_FRU_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x76",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SMB_U122_PMBUS_1"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x68",
+          "kernelDeviceName": "bp4f_xdpe12284",
+          "pmUnitScopedName": "SMB_U20_XDPE12284_1"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x6a",
+          "kernelDeviceName": "bp4f_xdpe12284",
+          "pmUnitScopedName": "SMB_U86_XDPE12284_2"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x72",
+          "kernelDeviceName": "bp4f_xdpe12284",
+          "pmUnitScopedName": "SMB_U229_XDPE12284_1"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x70",
+          "kernelDeviceName": "bp4f_xdpe12284",
+          "pmUnitScopedName": "SMB_U92_XDPE12284_2"
+        }
+      ]
     },
     "MINERVA_BMC": {
       "pluggedInSlotType": "RUNBMC_SLOT",
@@ -1810,24 +1863,40 @@
           "pmUnitScopedName": "PDB_PMBUS_2"
         }
       ]
+    },
+    "BCB": {
+      "pluggedInSlotType": "BCB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x5e",
+          "kernelDeviceName": "bp4f_max31790",
+          "pmUnitScopedName": "SMB_BCB_FAN_CPLD"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x5e",
+          "kernelDeviceName": "bp4f_max31790",
+          "pmUnitScopedName": "SMB_BCB_FAN_CPLD_2"
+        }
+      ]
     }
   },
   "symbolicLinkToDevicePath": {
     "/run/devmap/eeproms/COME_EEPROM": "/[IDPROM]",
     "/run/devmap/eeproms/COME_FRU": "/COME_SLOT@0/[IDPROM]",
-    "/run/devmap/eeproms/SMB_EEPROM": "/[SMB_EEPROM]",
+    "/run/devmap/eeproms/SMB_EEPROM": "/SMB_FRU_SLOT@0/[IDPROM]",
     "/run/devmap/eeproms/RUNBMC_EEPROM": "/RUNBMC_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
     "/run/devmap/sensors/SMB_E1S_SSD_TEMP": "/[SMB_E1S_SSD_TEMP]",
-    "/run/devmap/sensors/SMB_BCB_FAN_CPLD": "/[SMB_BCB_FAN_CPLD]",
-    "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2": "/[SMB_BCB_FAN_CPLD_2]",
-    "/run/devmap/watchdogs/BCB_FAN_WATCHDOG": "/[BCB_FAN_WATCHDOG]",
+    "/run/devmap/sensors/SMB_BCB_FAN_CPLD": "/BCB_SLOT@0/[SMB_BCB_FAN_CPLD]",
+    "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2": "/BCB_SLOT@0/[SMB_BCB_FAN_CPLD_2]",
     "/run/devmap/sensors/BMC_U9_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[BMC_U9_THERMAL_SENSOR]",
-    "/run/devmap/sensors/SMB_U122_PMBUS_1": "/[SMB_U122_PMBUS_1]",
-    "/run/devmap/sensors/SMB_U20_XDPE12284_1": "/[SMB_U20_XDPE12284_1]",
-    "/run/devmap/sensors/SMB_U86_XDPE12284_2": "/[SMB_U86_XDPE12284_2]",
-    "/run/devmap/sensors/SMB_U229_XDPE12284_1": "/[SMB_U229_XDPE12284_1]",
-    "/run/devmap/sensors/SMB_U92_XDPE12284_2": "/[SMB_U92_XDPE12284_2]",
+    "/run/devmap/sensors/SMB_U122_PMBUS_1": "/SMB_FRU_SLOT@0/[SMB_U122_PMBUS_1]",
+    "/run/devmap/sensors/SMB_U20_XDPE12284_1": "/SMB_FRU_SLOT@0/[SMB_U20_XDPE12284_1]",
+    "/run/devmap/sensors/SMB_U86_XDPE12284_2": "/SMB_FRU_SLOT@0/[SMB_U86_XDPE12284_2]",
+    "/run/devmap/sensors/SMB_U229_XDPE12284_1": "/SMB_FRU_SLOT@0/[SMB_U229_XDPE12284_1]",
+    "/run/devmap/sensors/SMB_U92_XDPE12284_2": "/SMB_FRU_SLOT@0/[SMB_U92_XDPE12284_2]",
     "/run/devmap/sensors/SMB_U327_TPS25990_COME": "/[SMB_U327_TPS25990_COME]",
     "/run/devmap/sensors/SMB_U69_LM75B_1": "/[SMB_U69_LM75B_1]",
     "/run/devmap/sensors/SMB_U67_LM75B_2": "/[SMB_U67_LM75B_2]",

--- a/fboss/platform/configs/tahan800bc/sensor_service.json
+++ b/fboss/platform/configs/tahan800bc/sensor_service.json
@@ -1,110 +1,6 @@
 {
   "pmUnitSensorsList": [
     {
-      "slotPath": "/PDB_SLOT@0",
-      "pmUnitName": "PDB_CARD",
-      "sensors": [
-        {
-          "name": "PDB_INLET_LM75_TEMP",
-          "sysfsPath": "/run/devmap/sensors/PDB_TSENSOR_1/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK1_VIN",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 56,
-            "maxAlarmVal": 54,
-            "minAlarmVal": 46,
-            "lowerCriticalVal": 44
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK1_VOUT",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK1_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 110,
-            "maxAlarmVal": 107
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK1_IOUT",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 80
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK2_VIN",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 56,
-            "maxAlarmVal": 54,
-            "minAlarmVal": 46,
-            "lowerCriticalVal": 44
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK2_VOUT",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK2_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 110,
-            "maxAlarmVal": 107
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "POWER_BRICK2_IOUT",
-          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 80
-          },
-          "compute": "@/1000.0"
-        }
-      ]
-    },
-    {
       "slotPath": "/",
       "pmUnitName": "TAHAN",
       "sensors": [
@@ -199,270 +95,12 @@
           "compute": "@/1000"
         },
         {
-          "name": "FCB_FANTRAY1_PWM3",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/pwm3",
-          "type": 5,
-          "thresholds": {
-            "upperCriticalVal": 255,
-            "lowerCriticalVal": 140
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN1_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan1_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN2_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan2_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN3_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan3_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN4_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan4_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN5_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan5_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN6_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan6_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN7_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan7_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY1_FAN8_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan8_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_PWM3",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/pwm3",
-          "type": 5,
-          "thresholds": {
-            "upperCriticalVal": 255,
-            "lowerCriticalVal": 140
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN1_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan1_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN2_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan2_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN3_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan3_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN4_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan4_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN5_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan5_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN6_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan6_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN7_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan7_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 12100,
-            "maxAlarmVal": 11000,
-            "minAlarmVal": 2400,
-            "lowerCriticalVal": 1250
-          }
-        },
-        {
-          "name": "FCB_FANTRAY2_FAN8_INPUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan8_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 14850,
-            "maxAlarmVal": 13500,
-            "minAlarmVal": 2900,
-            "lowerCriticalVal": 1500
-          }
-        },
-        {
           "name": "SMB_E1S_SSD_TEMP",
           "sysfsPath": "/run/devmap/sensors/SMB_E1S_SSD_TEMP/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 76.8,
             "upperCriticalVal": 84.8
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 850,
-            "maxAlarmVal": 830
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_VIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 0.98,
-            "maxAlarmVal": 0.9,
-            "minAlarmVal": 0.65,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_PIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 883,
-            "maxAlarmVal": 797
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 833,
-            "maxAlarmVal": 747
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "TH5_VDD_CORE_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 115,
-            "maxAlarmVal": 105
           },
           "compute": "@/1000.0"
         },
@@ -763,80 +401,6 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "XP3R3V_RIGHT_IIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 35,
-            "maxAlarmVal": 31
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 130,
-            "maxAlarmVal": 110
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_VIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 3.63,
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "3*@/1000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_PIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 500,
-            "maxAlarmVal": 410
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 470,
-            "maxAlarmVal": 380
-          },
-          "compute": "3*@/1000000.0"
-        },
-        {
-          "name": "XP3R3V_RIGHT_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
-          },
-          "compute": "@/1000.0"
-        },
-        {
           "name": "XP3R3V_SMB_CPLD",
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in0_input",
           "type": 1,
@@ -915,80 +479,6 @@
           "thresholds": {
             "upperCriticalVal": 75,
             "maxAlarmVal": 70
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_IIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 35,
-            "maxAlarmVal": 31
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 130,
-            "maxAlarmVal": 110
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_VIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 3.63,
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "3*@/1000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_PIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 500,
-            "maxAlarmVal": 410
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 470,
-            "maxAlarmVal": 380
-          },
-          "compute": "3*@/1000000.0"
-        },
-        {
-          "name": "XP3R3V_LEFT_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
           },
           "compute": "@/1000.0"
         },
@@ -1283,238 +773,6 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 15,
-            "maxAlarmVal": 11
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_1_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 84,
-            "maxAlarmVal": 72
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_1_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 48,
-            "maxAlarmVal": 36
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_1_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 0.99,
-            "maxAlarmVal": 0.945,
-            "minAlarmVal": 0.855,
-            "lowerCriticalVal": 0.81
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_1_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 0.825,
-            "maxAlarmVal": 0.7875,
-            "minAlarmVal": 0.7125,
-            "lowerCriticalVal": 0.675
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 145,
-            "maxAlarmVal": 120
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_1_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 85,
-            "maxAlarmVal": 70
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_1_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 40,
-            "maxAlarmVal": 30
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_1_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_1_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 15,
-            "maxAlarmVal": 11
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_0_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 84,
-            "maxAlarmVal": 72
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_0_IOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 48,
-            "maxAlarmVal": 36
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 14.4,
-            "maxAlarmVal": 13.2,
-            "minAlarmVal": 10.8,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_0_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 0.99,
-            "maxAlarmVal": 0.945,
-            "minAlarmVal": 0.855,
-            "lowerCriticalVal": 0.81
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_0_VOUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 0.825,
-            "maxAlarmVal": 0.7875,
-            "minAlarmVal": 0.7125,
-            "lowerCriticalVal": 0.675
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 145,
-            "maxAlarmVal": 120
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R9V_TH5_TRVDD_0_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 85,
-            "maxAlarmVal": 70
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_0_POUT",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
-          "type": 0,
-          "thresholds": {
-            "upperCriticalVal": 40,
-            "maxAlarmVal": 30
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "XP0R75V_TH5_TRVDD_0_TEMP",
-          "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 115
-          },
-          "compute": "@/1000.0"
-        },
-        {
           "name": "SMB_U327_TPS25990_COMe_XP12R0V_VIN",
           "sysfsPath": "/run/devmap/sensors/SMB_U327_TPS25990_COME/in1_input",
           "type": 1,
@@ -1575,373 +833,2741 @@
       ]
     },
     {
-      "slotPath": "/COME_SLOT@0",
-      "pmUnitName": "COME_CARD",
+      "slotPath": "/PDB_SLOT@0",
+      "pmUnitName": "PDB",
       "sensors": [
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 14,
-            "minAlarmVal": 9,
-            "upperCriticalVal": 15
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_P1V8_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 14,
-            "minAlarmVal": 9,
-            "upperCriticalVal": 15
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 2,
-            "upperCriticalVal": 2.2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in4_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 2,
-            "upperCriticalVal": 2.2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
+          "name": "PDB_INLET_LM75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PDB_TSENSOR_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
+            "upperCriticalVal": 65,
+            "maxAlarmVal": 60
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
+          "name": "POWER_BRICK1_VIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 56,
+            "maxAlarmVal": 54,
+            "minAlarmVal": 46,
+            "lowerCriticalVal": 44
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "POWER_BRICK1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "POWER_BRICK1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
+            "upperCriticalVal": 110,
+            "maxAlarmVal": 107
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 1024
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_P1V8_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 4096
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 1024
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_P1V8_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 125
-          },
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
+          "name": "POWER_BRICK1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/curr1_input",
           "type": 2,
           "thresholds": {
-            "maxAlarmVal": 12,
-            "upperCriticalVal": 15
+            "upperCriticalVal": 100,
+            "maxAlarmVal": 80
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU4_XDPE15284_P1V8_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
-          "type": 2,
-          "thresholds": {
-            "maxAlarmVal": 3,
-            "upperCriticalVal": 3.5
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "maxAlarmVal": 94,
-            "upperCriticalVal": 130
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr4_input",
-          "type": 2,
-          "thresholds": {
-            "maxAlarmVal": 3,
-            "upperCriticalVal": 6
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
+          "name": "POWER_BRICK2_VIN",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15
+            "upperCriticalVal": 56,
+            "maxAlarmVal": 54,
+            "minAlarmVal": 46,
+            "lowerCriticalVal": 44
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
+          "name": "POWER_BRICK2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.605,
-            "lowerCriticalVal": 0.805
+            "upperCriticalVal": 14.4,
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "lowerCriticalVal": 9.6
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
+          "name": "POWER_BRICK2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
+            "upperCriticalVal": 110,
+            "maxAlarmVal": 107
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
-          "type": 2,
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
+          "name": "POWER_BRICK2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 26
+            "upperCriticalVal": 100,
+            "maxAlarmVal": 80
           },
           "compute": "@/1000.0"
-        },
+        }
+      ]
+    },
+    {
+      "slotPath": "BCB_SLOT@0",
+      "pmUnitName": "BCB",
+      "sensors": [
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
-          "type": 1,
+          "name": "FCB_FANTRAY1_PWM3",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/pwm3",
+          "type": 5,
           "thresholds": {
-            "upperCriticalVal": 15
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 255,
+            "lowerCriticalVal": 140
+          }
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
-          "type": 1,
+          "name": "FCB_FANTRAY1_FAN1_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan1_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 1.4,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
-          "type": 3,
+          "name": "FCB_FANTRAY1_FAN2_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan2_input",
+          "type": 4,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
         },
         {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
-          "type": 2,
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
-          "type": 2,
+          "name": "FCB_FANTRAY1_FAN3_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan3_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 13
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
         },
         {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
-          "type": 1,
+          "name": "FCB_FANTRAY1_FAN4_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan4_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 15
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
         },
         {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
-          "type": 1,
+          "name": "FCB_FANTRAY1_FAN5_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan5_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 1.4,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
         },
         {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
-          "type": 3,
+          "name": "FCB_FANTRAY1_FAN6_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan6_input",
+          "type": 4,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
         },
         {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
-          "type": 2,
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
-          "type": 2,
+          "name": "FCB_FANTRAY1_FAN7_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan7_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 5
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
-          "type": 1,
+          "name": "FCB_FANTRAY1_FAN8_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD/fan8_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 15
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
-          "type": 1,
+          "name": "FCB_FANTRAY2_PWM3",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/pwm3",
+          "type": 5,
           "thresholds": {
-            "upperCriticalVal": 1.46,
-            "lowerCriticalVal": 0.66
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 255,
+            "lowerCriticalVal": 140
+          }
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
-          "type": 3,
+          "name": "FCB_FANTRAY2_FAN1_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan1_input",
+          "type": 4,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 115
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
         },
         {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
-          "type": 0,
-          "compute": "@/1000000.0"
-        },
-        {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
-          "type": 2,
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
-          "type": 2,
+          "name": "FCB_FANTRAY2_FAN2_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan2_input",
+          "type": 4,
           "thresholds": {
-            "upperCriticalVal": 20
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
         },
+        {
+          "name": "FCB_FANTRAY2_FAN3_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
+        },
+        {
+          "name": "FCB_FANTRAY2_FAN4_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
+        },
+        {
+          "name": "FCB_FANTRAY2_FAN5_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan5_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
+        },
+        {
+          "name": "FCB_FANTRAY2_FAN6_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan6_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
+        },
+        {
+          "name": "FCB_FANTRAY2_FAN7_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan7_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 12100,
+            "maxAlarmVal": 11000,
+            "minAlarmVal": 2400,
+            "lowerCriticalVal": 1250
+          }
+        },
+        {
+          "name": "FCB_FANTRAY2_FAN8_INPUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_BCB_FAN_CPLD_2/fan8_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14850,
+            "maxAlarmVal": 13500,
+            "minAlarmVal": 2900,
+            "lowerCriticalVal": 1500
+          }
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_FRU_SLOT@0",
+      "pmUnitName": "SMB",
+      "sensors": [],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "TH5_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 850,
+                "maxAlarmVal": 830
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.98,
+                "maxAlarmVal": 0.9,
+                "minAlarmVal": 0.65,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 883,
+                "maxAlarmVal": 797
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 833,
+                "maxAlarmVal": 747
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 0,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "TH5_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 850,
+                "maxAlarmVal": 830
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.98,
+                "maxAlarmVal": 0.9,
+                "minAlarmVal": 0.65,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 883,
+                "maxAlarmVal": 797
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 833,
+                "maxAlarmVal": 747
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "TH5_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 850,
+                "maxAlarmVal": 830
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.98,
+                "maxAlarmVal": 0.9,
+                "minAlarmVal": 0.65,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 883,
+                "maxAlarmVal": 797
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 833,
+                "maxAlarmVal": 747
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 3,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "TH5_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 850,
+                "maxAlarmVal": 830
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.98,
+                "maxAlarmVal": 0.9,
+                "minAlarmVal": 0.65,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 883,
+                "maxAlarmVal": 797
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 833,
+                "maxAlarmVal": 747
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 4,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "TH5_VDD_CORE_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 850,
+                "maxAlarmVal": 830
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.98,
+                "maxAlarmVal": 0.9,
+                "minAlarmVal": 0.65,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 883,
+                "maxAlarmVal": 797
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 833,
+                "maxAlarmVal": 747
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "TH5_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PHASE3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr5_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PHASE4_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 35,
+                "maxAlarmVal": 31
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PHASE3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr5_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PHASE4_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 32.5,
+                "maxAlarmVal": 27.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 3.63,
+                "maxAlarmVal": 3.465,
+                "minAlarmVal": 3.135,
+                "lowerCriticalVal": 2.97
+              },
+              "compute": "3*@/1000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 500,
+                "maxAlarmVal": 410
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 470,
+                "maxAlarmVal": 380
+              },
+              "compute": "3*@/1000000.0"
+            },
+            {
+              "name": "XP3R3V_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_PHASE3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr5_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr7_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 24,
+                "maxAlarmVal": 18
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr8_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 24,
+                "maxAlarmVal": 18
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 15,
+                "maxAlarmVal": 11
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 84,
+                "maxAlarmVal": 72
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_PHASE3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr5_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 28,
+                "maxAlarmVal": 24
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr6_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 48,
+                "maxAlarmVal": 36
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_PHASE1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr7_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 24,
+                "maxAlarmVal": 18
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_PHASE2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr8_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 24,
+                "maxAlarmVal": 18
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 14.4,
+                "maxAlarmVal": 13.2,
+                "minAlarmVal": 10.8,
+                "lowerCriticalVal": 9.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.99,
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.855,
+                "lowerCriticalVal": 0.81
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 0.825,
+                "maxAlarmVal": 0.7875,
+                "minAlarmVal": 0.7125,
+                "lowerCriticalVal": 0.675
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 145,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R9V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 85,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_TH5_TRVDD_0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 40,
+                "maxAlarmVal": 30
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 115,
+                "maxAlarmVal": 105
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 2,
+          "productSubVersion": 10
+        }
+      ]
+    },
+    {
+      "slotPath": "/COME_SLOT@0",
+      "pmUnitName": "NETLAKE",
+      "sensors": [
         {
           "name": "COMe_U18_Inlet_Sensor_TMP75_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_U18_INLET_TSENSOR/temp1_input",
@@ -1962,11 +3588,720 @@
           },
           "compute": "@/1000.0"
         }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 4096
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 12,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 3,
+                "upperCriticalVal": 3.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 94,
+                "upperCriticalVal": 130
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 3,
+                "upperCriticalVal": 6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.605,
+                "lowerCriticalVal": 0.805
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 26
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "lowerCriticalVal": 0.66
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COMe_PU4_MP2993_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9.5,
+                "upperCriticalVal": 15,
+                "lowerCriticalVal": 8.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 2046
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 117,
+                "upperCriticalVal": 130
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 4,
+                "upperCriticalVal": 6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.45,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 26
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.15,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.61,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 2
+        }
       ]
     },
     {
       "slotPath": "/RUNBMC_SLOT@0",
-      "pmUnitName": "BMC_CARD",
+      "pmUnitName": "MINERVA_BMC",
       "sensors": [
         {
           "name": "BMC_U9_Thermal_Sensor_TMP1075_TEMP",

--- a/fboss/platform/configs/tahan800bc/sensor_service.json
+++ b/fboss/platform/configs/tahan800bc/sensor_service.json
@@ -1138,7 +1138,7 @@
     },
     {
       "slotPath": "/SMB_FRU_SLOT@0",
-      "pmUnitName": "SMB",
+      "pmUnitName": "SMB_FRU",
       "sensors": [],
       "versionedSensors": [
         {


### PR DESCRIPTION
Description
This PR is for tahan 2nd source sensor service.

Motivation
1.Than 2nd source sensor list is as following:
https://docs.google.com/spreadsheets/d/1r0Vbv1cx3KelYLEM4vl0VNyIeEpFwurG5JJZ6BckMCI/edit?gid=1266933266#gid=1266933266
![image](https://github.com/user-attachments/assets/295d74a4-ac9f-48e6-ae6c-64ce3ea331db)

![image](https://github.com/user-attachments/assets/d5af257f-8ef4-4404-89dc-19d30eef21ef)

2.Currently,all the SMB number combinations and COME number combinations are as follows,in the future if factories have new numbers, we should add them.
![image](https://github.com/user-attachments/assets/9013c657-2471-442c-a6cc-3b4afd5fac9b)


3.In platform config, adjust SMBFRU_SLOT to SMB_FRU_SLOT,adjust BCB_SLOT.


4.Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:
Tested both in janga dvt main source & janga dvt 2nd source machine.

tahan 2nd source tested log:
![image](https://github.com/user-attachments/assets/2b83296e-24df-479e-aee8-e8c02b5670f4)





tahan main source tested log:

![tahan_dvt](https://github.com/user-attachments/assets/98785c48-c029-4985-b53c-782f2d4eb4e2)




[tahan_dvt_2nd_source_platform_test_log.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/13786/attachments/tahan_dvt_2nd_source_platform_test_log.txt) [tahan_dvt_2nd_source_sensor_test_log.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/13786/attachments/tahan_dvt_2nd_source_sensor_test_log.txt) [tahan_dvt_platform_test_log.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/13786/attachments/tahan_dvt_platform_test_log.txt) [tahan_dvt_sensor_test_log.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/13786/attachments/tahan_dvt_sensor_test_log.txt) 



FYI: the sensor_hw_test_log:
[tahan_dvt_2nd_source_sensor_hw_test_log.txt](https://github.com/user-attachments/files/17456086/tahan_dvt_2nd_source_sensor_hw_test_log.txt)
[tahan_dvt_sensor_hw_test_log.txt](https://github.com/user-attachments/files/17456087/tahan_dvt_sensor_hw_test_log.txt)
