### PR TITLE
DARWIN: sync pm, sensor, and led manager configs

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,22 +1,22 @@
 {
   "systemLedConfig": {
     "presentLedColor": 1,
-    "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
     "absentLedColor": 2,
-    "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PEM": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },
   "fruConfigs": [
@@ -66,6 +66,16 @@
       "presenceDetection": {
         "sysfsFileHandle": {
           "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
           "desiredValue": 1
         }
       }

--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -1,0 +1,1187 @@
+{
+  "platformName": "darwin",
+  "rootPmUnitName": "SMB",
+  "rootSlotType": "SMB_SLOT",
+  "slotTypeConfigs": {
+    "SMB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "pmUnitName": "SMB"
+    },
+    "FAN_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "pmUnitName": "FAN"
+    },
+    "RACKMON_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x52",
+        "kernelDeviceName": "24c512",
+        "offset": 0
+      },
+      "pmUnitName": "RACKMON"
+    },
+    "PEM_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c512",
+        "offset": 0
+      },
+      "pmUnitName": "PEM"
+    }
+  },
+  "pmUnitConfigs": {
+    "SMB": {
+      "pluggedInSlotType": "SMB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "ROOK_SMBUS0@0",
+          "address": "0x4c",
+          "kernelDeviceName": "bp4a_max6658",
+          "pmUnitScopedName": "CPU_BOARD_TEMP_MAX6658"
+        },
+        {
+          "busName": "ROOK_SMBUS3@2",
+          "address": "0x48",
+          "kernelDeviceName": "lm73",
+          "pmUnitScopedName": "CPU_FP_TEMP_LM73"
+        },
+        {
+          "busName": "ROOK_SMBUS0@2",
+          "address": "0x21",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "CPU_MPS1_PMBUS"
+        },
+        {
+          "busName": "ROOK_SMBUS0@2",
+          "address": "0x27",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "CPU_MPS2_PMBUS"
+        },
+        {
+          "busName": "ROOK_SMBUS0@1",
+          "address": "0x4e",
+          "kernelDeviceName": "ucd90160",
+          "pmUnitScopedName": "CPU_POS_UCD90160"
+        },
+        {
+          "busName": "ROOK_SMBUS3@0",
+          "address": "0x60",
+          "kernelDeviceName": "tehama_cpld",
+          "pmUnitScopedName": "FAN_CPLD"
+        },
+        {
+          "busName": "ROOK_SMBUS2@0",
+          "address": "0x23",
+          "kernelDeviceName": "blackhawk_cpld",
+          "pmUnitScopedName": "BLACKHAWK_CPLD"
+        },
+        {
+          "busName": "SCD_SMBUS1@0",
+          "address": "0x4d",
+          "kernelDeviceName": "max6581",
+          "pmUnitScopedName": "SC_BOARD_TEMP_MAX6581"
+        },
+        {
+          "busName": "ROOK_SMBUS2@2",
+          "address": "0x11",
+          "kernelDeviceName": "ucd90320",
+          "pmUnitScopedName": "SC_POS_UCD90320"
+        },
+        {
+          "busName": "SCD_SMBUS1@5",
+          "address": "0x40",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_TH3_CORE_IR35223"
+        },
+        {
+          "busName": "SCD_SMBUS1@6",
+          "address": "0x41",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_TH3_ANLG_IR35223"
+        },
+        {
+          "busName": "SCD_SMBUS1@7",
+          "address": "0x42",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SC_QSFPDD_IR35223"
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RACKMON_SLOT@0": {
+          "slotType": "RACKMON_SLOT",
+          "outgoingI2cBusNames": [
+            "SCD_SMBUS1@4"
+          ]
+        },
+        "FAN_SLOT@0": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan1_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@1": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan2_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@2": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan3_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@3": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan4_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "FAN_SLOT@4": {
+          "slotType": "FAN_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/[FAN_CPLD]",
+              "presenceFileName": "fan5_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": []
+        },
+        "PEM_SLOT@0": {
+          "slotType": "PEM_SLOT",
+          "outgoingI2cBusNames": [
+            "SCD_SMBUS1@3"
+          ]
+        }
+      },
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "ROOK_CPU_CPLD",
+          "vendorId": "0x8086",
+          "deviceId": "0x6f76",
+          "subSystemVendorId": "0x0000",
+          "subSystemDeviceId": "0x0000",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS0",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8000"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS1",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8080"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS2",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8100"
+              },
+              "numberOfAdapters": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "ROOK_SMBUS3",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8180"
+              },
+              "numberOfAdapters": 4
+            }
+          ],
+          "spiMasterConfigs": [],
+          "ledCtrlConfigs": [],
+          "xcvrCtrlConfigs": [],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "ROOK_CPU_CPLD_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x100"
+            }
+          ],
+          "desiredDriver": "scd"
+        },
+        {
+          "pmUnitScopedName": "SCD_FPGA",
+          "vendorId": "0x3475",
+          "deviceId": "0x0001",
+          "subSystemVendorId": "0x3475",
+          "subSystemDeviceId": "0x0002",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS0",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8000"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS1",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8080"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS2",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8100"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS3",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8180"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS4",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8200"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS5",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8280"
+              },
+              "numberOfAdapters": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SMBUS6",
+                "deviceName": "i2c_master",
+                "csrOffset": "0x8300"
+              },
+              "numberOfAdapters": 8
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SCD_SPI_MASTER",
+                "deviceName": "spi_master",
+                "csrOffset": "0x7900"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "SCD_SPI_MASTER_DEVICE1",
+                  "chipSelect": 0,
+                  "modalias": "spidev",
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "ledCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT1_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6100"
+              },
+              "portNumber": 1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT2_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6140"
+              },
+              "portNumber": 2,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT3_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6180"
+              },
+              "portNumber": 3,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT4_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x61c0"
+              },
+              "portNumber": 4,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT5_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6200"
+              },
+              "portNumber": 5,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT6_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6240"
+              },
+              "portNumber": 6,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT7_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6280"
+              },
+              "portNumber": 7,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT8_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x62c0"
+              },
+              "portNumber": 8,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT9_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6300"
+              },
+              "portNumber": 9,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT10_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6340"
+              },
+              "portNumber": 10,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT11_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6380"
+              },
+              "portNumber": 11,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT12_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x63c0"
+              },
+              "portNumber": 12,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT13_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6400"
+              },
+              "portNumber": 13,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT14_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6440"
+              },
+              "portNumber": 14,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT15_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6480"
+              },
+              "portNumber": 15,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT16_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x64c0"
+              },
+              "portNumber": 16,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT17_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6500"
+              },
+              "portNumber": 17,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT18_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6540"
+              },
+              "portNumber": 18,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT19_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6580"
+              },
+              "portNumber": 19,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT20_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x65c0"
+              },
+              "portNumber": 20,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT21_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6600"
+              },
+              "portNumber": 21,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT22_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6640"
+              },
+              "portNumber": 22,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT23_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6680"
+              },
+              "portNumber": 23,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT24_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x66c0"
+              },
+              "portNumber": 24,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT25_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6700"
+              },
+              "portNumber": 25,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT26_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6740"
+              },
+              "portNumber": 26,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT27_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6780"
+              },
+              "portNumber": 27,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT28_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x67c0"
+              },
+              "portNumber": 28,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT29_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6800"
+              },
+              "portNumber": 29,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT30_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6840"
+              },
+              "portNumber": 30,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT31_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x6880"
+              },
+              "portNumber": 31,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT32_LED",
+                "deviceName": "port_led_darwin",
+                "csrOffset": "0x68c0"
+              },
+              "portNumber": 32,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "SYSTEM_STATUS_LED",
+                "deviceName": "sys_led",
+                "csrOffset": "0x6050"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "FAN_STATUS_LED",
+                "deviceName": "fan_led",
+                "csrOffset": "0x6060"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PSU_STATUS_LED",
+                "deviceName": "psu_led",
+                "csrOffset": "0x6070"
+              },
+              "portNumber": -1,
+              "ledId": 1
+            }
+          ],
+          "xcvrCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT1_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa010"
+              },
+              "portNumber": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT2_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa020"
+              },
+              "portNumber": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT3_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa030"
+              },
+              "portNumber": 3
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT4_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa040"
+              },
+              "portNumber": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT5_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa050"
+              },
+              "portNumber": 5
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT6_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa060"
+              },
+              "portNumber": 6
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT7_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa070"
+              },
+              "portNumber": 7
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT8_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa080"
+              },
+              "portNumber": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT9_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa090"
+              },
+              "portNumber": 9
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT10_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0a0"
+              },
+              "portNumber": 10
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT11_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0b0"
+              },
+              "portNumber": 11
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT12_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0c0"
+              },
+              "portNumber": 12
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT13_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0d0"
+              },
+              "portNumber": 13
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT14_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0e0"
+              },
+              "portNumber": 14
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT15_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa0f0"
+              },
+              "portNumber": 15
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT16_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa100"
+              },
+              "portNumber": 16
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT17_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa110"
+              },
+              "portNumber": 17
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT18_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa120"
+              },
+              "portNumber": 18
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT19_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa130"
+              },
+              "portNumber": 19
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT20_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa140"
+              },
+              "portNumber": 20
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT21_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa150"
+              },
+              "portNumber": 21
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT22_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa160"
+              },
+              "portNumber": 22
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT23_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa170"
+              },
+              "portNumber": 23
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT24_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa180"
+              },
+              "portNumber": 24
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT25_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa190"
+              },
+              "portNumber": 25
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT26_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1a0"
+              },
+              "portNumber": 26
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT27_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1b0"
+              },
+              "portNumber": 27
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT28_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1c0"
+              },
+              "portNumber": 28
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT29_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1d0"
+              },
+              "portNumber": 29
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT30_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1e0"
+              },
+              "portNumber": 30
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT31_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa1f0"
+              },
+              "portNumber": 31
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "QSFP_PORT32_XCVR",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0xa200"
+              },
+              "portNumber": 32
+            }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "SCD_FPGA_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x100"
+            }
+          ],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SCD_WDT1",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x120"
+            },
+            {
+              "pmUnitScopedName": "SCD_WDT2",
+              "deviceName": "watchdog_darwin",
+              "csrOffset": "0x304"
+            }
+          ]
+        }
+      ],
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "PCH_THERMAL",
+          "sysfsPath": "/sys/devices/virtual/thermal/thermal_zone0"
+        },
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        }
+      ]
+    },
+    "FAN": {
+      "pluggedInSlotType": "FAN_SLOT",
+      "i2cDeviceConfigs": [],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    },
+    "RACKMON": {
+      "pluggedInSlotType": "RACKMON_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x08",
+          "kernelDeviceName": "aslg4f4527",
+          "pmUnitScopedName": "FS_FAN_SLG4F4527"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x74",
+          "kernelDeviceName": "pca9539",
+          "pmUnitScopedName": "RACKMON_PLS",
+          "isGpioChip": true
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x50",
+          "kernelDeviceName": "24c512",
+          "pmUnitScopedName": "FANSPINNER_EEPROM"
+        }
+      ],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    },
+    "PEM": {
+      "pluggedInSlotType": "PEM_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x3a",
+          "kernelDeviceName": "amax5970",
+          "pmUnitScopedName": "PEM_ECB_MAX5970"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x36",
+          "kernelDeviceName": "bp4a_max11645",
+          "pmUnitScopedName": "PEM_ADC_MAX11645"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4c",
+          "kernelDeviceName": "bp4a_max6658",
+          "pmUnitScopedName": "PEM_TEMP_MAX6658"
+        }
+      ],
+      "outgoingSlotConfigs": {},
+      "pciDeviceConfigs": []
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "SMBus I801 adapter at 1020"
+  ],
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/cplds/ROOK_CPU_CPLD": "/[ROOK_CPU_CPLD]",
+    "/run/devmap/cplds/ROOK_CPU_CPLD_INFO_ROM": "/[ROOK_CPU_CPLD_INFO_ROM]",
+    "/run/devmap/fpgas/SCD_FPGA": "/[SCD_FPGA]",
+    "/run/devmap/fpgas/SCD_FPGA_INFO_ROM": "/[SCD_FPGA_INFO_ROM]",
+    "/run/devmap/inforoms/SCD_FPGA_INFO_ROM": "/[SCD_FPGA_INFO_ROM]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH0": "/[ROOK_SMBUS0@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH1": "/[ROOK_SMBUS0@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH2": "/[ROOK_SMBUS0@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS0_CH3": "/[ROOK_SMBUS0@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH0": "/[ROOK_SMBUS1@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH1": "/[ROOK_SMBUS1@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH2": "/[ROOK_SMBUS1@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS1_CH3": "/[ROOK_SMBUS1@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH0": "/[ROOK_SMBUS2@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH1": "/[ROOK_SMBUS2@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH2": "/[ROOK_SMBUS2@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS2_CH3": "/[ROOK_SMBUS2@3]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH0": "/[ROOK_SMBUS3@0]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH1": "/[ROOK_SMBUS3@1]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH2": "/[ROOK_SMBUS3@2]",
+    "/run/devmap/i2c-busses/ROOK_SMBUS3_CH3": "/[ROOK_SMBUS3@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH0": "/[SCD_SMBUS0@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH1": "/[SCD_SMBUS0@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH2": "/[SCD_SMBUS0@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH3": "/[SCD_SMBUS0@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH4": "/[SCD_SMBUS0@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH5": "/[SCD_SMBUS0@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH6": "/[SCD_SMBUS0@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS0_CH7": "/[SCD_SMBUS0@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH0": "/[SCD_SMBUS1@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH1": "/[SCD_SMBUS1@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH2": "/[SCD_SMBUS1@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH3": "/[SCD_SMBUS1@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH4": "/[SCD_SMBUS1@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH5": "/[SCD_SMBUS1@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH6": "/[SCD_SMBUS1@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS1_CH7": "/[SCD_SMBUS1@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH0": "/[SCD_SMBUS2@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH1": "/[SCD_SMBUS2@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH2": "/[SCD_SMBUS2@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH3": "/[SCD_SMBUS2@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH4": "/[SCD_SMBUS2@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH5": "/[SCD_SMBUS2@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH6": "/[SCD_SMBUS2@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS2_CH7": "/[SCD_SMBUS2@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH0": "/[SCD_SMBUS3@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH1": "/[SCD_SMBUS3@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH2": "/[SCD_SMBUS3@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH3": "/[SCD_SMBUS3@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH4": "/[SCD_SMBUS3@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH5": "/[SCD_SMBUS3@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH6": "/[SCD_SMBUS3@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS3_CH7": "/[SCD_SMBUS3@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH0": "/[SCD_SMBUS4@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH1": "/[SCD_SMBUS4@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH2": "/[SCD_SMBUS4@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH3": "/[SCD_SMBUS4@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH4": "/[SCD_SMBUS4@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH5": "/[SCD_SMBUS4@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH6": "/[SCD_SMBUS4@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS4_CH7": "/[SCD_SMBUS4@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH0": "/[SCD_SMBUS5@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH1": "/[SCD_SMBUS5@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH2": "/[SCD_SMBUS5@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH3": "/[SCD_SMBUS5@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH4": "/[SCD_SMBUS5@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH5": "/[SCD_SMBUS5@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH6": "/[SCD_SMBUS5@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS5_CH7": "/[SCD_SMBUS5@7]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH0": "/[SCD_SMBUS6@0]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH1": "/[SCD_SMBUS6@1]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH2": "/[SCD_SMBUS6@2]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH3": "/[SCD_SMBUS6@3]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH4": "/[SCD_SMBUS6@4]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH5": "/[SCD_SMBUS6@5]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH6": "/[SCD_SMBUS6@6]",
+    "/run/devmap/i2c-busses/SCD_SMBUS6_CH7": "/[SCD_SMBUS6@7]",
+    "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658": "/[CPU_BOARD_TEMP_MAX6658]",
+    "/run/devmap/sensors/CPU_FP_TEMP_LM73": "/[CPU_FP_TEMP_LM73]",
+    "/run/devmap/sensors/CPU_MPS1_PMBUS": "/[CPU_MPS1_PMBUS]",
+    "/run/devmap/sensors/CPU_MPS2_PMBUS": "/[CPU_MPS2_PMBUS]",
+    "/run/devmap/sensors/CPU_POS_UCD90160": "/[CPU_POS_UCD90160]",
+    "/run/devmap/cplds/FAN_CPLD": "/[FAN_CPLD]",
+    "/run/devmap/sensors/FAN_CPLD": "/[FAN_CPLD]",
+    "/run/devmap/cplds/BLACKHAWK_CPLD": "/[BLACKHAWK_CPLD]",
+    "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581": "/[SC_BOARD_TEMP_MAX6581]",
+    "/run/devmap/sensors/SC_POS_UCD90320": "/[SC_POS_UCD90320]",
+    "/run/devmap/sensors/SC_TH3_CORE_IR35223": "/[SC_TH3_CORE_IR35223]",
+    "/run/devmap/sensors/SC_TH3_ANLG_IR35223": "/[SC_TH3_ANLG_IR35223]",
+    "/run/devmap/sensors/SC_QSFPDD_IR35223": "/[SC_QSFPDD_IR35223]",
+    "/run/devmap/sensors/PCH_THERMAL": "/[PCH_THERMAL]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/xcvrs/xcvr_1": "/[QSFP_PORT1_XCVR]",
+    "/run/devmap/xcvrs/xcvr_2": "/[QSFP_PORT2_XCVR]",
+    "/run/devmap/xcvrs/xcvr_3": "/[QSFP_PORT3_XCVR]",
+    "/run/devmap/xcvrs/xcvr_4": "/[QSFP_PORT4_XCVR]",
+    "/run/devmap/xcvrs/xcvr_5": "/[QSFP_PORT5_XCVR]",
+    "/run/devmap/xcvrs/xcvr_6": "/[QSFP_PORT6_XCVR]",
+    "/run/devmap/xcvrs/xcvr_7": "/[QSFP_PORT7_XCVR]",
+    "/run/devmap/xcvrs/xcvr_8": "/[QSFP_PORT8_XCVR]",
+    "/run/devmap/xcvrs/xcvr_9": "/[QSFP_PORT9_XCVR]",
+    "/run/devmap/xcvrs/xcvr_10": "/[QSFP_PORT10_XCVR]",
+    "/run/devmap/xcvrs/xcvr_11": "/[QSFP_PORT11_XCVR]",
+    "/run/devmap/xcvrs/xcvr_12": "/[QSFP_PORT12_XCVR]",
+    "/run/devmap/xcvrs/xcvr_13": "/[QSFP_PORT13_XCVR]",
+    "/run/devmap/xcvrs/xcvr_14": "/[QSFP_PORT14_XCVR]",
+    "/run/devmap/xcvrs/xcvr_15": "/[QSFP_PORT15_XCVR]",
+    "/run/devmap/xcvrs/xcvr_16": "/[QSFP_PORT16_XCVR]",
+    "/run/devmap/xcvrs/xcvr_17": "/[QSFP_PORT17_XCVR]",
+    "/run/devmap/xcvrs/xcvr_18": "/[QSFP_PORT18_XCVR]",
+    "/run/devmap/xcvrs/xcvr_19": "/[QSFP_PORT19_XCVR]",
+    "/run/devmap/xcvrs/xcvr_20": "/[QSFP_PORT20_XCVR]",
+    "/run/devmap/xcvrs/xcvr_21": "/[QSFP_PORT21_XCVR]",
+    "/run/devmap/xcvrs/xcvr_22": "/[QSFP_PORT22_XCVR]",
+    "/run/devmap/xcvrs/xcvr_23": "/[QSFP_PORT23_XCVR]",
+    "/run/devmap/xcvrs/xcvr_24": "/[QSFP_PORT24_XCVR]",
+    "/run/devmap/xcvrs/xcvr_25": "/[QSFP_PORT25_XCVR]",
+    "/run/devmap/xcvrs/xcvr_26": "/[QSFP_PORT26_XCVR]",
+    "/run/devmap/xcvrs/xcvr_27": "/[QSFP_PORT27_XCVR]",
+    "/run/devmap/xcvrs/xcvr_28": "/[QSFP_PORT28_XCVR]",
+    "/run/devmap/xcvrs/xcvr_29": "/[QSFP_PORT29_XCVR]",
+    "/run/devmap/xcvrs/xcvr_30": "/[QSFP_PORT30_XCVR]",
+    "/run/devmap/xcvrs/xcvr_31": "/[QSFP_PORT31_XCVR]",
+    "/run/devmap/xcvrs/xcvr_32": "/[QSFP_PORT32_XCVR]",
+    "/run/devmap/flashes/SCD_SPI_MASTER_DEVICE1": "/[SCD_SPI_MASTER_DEVICE1]",
+    "/run/devmap/xcvrs/xcvr_io_1": "/[SCD_SMBUS2@0]",
+    "/run/devmap/xcvrs/xcvr_ctrl_1": "/[QSFP_PORT1_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_2": "/[SCD_SMBUS2@1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_2": "/[QSFP_PORT2_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_3": "/[SCD_SMBUS2@2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_3": "/[QSFP_PORT3_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_4": "/[SCD_SMBUS2@3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_4": "/[QSFP_PORT4_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_5": "/[SCD_SMBUS2@4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_5": "/[QSFP_PORT5_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_6": "/[SCD_SMBUS2@5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_6": "/[QSFP_PORT6_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_7": "/[SCD_SMBUS2@6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_7": "/[QSFP_PORT7_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_8": "/[SCD_SMBUS2@7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_8": "/[QSFP_PORT8_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_9": "/[SCD_SMBUS3@0]",
+    "/run/devmap/xcvrs/xcvr_ctrl_9": "/[QSFP_PORT9_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_10": "/[SCD_SMBUS3@1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_10": "/[QSFP_PORT10_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_11": "/[SCD_SMBUS3@2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_11": "/[QSFP_PORT11_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_12": "/[SCD_SMBUS3@3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_12": "/[QSFP_PORT12_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_13": "/[SCD_SMBUS3@4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_13": "/[QSFP_PORT13_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_14": "/[SCD_SMBUS3@5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_14": "/[QSFP_PORT14_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_15": "/[SCD_SMBUS3@6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_15": "/[QSFP_PORT15_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_16": "/[SCD_SMBUS3@7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_16": "/[QSFP_PORT16_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_17": "/[SCD_SMBUS4@0]",
+    "/run/devmap/xcvrs/xcvr_ctrl_17": "/[QSFP_PORT17_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_18": "/[SCD_SMBUS4@1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_18": "/[QSFP_PORT18_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_19": "/[SCD_SMBUS4@2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_19": "/[QSFP_PORT19_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_20": "/[SCD_SMBUS4@3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_20": "/[QSFP_PORT20_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_21": "/[SCD_SMBUS4@4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_21": "/[QSFP_PORT21_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_22": "/[SCD_SMBUS4@5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_22": "/[QSFP_PORT22_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_23": "/[SCD_SMBUS4@6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_23": "/[QSFP_PORT23_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_24": "/[SCD_SMBUS4@7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_24": "/[QSFP_PORT24_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_25": "/[SCD_SMBUS5@0]",
+    "/run/devmap/xcvrs/xcvr_ctrl_25": "/[QSFP_PORT25_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_26": "/[SCD_SMBUS5@1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_26": "/[QSFP_PORT26_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_27": "/[SCD_SMBUS5@2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_27": "/[QSFP_PORT27_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_28": "/[SCD_SMBUS5@3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_28": "/[QSFP_PORT28_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_29": "/[SCD_SMBUS5@4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_29": "/[QSFP_PORT29_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_30": "/[SCD_SMBUS5@5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_30": "/[QSFP_PORT30_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_31": "/[SCD_SMBUS5@6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_31": "/[QSFP_PORT31_XCVR]",
+    "/run/devmap/xcvrs/xcvr_io_32": "/[SCD_SMBUS5@7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_32": "/[QSFP_PORT32_XCVR]",
+    "/run/devmap/eeproms/RACKMON_EEPROM": "/RACKMON_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/FS_FAN_SLG4F4527": "/RACKMON_SLOT@0/[FS_FAN_SLG4F4527]",
+    "/run/devmap/gpiochips/RACKMON_PLS": "/RACKMON_SLOT@0/[RACKMON_PLS]",
+    "/run/devmap/eeproms/FANSPINNER_EEPROM": "/RACKMON_SLOT@0/[FANSPINNER_EEPROM]",
+    "/run/devmap/sensors/PEM_ECB_MAX5970": "/PEM_SLOT@0/[PEM_ECB_MAX5970]",
+    "/run/devmap/sensors/PEM_ADC_MAX11645": "/PEM_SLOT@0/[PEM_ADC_MAX11645]",
+    "/run/devmap/sensors/PEM_TEMP_MAX6658": "/PEM_SLOT@0/[PEM_TEMP_MAX6658]"
+  },
+  "bspKmodsRpmName": "arista_bsp_kmods",
+  "bspKmodsRpmVersion": "0.7.7-1",
+  "requiredKmodsToLoad": [
+    "i2c_i801",
+    "scd"
+  ]
+}

