### PR TITLE
Darwin Rackmon ORV3 support

### DIFF
--- a/cmake/PlatformRackmon.cmake
+++ b/cmake/PlatformRackmon.cmake
@@ -3,9 +3,11 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/configs/interface/rackmon.conf fboss/platform/rackmon/configs/interface/rackmon.conf
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/configs/interface/rackmon_pls.conf fboss/platform/rackmon/configs/interface/rackmon_pls.conf
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/configs/register_map/orv2_psu.json fboss/platform/rackmon/configs/register_map/orv2_psu.json
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/configs/register_map/orv3_psu.json fboss/platform/rackmon/configs/register_map/orv3_psu.json
+  COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/configs/register_map/orv3_bbu.json fboss/platform/rackmon/configs/register_map/orv3_bbu.json
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/fboss/platform/rackmon/generate_rackmon_config.sh fboss/platform/rackmon/generate_rackmon_config.sh
   COMMAND fboss/platform/rackmon/generate_rackmon_config.sh --install_dir=fboss/platform/rackmon/
-  DEPENDS fboss/platform/rackmon/configs/interface/rackmon.conf fboss/platform/rackmon/configs/interface/rackmon_pls.conf fboss/platform/rackmon/configs/register_map/orv2_psu.json
+  DEPENDS fboss/platform/rackmon/configs/interface/rackmon.conf fboss/platform/rackmon/configs/interface/rackmon_pls.conf fboss/platform/rackmon/configs/register_map/orv2_psu.json fboss/platform/rackmon/configs/register_map/orv3_psu.json fboss/platform/rackmon/configs/register_map/orv3_bbu.json
 )
 
 add_fbthrift_cpp_library(

--- a/fboss/platform/rackmon/BUCK
+++ b/fboss/platform/rackmon/BUCK
@@ -41,6 +41,8 @@ custom_rule(
         "configs/interface/rackmon.conf",
         "configs/interface/rackmon_pls.conf",
         "configs/register_map/orv2_psu.json",
+        "configs/register_map/orv3_bbu.json",
+        "configs/register_map/orv3_psu.json",
     ],
     add_install_dir = True,
     build_script_dep = ":generate_rackmon_config.sh",
@@ -61,6 +63,8 @@ buck_filegroup(
         "configs/interface/rackmon.conf",
         "configs/interface/rackmon_pls.conf",
         "configs/register_map/orv2_psu.json",
+        "configs/register_map/orv3_bbu.json",
+        "configs/register_map/orv3_psu.json",
     ],
 )
 
