### PR TITLE
tahan: config: Delete the extra configuration SMB_FRU "3 5 20" and fix NETLAKE "3 1 2" wrong configuration

### DIFF
--- a/fboss/platform/configs/tahan800bc/sensor_service.json
+++ b/fboss/platform/configs/tahan800bc/sensor_service.json
@@ -3399,457 +3399,6 @@
         {
           "sensors": [
             {
-              "name": "TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "TH5_VDD_CORE_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 14.4,
-                "maxAlarmVal": 13.2,
-                "minAlarmVal": 10.8,
-                "lowerCriticalVal": 9.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "TH5_VDD_CORE_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.98,
-                "maxAlarmVal": 0.9,
-                "minAlarmVal": 0.65,
-                "lowerCriticalVal": 0.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "TH5_VDD_CORE_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "TH5_VDD_CORE_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "TH5_VDD_CORE_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 14.4,
-                "maxAlarmVal": 13.2,
-                "minAlarmVal": 10.8,
-                "lowerCriticalVal": 9.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "3*@/1000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
-              },
-              "compute": "3*@/1000000.0"
-            },
-            {
-              "name": "XP3R3V_RIGHT_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 14.4,
-                "maxAlarmVal": 13.2,
-                "minAlarmVal": 10.8,
-                "lowerCriticalVal": 9.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 3.63,
-                "maxAlarmVal": 3.465,
-                "minAlarmVal": 3.135,
-                "lowerCriticalVal": 2.97
-              },
-              "compute": "3*@/1000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
-              },
-              "compute": "3*@/1000000.0"
-            },
-            {
-              "name": "XP3R3V_LEFT_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 14.4,
-                "maxAlarmVal": 13.2,
-                "minAlarmVal": 10.8,
-                "lowerCriticalVal": 9.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.99,
-                "maxAlarmVal": 0.945,
-                "minAlarmVal": 0.855,
-                "lowerCriticalVal": 0.81
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.825,
-                "maxAlarmVal": 0.7875,
-                "minAlarmVal": 0.7125,
-                "lowerCriticalVal": 0.675
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_1_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_1_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_IIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_VIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 14.4,
-                "maxAlarmVal": 13.2,
-                "minAlarmVal": 10.8,
-                "lowerCriticalVal": 9.6
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.99,
-                "maxAlarmVal": 0.945,
-                "minAlarmVal": 0.855,
-                "lowerCriticalVal": 0.81
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.825,
-                "maxAlarmVal": 0.7875,
-                "minAlarmVal": 0.7125,
-                "lowerCriticalVal": 0.675
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_PIN",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R9V_TH5_TRVDD_0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "XP0R75V_XP0R9V_TH5_TRVDD_0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "XP0R75V_TH5_TRVDD_0_TEMP",
-              "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
-              },
-              "compute": "@/1000.0"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 5,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
               "name": "TH5_VDD_CORE_IIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
               "type": 2,