--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -905,7 +905,8 @@
               "deviceName": "watchdog_darwin",
               "csrOffset": "0x304"
             }
-          ]
+          ],
+          "desiredDriver": "scd"
         }
       ],
       "embeddedSensorConfigs": [

--- a/fboss/platform/configs/darwin/sensor_service.json
+++ b/fboss/platform/configs/darwin/sensor_service.json
@@ -2,14 +2,14 @@
   "pmUnitSensorsList": [
     {
       "slotPath": "/",
-      "pmUnitName": "CPU_CARD",
+      "pmUnitName": "SMB",
       "sensors": [
         {
           "name": "PCH_TEMP",
           "sysfsPath": "/run/devmap/sensors/PCH_THERMAL/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -18,7 +18,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -27,7 +27,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -36,7 +36,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -45,7 +45,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -54,7 +54,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105
+            "upperCriticalVal": 105.0
           },
           "compute": "@/1000.0"
         },
@@ -63,7 +63,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -72,7 +72,16 @@
           "sysfsPath": "/run/devmap/sensors/CPU_BOARD_TEMP_MAX6658/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "FRONT_PANEL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_FP_TEMP_LM73/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -81,8 +90,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "upperCriticalVal": 14.0,
+            "lowerCriticalVal": 9.0
           },
           "compute": "@/1000.0"
         },
@@ -91,7 +100,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110
+            "upperCriticalVal": 110.0
           },
           "compute": "@/1000.0"
         },
