### PR TITLE
Sync Darwin and Darwin48V configs

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,22 +1,22 @@
 {
   "systemLedConfig": {
     "presentLedColor": 1,
-    "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
     "absentLedColor": 2,
-    "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PEM": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },
   "fruConfigs": [
@@ -66,6 +66,16 @@
       "presenceDetection": {
         "sysfsFileHandle": {
           "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
           "desiredValue": 1
         }
       }

--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -1,5 +1,5 @@
 {
-  "platformName": "darwin48v",
+  "platformName": "darwin",
   "rootPmUnitName": "SMB",
   "rootSlotType": "SMB_SLOT",
   "slotTypeConfigs": {
@@ -17,13 +17,19 @@
         "busName": "INCOMING@0",
         "address": "0x52",
         "kernelDeviceName": "24c512",
-        "offset": 15360
+        "offset": 0
       },
       "pmUnitName": "RACKMON"
     },
-    "PSU_SLOT": {
+    "PEM_SLOT": {
       "numOutgoingI2cBuses": 1,
-      "pmUnitName": "PSU"
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c512",
+        "offset": 0
+      },
+      "pmUnitName": "PEM"
     }
   },
   "pmUnitConfigs": {
@@ -71,12 +77,6 @@
           "address": "0x23",
           "kernelDeviceName": "blackhawk_cpld",
           "pmUnitScopedName": "BLACKHAWK_CPLD"
-        },
-        {
-          "busName": "ROOK_SMBUS2@0",
-          "address": "0x50",
-          "kernelDeviceName": "24c16",
-          "pmUnitScopedName": "CHASSIS_EEPROM"
         },
         {
           "busName": "SCD_SMBUS1@0",
@@ -171,15 +171,8 @@
           },
           "outgoingI2cBusNames": []
         },
-        "PSU_SLOT@0": {
-          "slotType": "PSU_SLOT",
-          "presenceDetection": {
-            "sysfsFileHandle": {
-              "devicePath": "/[SCD_FPGA]",
-              "presenceFileName": "pem_present",
-              "desiredValue": 1
-            }
-          },
+        "PEM_SLOT@0": {
+          "slotType": "PEM_SLOT",
           "outgoingI2cBusNames": [
             "SCD_SMBUS1@3"
           ]
@@ -900,6 +893,18 @@
               "deviceName": "fpga_info_iob",
               "csrOffset": "0x100"
             }
+          ],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SCD_WDT1",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x120"
+            },
+            {
+              "pmUnitScopedName": "SCD_WDT2",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x304"
+            }
           ]
         }
       ],
@@ -946,14 +951,26 @@
       "outgoingSlotConfigs": {},
       "pciDeviceConfigs": []
     },
-    "PSU": {
-      "pluggedInSlotType": "PSU_SLOT",
+    "PEM": {
+      "pluggedInSlotType": "PEM_SLOT",
       "i2cDeviceConfigs": [
         {
           "busName": "INCOMING@0",
-          "address": "0x58",
-          "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PSU_PMBUS"
+          "address": "0x3a",
+          "kernelDeviceName": "amax5970",
+          "pmUnitScopedName": "PEM_ECB_MAX5970"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x36",
+          "kernelDeviceName": "bp4a_max11645",
+          "pmUnitScopedName": "PEM_ADC_MAX11645"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4c",
+          "kernelDeviceName": "bp4a_max6658",
+          "pmUnitScopedName": "PEM_TEMP_MAX6658"
         }
       ],
       "outgoingSlotConfigs": {},
@@ -1048,7 +1065,6 @@
     "/run/devmap/cplds/FAN_CPLD": "/[FAN_CPLD]",
     "/run/devmap/sensors/FAN_CPLD": "/[FAN_CPLD]",
     "/run/devmap/cplds/BLACKHAWK_CPLD": "/[BLACKHAWK_CPLD]",
-    "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_EEPROM]",
     "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581": "/[SC_BOARD_TEMP_MAX6581]",
     "/run/devmap/sensors/SC_POS_UCD90320": "/[SC_POS_UCD90320]",
     "/run/devmap/sensors/SC_TH3_CORE_IR35223": "/[SC_TH3_CORE_IR35223]",
@@ -1157,7 +1173,9 @@
     "/run/devmap/sensors/FS_FAN_SLG4F4527": "/RACKMON_SLOT@0/[FS_FAN_SLG4F4527]",
     "/run/devmap/gpiochips/RACKMON_PLS": "/RACKMON_SLOT@0/[RACKMON_PLS]",
     "/run/devmap/eeproms/FANSPINNER_EEPROM": "/RACKMON_SLOT@0/[FANSPINNER_EEPROM]",
-    "/run/devmap/sensors/PSU_PMBUS": "/PSU_SLOT@0/[PSU_PMBUS]"
+    "/run/devmap/sensors/PEM_ECB_MAX5970": "/PEM_SLOT@0/[PEM_ECB_MAX5970]",
+    "/run/devmap/sensors/PEM_ADC_MAX11645": "/PEM_SLOT@0/[PEM_ADC_MAX11645]",
+    "/run/devmap/sensors/PEM_TEMP_MAX6658": "/PEM_SLOT@0/[PEM_TEMP_MAX6658]"
   },
   "bspKmodsRpmName": "arista_bsp_kmods",
   "bspKmodsRpmVersion": "0.7.7-1",

--- a/fboss/platform/configs/darwin/sensor_service.json
+++ b/fboss/platform/configs/darwin/sensor_service.json
@@ -2,14 +2,14 @@
   "pmUnitSensorsList": [
     {
       "slotPath": "/",
-      "pmUnitName": "CPU_CARD",
+      "pmUnitName": "SMB",
       "sensors": [
         {
           "name": "PCH_TEMP",
           "sysfsPath": "/run/devmap/sensors/PCH_THERMAL/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -18,7 +18,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -27,7 +27,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -36,7 +36,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -45,7 +45,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -54,7 +54,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -63,7 +63,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -72,7 +72,16 @@
           "sysfsPath": "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "FRONT_PANEL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_FP_TEMP_LM73/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -81,8 +90,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "upperCriticalVal": 14.0,
+            "lowerCriticalVal": 9.0
           },
           "compute": "@/1000.0"
         },
@@ -91,7 +100,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110
+            "upperCriticalVal": 110.0
           },
           "compute": "@/1000.0"
         },
@@ -100,7 +109,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -109,7 +118,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 45
+            "upperCriticalVal": 45.0
           },
           "compute": "@/1000.0"
         },
