### PR TITLE
Add presence detection for minipack3n fans

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -75,6 +75,10 @@
       },
       "pmUnitName": "FCB_T"
     },
+    "FAN_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "pmUnitName": "FAN"
+    },
     "COMESE_SLOT": {
       "numOutgoingI2cBuses": 2,
       "idpromConfig": {
@@ -3067,7 +3071,49 @@
           "kernelDeviceName": "tmp1075",
           "pmUnitScopedName": "FCB_T_TSENSOR2"
         }
-      ]
+      ],
+      "outgoingSlotConfigs": {
+        "FAN_SLOT@0": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan1_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@1": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan3_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@2": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan5_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@3": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan7_present",
+              "desiredValue": 1
+            }
+          }
+        }
+      }
     },
     "FCB_B": {
       "pluggedInSlotType": "FCBBOTTOM_SLOT",
@@ -3084,7 +3130,52 @@
           "kernelDeviceName": "tmp1075",
           "pmUnitScopedName": "FCB_B_TSENSOR2"
         }
-      ]
+      ],
+      "outgoingSlotConfigs": {
+        "FAN_SLOT@0": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan2_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@1": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan4_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@2": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan6_present",
+              "desiredValue": 1
+            }
+          }
+        },
+        "FAN_SLOT@3": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_FAN_CPLD]",
+              "presenceFileName": "fan8_present",
+              "desiredValue": 1
+            }
+          }
+        }
+      }
+    },
+    "FAN": {
+      "pluggedInSlotType": "FAN_SLOT"
     },
     "NETLAKE": {
       "pluggedInSlotType": "COMESE_SLOT",


### PR DESCRIPTION
### Description:
Add the presenceDetection entry for the FCBBOTTOM_SLOT and FCBTOP_SLOT in platform_manager.json

### Motivation:
The presenceDetection for the PDB/FCB slots are missing.

### Test Plan:
1) Run platform_manager with the updated configuration. 
2) Plug in all FANs, then verify that all FCB slots are explored successfully.
   Log: [20250324_All_Fan_Present.txt](https://github.com/user-attachments/files/19426499/20250324_All_Fan_Present.txt)
3) Remove fans 1/3/5/7 and verify that FCBTOP_SLOT fails during exploration.
   Log: [20250324_FCB_T_FAN_1_not_present.txt](https://github.com/user-attachments/files/19426508/20250324_FCB_T_FAN_1_not_present.txt)
        [20250324_FCB_T_FAN_3_not_present.txt](https://github.com/user-attachments/files/19426509/20250324_FCB_T_FAN_3_not_present.txt)
        [20250324_FCB_T_FAN_5_not_present.txt](https://github.com/user-attachments/files/19426510/20250324_FCB_T_FAN_5_not_present.txt)
        [20250324_FCB_T_FAN_7_not_present.txt](https://github.com/user-attachments/files/19426511/20250324_FCB_T_FAN_7_not_present.txt)
4) Remove fans 2/4/6/8 and verify that FCBBOTTOM_SLOT fails during exploration.
   Log: [20250324_FCB_B_FAN_2_not_present.txt](https://github.com/user-attachments/files/19426513/20250324_FCB_B_FAN_2_not_present.txt)
        [20250324_FCB_B_FAN_4_not_present.txt](https://github.com/user-attachments/files/19426514/20250324_FCB_B_FAN_4_not_present.txt)
        [20250324_FCB_B_FAN_6_not_present.txt](https://github.com/user-attachments/files/19426515/20250324_FCB_B_FAN_6_not_present.txt)
        [20250324_FCB_B_FAN_8_not_present.txt](https://github.com/user-attachments/files/19426516/20250324_FCB_B_FAN_8_not_present.txt)