### PR TITLE
[minipack3n] Fix LED Mapping: Rename MCB_LED_PORT_66_LED_1 to _65_LED_2

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -1731,6 +1731,15 @@
             },
             {
               "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_65_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40510"
+              },
+              "portNumber": 65,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "MCB_LED_PORT_1_LED_2",
                 "deviceName": "port_led",
                 "csrOffset": "0x40414"
@@ -2600,15 +2609,6 @@
                 "csrOffset": "0x48510"
               },
               "portNumber": 65,
-              "ledId": 1
-            },
-            {
-              "fpgaIpBlockConfig": {
-                "pmUnitScopedName": "MCB_LED_PORT_66_LED_1",
-                "deviceName": "port_led",
-                "csrOffset": "0x40510"
-              },
-              "portNumber": 66,
               "ledId": 1
             }
           ],


### PR DESCRIPTION
### Description:
1) The original pmUnitScopedName "MCB_LED_PORT_66_LED_1" was incorrect. 
2) The correct port LED mapping corresponds to port-65-led-2. 
3) Renamed MCB_LED_PORT_66_LED_1 to MCB_LED_PORT_65_LED_2 to reflect the correct mapping.

### Test Plan:
1) Run platform_manager with the updated configuration. 
2) Verify that the correct sysfs files are created:
    ls /sys/class/leds/port65_led2\:*
    Test Log: [20250306_Port65_Led2_Test.txt](https://github.com/user-attachments/files/19104721/20250306_Port65_Led2_Test.txt)
3) Execute Port65_Led2_Test.py to ensure the LED color changes as expected.
   Test Log: [Port65_Led2_Test.py.txt](https://github.com/user-attachments/files/19104799/Port65_Led2_Test.py.txt)