### PR TITLE
Janga: config: disabe J3B during initial configuration of the Platfor…

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -2220,9 +2220,17 @@
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_10",
-          "address": "0x3e",
+          "address": "0x33",
           "kernelDeviceName": "janga_smbcpld",
-          "pmUnitScopedName": "JANGA_SMB_CPLD"
+          "pmUnitScopedName": "JANGA_SMB_CPLD",
+          "initRegSettings": [
+            {
+              "regOffset": 7,
+              "ioBuf": [
+                -65
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_3",


### PR DESCRIPTION
**Description**

Updated the Platform Manager configuration file to match the POR, disable the unused J3 ASIC in each blade via the Platform Manager configuration.

POR Information: "The Minerva rack configuration from 1xJanga + 4xTahan to 2xJanga+4xTahan. As part of this change, there is no impact to Janga HW design, and FBOSS will disable the unused J3 ASIC in each blade. "

**Motivation**

1. Disable the unused J3 ASIC in each blade via the Platform Manager config file
2. Switch the SMB CPLD2 driver to address 0x33 because of the functionality enabled by default at that address
![image](https://github.com/user-attachments/assets/7c58730c-d5e2-4137-9d6d-934c93a45614)

1.Added initial register value of -65 (-65 corresponds to hexadecimal value 0xBF) because the platform manager only supports signed 8-bit integers

**Test Plan**

- Run the jq to format the json file.
- Download the latest fboss platform manager and sensor service binary.
- Run platform manager and sensor service with config files are correct.
- Run SDK script is correct, no kernel panic when PCIe link down.

Check if the J3B ASIC is disabled:
![image](https://github.com/user-attachments/assets/a08dbaf4-630f-491a-b64e-47a737d32472)

Check the normal status of J3A and J3B:
![image](https://github.com/user-attachments/assets/59e06988-cf62-48b5-a8db-2713e9f81655)

Test log:
Test log of J3A and J3B in normal state:
[Janga-J3A_J3B_enable_log_20250304.txt](https://github.com/user-attachments/files/19085211/Janga-J3A_J3B_enable_log_20250304.txt)

Test log of J3B disabled state:
[Janga-J3A_enable_J3B_disable_log_20250304.txt](https://github.com/user-attachments/files/19085205/Janga-J3A_enable_J3B_disable_log_20250304.txt)