### PR TITLE
montblanc: config: updated 3V3 card pmUnitName

### DIFF
--- a/fboss/platform/configs/montblanc/platform_manager.json
+++ b/fboss/platform/configs/montblanc/platform_manager.json
@@ -91,7 +91,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "3_V_3_L_CARD"
+      "pmUnitName": "MINIPACK3_3V3_L"
     },
     "OPTICR_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -100,7 +100,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "3_V_3_R_CARD"
+      "pmUnitName": "MINIPACK3_3V3_R"
     }
   },
   "i2cAdaptersFromCpu": [
@@ -148,7 +148,7 @@
         "productSubVersion": 2
       }
     ],
-    "3_V_3_L_CARD": [
+    "MINIPACK3_3V3_L": [
       {
         "pmUnitConfig": {
           "pluggedInSlotType": "OPTICL_SLOT",
@@ -170,7 +170,7 @@
         "productSubVersion": 10
       }
     ],
-    "3_V_3_R_CARD": [
+    "MINIPACK3_3V3_R": [
       {
         "pmUnitConfig": {
           "pluggedInSlotType": "OPTICR_SLOT",
@@ -3339,7 +3339,7 @@
         }
       ]
     },
-    "3_V_3_L_CARD": {
+    "MINIPACK3_3V3_L": {
       "pluggedInSlotType": "OPTICL_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3356,7 +3356,7 @@
         }
       ]
     },
-    "3_V_3_R_CARD": {
+    "MINIPACK3_3V3_R": {
       "pluggedInSlotType": "OPTICR_SLOT",
       "i2cDeviceConfigs": [
         {

--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -4246,7 +4246,7 @@
     },
     {
       "slotPath": "/SMB_SLOT@0/OPTICL_SLOT@0",
-      "pmUnitName": "3_V_3_L_CARD",
+      "pmUnitName": "MINIPACK3_3V3_L",
       "sensors": [
         {
           "name": "SMB_3V3_L_U8_TEMP",
@@ -4601,7 +4601,7 @@
     },
     {
       "slotPath": "/SMB_SLOT@0/OPTICR_SLOT@0",
-      "pmUnitName": "3_V_3_R_CARD",
+      "pmUnitName": "MINIPACK3_3V3_R",
       "sensors": [
         {
           "name": "SMB_3V3_R_U8_TEMP",


### PR DESCRIPTION
**Description**
Updated the 3v3 card PmUnit name of platfom manager and sonsors config file to match eeprom data.

**Motivation:**

1. fixed the Platform Manager Logs Warning Messages on Minipack3 as "NEEDS FIX"

_Original update pmunit name log:_
W1218 14:45:48.690875 1611 PlatformExplorer.cpp:383] The PmUnit name in IDPROM -`MINIPACK3_3V3_L` is different from the one in config - `3_V_3_L_CARD`. NEEDS FIX.

W1218 14:45:49.379676 1611 PlatformExplorer.cpp:383] The PmUnit name in IDPROM -`MINIPACK3_3V3_R` is different from the one in config - `3_V_3_R_CARD`. NEEDS FIX.

_After updating pmunit name log:_
I1017 07:31:38.828907 13133 PlatformExplorer.cpp:370] Found PmUnit name `MINIPACK3_3V3_L` in IDPROM /sys/bus/i2c/devices/61-0051/eeprom at /SMB_SLOT@0/OPTICL_SLOT@0
I1017 07:31:38.828912 13133 PlatformExplorer.cpp:379] SlotType PmUnitName: MINIPACK3_3V3_L
I1017 07:31:38.828917 13133 PlatformExplorer.cpp:389] Going with PmUnit name `MINIPACK3_3V3_L` defined in config for /SMB_SLOT@0/OPTICL_SLOT@0

I1017 07:31:39.304987 13133 PlatformExplorer.cpp:370] Found PmUnit name `MINIPACK3_3V3_R` in IDPROM /sys/bus/i2c/devices/95-0051/eeprom at /SMB_SLOT@0/OPTICR_SLOT@0
I1017 07:31:39.304991 13133 PlatformExplorer.cpp:379] SlotType PmUnitName: MINIPACK3_3V3_R
I1017 07:31:39.304995 13133 PlatformExplorer.cpp:389] Going with PmUnit name `MINIPACK3_3V3_R` defined in config for /SMB_SLOT@0/OPTICR_SLOT@0
I1017 07:31:39.305000 13133 DataStore.cpp:117] At SlotPath /SMB_SLOT@0/OPTICR_SLOT@0, updating to PmUnit MINIPACK3_3V3_R with ProductProductionState 3, ProductVersion 0, ProductSubVersion 20

**Test Plan**

- Run the jq to format json file.
- download the latest fboss platform manager and sensor service binary.
- Run sensor service with updated config file is correct.
- Run the platform manager with the changed config files on DVT and 2nd source DVT device normally: LD_LIBRARY_PATH=./lib/ ./bin/platform_manager --config_file ./platform_manager.json --run_once=false --noenable_pkg_mgmnt
- Run sensor_service with the new config file: LD_LIBRARY_PATH=./lib/ ./bin/sensor_service --config_file ./sensor_service.json --logging=DBG1

[Montblanc-platform_manager_log_20241019.txt](https://github.com/user-attachments/files/18195266/Montblanc-platform_manager_log_20241019.txt)
![image](https://github.com/user-attachments/assets/a72af248-f0d9-43d8-80b6-1dde39cc29fb)

