### PR TITLE
PSU Presence detection in platform manager for morgan800cc

### DIFF
--- a/fboss/platform/configs/morgan800cc/platform_manager.json
+++ b/fboss/platform/configs/morgan800cc/platform_manager.json
@@ -438,7 +438,7 @@
           "presenceDetection": {
             "gpioLineHandle": {
               "devicePath": "/[MCB_MCB_GPIO]",
-              "ineIndex": 48,
+              "lineIndex": 48,
               "desiredValue": 1
             }
           }

--- a/fboss/platform/configs/morgan800cc/platform_manager.json
+++ b/fboss/platform/configs/morgan800cc/platform_manager.json
@@ -434,13 +434,27 @@
           "slotType": "PSU_SLOT",
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_1"
-          ]
+          ],
+          "presenceDetection": {
+            "gpioLineHandle": {
+              "devicePath": "/[MCB_MCB_GPIO]",
+              "ineIndex": 48,
+              "desiredValue": 1
+            }
+          }
         },
         "PSU_SLOT@1": {
           "slotType": "PSU_SLOT",
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_2"
-          ]
+          ],
+          "presenceDetection": {
+            "gpioLineHandle": {
+              "devicePath": "/[MCB_MCB_GPIO]",
+              "lineIndex": 52,
+              "desiredValue": 1
+            }
+          }
         },
         "FCB_SLOT@0": {
           "slotType": "FCB_SLOT",


### PR DESCRIPTION
Add GPIO pins for psu presence detection for platform manager for morgan800cc

UT:
I1203 10:20:30.099922   887 PresenceChecker.cpp:84] Value at /dev/gpiochip1 is 1. desiredValue is 1. Assuming presence of PmUnit at /PSU_SLOT@0
I1203 10:20:33.275860   887 PresenceChecker.cpp:84] Value at /dev/gpiochip1 is 1. desiredValue is 1. Assuming presence of PmUnit at /PSU_SLOT@1
