### PR TITLE
Change the artifact root directory to be docs/build

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: build
+          path: docs/build
 
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
Summary: When uploading the artifact, the files need to be taken from `docs/build`. Currently, they seem to be taken from `root/build`. Which I believe is why https://facebook.github.io/fboss/ is missing the index.html file.

Differential Revision: D71989752