@@ -120,6 +124,8 @@ cpp_binary(
         "configs/interface/rackmon.conf",
         "configs/interface/rackmon_pls.conf",
         "configs/register_map/orv2_psu.json",
+        "configs/register_map/orv3_bbu.json",
+        "configs/register_map/orv3_psu.json",
     ],
     deps = [
         ":handler",

--- a/fboss/platform/rackmon/RackmonThriftHandler.cpp
+++ b/fboss/platform/rackmon/RackmonThriftHandler.cpp
@@ -32,6 +32,12 @@ ModbusDeviceType typeFromString(const std::string& str) {
   if (str == "ORV2_PSU") {
     return ModbusDeviceType::ORV2_PSU;
   }
+  if (str == "ORV3_PSU") {
+    return ModbusDeviceType::ORV3_PSU;
+  }
+  if (str == "ORV3_BBU") {
+    return ModbusDeviceType::ORV3_BBU;
+  }
   throw std::runtime_error("Unknown PSU: " + str);
 }
 
@@ -39,6 +45,10 @@ std::string typeToString(ModbusDeviceType type) {
   switch (type) {
     case ModbusDeviceType::ORV2_PSU:
       return "ORV2_PSU";
+    case ModbusDeviceType::ORV3_PSU:
+      return "ORV3_PSU";
+    case ModbusDeviceType::ORV3_BBU:
+      return "ORV3_BBU";
     default:
       break;
   }

--- a/fboss/platform/rackmon/configs/register_map/orv3_bbu.json
+++ b/fboss/platform/rackmon/configs/register_map/orv3_bbu.json
@@ -1,0 +1,880 @@
+{
+    "name": "ORV3_BBU",
+    "address_range": [
+        [64, 69],
+        [80, 82],
+        [96, 101]
+    ],
+    "probe_register": 8,
+    "baudrate": 19200,
+    "special_handlers": [
+      {
+        "reg": 302,
+        "len": 2,
+        "period": 3600,
+        "action": "write",
+        "info": {
+          "interpret": "INTEGER",
+          "shell": "date +%s"
+        }
+      }
+    ],
+    "registers": [
+        {
+            "begin": 0,
+            "length": 8,
+            "format": "STRING",
+            "name": "Manufacture_Name"
+        },
+        {
+            "begin": 8,
+            "length": 8,
+            "format": "STRING",
+            "name": "Manufacture_Model"
+        },
+        {
+            "begin": 16,
+            "length": 8,
+            "format": "STRING",
+            "name": "Manufacture_Date"
+        },
+        {
+            "begin": 24,
+            "length": 8,
+            "format": "STRING",
+            "name": "Facebook_Part_Number"
+        },
+        {
+            "begin": 48,
+            "length": 2,
+            "format": "STRING",
+            "name": "Build_Revision"
+        },
+        {
+            "begin": 52,
+            "length": 4,
+            "format": "STRING",
+            "name": "HW_Revision"
+        },
+        {
+            "begin": 56,
+            "length": 4,
+            "format": "STRING",
+            "name": "FW_Revision"
+        },
+        {
+            "begin": 60,
+            "length": 4,
+            "format": "STRING",
+            "name": "Workorder"
+        },
+        {
+            "begin": 64,
+            "length": 16,
+            "format": "STRING",
+            "name": "MFR_Serial"
+        },
+        {
+            "begin": 80,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Random_Number_Of_SoH_Test"
+        },
+        {
+            "begin": 104,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [15, "Discharge_Not_Allowed"],
+                [14, "Charge_Not_Allowed"],
+                [13, "Temperature_Failure"],
+                [12, "Pack_Over_Current"],
+                [11, "Cell_Under_Voltage"],
+                [10, "Pack_Under_Voltage"],
+                [9, "Cell_Over_Voltage"],
+                [8, "Pack_Over_Voltage"],
+                [7, "EOL"],
+                [6, "Fan_Failure"],
+                [5, "Cell_Balancing_Failure"],
+                [4, "Micro_Failure"],
+                [3, "AFE_Failure"],
+                [2, "Discharge_Fuse_Failure"],
+                [1, "Charge_Fuse_Failure"],
+                [0, "Charge_FET_Failure"]
+            ],
+            "name": "BBU_Status"
+        },
+        {
+            "begin": 105,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [12, "Temp_Sensor_Failure"],
+                [11, "Other_Permanent_Faults"],
+                [10, "Charge_Timeout"],
+                [9, "Micro_Failure"],
+                [8, "Fuse_Failure"],
+                [7, "Fan_Failure"],
+                [6, "AFE_Failure"],
+                [5, "Discharge_FET_failure"],
+                [4, "Charge_FET_Failure"],
+                [3, "Cell_Balancing_Failure"],
+                [2, "Cell_Over_Temperature"],
+                [1, "Cell_Under_Voltage"],
+                [0, "Cell_Over_Voltage"]
+            ],
+            "name": "Permanent_Failures"
+        },
+        {
+            "begin": 106,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Manufacturer_Access"
+        },
+        {
+            "begin": 107,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [15, "VO_SEL_Pin_Enable_Disable"],
+                [14, "EOL_Threshold_Override"],
+                [13, "System_Control_Enable"],
+                [12, "CC_Charge_Timeout_Disable"],
+                [11, "PCM_Threshold_Override_Enable"],
+                [10, "Variable_Charger_Manual_Override"],
+                [9, "HW_Reset_Pin_Enable_Disable"],
+                [8, "SoH_Override"],
+                [7, "SoH_Test_Interval_Override"],
+                [6, "SMBUS_Communication_Failure"],
+                [5, "CANBUS_Communication_Failure"],
+                [4, "SoH_Test_OCV_Relaxation_Time"],
+                [3, "SoH_Test"],
+                [2, "Cell_Balancing"],
+                [1, "Discharge"],
+                [0, "Charging"]
+            ],
+            "name": "BBU_Mode"
+        },
+        {
+            "begin": 108,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [15, "Over_Charge_Alarm"],
+                [14, "Terminate_Charge_Alarm"],
+                [12, "Over_Temerature_Alarm"],
+                [11, "Terminate_Discharge_Alarm"],
+                [9, "Remaing_Capacity_Alarm"],
+                [8, "Remaining_Time_Alarm"],
+                [7, "Initialized"],
+                [6, "Discharging"],
+                [5, "Fully_Charged"],
+                [4, "Fully_Discharged"]
+            ],
+            "name": "Battery_Status"
+        },
+        {
+            "begin": 109,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage1"
+        },
+        {
+            "begin": 110,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage2"
+        },
+        {
+            "begin": 111,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage3"
+        },
+        {
+            "begin": 112,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage4"
+        },
+        {
+            "begin": 113,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage5"
+        },
+        {
+            "begin": 114,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage6"
+        },
+        {
+            "begin": 115,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage7"
+        },
+        {
+            "begin": 116,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage8"
+        },
+        {
+            "begin": 117,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage9"
+        },
+        {
+            "begin": 118,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage10"
+        },
+        {
+            "begin": 119,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cell_Voltage11"
+        },
+        {
+            "begin": 121,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "SOH_Count"
+        },
+        {
+            "begin": 122,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Temp1"
+        },
+        {
+            "begin": 123,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Temp2"
+        },
+        {
+            "begin": 124,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Temp3"
+        },
+        {
+            "begin": 125,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Temp4"
+        },
+        {
+            "begin": 126,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Relative_State_Of_Charge"
+        },
+        {
+            "begin": 127,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Absolute_State_Of_Charge"
+        },
+        {
+            "begin": 128,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Battery_Voltage"
+        },
+        {
+            "begin": 129,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "sign": true,
+            "name": "Battery_Current"
+        },
+        {
+            "begin": 130,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "sign": true,
+            "name": "Average_Current"
+        },
+        {
+            "begin": 131,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Remaining_Capacity"
+        },
+        {
+            "begin": 132,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Full_Charge_Capacity"
+        },
+        {
+            "begin": 133,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Run_Time_To_Empty"
+        },
+        {
+            "begin": 134,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Average_Time_To_Empty"
+        },
+        {
+            "begin": 135,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Cycle_Count"
+        },
+        {
+            "begin": 136,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Design_Capacity"
+        },
+        {
+            "begin": 137,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Design_Voltage"
+        },
+        {
+            "begin": 138,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "sign": true,
+            "name": "At_Rate"
+        },
+        {
+            "begin": 139,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "At_Rate_Time_To_Full"
+        },
+        {
+            "begin": 140,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "At_Rate_Time_To_Empty"
+        },
+        {
+            "begin": 141,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "At_Rate_OK"
+        },
+        {
+            "begin": 142,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "SOH"
+        },
+        {
+            "begin": 143,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Max_Error"
+        },
+        {
+            "begin": 144,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Charging_Current"
+        },
+        {
+            "begin": 145,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Charging_Voltage"
+        },
+        {
+            "begin": 146,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Discharge_Current"
+        },
+        {
+            "begin": 147,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Shelf_Busbar_Voltage"
+        },
+        {
+            "begin": 148,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Inlet_Ambient_Temperature"
+        },
+        {
+            "begin": 149,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Outlet_Ambient_Temperature"
+        },
+        {
+            "begin": 150,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Charge_Buck_Temperature"
+        },
+        {
+            "begin": 151,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Discharge_Buck_Temperature"
+        },
+        {
+            "begin": 152,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "Fan_Speed"
+        },
+        {
+            "begin": 153,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [7, "Second_Shelf_Detection"],
+                [4, "Fan_Fault"],
+                [3, "Charger_Converter_Fault"],
+                [2, "Buck_Converter_Fault"],
+                [1, "Power_Boost_Converter_Fault"],
+                [0, "Temperature_Fault"]
+            ],
+            "name": "BBU_Status_Word"
+        },
+        {
+            "begin": 154,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [4, "Power_Boost_UVP"],
+                [3, "Power_Boost_SCP2"],
+                [2, "Power_Boost_OVP"],
+                [1, "Power_Boost_OCP"],
+                [0, "Power_Boost_SCP1"]
+            ],
+            "name": "BBU_Status_Power_Boost"
+        },
+        {
+            "begin": 155,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [3, "Buck_Output_OVP"]
+            ],
+            "name": "BBU_Status_Buck_Converter"
+        },
+        {
+            "begin": 156,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [4, "Charger_Timeout"],
+                [3, "Charger_Output_OCP"],
+                [2, "Charger_Output_OVP"],
+                [1, "Charger_Input_UVP"],
+                [0, "Charger_Input_OVP"]
+            ],
+            "name": "BBU_Status_Charger"
+        },
+        {
+            "begin": 157,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [5, "Battery_Pack_OTP"],
+                [4, "Power_Boost_OTP"],
+                [3, "Buck_Converter_OTP"],
+                [2, "Charger_OTP"],
+                [1, "Output_Ambient_OTP"],
+                [0, "Input_Ambient_OTP"]
+            ],
+            "name": "BBU_Status_Temperature"
+        },
+        {
+            "begin": 158,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [0, "BBU_EOL"]
+            ],
+            "name": "End_of_Life_Status"
+        },
+        {
+            "begin": 159,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "BBU_Discharger_Output_Voltage_Inside_Oring"
+        },
+        {
+            "begin": 160,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Variable_Charge_Calculated_Current"
+        },
+        {
+            "begin": 161,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "BBU_Total_Service_Time"
+        },
+        {
+            "begin": 162,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [15, "Discharge_Power_Less_Than_500W"],
+                [14, "BBU_Failure"],
+                [13, "BBU_Not_Installed"],
+                [12, "BBU_EOL"],
+                [11, "BBU_In_Bootloader_Mode"],
+                [10, "BBU_Voltage_3900mV_Per_Cell"],
+                [9, "CAN_Failure"],
+                [8, "BBU_Backup"],
+                [7, "Others"]
+            ],
+            "name": "SOH_Failure_Reason"
+        },
+        {
+            "begin": 163,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Number_of_Installed_BBUs"
+        },
+        {
+            "begin": 164,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [15, "SYNC_STOP_L"],
+                [14, "PSKILL"],
+                [13, "BBU_ALERT_L"],
+                [12, "BBU_Reset"],
+                [11, "SOH_L"],
+                [10, "BKP_RED_L"],
+                [9, "VOUT_SEL"],
+                [8, "PLS_L"],
+                [7, "SYNC_START_L"],
+                [6, "A2"],
+                [5, "A1"],
+                [4, "A0"],
+                [3, "RS485_Addr2"],
+                [2, "RS485_Addr1"],
+                [1, "RS485_Addr0"]
+            ],
+            "name": "BBU_Module_Hardware_Signals"
+        },
+        {
+            "begin": 165,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [15, "SYS_PRES"],
+                [14, "PF_Flag"],
+                [13, "GG_SMD"],
+                [12, "GG_SMC"],
+                [11, "RTCSMD"],
+                [10, "RTCSMC"],
+                [7, "BMS_Not_Insert"],
+                [5, "PSU_Fault_L"],
+                [4, "BMS_Fail"],
+                [2, "BMS_SoH"],
+                [1, "BMS_Charge_Enable"],
+                [0, "BMS_Stop_Discharge"]
+            ],
+            "name": "Battery_Pack_Hardware_Signals"
+        },
+        {
+            "begin": 166,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [7, "FAULT_LOC_LED_Blink"],
+                [6, "FAULT_LOC_LED_On"],
+                [5, "EOL_LED_Blink"],
+                [4, "EOL_LED_On"],
+                [3, "LOWV_LED_Blink"],
+                [2, "LOWV_LED_On"],
+                [1, "Power_Good_LED_Blink"],
+                [0, "Power_Good_LED_On"]
+            ],
+            "name": "LED_Status"
+        },
+        {
+            "begin": 167,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Count_of_Discharge_Events"
+        },
+        {
+            "begin": 168,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [15, "Discharge_Power_Less_Than_500W"],
+                [14, "BBU_Failure"],
+                [13, "BBU_Not_Installed"],
+                [12, "BBU_EOL"],
+                [11, "BBU_In_Bootloader_Mode"],
+                [10, "BBU_Voltage_3900mV_Per_Cell"],
+                [9, "CAN_Failure"],
+                [8, "Other"]
+            ],
+            "name": "SOH_Not_Start_Reason"
+        },
+        {
+            "begin": 179,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Battery_Pack_Charge_Failure"
+        },
+        {
+            "begin": 180,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Battery_Pack_Discharge_Failure"
+        },
+        {
+            "begin": 181,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Battery_Pack_Permanent_Failure"
+        },
+        {
+            "begin": 182,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Battery_Pack_FW_Revision"
+        },
+        {
+            "begin": 183,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Specification_Info"
+        },
+        {
+            "begin": 184,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Manufacturer_Date"
+        },
+        {
+            "begin": 185,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Serial_Number"
+        },
+        {
+            "begin": 186,
+            "length": 2,
+            "format": "STRING",
+            "name": "Device_Chemistry"
+        },
+        {
+            "begin": 188,
+            "length": 4,
+            "format": "STRING",
+            "name": "Manufacturer_Data"
+        },
+        {
+            "begin": 192,
+            "length": 16,
+            "format": "STRING",
+            "name": "Manufacturer_Name"
+        },
+        {
+            "begin": 208,
+            "length": 16,
+            "format": "STRING",
+            "name": "Device_Name"
+        },
+        {
+            "begin": 288,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Variable_Modbus_Baud_Rate"
+        },
+        {
+            "begin": 289,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Configurable_BBU_Maximum_Discharge_Time"
+        },
+        {
+            "begin": 290,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Configurable_Power_Loss_Siren_Timing"
+        },
+        {
+            "begin": 291,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Variable_Charge_Override_Current"
+        },
+        {
+            "begin": 292,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [0, "Fault_LED_Blink"]
+            ],
+            "name": "LED_Override"
+        },
+        {
+            "begin": 293,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Fan_Speed_Override"
+        },
+        {
+            "begin": 294,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "PCM_Recharge_Threshold_Override"
+        },
+        {
+            "begin": 295,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Override_Random_Number_Of_SOH_Test"
+        },
+        {
+            "begin": 296,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Override_Interval_Of_SOH_Test"
+        },
+        {
+            "begin": 298,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "SOH_Timestamp"
+        },
+        {
+            "begin": 300,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Variable_Charge_Override_Timeout"
+        },
+        {
+            "begin": 302,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Wall_Clock_Time"
+        },
+        {
+            "begin": 304,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "EOL_Threshold_Override"
+        },
+        {
+            "begin": 305,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Forced_Discharge_Time"
+        },
+        {
+            "begin": 306,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "System_Control_Mode"
+        },
+        {
+            "begin": 307,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "BBU_Shelf_Configuration"
+        },
+        {
+            "begin": 308,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Forced_Detached_Mode_Timeout"
+        },
+        {
+            "begin": 310,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "PSU_Shelf_Output_Power"
+        },
+        {
+            "begin": 311,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "PSU_AC_OK"
+        },
+        {
+            "begin": 312,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Charge_Delay_Time"
+        },
+        {
+            "begin": 313,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [0, "Clear_BBU_Faults_And_Latch"]
+            ],
+            "name": "BBU_Clear_Fault"
+        }
+    ]
+}