@@ -100,7 +109,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -109,7 +118,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS1_PMBUS/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 45
+            "upperCriticalVal": 45.0
           },
           "compute": "@/1000.0"
         },
@@ -118,8 +127,8 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "upperCriticalVal": 14.0,
+            "lowerCriticalVal": 9.0
           },
           "compute": "@/1000.0"
         },
@@ -128,7 +137,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110
+            "upperCriticalVal": 110.0
           },
           "compute": "@/1000.0"
         },
@@ -137,7 +146,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -146,7 +155,7 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS2_PMBUS/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 35
+            "upperCriticalVal": 35.0
           },
           "compute": "@/1000.0"
         },
@@ -267,7 +276,8 @@
           "thresholds": {
             "upperCriticalVal": 3.795,
             "lowerCriticalVal": 2.8
-          }
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "POS_12V",
@@ -300,27 +310,12 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "FRONT_PANEL_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_FP_TEMP_LM73/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 85
-          },
-          "compute": "@/1000.0"
-        }
-      ]
-    },
-    {
-      "slotPath": "/FAN_SLOT@0",
-      "pmUnitName": "FAN",
-      "sensors": [
-        {
           "name": "FAN1_RPM",
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -328,8 +323,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -337,8 +332,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -346,8 +341,8 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
         {
@@ -355,31 +350,16 @@
           "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_input",
           "type": 4,
           "thresholds": {
-            "upperCriticalVal": 25500,
-            "lowerCriticalVal": 2600
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
           }
         },
-        {
-          "name": "FS_FAN_RPM",
-          "sysfsPath": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input",
-          "type": 4,
-          "thresholds": {
-            "upperCriticalVal": 29500,
-            "lowerCriticalVal": 2600
-          }
-        }
-      ]
-    },
-    {
-      "slotPath": "/SCM_SLOT@0",
-      "pmUnitName": "SWITCH_CARD",
-      "sensors": [
         {
           "name": "SC_BOARD_TEMP",
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -388,7 +368,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -397,7 +377,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -406,7 +386,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp4_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75
+            "upperCriticalVal": 75.0
           },
           "compute": "@/1000.0"
         },
@@ -415,7 +395,7 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp7_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 125
+            "upperCriticalVal": 125.0
           },
           "compute": "@/1000.0"
         },
