### PR TITLE
fboss : mp3 : corrected unsupported QSFP test lists.

### DIFF
--- a/fboss/oss/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON
+++ b/fboss/oss/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON
@@ -4252,7 +4252,7 @@
           "test_name_regex": "HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.TestProfile$"
         },
         {
-          "test_name_regex": "HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile$"
+          "test_name_regex": "HwTest_PROFILE_100G_1_PAM4_RS544_OPTICAL.TestProfile$"
         },
         {
           "test_name_regex": "HwTest_PROFILE_200G_4_PAM4_RS544X2N_COPPER.TestProfile$"
@@ -4428,7 +4428,7 @@
           "test_name_regex": "HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.TestProfile$"
         },
         {
-          "test_name_regex": "HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile$"
+          "test_name_regex": "HwTest_PROFILE_100G_1_PAM4_RS544_OPTICAL.TestProfile$"
         },
         {
           "test_name_regex": "HwTest_PROFILE_200G_4_PAM4_RS544X2N_COPPER.TestProfile$"


### PR DESCRIPTION
# Description

PR is raised to correct the unsupported QSFP tests list for MP3 platform.
1. Supported profile 23 (HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL) is removed from the list.
2. Unsupported profile 47 (HwTest_PROFILE_100G_1_PAM4_RS544_OPTICAL) is added to the list.

# Motivation

Commit [91bd8a933b0ea2ea74fd5b0d3a5a4b81194a394a](https://github.com/facebook/fboss/commit/91bd8a933b0ea2ea74fd5b0d3a5a4b81194a394a) incorrectly added the supported profile 23 (PROFILE_100G_4_NRZ_RS528_OPTICAL) to the unsupported test list for MP3.  This PR corrects the list by removing profile 23.  Profile 47 (PROFILE_100G_1_PAM4_RS544_OPTICAL) remains in the unsupported list as it is genuinely unsupported by MP3's [qsfp.conf](https://github.com/facebookexternal/fboss.bsp.celestica/blob/master/montblanc/osfp/qsfp.conf).  

[Workspace Post](https://fb.workplace.com/groups/264616536023347/permalink/660746433077020/)

# Testing

QSFP HW Tests are pass now without any failing test case.

```
Running all tests took 0:23:15.160951 between 2025-02-18 08:03:22.554600 and 2025-02-18 08:26:37.715551
[       OK ] cold_boot.EmptyHwTest.CheckInit (33634 ms)
[       OK ] warm_boot.EmptyHwTest.CheckInit (22193 ms)
[       OK ] cold_boot.HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile (26690 ms)
[       OK ] warm_boot.HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile (26695  ms)
[       OK ] cold_boot.HwTest_PROFILE_400G_4_PAM4_RS544X2N_OPTICAL.TestProfile (33630 ms)
[       OK ] warm_boot.HwTest_PROFILE_400G_4_PAM4_RS544X2N_OPTICAL.TestProfile (21807 ms)
[       OK ] cold_boot.HwTransceiverConfigTest.moduleConfigVerification (38483 ms)
[       OK ] warm_boot.HwTransceiverConfigTest.moduleConfigVerification (26692 ms)
[       OK ] cold_boot.HwTest.publishStats (33777 ms)
[       OK ] warm_boot.HwTest.publishStats (21821 ms)
[       OK ] cold_boot.HwTest.transceiverIOStats (38495 ms)
[       OK ] warm_boot.HwTest.transceiverIOStats (26700 ms)
[       OK ] cold_boot.HwTest.CheckTcvrNameAndInterfaces (33618 ms)
[       OK ] warm_boot.HwTest.CheckTcvrNameAndInterfaces (21566 ms)
[       OK ] cold_boot.HwTest.i2cStressRead (33760 ms)
[       OK ] warm_boot.HwTest.i2cStressRead (21943 ms)
[       OK ] cold_boot.HwTest.i2cStressWrite (37452 ms)
[       OK ] warm_boot.HwTest.i2cStressWrite (25655 ms)
[       OK ] cold_boot.HwTest.i2cLogCapacityRead (33626 ms)
[       OK ] warm_boot.HwTest.i2cLogCapacityRead (21829 ms)
[       OK ] cold_boot.HwTest.i2cLogCapacityWrite (33628 ms)
[       OK ] warm_boot.HwTest.i2cLogCapacityWrite (21571 ms)
[       OK ] cold_boot.HwTest.cmisPageChange (46514 ms)
[       OK ] warm_boot.HwTest.cmisPageChange (34721 ms)
[       OK ] cold_boot.HwTest.i2cUniqueSerialNumbers (33624 ms)
[       OK ] warm_boot.HwTest.i2cUniqueSerialNumbers (21557 ms)
[       OK ] cold_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (67056 ms)
[       OK ] warm_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (55531 ms)
[       OK ] cold_boot.HwTransceiverResetTest.verifyResetControl (58587 ms)
[       OK ] warm_boot.HwTransceiverResetTest.verifyResetControl (53560 ms)
[       OK ] cold_boot.HwStateMachineTestWithoutIphyProgramming.CheckOpticsDetection (10226 ms)
[       OK ] warm_boot.HwStateMachineTestWithoutIphyProgramming.CheckOpticsDetection (5223 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortsProgrammed (33627 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortsProgrammed (21559 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortStatusUpdated (43710 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortStatusUpdated (31645 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckTransceiverRemoved (36233 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckTransceiverRemoved (30958 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckAgentConfigChanged (91710 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckAgentConfigChanged (81216 ms)
Summary:
   OK : 40
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```