@@ -5247,199 +4796,155 @@
         {
           "sensors": [
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VIN",
+              "name": "COMe_PU4_MP2993_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in1_input",
               "type": 1,
               "thresholds": {
                 "maxAlarmVal": 14,
-                "minAlarmVal": 9,
-                "upperCriticalVal": 15
+                "minAlarmVal": 9.5,
+                "upperCriticalVal": 15,
+                "lowerCriticalVal": 8.5
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_VIN",
+              "name": "COMe_PU4_MP2993_PVCCIN_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in2_input",
               "type": 1,
               "thresholds": {
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9,
-                "upperCriticalVal": 15
+                "maxAlarmVal": 2,
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_VOUT",
+              "name": "COMe_PU4_MP2993_P1V8_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in3_input",
               "type": 1,
               "thresholds": {
                 "maxAlarmVal": 2,
-                "upperCriticalVal": 2.2,
-                "lowerCriticalVal": 1.4
+                "upperCriticalVal": 2.4,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/in4_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 2,
-                "upperCriticalVal": 2.2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_TEMP",
+              "name": "COMe_PU4_MP2993_PVCCIN_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_TEMP",
+              "name": "COMe_PU4_MP2993_P1V8_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_PIN",
+              "name": "COMe_PU4_MP2993_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 2046
               },
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_PIN",
+              "name": "COMe_PU4_MP2993_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
               "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 4096
-              },
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_POUT",
+              "name": "COMe_PU4_MP2993_P1V8_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
               "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 125
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IIN",
+              "name": "COMe_PU4_MP2993_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr1_input",
               "type": 2,
-              "thresholds": {
-                "maxAlarmVal": 12,
-                "upperCriticalVal": 15
-              },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_IIN",
+              "name": "COMe_PU4_MP2993_PVCCIN_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr2_input",
               "type": 2,
               "thresholds": {
-                "maxAlarmVal": 3,
-                "upperCriticalVal": 3.5
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COMe_PU4_XDPE15284_PVCCIN_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "maxAlarmVal": 94,
+                "maxAlarmVal": 117,
                 "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU4_XDPE15284_P1V8_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr4_input",
+              "name": "COMe_PU4_MP2993_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/curr3_input",
               "type": 2,
               "thresholds": {
-                "maxAlarmVal": 3,
+                "maxAlarmVal": 4,
                 "upperCriticalVal": 6
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VIN",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9,
                 "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_VOUT",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.605,
-                "lowerCriticalVal": 0.805
+                "upperCriticalVal": 1.45,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_TEMP",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 100,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_PIN",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
               "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IIN",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr1_input",
               "type": 2,
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_IOUT",
+              "name": "COMe_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/curr2_input",
               "type": 2,
               "thresholds": {
@@ -5448,7 +4953,7 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VIN",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
@@ -5457,45 +4962,44 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_VOUT",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
+                "upperCriticalVal": 1.6
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_TEMP",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 100,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_PIN",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_POUT",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/power2_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IIN",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr1_input",
               "type": 2,
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU31_TDA38640_PVNN_PCH_IOUT",
+              "name": "COMe_PU31_MP9941_PVNN_PCH_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/curr2_input",
               "type": 2,
               "thresholds": {
@@ -5504,7 +5008,7 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VIN",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
@@ -5513,45 +5017,45 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_VOUT",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.4,
-                "lowerCriticalVal": 0.6
+                "upperCriticalVal": 1.15,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_TEMP",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 100,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_PIN",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_POUT",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/power2_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IIN",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr1_input",
               "type": 2,
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU42_TDA38640_PVCCANA_CPU_1V_IOUT",
+              "name": "COMe_PU42_MP9941_PVCCANA_CPU_1V_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU42_TDA38640/curr2_input",
               "type": 2,
               "thresholds": {
@@ -5560,7 +5064,7 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VIN",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
@@ -5569,45 +5073,45 @@
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_VOUT",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_VOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.46,
-                "lowerCriticalVal": 0.66
+                "upperCriticalVal": 1.61,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_TEMP",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_TEMP",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 100,
-                "upperCriticalVal": 115
+                "maxAlarmVal": 125,
+                "upperCriticalVal": 135
               },
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_PIN",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_PIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power1_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_POUT",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/power2_input",
               "type": 0,
               "compute": "@/1000000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IIN",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IIN",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr1_input",
               "type": 2,
               "compute": "@/1000.0"
             },
             {
-              "name": "COMe_PU32_TDA38640_P1V05_STBY_IOUT",
+              "name": "COMe_PU32_MP9941_P1V05_STBY_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU32_TDA38640/curr2_input",
               "type": 2,
               "thresholds": {
@@ -5616,9 +5120,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 4,
+          "productProductionState": 3,
           "productVersion": 1,
-          "productSubVersion": 1
+          "productSubVersion": 2
         },
         {
           "sensors": [
@@ -5947,7 +5451,7 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 3,
+          "productProductionState": 4,
           "productVersion": 1,
           "productSubVersion": 2
         }


### PR DESCRIPTION
Description
This PR is for tahan come pvt sensor config file.

Motivation
The sensor config file submitted(https://github.com/facebook/fboss/pull/312) last time has errors(The wrong file was uploaded, resulting in an extra SMB_FRU "3 5 20" configuration and a wrong NETLAKE "3 1 2" configuration), in this PR revise it and submit the correct file again.
1.This is the wrong file content:
<img width="537" alt="image" src="https://github.com/user-attachments/assets/a5364476-c627-499c-a9eb-bb4886308066" />

2.This is the file after repair:

<img width="554" alt="image" src="https://github.com/user-attachments/assets/e4e7b8ed-27ee-4c20-9ccd-ea5e3778bcf4" />



Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:
Tested in tahan come pvt 2nd source machine.

![image](https://github.com/user-attachments/assets/04ae8fef-f56e-4e1f-aac6-7b2cbaca6c88)



[tahan_ppvt_sensor_service_test_12_20_log.txt](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/15210/attachments/tahan_ppvt_sensor_service_test_12_20_log.txt) 



