### PR TITLE
Build break fix for TH5/MP3 sai_link_test-sai_impl compilation.

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp
@@ -174,6 +174,7 @@ std::vector<sai_object_id_t> getPortTamIds(
   return portTamIds;
 }
 
+#if defined(BRCM_SAI_SDK_DNX_GTE_11_0)
 void bindTamObjectToSwitchAndPort(
     SaiManagerTable* managerTable,
     folly::F14FastMap<std::string, std::unique_ptr<SaiTamHandle>>& tamHandles,
@@ -186,6 +187,7 @@ void bindTamObjectToSwitchAndPort(
   XLOG(INFO) << "Binding TAM object " << tamId << " to switch";
   managerTable->switchManager().setTamObject(getSwitchTamIds(tamHandles));
 }
+#endif
 
 void unbindTamObjectFromSwitchAndPort(
     SaiManagerTable* managerTable,


### PR DESCRIPTION
# Description 

The compilation of TH5/MP3 `sai_link_test-sai_impl` is failing with a `-Werror=unused-function` error for the function `bindTamObjectToSwitchAndPort` in `SaiTamManager.cpp` file:

```
[968/1135] Building CXX object CMakeFiles/sai_switch.dir/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp.o
FAILED: CMakeFiles/sai_switch.dir/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp.o 
/usr/bin/c++ -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_NO_LIB -DGFLAGS_IS_A_DLL=0 -DIS_OSS=true -DIS_OSS_BRCM_SAI=true -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/repos/github.com-facebook-fboss.git -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/xxhash-bEQMSZSXBBasyiV3AXjNsQ2XCh0lc_9ZDFgUePWRFLY/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fatal -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/nlohmann-json-EtTnDJV1yL4fMFdC1hKtK9g2yT6NLVqdCKEytKkfoTg/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libsai-kHJjEjGkX5lZvbfDPmUWgLowkndH5hrdHeWiKAF-rSk/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libsai-kHJjEjGkX5lZvbfDPmUWgLowkndH5hrdHeWiKAF-rSk -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libnl-yJtwzTtVODCfVqzysAiBsodLZ1Pdh9PQlMfMGT9vDps/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libnl-yJtwzTtVODCfVqzysAiBsodLZ1Pdh9PQlMfMGT9vDps/include/libnl3 -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/iproute2-xOJ1lqKbT-XXqQLdZKlcSnSgcprRq0kWl1nWUQcHjEQ/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/yaml-cpp--d6i2TpCKw1353iZrUkyXiO19GirlJqZ0rjY3u30Eeo/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libyaml-wg-dzvzz4otlPOpimI5ZdrlJ-XhceWphIx-wJ1GZH9s/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libusb-t-JCc7QoY32Oj92BhcEGmTqS5dQ5wvNBZquabbQ1H0M/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libcurl-Qqc1v_kX2u_rINmHNUODU8_KIDngfCTkMm4ZY_zbhLw/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/re2-sLQrzeo5KkPa5jdmifou8ZeYfKyIvNplD7M6pqmUXqY/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/exprtk-S78AqzfpzEsVerE-BnWUVqH_DZ-JI1fVTMnSwv94lKA -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libgpiod--0dSjp4rzsmncoEZVW_tByes_5LIvmxyt4XScoxmArQ/include -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/sai_impl-fVjozyhZZ7wxa7AdmqG8s3sza6lQF-DbTByzjG6nVZA -I/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/build/fboss -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/double-conversion-bQqrl3qOHNyxKcug6qEXlwbYkPAXbKFk3vqVil7TRNI/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/gflags-3lgd-920_6wJ-QvXKMfxiHkyqdIjfmN5f1N3HscL6mQ/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/glog-8_hSg0bkyjgq3EDH_0XQ1ZHd9DyVSI018PUl071fGDg/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/folly/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/boost-70iGzoAZ6_ZP97GoD5zk-qiyY-lCmfZB-nYPTIUJaEM/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fb303/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/googletest-7rxikUbn_5g7V522lvuVK4W3zvHRthEd0Z-0md7QGM8/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fmt-z5lYzRrrta1VgqCFbCrOEQDN0SsLPgdwdxyNRH7jt2g/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fast_float-conP_nInnpT3cuF-JKsj7hCq-32_spfUVn7yAgdTa_M/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libevent-NK-bfpgvPi9ntoZpA7IsjeeYI_MBlAJOd4cBaRY0YnA/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/zlib-eUmYVkBq0chnKFndhWE0ioBVO-BYmPR079XzhQPlPCM/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/bz2-il4DM9TMpwxD7k9fAzRBTr99CTXx0di8vsRCS580Z1k/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/xz--V18odG74Npg25tRYm7ge_9vFs1MbT_PyHTtzxJcrKk/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/lz4-j0G5EhGwa4Z_KbFnDmg1feiTQTP0WK8iNyxVKtYnHHg/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/zstd-_dhO_9KrVST15pa3DsslvS2ev5NV0dodxJRnrgK8PJk/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/snappy-ZAC78csd0-7A9qNmKjDHHX6AuPUgg39xwmYqLBLjc-8/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libdwarf-nyEMZdfgYbMIUgloAkyPz7bmKutCSRyfRuXOBKk-9qw/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/libsodium-U_CVCvb-g_g31_j2wsvqhyLce_SRig0szp9BhFwgRnQ/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fbthrift/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/wangle/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/fizz/include -isystem /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/installed/mvfst/include -isystem /usr/include/python3.9 -DSAI_VERSION_10_2_0_0_ODP -Wall -Werror -Wno-sign-compare -Wno-maybe-uninitialized -Wno-deprecated-declarations -Os -DNDEBUG -std=gnu++20 -DSAI_VER_MAJOR=1   -DSAI_VER_MINOR=14    -DSAI_VER_RELEASE=0 -fsized-deallocation -MD -MT CMakeFiles/sai_switch.dir/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp.o -MF CMakeFiles/sai_switch.dir/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp.o.d -o CMakeFiles/sai_switch.dir/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp.o -c /work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/repos/github.com-facebook-fboss.git/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp
/work/agents/prod_hps25_metafboss_1/_work/12/s/build_sai_j3_fboss_20250122/repos/github.com-facebook-fboss.git/fboss/agent/hw/sai/switch/npu/bcm/SaiTamManager.cpp:177:6: error: ‘void facebook::fboss::{anonymous}::bindTamObjectToSwitchAndPort(facebook::fboss::SaiManagerTable*, folly::F14FastMap<std::__cxx11::basic_string<char>, std::unique_ptr<facebook::fboss::SaiTamHandle> >&, sai_object_id_t, facebook::fboss::PortID)’ defined but not used [-Werror=unused-function]
  177 | void bindTamObjectToSwitchAndPort(
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

**Root Cause:** The issue is happening after the [commit](https://github.com/facebook/fboss/commit/c20bcb7bf1a199e6bc842402dddd10452a58c241) where a new function `bindTamObjectToSwitchAndPort` is defined but its called only when the macro `BRCM_SAI_SDK_DNX_GTE_11_0` is enabled. As this macro is not enabled while compiling the TH5/MP3 `sai_link_test-sai_impl` binary , compiler assumes that function is defined but never called and throws this error.

**Solution:** Added function `bindTamObjectToSwitchAndPort` definition also inside the `BRCM_SAI_SDK_DNX_GTE_11_0` macro.

**Testing:**

1. Compilation of `sai_link_test-sai_impl` is successful.
2. `sai_link_test-sai_impl` test logs: 
[LinkTest.trafficRxTx.txt](https://github.com/user-attachments/files/18969979/LinkTest.trafficRxTx.txt)
[EmptyLinkTest.CheckInit.txt](https://github.com/user-attachments/files/18969998/EmptyLinkTest.CheckInit.txt)
[LinkTest.asicLinkFlap.txt](https://github.com/user-attachments/files/18970006/LinkTest.asicLinkFlap.txt)
