### PR TITLE
Initial config for minipack3n weutil

### DIFF
--- a/fboss/platform/configs/minipack3n/weutil.json
+++ b/fboss/platform/configs/minipack3n/weutil.json
@@ -1,0 +1,47 @@
+{
+  "chassisEepromName": "CHASSIS",
+  "fruEepromList": {
+    "MCB": {
+      "path": "/run/devmap/eeproms/MCB_EEPROM"
+    },
+    "COME": {
+      "path": "/run/devmap/eeproms/COME_EEPROM"
+    },
+    "SCM": {
+      "path": "/run/devmap/eeproms/SCM_EEPROM"
+    },
+    "RUNBMC": {
+      "path": "/run/devmap/eeproms/RUNBMC_EEPROM"
+    },
+    "PSU1": {
+      "path": "/run/devmap/eeproms/PSU1_EEPROM"
+    },
+    "PSU2": {
+      "path": "/run/devmap/eeproms/PSU2_EEPROM"
+    },
+    "PDB_L": {
+      "path": "/run/devmap/eeproms/PDB_L_EEPROM"
+    },
+    "PDB_R": {
+      "path": "/run/devmap/eeproms/PDB_R_EEPROM"
+    },
+    "SMB": {
+      "path": "/run/devmap/eeproms/SMB_EEPROM"
+    },
+    "FCB_B": {
+      "path": "/run/devmap/eeproms/FCB_B_EEPROM"
+    },
+    "FCB_T": {
+      "path": "/run/devmap/eeproms/FCB_T_EEPROM"
+    },
+    "CHASSIS": {
+      "path": "/run/devmap/eeproms/CHASSIS_EEPROM"
+    },
+    "3V3_L": {
+      "path": "/run/devmap/eeproms/3V3_L_EEPROM"
+    },
+    "3V3_R": {
+      "path": "/run/devmap/eeproms/3V3_R_EEPROM"
+    }
+  }
+}


### PR DESCRIPTION
Summary:
**Description**
Add `weutil.json` for the minipack3n weutil.  
This configuration has been tested on minipack3.

**Test Plan:**
- run weutil -config_file ./weutil.json: CHASSIS eeprom is displayed properly.
- run weutil -config_file ./weutil.json -list: Each FRU eeprom path and offset are displayed properly.
- run weutil -config_file ./weutil.json -eeprom FRU_NAME: The EEPROM data of the specified FRU is displayed properly.
- run weutil -config_file ./weutil.json -eeprom FRU_NAME -json: The EEPROM data of the specified FRU is displayed in JSON format properly.

[minipack3n-weutil_execute_on_mp3_log_20241212.txt](https://github.com/user-attachments/files/18193631/minipack3n-weutil_execute_on_mp3_log_20241212.txt)