### PR TITLE
[minipack3n] Add presenceDetection for FCB/PDB slot in platform_manager

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -2748,12 +2748,26 @@
         },
         "PDBLEFT_SLOT@0": {
           "slotType": "PDBLEFT_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_CPLD]",
+              "presenceFileName": "psu_l_present",
+              "desiredValue": 1
+            }
+          },
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_5"
           ]
         },
         "PDBRIGHT_SLOT@0": {
           "slotType": "PDBRIGHT_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_CPLD]",
+              "presenceFileName": "psu_r_present",
+              "desiredValue": 1
+            }
+          },
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_6"
           ]
@@ -2773,12 +2787,107 @@
         },
         "FCBBOTTOM_SLOT@0": {
           "slotType": "FCBBOTTOM_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan2_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_17"
+          ]
+        },
+        "FCBBOTTOM_SLOT@1": {
+          "slotType": "FCBBOTTOM_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan4_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_17"
+          ]
+        },
+        "FCBBOTTOM_SLOT@2": {
+          "slotType": "FCBBOTTOM_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan6_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_17"
+          ]
+        },
+        "FCBBOTTOM_SLOT@3": {
+          "slotType": "FCBBOTTOM_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan8_present",
+              "desiredValue": 1
+            }
+          },
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_17"
           ]
         },
         "FCBTOP_SLOT@0": {
           "slotType": "FCBTOP_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan1_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_15",
+            "MCB_IOB_I2C_MASTER_16"
+          ]
+        },
+        "FCBTOP_SLOT@1": {
+          "slotType": "FCBTOP_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan3_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_15",
+            "MCB_IOB_I2C_MASTER_16"
+          ]
+        },
+        "FCBTOP_SLOT@2": {
+          "slotType": "FCBTOP_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan5_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_15",
+            "MCB_IOB_I2C_MASTER_16"
+          ]
+        },
+        "FCBTOP_SLOT@3": {
+          "slotType": "FCBTOP_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan7_present",
+              "desiredValue": 1
+            }
+          },
           "outgoingI2cBusNames": [
             "MCB_IOB_I2C_MASTER_15",
             "MCB_IOB_I2C_MASTER_16"


### PR DESCRIPTION
### Description:
1) Add the `presenceDetection` entry for the below slots in platform_manager.json
   PDBLEFT_SLOT
   PDBRIGHT_SLOT
   FCBBOTTOM_SLOT
   FCBTOP_SLOT

### Motivation:
1) The presenceDetection for the PDB/FCB slots are missing. 
2) Add `psu_l_present` for `PDBLEFT_SLOT`
3) Add `psu_r_present` for `PDBRIGHT_SLOT`
4) Add `fan[2|4|6|8]_present` for `FCBBOTTOM_SLOT` 
5) Add `fan[1|3|5|7]_present` for `FCBTOP_SLOT`

### Test Plan:
1) Run `platform_manager` with the updated configuration. 
2) Plug in all FANs and PSUs, then verify that all FCB and PDB slots are explored successfully.
   [20250313_ALL_(FAN_PSU)_present_.txt](https://github.com/user-attachments/files/19223588/20250313_ALL_.FAN_PSU._present_.txt)
3) Remove the left PSU and verify that `PDBLEFT_SLOT` fails during exploration.
   [20250313_PDB_L_not_present.txt](https://github.com/user-attachments/files/19223616/20250313_PDB_L_not_present.txt)
4) Remove the right PSU and verify that `PDBRIGHT_SLOT` fails during exploration.
   [20250313_PDB_R_not_present.txt](https://github.com/user-attachments/files/19223618/20250313_PDB_R_not_present.txt)
5) Remove fans 1/3/5/7 and verify that `FCBTOP_SLOT` fails during exploration.
   [20250313_FCB_T_FAN_1_not_present.txt](https://github.com/user-attachments/files/19223623/20250313_FCB_T_FAN_1_not_present.txt)
   [20250313_FCB_T_FAN_3_not_present.txt](https://github.com/user-attachments/files/19223634/20250313_FCB_T_FAN_3_not_present.txt)
   [20250313_FCB_T_FAN_5_not_present.txt](https://github.com/user-attachments/files/19223727/20250313_FCB_T_FAN_5_not_present.txt)
   [20250313_FCB_T_FAN_7_not_present.txt](https://github.com/user-attachments/files/19223728/20250313_FCB_T_FAN_7_not_present.txt)
6) Remove fans 2/4/6/8 and verify that `FCBBOTTOM_SLOT` fails during exploration.
   [20250313_FCB_B_FAN_2_not_present.txt](https://github.com/user-attachments/files/19223730/20250313_FCB_B_FAN_2_not_present.txt)
   [20250313_FCB_B_FAN_4_not_present.txt](https://github.com/user-attachments/files/19223731/20250313_FCB_B_FAN_4_not_present.txt)
   [20250313_FCB_B_FAN_6_not_present.txt](https://github.com/user-attachments/files/19223732/20250313_FCB_B_FAN_6_not_present.txt)
   [20250313_FCB_B_FAN_8_not_present.txt](https://github.com/user-attachments/files/19223733/20250313_FCB_B_FAN_8_not_present.txt)