@@ -424,14 +404,369 @@
           "sysfsPath": "/run/devmap/sensors/SC_BOARD_TEMP_MAX6581/temp8_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 125
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_TH3_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_TH3_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_12V_STDBY",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 9.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_5V0",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.75,
+            "lowerCriticalVal": 4.25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in5_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_QSFPDD_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in6_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_QSFPDD_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in7_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_3V3_STDBY",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in8_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 3.795,
+            "lowerCriticalVal": 2.475
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_2V5_LT",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in9_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.1,
+            "lowerCriticalVal": 0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_2V5_RT",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in10_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 5.1,
+            "lowerCriticalVal": 0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V8",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in11_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 1.53
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V5_A",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in12_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 1.275
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V5_B",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in13_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 1.275
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_1V2",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in14_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 1.02
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_0V8_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in15_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0.72
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SC_POS_0V9_VDD",
+          "sysfsPath": "/run/devmap/sensors/SC_POS_UCD90320/in16_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.35,
+            "lowerCriticalVal": 0.38
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "TH3_VRD1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_CORE_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 464.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "TH3_VRD2_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "TH3_VRD2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SC_TH3_ANLG_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 124.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VIN",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.5,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VOUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in2_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_VOUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/in3_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_POUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_POUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 400.0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IIN",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 60.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IOUT_A",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "QSFPDD_VRD_IOUT_B",
+          "sysfsPath": "/run/devmap/sensors/SC_QSFPDD_IR35223/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 120.0
           },
           "compute": "@/1000.0"
         }
       ]
     },
     {
-      "slotPath": "/PSU_SLOT@0",
+      "slotPath": "/RACKMON_SLOT@0",
+      "pmUnitName": "RACKMON",
+      "sensors": [
+        {
+          "name": "FS_FAN_RPM",
+          "sysfsPath": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 29500.0,
+            "lowerCriticalVal": 2600.0
+          }
+        }
+      ]
+    },
+    {
+      "slotPath": "/PEM_SLOT@0",
       "pmUnitName": "PEM",
       "sensors": [
         {
@@ -439,7 +774,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14
+            "upperCriticalVal": 14.0
           },
           "compute": "(15.5*@)/1000.0"
         },
@@ -448,16 +783,16 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14
+            "upperCriticalVal": 14.0
           },
