### PR TITLE
janga: config: added janga SMB & COME card pvt sensor config

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -2121,12 +2121,6 @@
           ]
         },
         {
-          "busName": "SMB_IOB_I2C_MASTER_23",
-          "address": "0x4c",
-          "kernelDeviceName": "tmp422",
-          "pmUnitScopedName": "SMB_U68_TMP422"
-        },
-        {
           "busName": "SMB_IOB_I2C_MASTER_25",
           "address": "0x37",
           "kernelDeviceName": "adc128d818",
@@ -2155,12 +2149,6 @@
           ]
         },
         {
-          "busName": "SMB_IOB_I2C_MASTER_25",
-          "address": "0x4c",
-          "kernelDeviceName": "tmp422",
-          "pmUnitScopedName": "SMB_U351_TMP422"
-        },
-        {
           "busName": "SMB_IOB_I2C_MASTER_26",
           "address": "0x37",
           "kernelDeviceName": "adc128d818",
@@ -2187,12 +2175,6 @@
               ]
             }
           ]
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_26",
-          "address": "0x4c",
-          "kernelDeviceName": "tmp422",
-          "pmUnitScopedName": "SMB_U352_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_27",
@@ -2235,18 +2217,6 @@
               ]
             }
           ]
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_28",
-          "address": "0x4c",
-          "kernelDeviceName": "tmp422",
-          "pmUnitScopedName": "SMB_U150_TMP422"
-        },
-        {
-          "busName": "SMB_IOB_I2C_MASTER_29",
-          "address": "0x4c",
-          "kernelDeviceName": "tmp422",
-          "pmUnitScopedName": "SMB_U152_TMP422"
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_10",
@@ -2300,7 +2270,12 @@
             "SMB_IOB_I2C_MASTER_4",
             "SMB_IOB_I2C_MASTER_9",
             "SMB_IOB_I2C_MASTER_11",
-            "SMB_IOB_I2C_MASTER_12"
+            "SMB_IOB_I2C_MASTER_12",
+            "SMB_IOB_I2C_MASTER_23",
+            "SMB_IOB_I2C_MASTER_25",
+            "SMB_IOB_I2C_MASTER_26",
+            "SMB_IOB_I2C_MASTER_28",
+            "SMB_IOB_I2C_MASTER_29"
           ]
         }
       }
@@ -2367,6 +2342,36 @@
           "address": "0x76",
           "kernelDeviceName": "pmbus",
           "pmUnitScopedName": "SMB_U177_PMBUS_2"
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U68_TMP422"
+        },
+        {
+          "busName": "INCOMING@5",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U351_TMP422"
+        },
+        {
+          "busName": "INCOMING@6",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U352_TMP422"
+        },
+        {
+          "busName": "INCOMING@7",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U150_TMP422"
+        },
+        {
+          "busName": "INCOMING@8",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp422",
+          "pmUnitScopedName": "SMB_U152_TMP422"
         }
       ]
     },
@@ -2498,18 +2503,18 @@
     "/run/devmap/sensors/SMB_U279_ADM1272_1": "/[SMB_U279_ADM1272_1]",
     "/run/devmap/sensors/SMB_U104_LM75B_2": "/[SMB_U104_LM75B_2]",
     "/run/devmap/sensors/SMB_U355_ADC128D818_1": "/[SMB_U355_ADC128D818_1]",
-    "/run/devmap/sensors/SMB_U68_TMP422": "/[SMB_U68_TMP422]",
+    "/run/devmap/sensors/SMB_U68_TMP422": "/SMB_FRU_SLOT@0/[SMB_U68_TMP422]",
     "/run/devmap/sensors/SMB_U356_ADC128D818_1": "/[SMB_U356_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U360_ADC128D818_2": "/[SMB_U360_ADC128D818_2]",
-    "/run/devmap/sensors/SMB_U351_TMP422": "/[SMB_U351_TMP422]",
+    "/run/devmap/sensors/SMB_U351_TMP422": "/SMB_FRU_SLOT@0/[SMB_U351_TMP422]",
     "/run/devmap/sensors/SMB_U361_ADC128D818_1": "/[SMB_U361_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U357_ADC128D818_2": "/[SMB_U357_ADC128D818_2]",
