### PR TITLE
[Darwin]: Led_manager use sys leds paths and add missing fan module

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,22 +1,22 @@
 {
   "systemLedConfig": {
     "presentLedColor": 1,
-    "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
     "absentLedColor": 2,
-    "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PEM": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },
   "fruConfigs": [
@@ -66,6 +66,16 @@
       "presenceDetection": {
         "sysfsFileHandle": {
           "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
           "desiredValue": 1
         }
       }


### PR DESCRIPTION
# Description

- Sync Darwin led_manager paths to follow the same `/sys/class/leds` used on all other platforms.
- Add missing rackmon fan as a fru associated with the FAN led.

# Testing

The following sw_tests passed:
- async_logger_test
- fan_service_sw_test
- fsdb_client_test
- platform_config_lib_config_lib_test
- platform_data_corral_sw_test
- platform_helpers_platform_name_lib_test
- platform_manager_config_validator_test
- platform_manager_data_store_test
- platform_manager_device_path_resolver_test
- platform_manager_i2c_explorer_test
- platform_manager_platform_explorer_test
- platform_manager_presence_checker_test
- platform_manager_utils_test
- rackmon_test
- sensor_service_sw_test
- sensor_service_utils_test
- thrift_cow_visitor_tests
- thrift_node_tests
- weutil_crc16_ccitt_test
- weutil_fboss_eeprom_parser_test

The following hw_tests passed:
- data_corral_service_hw_test
- sensor_service_hw_test
- fan_service_hw_test
- weutil_hw_test


### Led Manager Testing
```
Jan 31 00:49:20 ...: I0131 00:49:20.856894  5161 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
Jan 31 00:49:20 ...: I0131 00:49:20.856950  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.857852  5161 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.857892  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.858802  5161 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
Jan 31 00:49:20 ...: I0131 00:49:20.858819  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.859799  5161 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
Jan 31 00:49:20 ...: I0131 00:49:20.859815  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.860829  5161 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
Jan 31 00:49:20 ...: I0131 00:49:20.860845  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN5 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861801  5161 FruPresenceExplorer.cpp:49] Detected that FAN5 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861817  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN6 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861846  5161 FruPresenceExplorer.cpp:49] Detected that FAN6 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861852  5161 FruPresenceExplorer.cpp:34] Detecting presence of PEM1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861869  5161 FruPresenceExplorer.cpp:49] Detected that PEM1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861877  5161 LedManager.cpp:45] Programming PEM LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861911  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861936  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861944  5161 LedManager.cpp:55] Programmed PEM LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.861950  5161 LedManager.cpp:45] Programming FAN LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861972  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861993  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861999  5161 LedManager.cpp:55] Programmed FAN LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.862005  5161 LedManager.cpp:25] Programming system LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.862026  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862047  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862054  5161 LedManager.cpp:34] Programmed system LED with true
```
![image](https://github.com/user-attachments/assets/b128036c-91fc-40ab-8f98-e139f28a54ec)