-          "compute": "15.5*@/1000.0"
+          "compute": "(15.5*@)/1000.0"
         },
         {
           "name": "PEM_ECB_IOUT_CH1",
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 60,
+            "upperCriticalVal": 60.0,
             "lowerCriticalVal": 0.5
           },
           "compute": "(48390/343)*@/1000.0"
@@ -467,7 +802,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_ECB_MAX5970/curr2_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 60,
+            "upperCriticalVal": 60.0,
             "lowerCriticalVal": 0.5
           },
           "compute": "(48390/343)*@/1000.0"
@@ -497,7 +832,7 @@
           "type": 1,
           "thresholds": {
             "upperCriticalVal": 0.08,
-            "lowerCriticalVal": 0
+            "lowerCriticalVal": 0.0
           },
           "compute": "@/1000.0"
         },
@@ -506,7 +841,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_TEMP_MAX6658/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         },
@@ -515,7 +850,7 @@
           "sysfsPath": "/run/devmap/sensors/PEM_TEMP_MAX6658/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85
+            "upperCriticalVal": 85.0
           },
           "compute": "@/1000.0"
         }


### PR DESCRIPTION
# Description

## Platform Manager
This PR includes changes from previous PRs updated with recent changes to be in sync: #329 #267 

**Summary of all changes**
- Initialize the qsfp ports (1-32) and generate the necessary symlinks.
- Port leds support using scd-leds-darwin. See PR introducing the driver for more details.
- Added infoRom support
- Syncing the config with PM updates to keep it valid. E.g. Removed outdated attributes: bspKmodsToReload, sharedKmodsToReload, and upstreamKmodsToLoad .