-    "/run/devmap/sensors/SMB_U352_TMP422": "/[SMB_U352_TMP422]",
+    "/run/devmap/sensors/SMB_U352_TMP422": "/SMB_FRU_SLOT@0/[SMB_U352_TMP422]",
     "/run/devmap/sensors/SMB_U354_ADC128D818_1": "/[SMB_U354_ADC128D818_1]",
     "/run/devmap/sensors/SMB_U288_ADC128D818_2": "/[SMB_U288_ADC128D818_2]",
     "/run/devmap/sensors/SMB_U353_ADC128D818_3": "/[SMB_U353_ADC128D818_3]",
-    "/run/devmap/sensors/SMB_U150_TMP422": "/[SMB_U150_TMP422]",
-    "/run/devmap/sensors/SMB_U152_TMP422": "/[SMB_U152_TMP422]",
+    "/run/devmap/sensors/SMB_U150_TMP422": "/SMB_FRU_SLOT@0/[SMB_U150_TMP422]",
+    "/run/devmap/sensors/SMB_U152_TMP422": "/SMB_FRU_SLOT@0/[SMB_U152_TMP422]",
     "/run/devmap/sensors/PDB_PMBUS_BRICK_1": "/PDB_SLOT@0/[PDB_PMBUS_BRICK_1]",
     "/run/devmap/sensors/PDB_PMBUS_BRICK_2": "/PDB_SLOT@0/[PDB_PMBUS_BRICK_2]",
     "/run/devmap/sensors/PDB_U1_LM75B": "/PDB_SLOT@0/[PDB_U1_LM75B]",

--- a/fboss/platform/configs/janga800bic/sensor_service.json
+++ b/fboss/platform/configs/janga800bic/sensor_service.json
@@ -1006,105 +1006,6 @@
           },
           "compute": "(1000/3650)*@/1000.0"
         }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_NIF1",
-              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_HBM_PHY0",
-              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp3_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_FAB1",
-              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_HBM_PHY2",
-              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp3_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_PADS",
-              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_NIF0",
-              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp3_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_NIF1",
-              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_HBM_PHY0",
-              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp3_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_FAB1",
-              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_HBM_PHY2",
-              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp3_input",
-              "type": 3,
-              "thresholds": {
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 20
-        }
       ]
     },
     {
@@ -4062,10 +3963,909 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_PADS",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_NIF0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
             }
           ],
           "productProductionState": 2,
           "productVersion": 4,
