### PR TITLE
[3/3]tahan: config: Adding fw_util json modification for Tahan platform 

### DIFF
--- a/fboss/platform/configs/tahan800bc/fw_util.json
+++ b/fboss/platform/configs/tahan800bc/fw_util.json
@@ -321,38 +321,19 @@
             "gpioChipValue": "1",
             "gpioChipPin": "55"
           }
-        },
-        {
-          "commandType": "i2cBusRead",
-          "path": "/run/devmap/i2c-busses/SMB_IOB_I2C_MASTER_6"
-        },
-        {
-          "commandType": "createI2cDevice",
-          "deviceId": "24c02",
-          "deviceAddress": "0x50",
-          "path": "/sys/bus/i2c/devices/{BUS}/new_device"
         }
       ],
       "upgrade": [
         {
-          "commandType": "ddDynamicBus",
-          "ddArgs": {
-            "if": "/sys/bus/i2c/devices/${oob_bus}/*-0050/eeprom"
+          "commandType": "i2cEeprom",
+          "i2cEepromArgs": {
+            "driverName": "24c02",
+            "deviceAddress": "0x50",   
+            "path": "/run/devmap/i2c-busses/SMB_IOB_I2C_MASTER_6"
           }
         }
       ],
-      "read": {
-        "commandType": "ddDynamicBus",
-        "ddArgs": {
-          "if": "/sys/bus/i2c/devices/${oob_bus}/*-0050/eeprom"
-        }
-      },
       "postUpgrade": [
-        {
-          "commandType": "deleteI2cdevice",
-          "deviceAddress": "0x50",
-          "path": "/sys/bus/i2c/devices/{BUS}/delete_device"
-        },
         {
           "commandType": "gpioset",
           "gpiosetArgs": {


### PR DESCRIPTION
**Description:**
This pull request modifies the "oob_eeprom" firmware upgrade process by replacing the manual I2C device creation and dynamic dd commands with a new i2cEeprom command. This change simplifies the upgrade operation for the OOB EEPROM.

**Motivation:**
The previous implementation of the oob_eeprom upgrade process involved multiple steps, including I2C bus reads, dynamic I2C device creation, and dd commands to read and write to the EEPROM. By introducing the i2cEeprom command, we encapsulate these steps into a single, more manageable operation. This improves readability, reduces the potential for errors, and simplifies maintenance.

**Testing:**
The changes were tested by:
- Verifying that the firmware upgrade process completes successfully using the new i2cEeprom command.
- Manually inspecting the firmware configuration to ensure that the changes are correctly applied.

**Unit test:**
Logs after merging PR's [1/3]common: I2cExplorer, [2/3]common: fw_utils and [3/3]tahan: config
[upgrade_log.txt](https://github.com/user-attachments/files/19443421/upgrade_log.txt)
[downgrade_log.txt](https://github.com/user-attachments/files/19443429/downgrade_log.txt)
[jg_log.txt](https://github.com/user-attachments/files/19443437/jg_log.txt)