## Sensor_service changes
- Sync Darwin sensor_service config to include all sensors.
- Match pmUnitNames generated used by PM
- Added missing compute attribute for POS_3V3_ALW

## Led manager config
- Sync Darwin led_manager paths to follow the same /sys/class/leds used on all other platforms.
- Add missing rackmon fan as a FRU associated with the FAN led.

# Testing

This testing section, while it includes general tests, focuses on changes introduced by this PR when compared to the outdated #329 #267.

## PM Init of Xcvrs
Ports on Darwin reflect the expected values through the scd-xcvr driver 
```
# ls /run/devmap/xcvrs/
xcvr_1   xcvr_17  xcvr_24  xcvr_31  xcvr_ctrl_1   xcvr_ctrl_17  xcvr_ctrl_24  xcvr_ctrl_31  xcvr_io_1   xcvr_io_17  xcvr_io_24  xcvr_io_31
xcvr_10  xcvr_18  xcvr_25  xcvr_32  xcvr_ctrl_10  xcvr_ctrl_18  xcvr_ctrl_25  xcvr_ctrl_32  xcvr_io_10  xcvr_io_18  xcvr_io_25  xcvr_io_32
xcvr_11  xcvr_19  xcvr_26  xcvr_4   xcvr_ctrl_11  xcvr_ctrl_19  xcvr_ctrl_26  xcvr_ctrl_4   xcvr_io_11  xcvr_io_19  xcvr_io_26  xcvr_io_4
xcvr_12  xcvr_2   xcvr_27  xcvr_5   xcvr_ctrl_12  xcvr_ctrl_2   xcvr_ctrl_27  xcvr_ctrl_5   xcvr_io_12  xcvr_io_2   xcvr_io_27  xcvr_io_5
xcvr_13  xcvr_20  xcvr_28  xcvr_6   xcvr_ctrl_13  xcvr_ctrl_20  xcvr_ctrl_28  xcvr_ctrl_6   xcvr_io_13  xcvr_io_20  xcvr_io_28  xcvr_io_6
xcvr_14  xcvr_21  xcvr_29  xcvr_7   xcvr_ctrl_14  xcvr_ctrl_21  xcvr_ctrl_29  xcvr_ctrl_7   xcvr_io_14  xcvr_io_21  xcvr_io_29  xcvr_io_7
xcvr_15  xcvr_22  xcvr_3   xcvr_8   xcvr_ctrl_15  xcvr_ctrl_22  xcvr_ctrl_3   xcvr_ctrl_8   xcvr_io_15  xcvr_io_22  xcvr_io_3   xcvr_io_8
xcvr_16  xcvr_23  xcvr_30  xcvr_9   xcvr_ctrl_16  xcvr_ctrl_23  xcvr_ctrl_30  xcvr_ctrl_9   xcvr_io_16  xcvr_io_23  xcvr_io_30  xcvr_io_9
```

