### PR TITLE
platform_manager:  Validating and Waiting for Watchdog Character Device Creation

### DIFF
--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -108,7 +108,7 @@ std::string Utils::resolveWatchdogCharDevPath(const std::string& sysfsPath) {
               "Watchdog CharDevPath is not created. Waited for at most {}s",
               kWatchdogDevCreationWaitSecs.count()),
           kWatchdogDevCreationWaitSecs)) {
-  	throw std::runtime_error(fmt::format(
+    throw std::runtime_error(fmt::format(
         "{}. Reason: {} does not exist in the system", failMsg, charDevPath));
   }
   return charDevPath;

--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -102,8 +102,13 @@ std::string Utils::resolveWatchdogCharDevPath(const std::string& sysfsPath) {
         "{}. Reason: Couldn't find watchdog under {}", failMsg, sysfsPath));
   }
   auto charDevPath = fmt::format("/dev/watchdog{}", *watchdogNum);
-  if (!fs::exists(charDevPath)) {
-    throw std::runtime_error(fmt::format(
+  if (!Utils().checkDeviceReadiness(
+          [&]() -> bool { return fs::exists(charDevPath); },
+          fmt::format(
+              "Watchdog CharDevPath is not created. Waited for at most {}s",
+              kWatchdogDevCreationWaitSecs.count()),
+          kWatchdogDevCreationWaitSecs)) {
+  	throw std::runtime_error(fmt::format(
         "{}. Reason: {} does not exist in the system", failMsg, charDevPath));
   }
   return charDevPath;


### PR DESCRIPTION
# Description:

 After creating the sysfs watchdog device, the corresponding character device entry in /dev/watchdog should be automatically generated. However, in some cases, the character device entry may take time to appear, which could cause the platform manager to fail.

 To address this, a validation check for the presence of the character device (/dev/watchdog) has been implemented.
 
>   [root@localhost ~]# ls -l /sys/bus/i2c/devices/15-0033/watchdog/ --full-time
> drwxr-xr-x 2 root root 0 2025-01-21 09:42:56.008935280 +0800 watchdog1 
> [root@localhost ~]# ls -l /dev/watchdog1 --full-time 
> crw------- 1 root root 246, 1 2025-01-21 09:42:56.030935280 +0800 /dev/watchdog1


 # Motivation:
 In rare scenarios, the initialization process for a device can extend beyond the standard timeframe. This can cause the platform_manager to fail to locate the watchdog device in the specified location, resulting in an error message.

`
I1207 16:37:55.981444 1201 ExplorationSummary.cpp:66] Failed to explore I2C device MCB_FAN_CPLD at /. Failed to resolve Watchdog CharDevPath. Reason: /dev/watchdog2 does not exist in the system `

# Testcase:
A) Delayed Device Registration
**Simulate Delay**: Introduce a simulated delay in the driver code to mimic a scenario where device registration takes longer than usual.
**Validation**: Implement a validation process that actively waits for the watchdog device to be successfully created.
**Assertion**: Verify that the platform_manager can locate and utilize the watchdog device within a reasonable timeframe, even with the simulated delay.
B) The above procedure was executed with a reboot and power cycle.