### PR TITLE
Meru800biab: Fix invalid led_manager config

### DIFF
--- a/fboss/platform/configs/meru800biab/led_manager.json
+++ b/fboss/platform/configs/meru800biab/led_manager.json
@@ -1,54 +1,84 @@
 {
-    "systemLedConfig": {
+  "systemLedConfig": {
+    "presentLedColor": 1,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
+    "absentLedColor": 2,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
-    "fruTypeLedConfigs": {
-      "FAN": {
-        "presentLedColor": 1,
-        "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
-        "absentLedColor": 2,
-        "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
-      },
-      "PSU": {
-        "presentLedColor": 1,
-        "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
-        "absentLedColor": 2,
-        "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
+    "PSU": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
       }
     },
-    "fruConfigs": [
-      {
-        "fruName": "FAN1",
-        "fruType": "FAN",
-        "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_present"
-      },
-      {
-        "fruName": "FAN2",
-        "fruType": "FAN",
-        "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_present"
-      },
-      {
-        "fruName": "FAN3",
-        "fruType": "FAN",
-        "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_present"
-      },
-      {
-        "fruName": "FAN4",
-        "fruType": "FAN",
-        "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_present"
-      },
-      {
-        "fruName": "PSU1",
-        "fruType": "PSU",
-        "presenceSysfsPath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu1_present"
-      },
-      {
-        "fruName": "PSU2",
-        "fruType": "PSU",
-        "presenceSysfsPath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu2_present"
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan2_present",
+          "desiredValue": 1
+        }
       }
-    ]
-  }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PSU1",
+      "fruType": "PSU",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu1_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PSU2",
+      "fruType": "PSU",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BIA_SMB_FPGA/psu2_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Description
Recently there have been changes to revamp the config structure. This PR updates the config to match the new revamped structure.

NOTE: This config is identical to that of meru800bia config.

# Test
```
[root@vpr402 ~]# systemctl status data_corral_service
● data_corral_service.service - Start data_corral_service
     Loaded: loaded (/etc/systemd/system/data_corral_service.service; enabled; preset: disabled)
     Active: active (running) since Wed 2024-12-04 01:08:48 UTC; 2s ago
   Main PID: 6680 (run_data_corral)
      Tasks: 50 (limit: 405268)
     Memory: 6.2M
        CPU: 10ms
     CGroup: /system.slice/data_corral_service.service
             ├─6680 /bin/bash /opt/fboss/bin/run_data_corral_service.sh
             └─6681 /opt/fboss/bin/data_corral_service -config_file /opt/fboss/share/platform_configs/led_manager.json

Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544359  6682 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544364  6682 LedManager.cpp:55] Programmed PSU LED with presence true
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544369  6682 LedManager.cpp:45] Programming FAN LED with true
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544387  6682 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544404  6682 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544409  6682 LedManager.cpp:55] Programmed FAN LED with presence true
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544414  6682 LedManager.cpp:25] Programming system LED with true
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544432  6682 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544451  6682 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
Dec 04 01:08:48 vpr402.sjc.aristanetworks.com run_data_corral_service.sh[6681]: I1204 01:08:48.544456  6682 LedManager.cpp:34] Programmed system LED with true
```