### PR TITLE
platform_manager:Validating and Waiting for Watchdog Device Creation.

### DIFF
--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -21,6 +21,7 @@ const std::string kGpioChip = "gpiochip";
 
 const re2::RE2 kWatchdogNameRe{"watchdog(\\d+)"};
 const std::string kWatchdog = "watchdog";
+constexpr auto kWatchdogDevCreationWaitSecs = std::chrono::seconds(2);
 } // namespace
 
 namespace facebook::fboss::platform::platform_manager {
@@ -76,7 +77,11 @@ std::string Utils::resolveWatchdogCharDevPath(const std::string& sysfsPath) {
   }
 
   fs::path watchdogDir = fs::path(sysfsPath) / "watchdog";
-  if (!fs::exists(watchdogDir)) {
+  if (!Utils().checkDeviceReadiness(
+         [&]() -> bool { return fs::exists(watchdogDir);},
+         fmt::format("Watchdog CharDevPath is not created. Waited for at most {}s",
+              kWatchdogDevCreationWaitSecs.count()),
+         kWatchdogDevCreationWaitSecs)) {
     throw std::runtime_error(fmt::format(
         "{}. Reason: Couldn't find watchdog directory under {}",
         failMsg,


### PR DESCRIPTION
# Description:
 Implementing Watchdog device creation validation in platform_manager  before PCI Explorer completion.
    1. Waiting for the device readiness.
    2. Granularly check every x ms until 2 seconds


# Motivation:
  In rare scenarios, the initialization process for a device can extend beyond  the standard timeframe. This can cause the platform_manager to fail to locate  the watchdog device in the specified location, resulting in an error message.

  

>   I1207 16:37:55.981444 1201 ExplorationSummary.cpp:66]
>   1. Failed to explore I2C device MCB_FAN_CPLD at /. Failed to resolve Watchdog CharDevPath. Reason: /dev/watchdog2 does 
 not exist in the system 

  
  #  Testcase:
  A) **Delayed Device Registration**
              Simulate Delay: Introduce a simulated delay in the driver code to mimic a scenario where device registration takes longer 
                                        than usual. 
              Validation: Implement a validation process that actively waits for the watchdog device to be successfully created. 
              Assertion: Verify that the platform_manager can locate and utilize the watchdog device within a reasonable 
                               timeframe, even with the simulated delay.

  B) **The above procedure was executed with a reboot and power cycle.**