### PR TITLE
fboss : fw_util : removed incorrect file existence check in fw_util for read operation.

### DIFF
--- a/fboss/platform/fw_util/fw_util.cpp
+++ b/fboss/platform/fw_util/fw_util.cpp
@@ -51,7 +51,8 @@ int main(int argc, char* argv[]) {
     exit(1);
   }
 
-  if (!FLAGS_fw_binary_file.empty() &&
+  // Check for file existence only for actions that require a binary file
+  if (!FLAGS_fw_binary_file.empty() && FLAGS_fw_action != "read" &&
       !std::filesystem::exists(FLAGS_fw_binary_file)) {
     XLOG(ERR) << "--fw_binary_file cannot be found in the specified path";
     exit(1);


### PR DESCRIPTION
# Description

**Issue:** While the `--fw_binary_file` option (and its corresponding file) is necessary for `program` and `verify `operations, it's erroneously required for the `read` operation as well.

**Current Behavior:** `fw_util` currently checks for the existence of the `--fw_binary_file` even during the `read` operation, despite the fact that this file is generated by the `read` operation itself.

**Expected Behavior:** The `--fw_binary_file` check should be bypassed for the `read` operation.

**Impact:** This regression prevents `fw_util` from functioning correctly with the `read` operation, breaking compatibility with the previous implementation.

**Error Log:**

```
[root@localhost gorav]# ./fboss_bins/bin/fw_util --fw_target_name=iob_fpga --fw_action=read --fw_binary_file=tmp.bin
I0131 11:08:31.803497  1944 PlatformNameLib.cpp:73] Platform name read from cache: MONTBLANC
I0131 11:08:31.803566  1944 ConfigLib.cpp:27] The inferred platform is montblanc
E0131 11:08:31.803661  1944 fw_util.cpp:56] --fw_binary_file cannot be found in the specified path
[root@localhost gorav]#
```

**Place where this check is introduced** : https://github.com/facebook/fboss/blob/main/fboss/platform/fw_util/fw_util.cpp#L54-L58 

**The correct check should be:**
```
  // Check for file existence only for actions that require a binary file
  if (!FLAGS_fw_binary_file.empty() && FLAGS_fw_action != "read" &&
      !std::filesystem::exists(FLAGS_fw_binary_file)) {
    XLOG(ERR) << "--fw_binary_file cannot be found in the specified path";
    exit(1);
  }
  ```

# Testing

**Before Fix:**

```
[root@localhost gorav]# ./fboss_bins/bin/fw_util --fw_target_name=iob_fpga --fw_action=read --fw_binary_file=tmp.bin
I0131 11:08:31.803497  1944 PlatformNameLib.cpp:73] Platform name read from cache: MONTBLANC
I0131 11:08:31.803566  1944 ConfigLib.cpp:27] The inferred platform is montblanc
E0131 11:08:31.803661  1944 fw_util.cpp:56] --fw_binary_file cannot be found in the specified path
[root@localhost gorav]#
```

**After Fix:**
```
[root@localhost gorav]# ./fw_util --fw_target_name=iob_fpga --fw_action=read --fw_binary_file=tmp.bin
I0131 11:10:40.529432  1967 PlatformNameLib.cpp:73] Platform name read from cache: MONTBLANC
I0131 11:10:40.529500  1967 ConfigLib.cpp:27] The inferred platform is montblanc
I0131 11:10:40.529594  1967 FwUtilImpl.cpp:61]  Analyzing the given FW action for execution
I0131 11:10:40.529603  1967 FwUtilRead.cpp:11] Running read operation for iob_fpga
I0131 11:10:40.529612  1967 FwUtilFlashrom.cpp:13] Detecting chip for iob_fpga
I0131 11:10:40.529621  1967 PlatformUtils.cpp:28] Running command: /usr/bin/flashrom -p linux_spi:dev=/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1
I0131 11:10:40.551964  1967 PlatformUtils.cpp:41] Running command: /bin/grep -q N25Q128..3E
I0131 11:10:40.552708  1967 FwUtilFlashrom.cpp:49] Detected chip: N25Q128..3E
I0131 11:10:40.552715  1967 PlatformUtils.cpp:28] Running command: /usr/bin/flashrom -p linux_spi:dev=/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1 -c N25Q128..3E -r tmp.bin
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] flashrom v1.2.1-dirty on Linux 6.4.3 (x86_64)
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] flashrom is free software, get the source code at https://flashrom.org
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171]
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] Using clock_gettime for delay loops (clk_id: 1, resolution: 1ns).
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] Using default 2000kHz clock. Use 'spispeed' parameter to override.
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] Found Micron/Numonyx/ST flash chip "N25Q128..3E" (16384 kB, SPI) on linux_spi.
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171] Reading flash... done.
I0131 11:10:56.645738  1967 FwUtilFlashrom.cpp:171]
[root@localhost gorav]# 
```