### PR TITLE
Add num-jobs flag to docker-build.py

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,0 +1,51 @@
+name: Build AGENT Service - Hourly
+run-name: Build AGENT Service - Hourly
+on:
+  pull_request:
+  # Allow manually triggering the workflow
+  workflow_dispatch:
+  # Also schedule the workflow to run every 3 hours during day only
+  # ShipIt job will sync hourly around HH:21, so schedule the run with 15 minute offset
+  schedule:
+    # Run daily at 1:36AM UTC = 6:36PM PDT
+    # Run daily at 1:36PM UTC = 6:36AM PDT
+    # Run daily at 4:36PM UTC = 9:36AM PDT
+    # Run daily at 7:36PM UTC = 12:36PM PDT
+    # Run daily at 10:36PM UTC = 3:36PM PDT
+    - cron: '36 1,13,16,19,22 * * *'
+jobs:
+  Agent-Service-Build-Hourly:
+    runs-on: 32-core-ubuntu
+    steps:
+      - run: echo "Confirming hardware specifications:"; sudo lscpu
+      - name: Clean workspace
+        run: sudo rm -rf ${{ github.workspace }}/*
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Run Docker-based build for FBOSS
+        run: >
+          sudo
+          ./fboss/oss/scripts/docker-build.py
+          --scratch-path
+          ${{ github.workspace }}/build-output
+          --target
+          fboss_fake_agent_targets
+          --no-docker-output
+          --no-system-deps
+          --local
+          --env-var
+          BUILD_SAI_FAKE
+      - name: Package FBOSS binaries and library dependencies
+        run: >
+          sudo
+          ./fboss/oss/scripts/package-fboss.py
+          --scratch-path
+          ${{ github.workspace }}/build-output
+          --compress
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fboss
+          path: ${{ github.workspace }}/build-output/fboss_bins.tar.zst
+          # Explicitly set the retention at the object level
+          retention-days: 14

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,7 @@ add_dependencies(fboss_fake_agent_targets
   sai_agent_hw_test-fake
   multi_switch_agent_hw_test
   fboss_agent_thrift_libs
+  fboss_sw_agent
 )
 if (BUILD_SAI_FAKE_LINK_TEST)
 add_dependencies(fboss_fake_agent_targets

--- a/fboss/oss/scripts/docker-build.py
+++ b/fboss/oss/scripts/docker-build.py
@@ -18,6 +18,7 @@ OPT_ARG_NO_DOCKER_OUTPUT = "--no-docker-output"
 OPT_ARG_NO_SYSTEM_DEPS = "--no-system-deps"
 OPT_ARG_ADD_BUILD_ENV_VAR = "--env-var"
 OPT_ARG_LOCAL = "--local"
+OPT_ARG_NUM_JOBS = "--num-jobs"
 
 FBOSS_IMAGE_NAME = "fboss_image"
 FBOSS_CONTAINER_NAME = "FBOSS_BUILD_CONTAINER"
@@ -146,6 +147,15 @@ def parse_args():
         default=False,
         action="store_true",
     )
+    parser.add_argument(
+        OPT_ARG_NUM_JOBS,
+        type=int,
+        required=False,
+        help=(
+            "Tell getdeps.py how many concurrent jobs to use while building. "
+            "If unspecified, the default is the number of cpus. (CPU(s) in lspcu output)"
+        ),
+    )
 
     return parser.parse_args()
 
@@ -198,6 +208,7 @@ def run_fboss_build(
     use_system_deps: bool,
     env_vars: list[str],
     use_local: bool,
+    num_jobs: Optional[int],
 ):
     cmd_args = ["sudo", "docker", "run"]
     # Add build environment variables, if any.
@@ -230,6 +241,9 @@ def run_fboss_build(
         "--scratch-path",
         f"{CONTAINER_SCRATCH_PATH}",
     ]
+    if num_jobs is not None:
+        build_cmd.append("--num-jobs")
+        build_cmd.append(str(num_jobs))
     if use_system_deps:
         build_cmd.append("--allow-system-packages")
     if target is not None:
@@ -289,6 +303,7 @@ def main():
         args.use_system_deps,
         args.env_vars,
         args.local,
+        args.num_jobs,
     )
 
     cleanup_fboss_build_container()


### PR DESCRIPTION
Summary:
docker-build.py makes a call to getdeps.py which contains control over parallelism. This diff will add a flag "num-jobs" to docker-build.py to more easily control the behavior of getdeps.py

this will help us in the future in the case that docker-build.py is causing memory to fill up during builds.

Differential Revision: D72008533


