### PR TITLE
Darwin48V: Configure Aboot configuration on upgrade

### DIFF
--- a/fboss/platform/configs/darwin/fw_util.json
+++ b/fboss/platform/configs/darwin/fw_util.json
@@ -1,7 +1,7 @@
 {
   "fwConfigs" : {
     "BIOS" : {
-      "preUpgradeCmd" : "printf 'A00000:FFFFFF normal\n400000:9EFFFF fallback\n9FA000:9FEFFF aboot_conf\n000000:FFFFFF total\n001000:01EFFF prefdl' > /home/bios_spi_layout;flashrom -p internal 2>&1 > /home/flashrom-output.txt; grep -w 'MX25L12805D' /home/flashrom-output.txt && echo 'MX25L12805D' > /home/chip.txt || grep 'N25Q128..3E' /home/flashrom-output.txt && echo 'N25Q128..3E' > /home/chip.txt || echo '****** error finding chip ****** ...'",
+      "preUpgradeCmd" : "printf 'A00000:FFFFFF normal\n400000:9EFFFF fallback\n9FA000:9FEFFF aboot_conf\n000000:FFFFFF total\n001000:01EFFF prefdl' > /home/bios_spi_layout;flashrom -p internal 2>&1 > /home/flashrom-output.txt; ( grep -w 'MX25L12805D' /home/flashrom-output.txt && echo 'MX25L12805D' > /home/chip.txt ) || ( grep 'N25Q128..3E' /home/flashrom-output.txt && echo 'N25Q128..3E' > /home/chip.txt ) || echo '****** error finding chip ****** ...'",
       "getVersionCmd" : "cat /sys/devices/virtual/dmi/id/bios_version | cut -d ':' -f 2 | cut -d '-' -f 3",
       "priority" : 1,
       "upgradeCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback -i aboot_conf --noverify-all -w $bios_filename",

--- a/fboss/platform/configs/darwin48v/fw_util.json
+++ b/fboss/platform/configs/darwin48v/fw_util.json
@@ -1,13 +1,13 @@
 {
   "fwConfigs" : {
     "bios" : {
-      "preUpgradeCmd" : "printf 'A00000:FFFFFF normal\n400000:9EFFFF fallback\n9FA000:9FEFFF aboot_conf\n000000:FFFFFF total\n001000:01EFFF prefdl' > /home/bios_spi_layout;flashrom -p internal 2>&1 > /home/flashrom-output.txt; grep -w 'MX25L12805D' /home/flashrom-output.txt && echo 'MX25L12805D' > /home/chip.txt || grep 'N25Q128..3E' /home/flashrom-output.txt && echo 'N25Q128..3E' > /home/chip.txt || echo '****** error finding chip ****** ...'",
+      "preUpgradeCmd" : "dd if=/dev/zero of=/home/aboot_conf.bin bs=4096 count=4096 && printf 'BOOT_METHOD1=SVBWNl9QWEU=\nBOOT_METHOD2=TE9DQUw=\nBOOT_METHOD3=QVJJU1RB\nBOOT_METHOD4=UkVCT09U\nDMI_BOARD_NAME=REFSV0lONDhW\n' | dd of=/home/aboot_conf.bin bs=4096 seek=2554 conv=notrunc && printf 'A00000:FFFFFF normal\n400000:9EFFFF fallback\n9FA000:9FEFFF aboot_conf\n000000:FFFFFF total\n001000:01EFFF prefdl' > /home/bios_spi_layout;flashrom -p internal 2>&1 > /home/flashrom-output.txt; ( grep -w 'MX25L12805D' /home/flashrom-output.txt && echo 'MX25L12805D' > /home/chip.txt ) || ( grep 'N25Q128..3E' /home/flashrom-output.txt && echo 'N25Q128..3E' > /home/chip.txt ) || echo '****** error finding chip ****** ...'",
       "getVersionCmd" : "cat /sys/devices/virtual/dmi/id/bios_version | cut -d ':' -f 2 | cut -d '-' -f 3",
       "priority" : 1,
-      "upgradeCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback -i aboot_conf --noverify-all -w $bios_filename",
-      "postUpgradeCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback -i aboot_conf --noverify-all -v $bios_filename",
-      "verifyFwCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback -i aboot_conf --noverify-all -v $bios_filename",
-      "readFwCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback -i aboot_conf --noverify-all -r $bios_filename",
+      "upgradeCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback --noverify-all -w $bios_filename && flashrom -p internal -c $chip -l /home/bios_spi_layout -i aboot_conf --noverify-all -w /home/aboot_conf.bin",
+      "postUpgradeCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback --noverify-all -v $bios_filename && flashrom -p internal -c $chip -l /home/bios_spi_layout -i aboot_conf --noverify-all -v /home/aboot_conf.bin",
+      "verifyFwCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback --noverify-all -v $bios_filename && flashrom -p internal -c $chip -l /home/bios_spi_layout -i aboot_conf --noverify-all -v /home/aboot_conf.bin",
+      "readFwCmd" : "chip=$(head -n 1 /home/chip.txt); bios_filename=$(head -n 1 /home/bios_filename.txt); flashrom -p internal -c $chip -l /home/bios_spi_layout -i normal -i fallback --noverify-all -r $bios_filename",
       "sha1sum" : "f821367de316fdcd28bdaae64a83d9d0876aeebe"
     },
     "cpu_cpld" : {


### PR DESCRIPTION
When upgrading to the official Aboot 7.5.3 version, existing fw_util scripts configure the aboot_conf section from the Aboot image. Since boot methods are built into the image, this is not an issue for Darwin. But for Darwin48V, the DMI_BOARD_NAME needs to be configured in order for dmidecode to show the right thing.

In addition to the Darwin48V change, there is a change to the Darwin config to fix an issue where fw_util was not working with certain SPI chips. The issue was the and/or operators in the command did not contain parenthesis, so the chip type N25Q128..3E was being used unconditionally.

Test Plan

1. Tested the upgrade on a Darwin48V system. Verified that after the upgrade, dmidecode -t 2 showed DARWIN48V.

2. Tested the upgrade on a Darwin system. Verified that after the upgrade, dmidecode -t 2 showed DARWIN.

3. Tested the upgrade on a Darwin system with a MX25L12805D SPI chip. Verified the upgrade succeeded.