--- a/fboss/platform/rackmon/configs/register_map/orv3_psu.json
+++ b/fboss/platform/rackmon/configs/register_map/orv3_psu.json
@@ -1,0 +1,423 @@
+{
+    "name": "ORV3_PSU",
+    "address_range": [
+        [200, 205],
+        [232, 237],
+        [240, 242]
+    ],
+    "probe_register": 8,
+    "baudrate": 19200,
+    "special_handlers": [
+      {
+        "reg": 98,
+        "len": 2,
+        "period": 3600,
+        "action": "write",
+        "info": {
+          "interpret": "INTEGER",
+          "shell": "date +%s"
+        }
+      }
+    ],
+    "registers": [
+        {
+            "begin": 0,
+            "length": 8,
+            "format": "STRING",
+            "name": "PSU_FBPN"
+        },
+        {
+            "begin": 8,
+            "length": 8,
+            "format": "STRING",
+            "name": "PSU_MFR_Model"
+        },
+        {
+            "begin": 16,
+            "length": 8,
+            "format": "STRING",
+            "name": "PSU_MFR_Date"
+        },
+        {
+            "begin": 24,
+            "length": 16,
+            "format": "STRING",
+            "name": "PSU_MFR_Serial"
+        },
+        {
+            "begin": 40,
+            "length": 4,
+            "format": "STRING",
+            "name": "PSU_Workorder"
+        },
+        {
+            "begin": 44,
+            "length": 4,
+            "format": "STRING",
+            "name": "PSU_HW_Revision"
+        },
+        {
+            "begin": 48,
+            "length": 4,
+            "format": "STRING",
+            "name": "PSU_FW_Revision"
+        },
+        {
+            "begin": 52,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Total_Up_Time"
+        },
+        {
+            "begin": 54,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Time_Since_Last_On"
+        },
+        {
+            "begin": 56,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "AC_Power_Cycle_Counter"
+        },
+        {
+            "begin": 57,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "AC_Outage_Counter"
+        },
+        {
+            "begin": 60,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [11, "Fan_Alarm"],
+                [10, "Temp_Alarm"],
+                [9, "DCDC_Converter_Failure"],
+                [8, "PFC_Converter_Fail"],
+                [3, "Communication"],
+                [2, "Temperature"],
+                [1, "DCDC"],
+                [0, "PFC"]
+            ],
+            "name": "General_Alarm_Status_Register"
+        },
+        {
+            "begin": 61,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [11, "PFC_Fail"],
+                [10, "Input_Relay_Off"],
+                [9, "Bulk_Not_Ok"],
+                [8, "AC_Not_OK"],
+                [5, "Freq_High"],
+                [4, "Freq_Low"],
+                [1, "AC_OVP"],
+                [0, "AC_UVP"]
+            ],
+            "name": "PFC_Alarm_Status_Register"
+        },
+        {
+            "begin": 62,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [10, "Oring_Fail"],
+                [9, "Secondary_MCU_Fail"],
+                [8, "DCDC_Fail"],
+                [3, "Main_SCKT"],
+                [2, "Main_OCP"],
+                [1, "Main_OVP"],
+                [0, "Main_UVP"]
+            ],
+            "name": "DCDC_Alarm_Status_Register"
+        },
+        {
+            "begin": 63,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [8, "Fan_Failure"],
+                [5, "PFC_Temp_Alarm"],
+                [4, "LLC_Temp_Alarm"],
+                [3, "Sync_Temp_Alarm"],
+                [2, "Oring_Temp_Alarm"],
+                [1, "Inlet_Temp_Alarm"],
+                [0, "Outlet_Temp_Alarm"]
+            ],
+            "name": "Temperature_Alarm_Status_Register"
+        },
+        {
+            "begin": 64,
+            "length": 1,
+            "keep": 10,
+            "changes_only": true,
+            "format": "FLAGS",
+            "flags": [
+                [9, "PMBus_Active"],
+                [8, "Modbus_Active"],
+                [1, "Secondary_Logic_MCU_Fault"],
+                [0, "Primary_Secondary_MCU_Fault"]
+            ],
+            "name": "Communication_Alarm_Status_Register"
+        },
+        {
+            "begin": 67,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "PSU_RPM_Fan0"
+        },
+        {
+            "begin": 68,
+            "length": 1,
+            "keep": 10,
+            "format": "INTEGER",
+            "name": "PSU_RPM_Fan1"
+        },
+        {
+            "begin": 69,
+            "length": 1,
+            "keep": 10,
+            "format": "FLOAT",
+            "precision": 7,
+            "sign": true,
+            "name": "PSU_Temp0_Inlet"
+        },
+        {
+            "begin": 70,
+            "length": 1,
+            "keep": 10,
+            "format": "FLOAT",
+            "precision": 7,
+            "sign": true,
+            "name": "PSU_Temp1_Outlet"
+        },
+        {
+            "begin": 71,
+            "length": 1,
+            "keep": 10,
+            "format": "FLOAT",
+            "precision": 7,
+            "sign": true,
+            "name": "PSU_Max_Temp"
+        },
+        {
+            "begin": 72,
+            "length": 1,
+            "keep": 10,
+            "format": "FLOAT",
+            "precision": 7,
+            "sign": true,
+            "name": "PSU_Min_Temp"
+        },
+        {
+            "begin": 73,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "PSU_Position_Number"
+        },
+        {
+            "begin": 75,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "CRC_Error_Counter"
+        },
+        {
+            "begin": 77,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Timeout_Error_Counter"
+        },
+        {
+            "begin": 79,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 10,
+            "name": "PSU_Output_Voltage"
+        },
+        {
+            "begin": 80,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "PSU_Output_Current"
+        },
+        {
+            "begin": 81,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "I_Share_Current_Value"
+        },
+        {
+            "begin": 82,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 3,
+            "name": "PSU_Output_Power"
+        },
+        {
+            "begin": 83,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "PSU_Bulk_Cap_Voltage"
+        },
+        {
+            "begin": 84,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 0,
+            "name": "PSU_Input_Frequency_AC"
+        },
+        {
+            "begin": 85,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 9,
+            "name": "PSU_ITHD"
+        },
+        {
+            "begin": 86,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 9,
+            "name": "PSU_Power_Factor"
+        },
+        {
+            "begin": 87,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 3,
+            "name": "PSU_Input_Power"
+        },
+        {
+            "begin": 88,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "PSU_Input_Voltage_AC"
+        },
+        {
+            "begin": 89,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 10,
+            "name": "PSU_Input_Current_AC"
+        },
+        {
+            "begin": 90,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "PSU_Fault_Counter"
+        },
+        {
+            "begin": 92,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Power_Cycle_Unix_Time"
+        },
+        {
+            "begin": 94,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [15, "Power_Cycle_5s"],
+                [14, "Clear_Faults_Latch"],
+                [13, "VO_Sel_Pin_Enable"],
+                [12, "HW_Reset_Pin_Enable"],
+                [11, "Active_Current_Sharing_Enable"],
+                [10, "Operation_At_Low_Voltage"],
+                [9, "Output_Voltage_Setting_51V_48V"],
+                [8, "PLS_Enable_Disable"],
+                [0, "PSU_Write_Enable"]
+            ],
+            "name": "PSU_Setting_Register"
+        },
+        {
+            "begin": 95,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Communication_Baud_Rate"
+        },
+        {
+            "begin": 96,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Fan_Duty_Cycle_Override"
+        },
+        {
+            "begin": 97,
+            "length": 1,
+            "format": "FLAGS",
+            "flags": [
+                [6, "Amber_LED"],
+                [5, "Blue_LED"],
+                [0, "LED_Override"]
+            ],
+            "name": "LED_Override"
+        },
+        {
+            "begin": 98,
+            "length": 2,
+            "format": "INTEGER",
+            "name": "Unix_Time"
+        },
+        {
+            "begin": 100,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Configurable_PLS_Timing"
+        },
+        {
+            "begin": 101,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "Vin_Min"
+        },
+        {
+            "begin": 102,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 6,
+            "name": "Vin_Max"
+        },
+        {
+            "begin": 103,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 10,
+            "name": "Vout_Setpoint_H"
+        },
+        {
+            "begin": 104,
+            "length": 1,
+            "format": "FLOAT",
+            "precision": 10,
+            "name": "Vout_Setpoint_L"
+        },
+        {
+            "begin": 105,
+            "length": 1,
+            "format": "INTEGER",
+            "name": "Vout_Change_Timer"
+        },
+        {
+            "begin": 106,
+            "length": 4,
+            "format": "STRING",
+            "name": "PSU_FBL_FW_Revision"
+        }
+    ]
+}

