### PR TITLE
Remove unused SMB_CPLD from platform_manager.json sensors

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -3196,7 +3196,6 @@
     "/run/devmap/sensors/PDB_R_TSENSOR": "/PDBRIGHT_SLOT@0/[PDB_R_TSENSOR]",
     "/run/devmap/sensors/SMB_VRM1": "/SMB_SLOT@0/[SMB_VRM1]",
     "/run/devmap/sensors/SMB_VOLTAGE_MONITOR1": "/SMB_SLOT@0/[SMB_VOLTAGE_MONITOR1]",
-    "/run/devmap/sensors/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
     "/run/devmap/sensors/SMB_VRM2": "/SMB_SLOT@0/[SMB_VRM2]",
     "/run/devmap/sensors/SMB_VRM3": "/SMB_SLOT@0/[SMB_VRM3]",
     "/run/devmap/sensors/SMB_VRM4": "/SMB_SLOT@0/[SMB_VRM4]",


### PR DESCRIPTION
### Description:
1) Remove the following configuration from platform_manager.json:
  `/run/devmap/sensors/SMB_CPLD`: `/SMB_SLOT@0/[SMB_CPLD]`

### Motivation:
1) The 0xB8 register in SMB_CPLD has no effect because SP4 lacks a TEMP_CLK signal.
   So the max temperature defined in register 0xB8 cannot be detected.
2) As a result, `temp1_input` in the SMB_CPLD driver has been removed, so this config needs to be updated accordingly. 
3) This sensor was already removed from `sensor_service.json` earlier, so no changes are needed for the sensor_service config.

### Test plan:
1) Ran `platform_manager` with the updated config.
2) Confirmed that SMB_CPLD no longer exists in `/run/devmap/sensors/` by checking the directory