### PR TITLE
fboss : fw_util : fixed breakage in fw_util read and verify actions.

### DIFF
--- a/fboss/platform/fw_util/FwUtilImpl.cpp
+++ b/fboss/platform/fw_util/FwUtilImpl.cpp
@@ -109,9 +109,29 @@ void FwUtilImpl::doFirmwareAction(
       doPostUpgrade(fpd);
     }
   } else if (action == "read" && fwConfig.read().has_value()) {
-    performRead(fwConfig.read().value(), fpd);
+      // do pre upgrade operation
+      if (fwConfig.preUpgrade().has_value()) {
+        doPreUpgrade(fpd);
+      }
+
+      performRead(fwConfig.read().value(), fpd);
+
+      // do post upgrade operation
+      if (fwConfig.postUpgrade().has_value()) {
+        doPostUpgrade(fpd);
+      }
   } else if (action == "verify" && fwConfig.verify().has_value()) {
-    performVerify(fwConfig.verify().value(), fpd);
+      // do pre upgrade operation
+      if (fwConfig.preUpgrade().has_value()) {
+        doPreUpgrade(fpd);
+      }
+
+      performVerify(fwConfig.verify().value(), fpd);
+
+      // do post upgrade operation
+      if (fwConfig.postUpgrade().has_value()) {
+        doPostUpgrade(fpd);
+      }
   } else {
     XLOG(INFO) << "Invalid action: " << action
                << ". Please run ./fw-util --helpon=Flags for the right usage";

--- a/fboss/platform/fw_util/FwUtilImpl.cpp
+++ b/fboss/platform/fw_util/FwUtilImpl.cpp
@@ -109,29 +109,29 @@ void FwUtilImpl::doFirmwareAction(
       doPostUpgrade(fpd);
     }
   } else if (action == "read" && fwConfig.read().has_value()) {
-      // do pre upgrade operation
-      if (fwConfig.preUpgrade().has_value()) {
-        doPreUpgrade(fpd);
-      }
+    // do pre upgrade operation
+    if (fwConfig.preUpgrade().has_value()) {
+      doPreUpgrade(fpd);
+    }
 
-      performRead(fwConfig.read().value(), fpd);
+    performRead(fwConfig.read().value(), fpd);
 
-      // do post upgrade operation
-      if (fwConfig.postUpgrade().has_value()) {
-        doPostUpgrade(fpd);
-      }
+    // do post upgrade operation
+    if (fwConfig.postUpgrade().has_value()) {
+      doPostUpgrade(fpd);
+    }
   } else if (action == "verify" && fwConfig.verify().has_value()) {
-      // do pre upgrade operation
-      if (fwConfig.preUpgrade().has_value()) {
-        doPreUpgrade(fpd);
-      }
+    // do pre upgrade operation
+    if (fwConfig.preUpgrade().has_value()) {
+      doPreUpgrade(fpd);
+    }
 
-      performVerify(fwConfig.verify().value(), fpd);
+    performVerify(fwConfig.verify().value(), fpd);
 
-      // do post upgrade operation
-      if (fwConfig.postUpgrade().has_value()) {
-        doPostUpgrade(fpd);
-      }
+    // do post upgrade operation
+    if (fwConfig.postUpgrade().has_value()) {
+      doPostUpgrade(fpd);
+    }
   } else {
     XLOG(INFO) << "Invalid action: " << action
                << ". Please run ./fw-util --helpon=Flags for the right usage";


### PR DESCRIPTION
# Description

This PR fixes an issue where the `fw_util`'s `read` and `verify` actions were failing to detect the correct flash chip for certain targets. This failure occurred because the necessary pre-upgrade GPIO settings, crucial for proper chip detection, were not being executed before the `read` and `verify` operations similar to `program` operation.

**Failure Logs:** 
[failure_logs.txt](https://github.com/user-attachments/files/18674113/failure_logs.txt)


**Root Cause and Fix:**

The root cause was that the `doPreUpgrade()` function, responsible for setting up the GPIO pins was only being called for the `program` action, but not for `read` or `verify`. As a result, `flashrom` was unable to correctly identify the chip, leading to errors.

This PR addresses the issue by adding calls to `doPreUpgrade()` before executing `performRead()` and `performVerify()` when a `preUpgrade` configuration is present. This ensures that the required GPIO settings are applied before chip detection, enabling successful `read` and `verify` operations. Also enabled the `doPostUpgrade()` so that after action is completed , GPIO setting are reverted to default if configured.

**NOTE:** It was handled in the older `fw_util` implementation but was broken after recent `fw_util` refactoring done in the following commit:
https://github.com/facebook/fboss/commit/34265a59cc0583a8e449c4896ed6014f1a4b52da 

# Testing Done 

**J3 Test Logs:** 
[J3_fw_util_logs.txt](https://github.com/user-attachments/files/18674159/J3_fw_util_logs.txt)


**Th5 Test Logs:** 
[TH5_fw_util_logs.txt](https://github.com/user-attachments/files/18674160/TH5_fw_util_logs.txt)


**MP3 Test Logs:** 
[MP3_fw_util_logs.txt](https://github.com/user-attachments/files/18674165/MP3_fw_util_logs.txt)