@@ -118,8 +127,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "upperCriticalVal": 14.0,
+            "lowerCriticalVal": 9.0
           },
           "compute": "@/1000.0"
         },
@@ -128,7 +137,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110
+            "upperCriticalVal": 110.0
           },
           "compute": "@/1000.0"
         },
@@ -137,7 +146,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -146,7 +155,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 35
+            "upperCriticalVal": 35.0
           },
           "compute": "@/1000.0"
         },
@@ -267,7 +276,8 @@
           "thresholds": {
             "upperCriticalVal": 3.795,
             "lowerCriticalVal": 2.8
-          }
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "POS_12V",
@@ -300,27 +310,12 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "FRONT_PANEL_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_FP_TEMP_LM73/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 85
-          },
-          "compute": "@/1000.0"
-        }
-      ]
-    },
-    {
-      "slotPath": "/FAN_SLOT@0",
-      "pmUnitName": "FAN",
-      "sensors": [
-        {
           "name": "FAN1_RPM",
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -328,8 +323,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -337,8 +332,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -346,8 +341,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -355,31 +350,16 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
-        {
-          "name": "FS_FAN_RPM",
-          "sysfsPath": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 29500,
-            "lowerCriticalVal": 2600
-          }
-        }
-      ]
-    },
-    {
-      "slotPath": "/SCM_SLOT@0",
-      "pmUnitName": "SWITCH_CARD",
-      "sensors": [
         {
           "name": "SC_BOARD_TEMP",
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -388,7 +368,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -397,7 +377,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -406,7 +386,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp4_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -415,7 +395,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp7_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 125
+            "upperCriticalVal": 125.0
           },
           "compute": "@/1000.0"
         },
@@ -424,14 +404,369 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp8_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 125
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_TH3_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_TH3_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_STDBY",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_5V0",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.75,
+            "lowerCriticalVal": 4.25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_QSFPDD_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in6_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_QSFPDD_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in7_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_STDBY",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in8_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.475
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_2V5_LT",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in9_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.1,
+            "lowerCriticalVal": 0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_2V5_RT",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in10_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.1,
+            "lowerCriticalVal": 0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V8",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in11_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 1.53
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V5_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in12_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 1.275
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V5_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in13_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 1.275
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V2",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in14_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 1.02
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_0V8_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in15_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0.72
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_0V9_VDD",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in16_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.35,
+            "lowerCriticalVal": 0.38
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "TH3_VRD1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 464.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "TH3_VRD2_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 124.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VOUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VOUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in3_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_POUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_POUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IOUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IOUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 120.0
           },
           "compute": "@/1000.0"
         }
       ]
     },
     {
-      "slotPath": "/PSU_SLOT@0",
+      "slotPath": "/RACKMON_SLOT@0",
+      "pmUnitName": "RACKMON",
+      "sensors": [
+        {
+          "name": "FS_FAN_RPM",
+          "sysfsPath": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
+          }
+        }
+      ]
+    },
+    {
+      "slotPath": "/PEM_SLOT@0",
       "pmUnitName": "PEM",
       "sensors": [
         {
@@ -439,7 +774,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14
+            "upperCriticalVal": 14.0
           },
           "compute": "(15.5*@)/1000.0"
         },
@@ -448,16 +783,16 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14
+            "upperCriticalVal": 14.0
           },
-          "compute": "15.5*@/1000.0"
+          "compute": "(15.5*@)/1000.0"
         },
         {
           "name": "PEM_ECB_IOUT_CH1",
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 60,
+            "upperCriticalVal": 60.0,
             "lowerCriticalVal": 0.5
           },
           "compute": "(48390/343)*@/1000.0"
