### PR TITLE
[minipack3n]: Remove AccessMethod option from watchdog thrift interface

### DIFF
--- a/fboss/platform/configs/minipack3n/fan_service.json
+++ b/fboss/platform/configs/minipack3n/fan_service.json
@@ -7,10 +7,7 @@
   "pwmLowerThreshold": 60,
   "pwmUpperThreshold": 60,
   "watchdog": {
-    "access": {
-      "accessType": "ACCESS_TYPE_SYSFS",
-      "path": "/run/devmap/watchdogs/FAN_WATCHDOG"
-    },
+    "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
   },
   "controlInterval": {


### PR DESCRIPTION
### Description:
1) The fan_service.json file needs to be updated based on the following commit:
   https://github.com/facebook/fboss/commit/fe56a12887db6917ea3d6ce9abc806f10874944b
2) Updated fan_service.json as follows:
  "watchdog": {
    "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
    "value": 0
  },

### Motivation:
1) The fan_service.json format has changed, causing errors in the fan service.
   Error log example:
   E0304 21:18:48.154161  6430 Bsp.h:76] Failed to write to file descriptor -1: Bad file descriptor
   E0304 21:18:48.154166  6430 Bsp.cpp:114] Failed to kick watchdog

### Test Plan:
1) Run fan_service with the updated configuration. 
2) Confirm that the error message "Failed to kick watchdog" no longer appears. 
3) Verify that the watchdog is running by reading "MCB FAN WDT CTRL 0" register 0x1F:
   [root@localhost ~]# i2cget -f -y 15 0x33 0x1f  # Expected output: 0x10
   0x10
4) Verify the watchdog timer is counting by reading "MCB FAN WDT STA" register 0x21
   [root@localhost ~]# i2cget -f -y 15 0x33 0x21
   0x01
   [root@localhost ~]# i2cget -f -y 15 0x33 0x21
   0x05
5) Stop fan_service
6) Verify that the watchdog is stopped by reading "MCB FAN WDT CTRL 0" register 0x1F
   [root@localhost ~]# i2cget -f -y 15 0x33 0x1f # Expected output: 0x00
   0x00
7) Ensure the watchdog timer is not counting by checking "MCB FAN WDT STA" register 0x21
   [root@localhost ~]# i2cget -f -y 15 0x33 0x21  # Expected output: 0x00
   0x00

### Test Log:
[20250305_fan_service_test.txt](https://github.com/user-attachments/files/19083956/20250305_fan_service_test.txt)
[20250305_monitor_fan_cpld_register.txt](https://github.com/user-attachments/files/19083959/20250305_monitor_fan_cpld_register.txt)