+          "productSubVersion": 20
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_U210_J3A_XP1R2V_HBM_1_2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP1R2V_HBM_1_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP1R2V_HBM_1_2_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 63,
+                "upperCriticalVal": 68
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP0R9V_SW_TRVDD0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 51,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP0R9V_SW_TRVDD0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.945,
+                "minAlarmVal": 0.85,
+                "upperCriticalVal": 1,
+                "lowerCriticalVal": 0.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP0R9V_SW_TRVDD0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP1R2V_SW_HBM_1_2_A_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U210_J3A_XP0R9V_SW_TRVDD0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U210_XDPE12284_1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U216_XP3R3V_OSFP_RIGHT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U216_XDPE12284_4/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 130,
+                "upperCriticalVal": 140
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U216_XP3R3V_OSFP_RIGHT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U216_XDPE12284_4/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 3.5,
+                "minAlarmVal": 3.1,
+                "upperCriticalVal": 3.6,
+                "lowerCriticalVal": 3
+              },
+              "compute": "2*@/1000.0"
+            },
+            {
+              "name": "SMB_U216_XP3R3V_OSFP_RIGHT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U216_XDPE12284_4/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 420,
+                "upperCriticalVal": 430
+              },
+              "compute": "2*@/1000000.0"
+            },
+            {
+              "name": "SMB_U216_XP3R3V_OSFP_RIGHT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U216_XDPE12284_4/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U229_XP3R3V_OSFP_LEFT_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 130,
+                "upperCriticalVal": 140
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U229_XP3R3V_OSFP_LEFT_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 3.5,
+                "minAlarmVal": 3.1,
+                "upperCriticalVal": 3.6,
+                "lowerCriticalVal": 3
+              },
+              "compute": "2*@/1000.0"
+            },
+            {
+              "name": "SMB_U229_XP3R3V_OSFP_LEFT_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 420,
+                "upperCriticalVal": 430
+              },
+              "compute": "2*@/1000000.0"
+            },
+            {
+              "name": "SMB_U229_XP3R3V_OSFP_LEFT_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R9V_TRVDD1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 51,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R9V_TRVDD1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.95,
+                "minAlarmVal": 0.85,
+                "upperCriticalVal": 1,
+                "lowerCriticalVal": 0.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R9V_TRVDD1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R75V_TRVDD1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 33,
+                "upperCriticalVal": 35
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R75V_TRVDD1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "upperCriticalVal": 0.85,
+                "lowerCriticalVal": 0.65
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R75V_TRVDD1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 25,
+                "upperCriticalVal": 27
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R9V_TRVDD1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U237_J3A_XP0R75V_TRVDD1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U237_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_1V2_HBM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_1V2_HBM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_1V2_HBM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_0V75_TRVDD1_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 33,
+                "upperCriticalVal": 35
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_0V75_TRVDD1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "upperCriticalVal": 0.85,
+                "lowerCriticalVal": 0.65
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_0V75_TRVDD1_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 25,
+                "upperCriticalVal": 27
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_1V2_HBM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U86_J3B_0V75_TRVDD1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R9V_TRVDD0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 51,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R9V_TRVDD0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.95,
+                "minAlarmVal": 0.85,
+                "upperCriticalVal": 1,
+                "lowerCriticalVal": 0.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R9V_TRVDD0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R75V_TRVDD0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 33,
+                "upperCriticalVal": 35
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R75V_TRVDD0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "upperCriticalVal": 0.85,
+                "lowerCriticalVal": 0.65
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R75V_TRVDD0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 25,
+                "upperCriticalVal": 27
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R9V_TRVDD0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U92_J3B_XP0R75V_TRVDD0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_3/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_1V2_HBM0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 26,
+                "upperCriticalVal": 28
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_1V2_HBM0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_1V2_HBM0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 32,
+                "upperCriticalVal": 34
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_0V75_TRVDD0_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 33,
+                "upperCriticalVal": 35
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_0V75_TRVDD0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.8,
+                "minAlarmVal": 0.7,
+                "upperCriticalVal": 0.85,
+                "lowerCriticalVal": 0.65
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_0V75_TRVDD0_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 25,
+                "upperCriticalVal": 27
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_1V2_HBM0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U343_J3A_0V75_TRVDD0_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U343_XDPE12284_1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_1V2_HBM_1_2_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_1V2_HBM_1_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.26,
+                "minAlarmVal": 1.14,
+                "upperCriticalVal": 1.3,
+                "lowerCriticalVal": 1.1
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_1V2_HBM_1_2_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 50,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_XP0R9V_SW_TRVDD1_B_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 51,
+                "upperCriticalVal": 55
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_XP0R9V_SW_TRVDD1_B_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.95,
+                "minAlarmVal": 0.85,
+                "upperCriticalVal": 1,
+                "lowerCriticalVal": 0.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_XP0R9V_SW_TRVDD1_B_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 63,
+                "upperCriticalVal": 68
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_1V2_HBM1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U347_J3B_XP0R9V_SW_TRVDD1_B_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U347_XDPE12284_2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_IOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 850,
+                "upperCriticalVal": 870
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.814,
+                "minAlarmVal": 0.736,
+                "upperCriticalVal": 0.95,
+                "lowerCriticalVal": 0.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 660,
+                "upperCriticalVal": 680
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.5,
+                "minAlarmVal": 10.5,
+                "upperCriticalVal": 14,
+                "lowerCriticalVal": 10
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U337_J3B_XP0R75V_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U337_PMBUS_1/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_IOUT_",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 850,
+                "upperCriticalVal": 870
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.814,
+                "minAlarmVal": 0.736,
+                "upperCriticalVal": 0.95,
+                "lowerCriticalVal": 0.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_POUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 660,
+                "upperCriticalVal": 680
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_TEMP",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_VIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.5,
+                "minAlarmVal": 10.5,
+                "upperCriticalVal": 14,
+                "lowerCriticalVal": 10
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U177_J3A_XP0R75V_VDD_CORE_PIN",
+              "sysfsPath": "/run/devmap/sensors/SMB_U177_PMBUS_2/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U68_TMP422_J3_A_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U68_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U150_TMP422_J3_A_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U150_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_PADS",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U351_TMP422_J3_B_TEMPDIODE_NIF0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U351_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_NIF1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U352_TMP422_J3_B_TEMPDIODE_HBM_PHY0",
+              "sysfsPath": "/run/devmap/sensors/SMB_U352_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_FAB1",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_U152_TMP422_J3_B_TEMPDIODE_HBM_PHY2",
+              "sysfsPath": "/run/devmap/sensors/SMB_U152_TMP422/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 5,
           "productSubVersion": 20
         },
         {
@@ -5334,6 +6134,382 @@
         {
           "sensors": [
             {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 4096
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 12,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 3,
+                "upperCriticalVal": 3.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 94,
+                "upperCriticalVal": 130
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 3,
+                "upperCriticalVal": 6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9,
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.605,
+                "lowerCriticalVal": 0.805
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 26
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.4,
+                "lowerCriticalVal": 0.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "lowerCriticalVal": 0.66
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100,
+                "upperCriticalVal": 115
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 1,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
               "name": "COMe_PU4_MP2993_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
               "type": 1,
@@ -5659,6 +6835,337 @@
             }
           ],
           "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COMe_PU4_MP2993_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 14,
+                "minAlarmVal": 9.5,
+                "upperCriticalVal": 15,
+                "lowerCriticalVal": 8.5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 2046
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 117,
+                "upperCriticalVal": 130
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU4_MP2993_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 4,
+                "upperCriticalVal": 6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.45,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 26
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.6
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 13
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.15,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 5
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 15
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.61,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_PIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
+              "type": 0,
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IIN",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
+              "type": 2,
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 20
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 4,
           "productVersion": 1,
           "productSubVersion": 2
         }


### PR DESCRIPTION
# Description

This PR is for janga SMB & COME card pvt sensor config.

# Motivation

1.According to the factory they have added SMB card '3 5 20' about productionstate, productversion,productsubversion.
COME card '4 1 1','4 1 2' about productionstate, productversion,productsubversion.



<img width="1079" alt="image" src="https://github.com/user-attachments/assets/774ab0a1-a011-446d-8655-8a23c436b9b7">

2.So i have added the following configs.

<img width="698" alt="image" src="https://github.com/user-attachments/assets/90b5dd71-a76b-4d15-93a6-1e37cec7282e" />

3.Note: I still put 
SMB_U68_TMP422
SMB_U150_TMP422
SMB_U351_TMP422
SMB_U352_TMP422
SMB_U152_TMP422
them in SMB_FRU_SLOT because they can be recognized in SMB eeprom can not Recognized in JANGA eeprom.I have manually change the SMB eeprom to '3 5 20' it tested ok, if you put them in JANGA slot it tested fail because they belongs to SMB board.

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/03a0c443-68fc-4ae2-911f-939841d2ecf8">
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/fca2bbc6-3735-4102-a63e-7405e2a3a9c6">



In the hardware table, they belongs to SMB board
https://docs.google.com/spreadsheets/d/1r0Vbv1cx3KelYLEM4vl0VNyIeEpFwurG5JJZ6BckMCI/edit?gid=1519693354#gid=1519693354
![image](https://github.com/user-attachments/assets/d3b591d4-2ed4-4987-9dbc-0154cb2fade9)




# Test Plan

1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:
[janga_main_source_platform_test_log_11_28.txt](https://github.com/user-attachments/files/17986497/janga_main_source_platform_test_log_11_28.txt)
[janga_main_source_sensor_test_log_11_28.txt](https://github.com/user-attachments/files/17986498/janga_main_source_sensor_test_log_11_28.txt)