--- a/fboss/platform/rackmon/tests/RackmonConfigTest.cpp
+++ b/fboss/platform/rackmon/tests/RackmonConfigTest.cpp
@@ -16,10 +16,20 @@ TEST(RackmonConfig, Interface) {
 
 TEST(RackmonConfig, RegisterMap) {
   const std::vector<std::string> mapsConfig = getRegisterMapConfig();
-  ASSERT_EQ(mapsConfig.size(), 1);
+  ASSERT_EQ(mapsConfig.size(), 3);
   json maps = json::parse(mapsConfig.at(0));
   ASSERT_EQ(maps["name"], "ORV2_PSU");
   ASSERT_EQ(maps["probe_register"], 104);
   ASSERT_GE(maps["registers"].size(), 30);
   ASSERT_EQ(maps["registers"][0]["name"], "PSU MFR MODEL");
+  maps = json::parse(mapsConfig.at(1));
+  ASSERT_EQ(maps["name"], "ORV3_BBU");
+  ASSERT_EQ(maps["probe_register"], 8);
+  ASSERT_GE(maps["registers"].size(), 30);
+  ASSERT_EQ(maps["registers"][0]["name"], "Manufacture_Name");
+  maps = json::parse(mapsConfig.at(2));
+  ASSERT_EQ(maps["name"], "ORV3_PSU");
+  ASSERT_EQ(maps["probe_register"], 8);
+  ASSERT_GE(maps["registers"].size(), 30);
+  ASSERT_EQ(maps["registers"][0]["name"], "PSU_FBPN");
 }


### PR DESCRIPTION
Provide additional config and enhancements to Rackmon logic to support ORV3 for Darwin. Darwin is the only platform so far to support Rackmon from FBOSS.

# Test Plan:

1. On a Darwin system connected to PSUs and BBUs, used the thriftctl utility to verify rackmon was monitoring the devices:
```
[root@rkdo301 ~]# thriftctl listPorts
5909: neteng.fboss.ctrl.FbossCtrl
5910: neteng.fboss.qsfp.QsfpService
5931: neteng.fboss.hw_ctrl.FbossHwCtrl
5932: neteng.fboss.hw_ctrl.FbossHwCtrl
5970: neteng.fboss.platform.sensor_service.SensorServiceThrift 5972: fan_service.FanService
5973: rackmonsvc.rackmonsvc.RackmonCtrl
[root@rkdo301 ~]# thriftctl listMethods -p 5973
Found 10 available methods under port:5973
        controlRackmond
        getMonitorData
        getMonitorDataEx
        getPowerLossSiren
        listModbusDevices
        presetMultipleRegisters
        readFileRecord
        readHoldingRegisters
        reload
        writeSingleRegister
[root@rkdo301 ~]# thriftctl request listModbusDevices -p 5973 [ModbusDeviceInfo(
    devAddress=64,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=65,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=66,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=67,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=68,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=69,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=96,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=97,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=98,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=99,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=100,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=101,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=3), ModbusDeviceInfo(
    devAddress=200,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=201,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=202,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=203,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=204,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=205,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=232,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=233,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=234,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=235,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=236,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1), ModbusDeviceInfo(
    devAddress=237,
    mode=0,
    baudrate=19200,
    timeouts=0,
    crcErrors=0,
    miscErrors=0,
    deviceType=1)]
[root@rkdo301 ~]# thriftctl request getMonitorData -p 5973 > /tmp/monitordata.txt
```

2. Ran the rackmon_test on a Darwin system:

```
[root@rkd205 ~]# /tmp/rackmon_test --gtest_filter=RackmonConfig.RegisterMap
Running main() from gmock_main.cc
Note: Google Test filter = RackmonConfig.RegisterMap
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from RackmonConfig
[ RUN      ] RackmonConfig.RegisterMap
[       OK ] RackmonConfig.RegisterMap (1 ms)
[----------] 1 test from RackmonConfig (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1 ms total)
[  PASSED  ] 1 test.
```

Monitored data is attached to this PR.
[rackmondata.txt](https://github.com/user-attachments/files/17637889/rackmondata.txt)