@@ -467,7 +802,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 60,
+            "upperCriticalVal": 60.0,
             "lowerCriticalVal": 0.5
           },
           "compute": "(48390/343)*@/1000.0"
@@ -497,7 +832,7 @@
           "type": 1,
           "thresholds": {
             "upperCriticalVal": 0.08,
-            "lowerCriticalVal": 0
+            "lowerCriticalVal": 0.0
           },
           "compute": "@/1000.0"
         },
@@ -506,7 +841,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_TEMP_MAX6658/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -515,7 +850,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_TEMP_MAX6658/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         }


### PR DESCRIPTION
# Description

- Updates the PM configs for darwin & darwin48v to initialize the qsfp ports (1-32) and generate the necessary symlinks.
- Fix misconfigured infoRomConfigs to use the correct register offset of 0x100.
- Sync Darwin sensor_service config to include all sensors.
- Sync Darwin led_manager paths to follow the same `/sys/class/leds` used on other platforms. Also adds missing rackmon fan as a fru associated with the FAN led.

**NOTE**: The SFP ports on 33 & 34 aren't initialized as driver lacks support

Additionally, this fixes a recent escalated issue where the sensor`POS_3V3_ALW` was throwing critical alarms due to a missing configuration with how the sensor value is computed.

# Testing

Ports on Darwin48V reflect the expected values through the scd-xcvr driver 
```
# ls /run/devmap/xcvrs/
xcvr_1   xcvr_17  xcvr_24  xcvr_31  xcvr_ctrl_1   xcvr_ctrl_17  xcvr_ctrl_24  xcvr_ctrl_31  xcvr_io_1   xcvr_io_17  xcvr_io_24  xcvr_io_31
xcvr_10  xcvr_18  xcvr_25  xcvr_32  xcvr_ctrl_10  xcvr_ctrl_18  xcvr_ctrl_25  xcvr_ctrl_32  xcvr_io_10  xcvr_io_18  xcvr_io_25  xcvr_io_32
xcvr_11  xcvr_19  xcvr_26  xcvr_4   xcvr_ctrl_11  xcvr_ctrl_19  xcvr_ctrl_26  xcvr_ctrl_4   xcvr_io_11  xcvr_io_19  xcvr_io_26  xcvr_io_4
xcvr_12  xcvr_2   xcvr_27  xcvr_5   xcvr_ctrl_12  xcvr_ctrl_2   xcvr_ctrl_27  xcvr_ctrl_5   xcvr_io_12  xcvr_io_2   xcvr_io_27  xcvr_io_5
xcvr_13  xcvr_20  xcvr_28  xcvr_6   xcvr_ctrl_13  xcvr_ctrl_20  xcvr_ctrl_28  xcvr_ctrl_6   xcvr_io_13  xcvr_io_20  xcvr_io_28  xcvr_io_6
xcvr_14  xcvr_21  xcvr_29  xcvr_7   xcvr_ctrl_14  xcvr_ctrl_21  xcvr_ctrl_29  xcvr_ctrl_7   xcvr_io_14  xcvr_io_21  xcvr_io_29  xcvr_io_7
xcvr_15  xcvr_22  xcvr_3   xcvr_8   xcvr_ctrl_15  xcvr_ctrl_22  xcvr_ctrl_3   xcvr_ctrl_8   xcvr_io_15  xcvr_io_22  xcvr_io_3   xcvr_io_8
xcvr_16  xcvr_23  xcvr_30  xcvr_9   xcvr_ctrl_16  xcvr_ctrl_23  xcvr_ctrl_30  xcvr_ctrl_9   xcvr_io_16  xcvr_io_23  xcvr_io_30  xcvr_io_9
```

Port 1 is expected to be present
```
# cat /run/devmap/xcvrs/xcvr_ctrl_1/xcvr1_present
0 <-- 0 is present
```

Testing with a non-existing xcvr
```
# cat /run/devmap/xcvrs/xcvr_ctrl_5/xcvr5_present
1  <---- 1 is absent
```

### General Tests
The following sw_tests passed:
- async_logger_test
- fan_service_sw_test
- fsdb_client_test
- platform_config_lib_config_lib_test
- platform_data_corral_sw_test
- platform_helpers_platform_name_lib_test
- platform_manager_config_validator_test
- platform_manager_data_store_test
- platform_manager_device_path_resolver_test
- platform_manager_i2c_explorer_test
- platform_manager_platform_explorer_test
- platform_manager_presence_checker_test
- platform_manager_utils_test
- rackmon_test
- sensor_service_sw_test
- sensor_service_utils_test
- thrift_cow_visitor_tests
- thrift_node_tests
- weutil_crc16_ccitt_test
- weutil_fboss_eeprom_parser_test


The following hw_tests passed:
- data_corral_service_hw_test
- sensor_service_hw_test
- fan_service_hw_test
- weutil_hw_test