### PR TITLE
janga/tahan: update pwmBoostValue in fan_service config file

### DIFF
--- a/fboss/platform/configs/janga800bic/fan_service.json
+++ b/fboss/platform/configs/janga800bic/fan_service.json
@@ -2,7 +2,7 @@
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 75,
+  "pwmBoostValue": 100,
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,

--- a/fboss/platform/configs/tahan800bc/fan_service.json
+++ b/fboss/platform/configs/tahan800bc/fan_service.json
@@ -2,7 +2,7 @@
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 75,
+  "pwmBoostValue": 100,
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,


### PR DESCRIPTION
### Description
As thermal team's verification test result, update the pwmBoostValue value to 100.

### Test log
I1115 19:13:17.242436  3025 ControlLogic.cpp:109] Successfully fetched optics data.
I1115 19:13:17.242441  3025 ControlLogic.cpp:578] Processing Fans ...
I1115 19:13:17.242471  3025 ControlLogic.cpp:365] FANTRAY1_FAN1: is present in the host (through sysfs)
I1115 19:13:17.254177  3025 ControlLogic.cpp:168] FANTRAY1_FAN1: RPM read is 5851
I1115 19:13:17.254189  3025 ControlLogic.cpp:365] FANTRAY1_FAN2: is present in the host (through sysfs)
I1115 19:13:17.254205  3025 ControlLogic.cpp:168] FANTRAY1_FAN2: RPM read is 7228
I1115 19:13:17.254213  3025 ControlLogic.cpp:365] FANTRAY1_FAN3: is present in the host (through sysfs)
I1115 19:13:17.254226  3025 ControlLogic.cpp:168] FANTRAY1_FAN3: RPM read is 5851
I1115 19:13:17.254234  3025 ControlLogic.cpp:365] FANTRAY1_FAN4: is present in the host (through sysfs)
I1115 19:13:17.254249  3025 ControlLogic.cpp:168] FANTRAY1_FAN4: RPM read is 7228
I1115 19:13:17.254258  3025 ControlLogic.cpp:365] FANTRAY1_FAN5: is present in the host (through sysfs)
I1115 19:13:17.254273  3025 ControlLogic.cpp:168] FANTRAY1_FAN5: RPM read is 5851
I1115 19:13:17.254282  3025 ControlLogic.cpp:365] FANTRAY1_FAN6: is present in the host (through sysfs)
I1115 19:13:17.254297  3025 ControlLogic.cpp:168] FANTRAY1_FAN6: RPM read is 7072
I1115 19:13:17.254306  3025 ControlLogic.cpp:365] FANTRAY1_FAN7: is present in the host (through sysfs)
I1115 19:13:17.254322  3025 ControlLogic.cpp:168] FANTRAY1_FAN7: RPM read is 5851
I1115 19:13:17.254332  3025 ControlLogic.cpp:365] FANTRAY1_FAN8: is present in the host (through sysfs)
I1115 19:13:17.254347  3025 ControlLogic.cpp:168] FANTRAY1_FAN8: RPM read is 7228
I1115 19:13:17.254357  3025 ControlLogic.cpp:365] FANTRAY2_FAN1: is present in the host (through sysfs)
I1115 19:13:17.265939  3025 ControlLogic.cpp:168] FANTRAY2_FAN1: RPM read is 5851
I1115 19:13:17.265950  3025 ControlLogic.cpp:365] FANTRAY2_FAN2: is present in the host (through sysfs)
I1115 19:13:17.265965  3025 ControlLogic.cpp:168] FANTRAY2_FAN2: RPM read is 7228
I1115 19:13:17.265974  3025 ControlLogic.cpp:365] FANTRAY2_FAN3: is present in the host (through sysfs)
I1115 19:13:17.265990  3025 ControlLogic.cpp:168] FANTRAY2_FAN3: RPM read is 5851
I1115 19:13:17.265998  3025 ControlLogic.cpp:365] FANTRAY2_FAN4: is present in the host (through sysfs)
I1115 19:13:17.266013  3025 ControlLogic.cpp:168] FANTRAY2_FAN4: RPM read is 7228
I1115 19:13:17.266022  3025 ControlLogic.cpp:365] FANTRAY2_FAN5: is present in the host (through sysfs)
I1115 19:13:17.266038  3025 ControlLogic.cpp:168] FANTRAY2_FAN5: RPM read is 5851
I1115 19:13:17.266049  3025 ControlLogic.cpp:365] FANTRAY2_FAN6: is present in the host (through sysfs)
I1115 19:13:17.266064  3025 ControlLogic.cpp:168] FANTRAY2_FAN6: RPM read is 7072
I1115 19:13:17.266073  3025 ControlLogic.cpp:365] FANTRAY2_FAN7: is present in the host (through sysfs)
I1115 19:13:17.266088  3025 ControlLogic.cpp:168] FANTRAY2_FAN7: RPM read is 5851
I1115 19:13:17.266096  3025 ControlLogic.cpp:365] FANTRAY2_FAN8: is present in the host (through sysfs)
I1115 19:13:17.266115  3025 ControlLogic.cpp:168] FANTRAY2_FAN8: RPM read is 7228
I1115 19:13:17.266120  3025 ControlLogic.cpp:624] Processing Sensors ...
E1115 19:13:17.266127  3025 ControlLogic.cpp:238] SMB_U77_INLET_LEFT_BOT_LM75_TEMP: Sensor read value (after scaling) is 27
I1115 19:13:17.266134  3025 ControlLogic.cpp:220] SMB_U77_INLET_LEFT_BOT_LM75_TEMP: Calculated PWM is 45
E1115 19:13:17.266140  3025 ControlLogic.cpp:238] CPU_UNCORE_TEMP: Sensor read value (after scaling) is 47
V1115 19:13:17.266152  3025 PidLogic.cpp:40] Measurement: 47, Error: 45, Last PWM: 50, New PWM: 0
I1115 19:13:17.266156  3025 ControlLogic.cpp:220] CPU_UNCORE_TEMP: Calculated PWM is 0
I1115 19:13:17.266163  3025 ControlLogic.cpp:628] Processing Optics ...
I1115 19:13:17.266168  3025 ControlLogic.cpp:638] **Boost mode enabled** for optics update missing for 1731669197s
I1115 19:13:17.266174  3025 ControlLogic.cpp:507] zone1: Components: SMB_U77_INLET_LEFT_BOT_LM75_TEMP,CPU_UNCORE_TEMP,qsfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate **PWM is 100**.
