### PR TITLE
EepromV6: Validating the ProductionState as per new fboss commit 

### DIFF
--- a/fboss/platform/weutil/CachedFbossEepromParser.h
+++ b/fboss/platform/weutil/CachedFbossEepromParser.h
@@ -40,27 +40,22 @@ class CachedFbossEepromParser {
     for (const auto& [key, value] : getContents(eepromFilePath, offset)) {
       // < V6 - "Product Production State"
       // = V6 - "Production State"
-      if (key == "Product Production State" || key == "Production State") {
-        try {
-            // Attempt conversion to integer first.
-            return std::stoi(value);
-        } catch (const std::invalid_argument& e) {
-            // If integer conversion fails, check for string values.
-            if (value == "0") {
-                 throw std::runtime_error("Production State is not set!");
-            } else if (value == "EVT") {
-                 return 1;
-            } else if (value == "DVT") {
-                 return 2;
-            } else if (value == "PVT") {
-                 return 3;
-            } else if (value == "MP") {
-                 return 4;
-            } else {
-                 throw std::runtime_error("Unknown Production State: " + value); // Include the value in the error message
-             }
-        } catch (const std::out_of_range& e) {
-             throw std::runtime_error("Production State value out of range: " + value); // Handle potential out-of-range errors
+      if (key == "Product Production State"){
+        return std::stoi(value);
+      } else if (key == "Production State") {
+        // If integer conversion fails, check for string values.
+        if (value == "0") {
+          throw std::runtime_error("Production State is not set!");
+        } else if (value == "EVT") {
+           return 1;
+        } else if (value == "DVT") {
+           return 2;
+        } else if (value == "PVT") {
+           return 3;
+        } else if (value == "MP") {
+           return 4;
+        } else {
+           throw std::runtime_error("Unknown Production State!"); 
         }
       }
     }

--- a/fboss/platform/weutil/CachedFbossEepromParser.h
+++ b/fboss/platform/weutil/CachedFbossEepromParser.h
@@ -40,8 +40,28 @@ class CachedFbossEepromParser {
     for (const auto& [key, value] : getContents(eepromFilePath, offset)) {
       // < V6 - "Product Production State"
       // = V6 - "Production State"
-      if (key == "Product Production State" || key == "Production State ") {
-        return std::stoi(value);
+      if (key == "Product Production State" || key == "Production State") {
+        try {
+            // Attempt conversion to integer first.
+            return std::stoi(value);
+        } catch (const std::invalid_argument& e) {
+            // If integer conversion fails, check for string values.
+            if (value == "0") {
+                 throw std::runtime_error("Production State is not set!");
+            } else if (value == "EVT") {
+                 return 1;
+            } else if (value == "DVT") {
+                 return 2;
+            } else if (value == "PVT") {
+                 return 3;
+            } else if (value == "MP") {
+                 return 4;
+            } else {
+                 throw std::runtime_error("Unknown Production State: " + value); // Include the value in the error message
+             }
+        } catch (const std::out_of_range& e) {
+             throw std::runtime_error("Production State value out of range: " + value); // Handle potential out-of-range errors
+        }
       }
     }
     return std::nullopt;


### PR DESCRIPTION
# Description:
  A recent update to the EEPROM format (V6) in fboss (commit [18b03f1e74d78a302adbaa1bb754bc08569ebf67](https://github.com/facebook/fboss/commit/18b03f1e74d78a302adbaa1bb754bc08569ebf67)) changes the `ProductionState` field to a human-readable string.  This change doesn't affect the V5 EEPROM format, which uses a numerical representation. The existing code doesn't handle the new human-readable format introduced in V6.  Therefore, this change modifies the code to support both the numerical (V5) and human-readable (V6) formats for the `ProductionState` field.
![image](https://github.com/user-attachments/assets/b91f8872-c0ac-4558-9f21-939e57486dfd)

# Motivation:
 In V6, the platform manager reports an error because it cannot handle the human-readable `ProductionState` field.
 This unsupported format causes the platform manager to fail and return an error.

> 1554 PlatformExplorer.cpp:349] Found ProductProductionState `<ABSENT>` ProductVersion `1` ProductSubVersion `2` in IDPROM /sys/bus/i2c/devices/16-0056/eeprom at /COME_SLOT@0
> 1554 PlatformExplorer.cpp:371] Found PmUnit name `NETLAKE` in IDPROM /sys/bus/i2c/devices/16-0056/eeprom at /COME_SLOT@0
> 1554 PlatformExplorer.cpp:380] SlotType PmUnitName: NETLAKE
> 1554 PlatformExplorer.cpp:390] Going with PmUnit name `NETLAKE` defined in config for /COME_SLOT@0
> 1554 DataStore.cpp:107] At SlotPath /COME_SLOT@0, unexpected partial versions: ProductProductionState `<ABSENT>` ProductVersion `1` ProductSubVersion `2`. Skipping updating PmUnit NETLAKE
> 1554 DataStore.cpp:117] At SlotPath /COME_SLOT@0, updating to PmUnit NETLAKE with
> 1554 DataStore.cpp:140] Resolved /COME_SLOT@0 to default PmUnitConfig of NETLAKE. No ProductSubversion was read from IDPROM at the slotPath.
**Refer to the complete log :**  
[platform_manager_GITHUB_ACTION.txt.log](https://github.com/user-attachments/files/18619160/platform_manager_GITHUB_ACTION.txt.log)

# Test Case:

1. The platform manager executes successfully with both V5 and V6 EEPROM formats.
2. The above test is performed after a power cycle.
**[Unit test Log:]**- 
[platform_manager.txt](https://github.com/user-attachments/files/18618230/platform_manager.txt)
[Weutil.txt](https://github.com/user-attachments/files/18618231/Weutil.txt)
