### PR TITLE
added fw_util support to program custom contents in a flash device

### DIFF
--- a/fboss/platform/fw_util/FwUtilFlashrom.cpp
+++ b/fboss/platform/fw_util/FwUtilFlashrom.cpp
@@ -64,9 +64,10 @@ void FwUtilImpl::addCommonFlashromArgs(
 
   if (flashromConfig.custom_content().has_value() &&
       flashromConfig.custom_content_offset().has_value()) {
-     /* Create a file with custom_content written at custom_content_offset.
-        The flashrom command would use this file instead of the firmware image */
-    const std::string customContentFileName = "/tmp/" + fpd + "_custom_content.bin";
+    /* Create a file with custom_content written at custom_content_offset.
+       The flashrom command would use this file instead of the firmware image */
+    const std::string customContentFileName =
+        "/tmp/" + fpd + "_custom_content.bin";
     if (createCustomContentFile(
             *flashromConfig.custom_content(),
             *flashromConfig.custom_content_offset(),
@@ -146,8 +147,7 @@ bool FwUtilImpl::createCustomContentFile(
      The custom content file should have the same size as the image */
   customContentFileSize = std::filesystem::file_size(fwBinaryFile_);
   customContentFile.open(
-      customContentFileName,
-      std::ofstream::out | std::ofstream::binary);
+      customContentFileName, std::ofstream::out | std::ofstream::binary);
   std::filesystem::resize_file(customContentFileName, customContentFileSize);
   customContentFile.seekp(customContentOffset);
   customContentFile << customContent;
@@ -174,7 +174,8 @@ void FwUtilImpl::addFileOption(
   } else {
     XLOG(ERR) << "Unsupported operation: " << operation;
   }
-  /* Use firmware image or custom content file based on the command description */
+  /* Use firmware image or custom content file based on the command description
+   */
   if (customContent.has_value()) {
     flashromCmd.push_back(*customContent);
   } else {

--- a/fboss/platform/fw_util/FwUtilFlashrom.cpp
+++ b/fboss/platform/fw_util/FwUtilFlashrom.cpp
@@ -57,8 +57,25 @@ void FwUtilImpl::addCommonFlashromArgs(
     const std::string& fpd,
     const std::string& operation,
     std::vector<std::string>& flashromCmd) {
+  std::optional<std::string> customContentFile;
+
   // layout file will be added to the command if present
   addLayoutFile(flashromConfig, flashromCmd, fpd);
+
+  if (flashromConfig.custom_content().has_value() &&
+      flashromConfig.custom_content_offset().has_value()) {
+     /* Create a file with custom_content written at custom_content_offset.
+        The flashrom command would use this file instead of the firmware image */
+    const std::string customContentFileName = "/tmp/" + fpd + "_custom_content.bin";
+    if (createCustomContentFile(
+            *flashromConfig.custom_content(),
+            *flashromConfig.custom_content_offset(),
+            customContentFileName)) {
+      customContentFile = customContentFileName;
+    } else {
+      throw std::runtime_error("Error creating custom content file for " + fpd);
+    }
+  }
 
   // Add extra arguments if present
   if (flashromConfig.flashromExtraArgs().has_value()) {
@@ -68,7 +85,7 @@ void FwUtilImpl::addCommonFlashromArgs(
   }
 
   // Add file option
-  addFileOption(operation, flashromCmd);
+  addFileOption(operation, flashromCmd, customContentFile);
 }
 
 void FwUtilImpl::setProgrammerAndChip(
@@ -114,9 +131,34 @@ void FwUtilImpl::addLayoutFile(
   }
 }
 
+bool FwUtilImpl::createCustomContentFile(
+    const std::string& customContent,
+    const int& customContentOffset,
+    const std::string& customContentFileName) {
+  std::uintmax_t customContentFileSize;
+  std::ofstream customContentFile;
+
+  if (!std::filesystem::exists(fwBinaryFile_)) {
+    return false;
+  }
+
+  /* Use firmware image size to determine the flash chip size.
+     The custom content file should have the same size as the image */
+  customContentFileSize = std::filesystem::file_size(fwBinaryFile_);
+  customContentFile.open(
+      customContentFileName,
+      std::ofstream::out | std::ofstream::binary);
+  std::filesystem::resize_file(customContentFileName, customContentFileSize);
+  customContentFile.seekp(customContentOffset);
+  customContentFile << customContent;
+  customContentFile.close();
+  return true;
+}
+
 void FwUtilImpl::addFileOption(
     const std::string& operation,
-    std::vector<std::string>& flashromCmd) {
+    std::vector<std::string>& flashromCmd,
+    std::optional<std::string>& customContent) {
   if (operation == "read") {
     flashromCmd.push_back("-r");
   } else if (operation == "write" || operation == "verify") {
@@ -132,7 +174,12 @@ void FwUtilImpl::addFileOption(
   } else {
     XLOG(ERR) << "Unsupported operation: " << operation;
   }
-  flashromCmd.push_back(fwBinaryFile_);
+  /* Use firmware image or custom content file based on the command description */
+  if (customContent.has_value()) {
+    flashromCmd.push_back(*customContent);
+  } else {
+    flashromCmd.push_back(fwBinaryFile_);
+  }
 }
 
 void FwUtilImpl::performFlashromUpgrade(

--- a/fboss/platform/fw_util/FwUtilImpl.h
+++ b/fboss/platform/fw_util/FwUtilImpl.h
@@ -64,6 +64,7 @@ class FwUtilImpl {
       const FlashromConfig&,
       std::vector<std::string>&,
       const std::string&);
+  bool createCustomContentFile(const std::string&, const int &, const std::string&);
   std::string detectFlashromChip(const FlashromConfig&, const std::string&);
   void performJamUpgrade(const JamConfig&, const std::string&);
   void performXappUpgrade(const XappConfig&, const std::string&);
@@ -77,7 +78,10 @@ class FwUtilImpl {
       const ReadFirmwareOperationConfig&,
       const std::string&);
   void performFlashromRead(const FlashromConfig&, const std::string&);
-  void addFileOption(const std::string&, std::vector<std::string>&);
+  void addFileOption(
+      const std::string&,
+      std::vector<std::string>&,
+      std::optional<std::string>&);
   void performFlashromVerify(const FlashromConfig&, const std::string&);
   void performVerify(const VerifyFirmwareOperationConfig&, const std::string&);
   void doWriteToPortOperation(const WriteToPortConfig&, const std::string&);

--- a/fboss/platform/fw_util/FwUtilImpl.h
+++ b/fboss/platform/fw_util/FwUtilImpl.h
@@ -64,7 +64,8 @@ class FwUtilImpl {
       const FlashromConfig&,
       std::vector<std::string>&,
       const std::string&);
-  bool createCustomContentFile(const std::string&, const int &, const std::string&);
+  bool
+  createCustomContentFile(const std::string&, const int&, const std::string&);
   std::string detectFlashromChip(const FlashromConfig&, const std::string&);
   void performJamUpgrade(const JamConfig&, const std::string&);
   void performXappUpgrade(const XappConfig&, const std::string&);

--- a/fboss/platform/fw_util/if/fw_util_config.thrift
+++ b/fboss/platform/fw_util/if/fw_util_config.thrift
@@ -23,6 +23,10 @@ struct FlashromConfig {
   4: optional list<string> flashromExtraArgs;
   // argument for the spi_layout
   5: optional string spi_layout;
+  // Contents for overriding sections in the binary
+  6: optional string custom_content;
+  // Offset for the custom content
+  7: optional i32 custom_content_offset;
 }
 
 // Define the struct for Jam tooling upgrade cases


### PR DESCRIPTION
### Background
During BIOS upgrade in Darwin48V systems, `DMI_BOARD_NAME` needs to be updated through Aboot aconf programming. Previously we achieved this by adding the aconf programming logic to the `fw_util` config file.
However, a recent refactoring of the `fw_util` prevents adding arbitrary shell commands in the config file. This change addresses the issue by adding the support to program custom contents in a flash device which is updated through `flashrom`.
### Summary of changes

- Added two optional arguments `custom_content` and `custom_content_offset` in the Thrift description for `FlashromConfig`
- If a `flashrom` command description with both `custom_content` and `custom_content_offset` are found in the `fw_util` config file, a temporary binary file will be created. The binary file will have `custom_content` written at `custom_content_offset`. A `flashrom` command would then be constructed using this temporary binary file instead of the firmware image. The regions in the flash memory which will be updated are restricted by specifying the layout
- The command to program the custom content will be in addition to the existing command to program the firmware binary. We are able to specify multiple commands because it’s allowed by the thrift description for upgrade operation

### Testing
Upgraded BIOS in a Darwin48V system with fw_util and verified that DMI_BOARD_NAME was programmed.