### PR TITLE
[Fwutil] Add missing new line to version prints

### DIFF
--- a/fboss/platform/fw_util/FwUtilImpl.cpp
+++ b/fboss/platform/fw_util/FwUtilImpl.cpp
@@ -163,7 +163,7 @@ void FwUtilImpl::printVersion(const std::string& fpd) {
       fwUtilVersionHandler_->printAllVersions();
     } else {
       std::string version = fwUtilVersionHandler_->getSingleVersion(fpd);
-      std::cout << fpd << " : " << version;
+      std::cout << fmt::format("{} : {}", fpd, version) << std::endl;
     }
   }
 }

--- a/fboss/platform/fw_util/FwUtilVersionHandler.cpp
+++ b/fboss/platform/fw_util/FwUtilVersionHandler.cpp
@@ -28,7 +28,7 @@ void FwUtilVersionHandler::printDarwinVersion(const std::string& fpd) {
       if (exitStatus != 0) {
         throw std::runtime_error("Run " + versionCmd + " failed!");
       }
-      std::cout << fpd << " : " << version;
+      std::cout << fmt::format("{} : {}", fpd, version) << std::endl;
     } else {
       XLOG(INFO)
           << fpd


### PR DESCRIPTION
# Description
fw_util version prints were missing a new line at the end. See the log below to explain

Pre fw_util new-line fix
```
[ ~]# fw_util --config_file=/opt/fboss/share/platform_configs/fw_util.json --fw_target_name=fan_cpld0 --fw_action=version
I0205 03:51:04.610634  3325 PlatformNameLib.cpp:73] Platform name read from cache: MERU800BFA
I0205 03:51:04.610693  3325 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fw_util.json
fan_cpld0 : 1.2[ ~]# 
[ ~]# 
```

After
```
[ ~]# fw_util --config_file=/opt/fboss/share/platform_configs/fw_util.json --fw_target_name=fan_cpld0 --fw_action=version
I0205 03:51:04.610634  3325 PlatformNameLib.cpp:73] Platform name read from cache: MERU800BFA
I0205 03:51:04.610693  3325 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fw_util.json
fan_cpld0 : 1.2
[ ~]# 
[ ~]# 
```
