### PR TITLE
janga: config: added new sensor tmp422 in platform and sensor config file

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -2114,9 +2114,17 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_23",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U68_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_25",
@@ -2126,7 +2134,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -2138,9 +2148,17 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_25",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U351_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_26",
@@ -2150,7 +2168,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -2162,9 +2182,17 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_26",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U352_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_27",
@@ -2174,7 +2202,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -2186,7 +2216,9 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
         },
@@ -2198,9 +2230,23 @@
           "initRegSettings": [
             {
               "regOffset": 11,
-              "ioBuf": [2]
+              "ioBuf": [
+                2
+              ]
             }
           ]
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_28",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U150_TMP422"
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_29",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U152_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_10",
@@ -2452,13 +2498,18 @@
     "/run/devmap/sensors/SMB_U279_ADM1272_1": "/[SMB_U279_ADM1272_1]",
     "/run/devmap/sensors/SMB_U104_LM75B_2": "/[SMB_U104_LM75B_2]",
     "/run/devmap/sensors/SMB_U355_ADC128D818_1": "/[SMB_U355_ADC128D818_1]",
+    "/run/devmap/sensors/SMB_U68_TMP422": "/[SMB_U68_TMP422]",
     "/run/devmap/sensors/SMB_U356_ADC128D818_1": "/[SMB_U356_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U360_ADC128D818_2": "/[SMB_U360_ADC128D818_2]",
+    "/run/devmap/sensors/SMB_U351_TMP422": "/[SMB_U351_TMP422]",
     "/run/devmap/sensors/SMB_U361_ADC128D818_1": "/[SMB_U361_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U357_ADC128D818_2": "/[SMB_U357_ADC128D818_2]",
+    "/run/devmap/sensors/SMB_U352_TMP422": "/[SMB_U352_TMP422]",
     "/run/devmap/sensors/SMB_U354_ADC128D818_1": "/[SMB_U354_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U288_ADC128D818_2": "/[SMB_U288_ADC128D818_2]",
     "/run/devmap/sensors/SMB_U353_ADC128D818_3": "/[SMB_U353_ADC128D818_3]",
+    "/run/devmap/sensors/SMB_U150_TMP422": "/[SMB_U150_TMP422]",
+    "/run/devmap/sensors/SMB_U152_TMP422": "/[SMB_U152_TMP422]",
     "/run/devmap/sensors/PDB_PMBUS_BRICK_1": "/PDB_SLOT@0/[PDB_PMBUS_BRICK_1]",
     "/run/devmap/sensors/PDB_PMBUS_BRICK_2": "/PDB_SLOT@0/[PDB_PMBUS_BRICK_2]",
     "/run/devmap/sensors/PDB_U1_LM75B": "/PDB_SLOT@0/[PDB_U1_LM75B]",

--- a/fboss/platform/configs/janga800bic/sensor_service.json
+++ b/fboss/platform/configs/janga800bic/sensor_service.json
@@ -3963,6 +3963,96 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_PADS",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_NIF0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
             }
           ],
           "productProductionState": 2,


### PR DESCRIPTION
Description
This PR is for janga 2nd source sensor service.

Motivation
1.In the table hw has added new sensor tmp422,https://docs.google.com/spreadsheets/d/1r0Vbv1cx3KelYLEM4vl0VNyIeEpFwurG5JJZ6BckMCI/edit?gid=1519693354#gid=1519693354,so i have changed platform and sensor config file.

![image](https://github.com/user-attachments/assets/c3d7326d-4c25-4766-bf30-2bed3d9c2cd0)


2.It has 5 tmp422 sensors in total.

3.Note: According to hw these 5 tmp422 sensors will be add in janga DVT2 and after machine(that is one is DVT and productversion is 4,and the other is all the pvt will have 5 tmp422 sensors).They are only added into this place.
![image](https://github.com/user-attachments/assets/9ca37c6b-1fb2-47fd-9dc0-12883d1294a8)


Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:
Tested both in janga dvt main source & janga dvt 2nd source machine.

janga dvt main source:

![image](https://github.com/user-attachments/assets/bbcfc70d-628c-4d63-9497-3930b0fcffcb)

![image](https://github.com/user-attachments/assets/e69d2c6e-3276-4313-b43c-f8f5572c4642)

janga dvt 2nd source machine

![image](https://github.com/user-attachments/assets/405e9524-2632-4e4b-bf09-a0fc4b1d967c)
![image](https://github.com/user-attachments/assets/b0b5b0a7-240b-46d8-8189-32fa3c0a2a96)


because currently i have no productversion 4 machine so i manually change the eeprom to simulate it
![image](https://github.com/user-attachments/assets/67e70db4-fe60-4d91-b5fe-2ada111fcb67)


[janga_dvt_second_platform_test_log_11_4.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/14132/attachments/janga_dvt_second_platform_test_log_11_4.txt) [janga_dvt_second_sensor_test_log_11_4.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/14132/attachments/janga_dvt_second_sensor_test_log_11_4.txt) [janga_dvt_main_platform_test_log_11_4.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/14132/attachments/janga_dvt_main_platform_test_log_11_4.txt) [janga_dvt_main_sensor_test_log_11_4.txt](https://dev.azure.com/celestica-hps/89689cf2-cfd3-42fd-afd4-dd867f890ff0/_apis/git/repositories/4c32c16c-7172-448c-b01f-4d18aa18cd31/pullRequests/14132/attachments/janga_dvt_main_sensor_test_log_11_4.txt) 
