### PR TITLE
fboss : tahan : added HwPimTest.CheckPimPresent to the unsupported QSFP tests list.

### DIFF
--- a/fboss/oss/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON
+++ b/fboss/oss/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON
@@ -4851,6 +4851,9 @@
           "test_name_regex": "HwMacsecTest.*$"
         },
         {
+          "test_name_regex": "HwPimTest.CheckPimPresent$"
+        },
+        {
           "test_name_regex": "HwTest.CheckDefaultXphyFirmwareVersion$"
         },
         {
@@ -5022,6 +5025,9 @@
     "tahan800bc/physdk-credo-0.9.0/credo-0.9.0": [
         {
           "test_name_regex": "HwMacsecTest.*$"
+        },
+        {
+          "test_name_regex": "HwPimTest.CheckPimPresent$"
         },
         {
           "test_name_regex": "HwTest.CheckDefaultXphyFirmwareVersion$"


### PR DESCRIPTION
# Description

After the [recent commit](https://github.com/facebook/fboss/commit/b8f0310f3dd3a91865505cb630489ef9c6a9dc75) `HwPimTest.CheckPimPresent` test fails for Tahan.

The old implementation had the following statement which always compared a value to itself. It wouldn't have caught any issues with the number of slots or PIMs.

`EXPECT_EQ(phyManager->getNumOfSlot(), phyManager->getNumOfSlot());` // This is always true!

The new implementation now correctly checks if the number of slots reported by the `phyManager` matches the number of PIMs reported by the `getSystemContainer`. The failure indicates these numbers are different.

Following the aforementioned commit that introduced the failing test, Meta added `HwPimTest.CheckPimPresent` to the unsupported test list for MP3 in the[ commit](https://github.com/facebook/fboss/commit/8261846e96def20330a9268e7b1fdc90a9d372d1)

Please note, this test is already on the unsupported list for Janga and now failing only on Tahan.
PR is raised to add it to the unsupported list for Tahan as well, similar to MP3 and Janga.

# Testing

```
Running all tests took 0:23:28.278296 between 2025-02-20 03:32:54.518343 and 2025-02-20 03:56:22.796639
[       OK ] cold_boot.EmptyHwTest.CheckInit (33582 ms)
[       OK ] warm_boot.EmptyHwTest.CheckInit (22565 ms)
[       OK ] cold_boot.HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile (33703 ms)
[       OK ] warm_boot.HwTest_PROFILE_100G_4_NRZ_RS528_OPTICAL.TestProfile (38440 ms)
[       OK ] cold_boot.HwTest_PROFILE_400G_4_PAM4_RS544X2N_OPTICAL.TestProfile (34068 ms)
[       OK ] warm_boot.HwTest_PROFILE_400G_4_PAM4_RS544X2N_OPTICAL.TestProfile (22589 ms)
[       OK ] cold_boot.HwTransceiverConfigTest.moduleConfigVerification (38578 ms)
[       OK ] warm_boot.HwTransceiverConfigTest.moduleConfigVerification (26647 ms)
[       OK ] cold_boot.HwTest.publishStats (33580 ms)
[       OK ] warm_boot.HwTest.publishStats (21780 ms)
[       OK ] cold_boot.HwTest.transceiverIOStats (38440 ms)
[       OK ] warm_boot.HwTest.transceiverIOStats (26651 ms)
[       OK ] cold_boot.HwTest.CheckTcvrNameAndInterfaces (33457 ms)
[       OK ] warm_boot.HwTest.CheckTcvrNameAndInterfaces (21783 ms)
[       OK ] cold_boot.HwTest.i2cStressRead (33703 ms)
[       OK ] warm_boot.HwTest.i2cStressRead (22779 ms)
[       OK ] cold_boot.HwTest.i2cStressWrite (37805 ms)
[       OK ] warm_boot.HwTest.i2cStressWrite (27020 ms)
[       OK ] cold_boot.HwTest.i2cLogCapacityRead (33573 ms)
[       OK ] warm_boot.HwTest.i2cLogCapacityRead (21765 ms)
[       OK ] cold_boot.HwTest.i2cLogCapacityWrite (33578 ms)
[       OK ] warm_boot.HwTest.i2cLogCapacityWrite (22122 ms)
[       OK ] cold_boot.HwTest.cmisPageChange (47101 ms)
[       OK ] warm_boot.HwTest.cmisPageChange (34942 ms)
[       OK ] cold_boot.HwTest.i2cUniqueSerialNumbers (33572 ms)
[       OK ] warm_boot.HwTest.i2cUniqueSerialNumbers (22564 ms)
[       OK ] cold_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (67052 ms)
[       OK ] warm_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (55118 ms)
[       OK ] cold_boot.HwTransceiverResetTest.verifyResetControl (58535 ms)
[       OK ] warm_boot.HwTransceiverResetTest.verifyResetControl (53509 ms)
[       OK ] cold_boot.HwStateMachineTestWithoutIphyProgramming.CheckOpticsDetection (10190 ms)
[       OK ] warm_boot.HwStateMachineTestWithoutIphyProgramming.CheckOpticsDetection (5184 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortsProgrammed (34063 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortsProgrammed (22115 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortStatusUpdated (44003 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortStatusUpdated (31848 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckTransceiverRemoved (36179 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckTransceiverRemoved (31174 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckAgentConfigChanged (95276 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckAgentConfigChanged (83970 ms)
Summary:
   OK : 40
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```