### PR TITLE
updated config files for meru systems

### DIFF
--- a/fboss/platform/configs/meru800bfa/led_manager.json
+++ b/fboss/platform/configs/meru800bfa/led_manager.json
@@ -145,7 +145,7 @@
       "fruType": "PSU",
             "presenceDetection": {
         "sysfsFileHandle": {
-          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu1_prsnt",
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu1_present",
           "desiredValue": 1
         }
       }
@@ -155,7 +155,7 @@
       "fruType": "PSU",
             "presenceDetection": {
         "sysfsFileHandle": {
-          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu2_prsnt",
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu2_present",
           "desiredValue": 1
         }
       }
@@ -165,7 +165,7 @@
       "fruType": "PSU",
             "presenceDetection": {
         "sysfsFileHandle": {
-          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu3_prsnt",
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu3_present",
           "desiredValue": 1
         }
       }
@@ -175,7 +175,7 @@
       "fruType": "PSU",
             "presenceDetection": {
         "sysfsFileHandle": {
-          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu4_prsnt",
+          "presenceFilePath": "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0/psu4_present",
           "desiredValue": 1
         }
       }

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -41,24 +41,6 @@
           "address": "0x40",
           "kernelDeviceName": "pmbus",
           "pmUnitScopedName": "SCM_MPS_PMBUS"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x30",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_1"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x3e",
-          "kernelDeviceName": "pxe1610",
-          "pmUnitScopedName": "SCM_PXE1211"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x40",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_2"
         }
       ],
       "outgoingSlotConfigs": {
@@ -113,6 +95,10 @@
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
           "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
         }
       ]
     },
@@ -129,7 +115,17 @@
           "busName": "INCOMING@0",
           "address": "0x4d",
           "kernelDeviceName": "max6581",
-          "pmUnitScopedName": "SMB_MAX6581"
+          "pmUnitScopedName": "SMB_MAX6581",
+          "initRegSettings": [
+            {
+              "regOffset": 75,
+              "ioBuf": [31]
+            },
+            {
+              "regOffset": 76,
+              "ioBuf": [3]
+            }
+          ]
         },
         {
           "busName": "INCOMING@0",
@@ -212,7 +208,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x60",
-          "kernelDeviceName": "oasis_cpld0",
+          "kernelDeviceName": "fan_cpld0",
           "pmUnitScopedName": "FAN0_CPLD"
         },
         {
@@ -224,7 +220,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x61",
-          "kernelDeviceName": "oasis_cpld1",
+          "kernelDeviceName": "fan_cpld1",
           "pmUnitScopedName": "FAN1_CPLD"
         },
         {
@@ -236,7 +232,7 @@
         {
           "busName": "INCOMING@3",
           "address": "0x62",
-          "kernelDeviceName": "oasis_cpld2",
+          "kernelDeviceName": "fan_cpld2",
           "pmUnitScopedName": "FAN2_CPLD"
         }
       ],
@@ -246,7 +242,7 @@
           "presenceDetection": {
             "sysfsFileHandle": {
               "devicePath": "/SMB_SLOT@0/[SMB_FPGA0]",
-              "presenceFileName": "psu1_prsnt",
+              "presenceFileName": "psu1_present",
               "desiredValue": 1
             }
           },
@@ -259,7 +255,7 @@
           "presenceDetection": {
             "sysfsFileHandle": {
               "devicePath": "/SMB_SLOT@0/[SMB_FPGA0]",
-              "presenceFileName": "psu2_prsnt",
+              "presenceFileName": "psu2_present",
               "desiredValue": 1
             }
           },
@@ -272,7 +268,7 @@
           "presenceDetection": {
             "sysfsFileHandle": {
               "devicePath": "/SMB_SLOT@0/[SMB_FPGA0]",
-              "presenceFileName": "psu3_prsnt",
+              "presenceFileName": "psu3_present",
               "desiredValue": 1
             }
           },
@@ -285,7 +281,7 @@
           "presenceDetection": {
             "sysfsFileHandle": {
               "devicePath": "/SMB_SLOT@0/[SMB_FPGA0]",
-              "presenceFileName": "psu4_prsnt",
+              "presenceFileName": "psu4_present",
               "desiredValue": 1
             }
           },
@@ -4146,10 +4142,8 @@
     "/run/devmap/i2c-busses/MERU_SCM_CPLD_SMBUS1_CH7": "/[SCM_I2C_MASTER1@7]",
     "/run/devmap/eeproms/MERU800BFA_SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
-    "/run/devmap/sensors/CPU_PXM1310_1": "/[SCM_PXM1310_1]",
-    "/run/devmap/sensors/CPU_PXE1211": "/[SCM_PXE1211]",
-    "/run/devmap/sensors/CPU_PXM1310_2": "/[SCM_PXM1310_2]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0": "/SMB_SLOT@0/[SMB_FPGA0]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA1": "/SMB_SLOT@0/[SMB_FPGA1]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA2": "/SMB_SLOT@0/[SMB_FPGA2]",

--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -95,6 +95,15 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -41,24 +41,6 @@
           "address": "0x40",
           "kernelDeviceName": "pmbus",
           "pmUnitScopedName": "SCM_MPS_PMBUS"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x30",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_1"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x3e",
-          "kernelDeviceName": "pxe1610",
-          "pmUnitScopedName": "SCM_PXE1211"
-        },
-        {
-          "busName": "SCM_I2C_MASTER0@2",
-          "address": "0x40",
-          "kernelDeviceName": "pxm1310",
-          "pmUnitScopedName": "SCM_PXM1310_2"
         }
       ],
       "outgoingSlotConfigs": {
@@ -112,12 +94,22 @@
         {
           "pmUnitScopedName": "CPU_CORE_TEMP",
           "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
         }
       ]
     },
     "SMB": {
       "pluggedInSlotType": "SMB_SLOT",
       "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x23",
+          "kernelDeviceName": "scd_vcpld",
+          "pmUnitScopedName": "SCD_VCPLD"
+        },
         {
           "busName": "INCOMING@0",
           "address": "0x74",
@@ -186,6 +178,14 @@
             {
               "regOffset": 39,
               "ioBuf": [-121]
+            },
+            {
+              "regOffset": 75,
+              "ioBuf": [31]
+            },
+            {
+              "regOffset": 76,
+              "ioBuf": [127]
             }
           ]
         },
@@ -204,7 +204,7 @@
         {
           "busName": "INCOMING@2",
           "address": "0x60",
-          "kernelDeviceName": "pali2_cpld",
+          "kernelDeviceName": "fan_cpld",
           "pmUnitScopedName": "FAN_CPLD"
         },
         {
@@ -1505,10 +1505,8 @@
     "/run/devmap/i2c-busses/MERU_SCM_CPLD_SMBUS1_CH7": "/[SCM_I2C_MASTER1@7]",
     "/run/devmap/eeproms/MERU800BIA_SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
-    "/run/devmap/sensors/CPU_PXM1310_1": "/[SCM_PXM1310_1]",
-    "/run/devmap/sensors/CPU_PXE1211": "/[SCM_PXE1211]",
-    "/run/devmap/sensors/CPU_PXM1310_2": "/[SCM_PXM1310_2]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA": "/SMB_SLOT@0/[SMB_FPGA]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
     "/run/devmap/inforoms/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -95,6 +95,15 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,


### PR DESCRIPTION
Updated config files for meru systems to:

- Initialize MAX6581 ideality register
- Bind meru800bia virtual CPLD to its driver
- Add NVME temperature readings
- Use device names and sysfs endpoints matching the latest BSP
- Remove VRM devices which can intermittently cause false alarms