### PR TITLE
Darwin48V: Sync PM, led_manager, and weutil configs

### DIFF
--- a/fboss/platform/configs/darwin48v/led_manager.json
+++ b/fboss/platform/configs/darwin48v/led_manager.json
@@ -1,94 +1,94 @@
 {
-    "systemLedConfig": {
+  "systemLedConfig": {
+    "presentLedColor": 1,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
+    "absentLedColor": 2,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
-    "fruTypeLedConfigs": {
-      "FAN": {
-        "presentLedColor": 1,
-        "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
-        "absentLedColor": 2,
-        "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
-      },
-      "PSU": {
-        "presentLedColor": 1,
-        "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
-        "absentLedColor": 2,
-        "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
+    "PSU": {
+      "presentLedColor": 1,
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
+      "absentLedColor": 2,
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
       }
     },
-    "fruConfigs": [
-      {
-        "fruName": "FAN1",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan1_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "FAN2",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan2_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "FAN3",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan3_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "FAN4",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan4_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "FAN5",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "FAN6",
-        "fruType": "FAN",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
-            "desiredValue": 1
-          }
-        }
-      },
-      {
-        "fruName": "PSU1",
-        "fruType": "PSU",
-        "presenceDetection": {
-          "sysfsFileHandle": {
-            "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/pem_present",
-            "desiredValue": 1
-          }
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan2_present",
+          "desiredValue": 1
         }
       }
-    ]
-  }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN5",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PSU1",
+      "fruType": "PSU",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/pem_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}

--- a/fboss/platform/configs/darwin48v/platform_manager.json
+++ b/fboss/platform/configs/darwin48v/platform_manager.json
@@ -323,7 +323,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT1_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6100"
               },
               "portNumber": 1,
@@ -332,7 +332,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT2_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6140"
               },
               "portNumber": 2,
@@ -341,7 +341,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT3_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6180"
               },
               "portNumber": 3,
@@ -350,7 +350,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT4_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x61c0"
               },
               "portNumber": 4,
@@ -359,7 +359,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT5_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6200"
               },
               "portNumber": 5,
@@ -368,7 +368,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT6_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6240"
               },
               "portNumber": 6,
@@ -377,7 +377,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT7_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6280"
               },
               "portNumber": 7,
@@ -386,7 +386,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT8_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x62c0"
               },
               "portNumber": 8,
@@ -395,7 +395,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT9_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6300"
               },
               "portNumber": 9,
@@ -404,7 +404,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT10_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6340"
               },
               "portNumber": 10,
@@ -413,7 +413,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT11_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6380"
               },
               "portNumber": 11,
@@ -422,7 +422,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT12_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x63c0"
               },
               "portNumber": 12,
@@ -431,7 +431,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT13_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6400"
               },
               "portNumber": 13,
@@ -440,7 +440,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT14_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6440"
               },
               "portNumber": 14,
@@ -449,7 +449,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT15_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6480"
               },
               "portNumber": 15,
@@ -458,7 +458,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT16_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x64c0"
               },
               "portNumber": 16,
@@ -467,7 +467,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT17_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6500"
               },
               "portNumber": 17,
@@ -476,7 +476,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT18_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6540"
               },
               "portNumber": 18,
@@ -485,7 +485,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT19_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6580"
               },
               "portNumber": 19,
@@ -494,7 +494,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT20_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x65c0"
               },
               "portNumber": 20,
@@ -503,7 +503,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT21_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6600"
               },
               "portNumber": 21,
@@ -512,7 +512,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT22_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6640"
               },
               "portNumber": 22,
@@ -521,7 +521,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT23_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6680"
               },
               "portNumber": 23,
@@ -530,7 +530,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT24_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x66c0"
               },
               "portNumber": 24,
@@ -539,7 +539,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT25_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6700"
               },
               "portNumber": 25,
@@ -548,7 +548,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT26_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6740"
               },
               "portNumber": 26,
@@ -557,7 +557,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT27_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6780"
               },
               "portNumber": 27,
@@ -566,7 +566,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT28_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x67c0"
               },
               "portNumber": 28,
@@ -575,7 +575,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT29_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6800"
               },
               "portNumber": 29,
@@ -584,7 +584,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT30_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6840"
               },
               "portNumber": 30,
@@ -593,7 +593,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT31_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x6880"
               },
               "portNumber": 31,
@@ -602,7 +602,7 @@
             {
               "fpgaIpBlockConfig": {
                 "pmUnitScopedName": "QSFP_PORT32_LED",
-                "deviceName": "port_led",
+                "deviceName": "port_led_darwin",
                 "csrOffset": "0x68c0"
               },
               "portNumber": 32,
@@ -953,7 +953,13 @@
           "busName": "INCOMING@0",
           "address": "0x58",
           "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PSU_PMBUS"
+          "pmUnitScopedName": "PSU_PMBUS",
+          "initRegSettings": [
+            {
+              "regOffset": 16,
+              "ioBuf": [-128]
+            }
+          ]
         }
       ],
       "outgoingSlotConfigs": {},
@@ -1163,7 +1169,7 @@
   "bspKmodsRpmName": "arista_bsp_kmods",
   "bspKmodsRpmVersion": "0.7.7-1",
   "requiredKmodsToLoad": [
-    "i2c-i801",
+    "i2c_i801",
     "scd"
   ]
 }

--- a/fboss/platform/configs/darwin48v/platform_manager.json
+++ b/fboss/platform/configs/darwin48v/platform_manager.json
@@ -900,7 +900,8 @@
               "deviceName": "fpga_info_iob",
               "csrOffset": "0x100"
             }
-          ]
+          ],
+          "desiredDriver": "scd"
         }
       ],
       "embeddedSensorConfigs": [

--- a/fboss/platform/configs/darwin48v/weutil.json
+++ b/fboss/platform/configs/darwin48v/weutil.json
@@ -5,10 +5,6 @@
       "path": "/run/devmap/eeproms/CHASSIS_EEPROM",
       "offset": 1536
     },
-    "FANSPINNER": {
-      "path": "/run/devmap/eeproms/FANSPINNER_EEPROM",
-      "offset": 15360
-    },
     "RACKMON": {
       "path": "/run/devmap/eeproms/RACKMON_EEPROM",
       "offset": 15360


### PR DESCRIPTION
# Description

## Platform manager
### Port leds support
Added port leds support using scd-leds-darwin. Requires new bsp. See PR containing the new bsp changes for more details on testing.

### Ensure write-protect (WP) is set prior to initializing the PSUs.

This is required for the pmbus kernel driver to initialize telemtry data on unsupported commands by the hardware. Enabling WP causes the driver to not consider the status register, which reports unsupported command errors, therefore preventing the issue where certain telemetry data points are omitted (in3_input, fan1_input, fan2_input.).

The default value of WP is enabled, however this issue arises when transitioning from an OS that utilizes a driver that disables WP. Therefore, the problem with the missing endpoints occurs and is only recovered manually or by powering off/on the PSUs.

```
              "regOffset": 16,   -> 0x10 (WP register)
              "ioBuf": [-128].    -> 0x80 (Write protect enabled)
```

## Led manager config
No logical changes, config clean up.

## Weutil config
Remove weutil support for fanspinner because it is not supported. This is because it lacks certain fields required by the Meta EEPROM format (namely, the Product Production State).