### PR TITLE
Eepromv6: Bug fix in getProductionState V6.

### DIFF
--- a/fboss/platform/weutil/CachedFbossEepromParser.h
+++ b/fboss/platform/weutil/CachedFbossEepromParser.h
@@ -40,7 +40,7 @@ class CachedFbossEepromParser {
     for (const auto& [key, value] : getContents(eepromFilePath, offset)) {
       // < V6 - "Product Production State"
       // = V6 - "Production State"
-      if (key == "Product Production State" || key == "Production State ") {
+      if (key == "Product Production State" || key == "Production State") {
         return std::stoi(value);
       }
     }


### PR DESCRIPTION
# Description:-
 The platform manager is reporting an error because it cannot parse the production state value from the Eepromv6. This is due to an extra space in the key `Production State  `. The parsing logic is failing to recognize the key with the added space.
![image](https://github.com/user-attachments/assets/a2695525-00d3-45eb-b6de-00f8510fd672)
https://github.com/facebook/fboss/blob/main/fboss/platform/weutil/CachedFbossEepromParser.h#L43

# Motivation:-
 In V6, the platform manager reports an error because it cannot able to parse the ProductionState

> 1273 PlatformExplorer.cpp:349] Found ProductProductionState `<ABSENT>` ProductVersion `1` ProductSubVersion `2` in IDPROM /sys/bus/i2c/devices/16-0056/eeprom at /COME_SLOT@0
> 1273 PlatformExplorer.cpp:371] Found PmUnit name `NETLAKE` in IDPROM /sys/bus/i2c/devices/16-0056/eeprom at COME_SLOT@0
> 1273 PlatformExplorer.cpp:380] SlotType PmUnitName: NETLAKE
> 1273 PlatformExplorer.cpp:390] Going with PmUnit name `NETLAKE` defined in config for /COME_SLOT@0
> 1273 DataStore.cpp:107] At SlotPath /COME_SLOT@0, unexpected partial versions: ProductProductionState `<ABSENT>` ProductVersion `1` ProductSubVersion `2`. Skipping updating PmUnit NETLAKE
> 1273 DataStore.cpp:117] At SlotPath /COME_SLOT@0, updating to PmUnit NETLAKE with
> 1273 DataStore.cpp:140] Resolved /COME_SLOT@0 to default PmUnitConfig of NETLAKE. No ProductSubversion was read from IDPROM at the slotPath.
> 1273 PlatformExplorer.cpp:180] Exploring PmUnit NETLAKE at /COME_SLOT@0

**Complete Failure log:-** 
[Platform_manager_failure_log.txt](https://github.com/user-attachments/files/18640276/Platform_manager_failure_log.txt)


# Testcase:-
1. The platform manager executes successfully with both V5 and V6 EEPROM formats. 
2. The platform manager executes successfully with both COMe SKU1 and COMe SKU2. 
3. The above test is performed after a power cycle.

**Unit test log:-** 
[Platform_manager_pass_log.txt](https://github.com/user-attachments/files/18640283/Platform_manager_pass_log.txt)
[EEprom_content.txt](https://github.com/user-attachments/files/18640285/EEprom_content.txt)

