### PR TITLE
Meru config updates: Update inforoms, add NVMEs, remove SCM VRMs

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -41,24 +41,6 @@
           "address": "0x40",
           "kernelDeviceName": "pmbus",
           "pmUnitScopedName": "SCM_MPS_PMBUS"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x30",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_1"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x3e",
-          "kernelDeviceName": "pxe1610",
-          "pmUnitScopedName": "SCM_PXE1211"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x40",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_2"
         }
       ],
       "outgoingSlotConfigs": {
@@ -113,6 +95,10 @@
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
           "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
         }
       ]
     },
@@ -4146,10 +4132,8 @@
     "/run/devmap/i2c-busses/MERU_SCM_CPLD_SMBUS1_CH7": "/[SCM_I2C_MASTER1@7]",
     "/run/devmap/eeproms/MERU800BFA_SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
-    "/run/devmap/sensors/CPU_PXM1310_1": "/[SCM_PXM1310_1]",
-    "/run/devmap/sensors/CPU_PXE1211": "/[SCM_PXE1211]",
-    "/run/devmap/sensors/CPU_PXM1310_2": "/[SCM_PXM1310_2]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0": "/SMB_SLOT@0/[SMB_FPGA0]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA1": "/SMB_SLOT@0/[SMB_FPGA1]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA2": "/SMB_SLOT@0/[SMB_FPGA2]",

--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -95,6 +95,15 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -41,24 +41,6 @@
           "address": "0x40",
           "kernelDeviceName": "pmbus",
           "pmUnitScopedName": "SCM_MPS_PMBUS"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x30",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_1"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x3e",
-          "kernelDeviceName": "pxe1610",
-          "pmUnitScopedName": "SCM_PXE1211"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x40",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_2"
         }
       ],
       "outgoingSlotConfigs": {
@@ -112,6 +94,10 @@
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
           "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
         }
       ]
     },
@@ -1505,10 +1491,8 @@
     "/run/devmap/i2c-busses/MERU_SCM_CPLD_SMBUS1_CH7": "/[SCM_I2C_MASTER1@7]",
     "/run/devmap/eeproms/MERU800BIA_SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
-    "/run/devmap/sensors/CPU_PXM1310_1": "/[SCM_PXM1310_1]",
-    "/run/devmap/sensors/CPU_PXE1211": "/[SCM_PXE1211]",
-    "/run/devmap/sensors/CPU_PXM1310_2": "/[SCM_PXM1310_2]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA": "/SMB_SLOT@0/[SMB_FPGA]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
     "/run/devmap/inforoms/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -95,6 +95,15 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/meru800biab/platform_manager.json
+++ b/fboss/platform/configs/meru800biab/platform_manager.json
@@ -85,7 +85,7 @@
             {
               "pmUnitScopedName": "SCM_FPGA_INFO_ROM",
               "deviceName": "fpga_info_iob",
-              "csrOffset": "0x0000"
+              "csrOffset": "0x100"
             }
           ]
         }
@@ -1440,7 +1440,7 @@
             {
               "pmUnitScopedName": "SMB_FPGA_INFO_ROM",
               "deviceName": "fpga_info_iob",
-              "csrOffset": "0x0000"
+              "csrOffset": "0x100"
             }
           ]
         }


### PR DESCRIPTION
Updating all the meru configs:

meru800biab inforom offsets were out of date and are now updated.

SCM VRMs are no longer used - previously removed from sensor_service in this PR. https://github.com/facebook/fboss/pull/286 Now removed from platform_manager


**Testing**

No relevant platform_manager or sensor_service errors.

For all meru, in /run/devmap/sensors, NVME_TEMP is present and SCM VRMs are not.

```
ls -al NVME_TEMP
lrwxrwxrwx 1 root root 28 Mar 19 15:28 NVME_TEMP -> /sys/class/nvme/nvme0/hwmon0

ls -al SCM*
ls: cannot access 'SCM*': No such file or directory
```

