### PR TITLE
Add presence detection for minipack3n PSUs

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -2925,7 +2925,14 @@
           "slotType": "PSU_SLOT",
           "outgoingI2cBusNames": [
             "INCOMING@0"
-          ]
+          ],
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_CPLD]",
+              "presenceFileName": "psu_l_present",
+              "desiredValue": 1
+            }
+          }
         }
       }
     },
@@ -2944,7 +2951,14 @@
           "slotType": "PSU_SLOT",
           "outgoingI2cBusNames": [
             "INCOMING@0"
-          ]
+          ],
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[MCB_CPLD]",
+              "presenceFileName": "psu_r_present",
+              "desiredValue": 1
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
### Description:
Add the presenceDetection entry for the PSU_SLOT in platform_manager.json

### Motivation:
The presenceDetection for the PSU slots was missing.

### Test Plan:
1) Run platform_manager with the updated configuration.
2) Plug in all PSUs, then verify that all PSU slots are explored successfully.
   Log: [20250325_psu_all_present.txt](https://github.com/user-attachments/files/19445088/20250325_psu_all_present.txt)
3) Remove PSU from /PDBLEFT_SLOT@0/PSU_SLOT@0 and verify that PDBLEFT_SLOT fails during exploration.
   Log: [20250325_PSU_L_not_present.txt](https://github.com/user-attachments/files/19445089/20250325_PSU_L_not_present.txt)
4) Remove PSU from /PDBRIGHT_SLOT@0/PSU_SLOT@0 and verify that PDBRIGHT_SLOT fails during exploration.
   Log: [20250325_PSU_R_not_present.txt](https://github.com/user-attachments/files/19445090/20250325_PSU_R_not_present.txt)