Port 1 is expected to be present
```
# cat /run/devmap/xcvrs/xcvr_ctrl_1/xcvr1_present
0 <-- 0 is present
```

Testing with a non-existing xcvr
```
# cat /run/devmap/xcvrs/xcvr_ctrl_5/xcvr5_present
1  <---- 1 is absent
```

## Port Leds
Verified that the green led is on at first, and turning on yellow leds turns off the green led:
E.g. Setting Port 1 LED to yellow `# echo 1 > port1_led1\:yellow\:status/brightness`
![image](https://github.com/user-attachments/assets/fc678155-c581-4d16-ba55-a81d5df0bc75)
![image](https://github.com/user-attachments/assets/bc0228cd-3e0c-4c4a-8b73-d5fc42e8421a)

## Led Manager Testing
```
Jan 31 00:49:20 ...: I0131 00:49:20.856894  5161 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
Jan 31 00:49:20 ...: I0131 00:49:20.856950  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.857852  5161 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.857892  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.858802  5161 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
Jan 31 00:49:20 ...: I0131 00:49:20.858819  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.859799  5161 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
Jan 31 00:49:20 ...: I0131 00:49:20.859815  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.860829  5161 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
Jan 31 00:49:20 ...: I0131 00:49:20.860845  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN5 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861801  5161 FruPresenceExplorer.cpp:49] Detected that FAN5 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861817  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN6 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861846  5161 FruPresenceExplorer.cpp:49] Detected that FAN6 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861852  5161 FruPresenceExplorer.cpp:34] Detecting presence of PEM1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861869  5161 FruPresenceExplorer.cpp:49] Detected that PEM1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861877  5161 LedManager.cpp:45] Programming PEM LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861911  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861936  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861944  5161 LedManager.cpp:55] Programmed PEM LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.861950  5161 LedManager.cpp:45] Programming FAN LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861972  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861993  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861999  5161 LedManager.cpp:55] Programmed FAN LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.862005  5161 LedManager.cpp:25] Programming system LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.862026  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862047  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862054  5161 LedManager.cpp:34] Programmed system LED with true
```
![Screenshot 2025-03-25 at 2 56 06 PM](https://github.com/user-attachments/assets/d007b2af-ee33-429d-99ca-78c048b2ca70)



## General Tests
The following sw_tests passed:
- async_logger_test
- fan_service_sw_test
- fsdb_client_test
- platform_config_lib_config_lib_test
- platform_data_corral_sw_test
- platform_helpers_platform_name_lib_test
- platform_manager_config_validator_test
- platform_manager_data_store_test
- platform_manager_device_path_resolver_test
- platform_manager_i2c_explorer_test
- platform_manager_platform_explorer_test
- platform_manager_presence_checker_test
- platform_manager_utils_test
- rackmon_test
- sensor_service_sw_test
- sensor_service_utils_test
- thrift_cow_visitor_tests
- thrift_node_tests
- weutil_crc16_ccitt_test
- weutil_fboss_eeprom_parser_test


The following hw_tests passed:
- data_corral_service_hw_test
- sensor_service_hw_test
- fan_service_hw_test
- weutil_hw_test