### PR TITLE
Add fan presence to platform manager

### DIFF
--- a/fboss/platform/configs/morgan800cc/platform_manager.json
+++ b/fboss/platform/configs/morgan800cc/platform_manager.json
@@ -446,89 +446,7 @@
           "slotType": "FCB_SLOT",
           "outgoingI2cBusNames": [
             "MCB_MUX_A@0"
-          ],
-          "outgoingSlotConfigs": {
-            "FANTRAY_SLOT@0": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan1_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@1": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan2_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@2": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan3_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@3": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan4_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@4": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan5_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@5": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan6_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@6": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan7_presence",
-                  "desiredValue": 1
-                }
-              }
-            },
-            "FANTRAY_SLOT@7": {
-              "slotType": "FANTRAY_SLOT",
-              "presenceDetection": {
-                "sysfsFileHandle": {
-                  "devicePath": "/[MCB_FAN_PWM]",
-                  "presenceFileName": "fan8_presence",
-                  "desiredValue": 1
-                }
-              }
-            }
-          }
+          ]
         },
         "SMB_SLOT@0": {
           "slotType": "SMB_SLOT",
@@ -567,7 +485,92 @@
       }
     },
     "MORGAN800CC": {
-      "pluggedInSlotType": "FCB_SLOT"
+      "pluggedInSlotType": "FCB_SLOT",
+      "outgoingSlotConfigs": {
+        "FANTRAY_SLOT@0": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan1_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@1": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan2_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@2": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan3_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@3": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan4_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@4": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan5_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@5": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan6_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@6": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan7_presence",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FANTRAY_SLOT@7": {
+          "slotType": "FANTRAY_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_PWM]",
+              "presenceFileName": "fan8_presence",
+              "desiredValue": 1
+            }
+          }
+        }
+      }
+    },
+    "FAN": {
+      "pluggedInSlotType": "FANTRAY_SLOT"
     },
     "PDB": {
       "pluggedInSlotType": "PDB_SLOT"

--- a/fboss/platform/configs/morgan800cc/platform_manager.json
+++ b/fboss/platform/configs/morgan800cc/platform_manager.json
@@ -446,7 +446,89 @@
           "slotType": "FCB_SLOT",
           "outgoingI2cBusNames": [
             "MCB_MUX_A@0"
-          ]
+          ],
+          "outgoingSlotConfigs": {
+            "FANTRAY_SLOT@0": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan1_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@1": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan2_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@2": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan3_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@3": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan4_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@4": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan5_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@5": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan6_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@6": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan7_presence",
+                  "desiredValue": 1
+                }
+              }
+            },
+            "FANTRAY_SLOT@7": {
+              "slotType": "FANTRAY_SLOT",
+              "presenceDetection": {
+                "sysfsFileHandle": {
+                  "devicePath": "/[MCB_FAN_PWM]",
+                  "presenceFileName": "fan8_presence",
+                  "desiredValue": 1
+                }
+              }
+            }
+          }
         },
         "SMB_SLOT@0": {
           "slotType": "SMB_SLOT",


### PR DESCRIPTION
This add fan presence to the platform_manager.json file for the morgan800cc program.

UT:
I1203 10:20:23.575926   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan1_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@0
I1203 10:20:23.575988   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan2_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@1
I1203 10:20:23.576049   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan3_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@2
I1203 10:20:23.576102   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan4_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@3
I1203 10:20:23.576156   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan5_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@4
I1203 10:20:23.576209   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan6_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@5
I1203 10:20:23.576261   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan7_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@6
I1203 10:20:23.576317   887 PresenceChecker.cpp:60] Value at /sys/bus/pci/devices/0000:01:00.0/cisco_meta.fan_ctrl.1021/hwmon/hwmon2/fan8_presence is 1. desiredValue is 1. Assuming presence of PmUnit at /FCB_SLOT@0/FANTRAY_SLOT@7

