### PR TITLE
platform_manager:updated the relavant debug context

### DIFF
--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -80,7 +80,7 @@ std::string Utils::resolveWatchdogCharDevPath(const std::string& sysfsPath) {
   if (!Utils().checkDeviceReadiness(
           [&]() -> bool { return fs::exists(watchdogDir); },
           fmt::format(
-              "Watchdog CharDevPath is not created. Waited for at most {}s",
+              "Watchdog SysfsPath is not created. Waited for at most {}s",
               kWatchdogDevCreationWaitSecs.count()),
           kWatchdogDevCreationWaitSecs)) {
     throw std::runtime_error(fmt::format(


### PR DESCRIPTION
# Description:
During Watchdog sysfsPath validation, debug logs incorrectly displayed CharDevPath. This has been corrected to reflect the actual Sysfspath.

# Motivation:
To improve code clarity.

# Testcase:
 platform_manager binary built and loaded successfully.