### PR TITLE
Mp3:platform_manager:Validating and Waiting for Watchdog Device Creation.

### DIFF
--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -21,6 +21,7 @@ const std::string kGpioChip = "gpiochip";
 
 const re2::RE2 kWatchdogNameRe{"watchdog(\\d+)"};
 const std::string kWatchdog = "watchdog";
+constexpr auto kWatchdogDevCreationWaitSecs = std::chrono::seconds(5);
 } // namespace
 
 namespace facebook::fboss::platform::platform_manager {
@@ -76,7 +77,11 @@ std::string Utils::resolveWatchdogCharDevPath(const std::string& sysfsPath) {
   }
 
   fs::path watchdogDir = fs::path(sysfsPath) / "watchdog";
-  if (!fs::exists(watchdogDir)) {
+  if (!Utils().checkDeviceReadiness(
+         [&]() -> bool { return fs::exists(watchdogDir);},
+         fmt::format("Watchdog CharDevPath is not created. Waited for at most {}s",
+              kWatchdogDevCreationWaitSecs.count()),
+         kWatchdogDevCreationWaitSecs)) {
     throw std::runtime_error(fmt::format(
         "{}. Reason: Couldn't find watchdog directory under {}",
         failMsg,


### PR DESCRIPTION
# Description:
  Implementing Watchdog device creation validation in platform_managerv  before PCI Explorer completion.
    1. Waiting for the device readiness.
    2. Granularly check every x ms until 5 seconds

# Motivation:
 In rare scenarios, the initialization process for a device can extend beyond the standard timeframe. This can cause the platform_manager to fail to locate the watchdog device in the specified location, resulting in an error message.

     I1216 08:09:08.409639  2801 ExplorationSummary.cpp:50] Explored montblanc with 2 unexpected errors and 0 expected errors...
     I1216 08:09:08.409647  2801 ExplorationSummary.cpp:58] Unexpected Failures in Device MCB_FAN_CPLD for PmUnit 
     MINIPACK3_MCB at SlotPath /
      I1216 08:09:08.409651  2801 ExplorationSummary.cpp:66] 1. Failed to explore I2C device MCB_FAN_CPLD at /. Failed to 
      resolve Watchdog CharDevPath. Reason: Couldn't find watchdog directory under /sys/bus/i2c/devices/15-0033
      I1216 08:09:08.409656  2801 ExplorationSummary.cpp:66] 2. Failed to create a symlink 
      /run/devmap/watchdogs/FAN_WATCHDOG for DevicePath /[MCB_FAN_CPLD]. Reason: Could not find CharDevPath for 
      /[MCB_FAN_CPLD] 
 

# Testcase:
  A) Delayed Device Registration
       **Simulate Delay:** Introduce a simulated delay in the driver code to mimic a scenario where device registration takes 
                                       longer than usual. 
        **Validation:** Implement a validation process that actively waits for the watchdog device to be successfully created. 
        **Assertion:** Verify that the platform_manager can locate and utilize the watchdog device within a reasonable timeframe, even with the simulated delay.

   B) The above procedure was executed with a reboot and power cycle.
   
[platform_manager_Before_fix.txt](https://github.com/user-attachments/files/18183519/platform_manager_Before_fix.txt)
[platform_manager_After_fix.txt](https://github.com/user-attachments/files/18183521/platform_manager_After_fix.txt)
