### PR TITLE
icecube: config: added the preEVT first version of platform config 

### DIFF
--- a/fboss/platform/configs/icecube800bc/platform_manager.json
+++ b/fboss/platform/configs/icecube800bc/platform_manager.json
@@ -1,0 +1,3292 @@
+{
+  "platformName": "ICECUBE800BC",
+  "rootPmUnitName": "ICECUBE800BC_MCB",
+  "rootSlotType": "MCB_SLOT",
+  "slotTypeConfigs": {
+    "MCB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "idpromConfig": {
+        "busName": "SMBus I801 adapter at 5000",
+        "address": "0x53",
+        "kernelDeviceName": "24c02"
+      },
+      "pmUnitName": "ICECUBE800BC_MCB"
+    },
+    "RUNBMC_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x51",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "ICECUBE800BC_BMC"
+    },
+    "COMESE_SLOT": {
+      "numOutgoingI2cBuses": 2,
+      "idpromConfig": {
+        "busName": "INCOMING@1",
+        "address": "0x56",
+        "kernelDeviceName": "24c128"
+      },
+      "pmUnitName": "NETLAKE"
+    },
+    "PICT_SLOT": {
+      "numOutgoingI2cBuses": 3,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "ICECUBE800BC_PIC_T"
+    },
+    "PICB_SLOT": {
+      "numOutgoingI2cBuses": 3,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "ICECUBE800BC_PIC_B"
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "SMBus I801 adapter at 5000",
+    "SMBus iSMT adapter at 20fffa7b000"
+  ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x11",
+              "kernelDeviceName": "bp4f_mp9941",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x22",
+              "kernelDeviceName": "bp4f_mp9941",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x45",
+              "kernelDeviceName": "bp4f_mp9941",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x66",
+              "kernelDeviceName": "bp4f_mp9941",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x76",
+              "kernelDeviceName": "bp4f_mp2993",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
+            }
+          ]
+        },
+        "productSubVersion": 2
+      }
+    ]
+  },
+  "pmUnitConfigs": {
+    "ICECUBE800BC_MCB": {
+      "pluggedInSlotType": "MCB_SLOT",
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        }
+      ],
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "MCB_IOB",
+          "vendorId": "0x1d9b",
+          "deviceId": "0x0011",
+          "subSystemVendorId": "0x10ee",
+          "subSystemDeviceId": "0x0007",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_1",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_2",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_3",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_4",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_5",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_6",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_7",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_8",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_9",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_10",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_11",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_12",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_13",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_14",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_15",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_16",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_17",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_18",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_19",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_20",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_21",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_22",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_23",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_24",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_25",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_26",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_27",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_28",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_1",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_2",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_3",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_4",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_5",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_6",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_7",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_8",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_9",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_10",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_11",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_12",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_13",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_14",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_15",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_16",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_17",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_18",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_19",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_20",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_21",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_22",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_23",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_24",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_25",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_26",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_27",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_28",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_29",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_30",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_31",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_32",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_33",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x44000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_I2C_MASTER_34",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x44100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_1",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_2",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_3",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_4",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_5",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_6",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_7",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_8",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_9",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_10",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4a900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_11",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4aa00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_12",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4ab00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_13",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4ac00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_14",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4ad00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_15",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4ae00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_16",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4af00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_17",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_18",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_19",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_20",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_21",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_22",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_23",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_24",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_25",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_26",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4b900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_27",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4ba00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_28",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4bb00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_29",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4bc00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_30",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4bd00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_31",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4be00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_32",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4bf00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_33",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4c000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_34",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4c100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_I2C_MASTER_35",
+                "deviceName": "dom2_i2c_master",
+                "csrOffset": "0x4cc00"
+              }
+            }
+          ],
+          "gpioChipConfigs": [
+            {
+              "pmUnitScopedName": "MCB_GPIO_CHIP_1",
+              "deviceName": "gpiochip",
+              "csrOffset": "0x0400"
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_1",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10000",
+                "iobufOffset": "0x12000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_1_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_2",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10080",
+                "iobufOffset": "0x12400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_2_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_3",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10100",
+                "iobufOffset": "0x12800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_3_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_4",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10180",
+                "iobufOffset": "0x12c00"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_4_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_5",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10200",
+                "iobufOffset": "0x13000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_5_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_6",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10280",
+                "iobufOffset": "0x13400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_6_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_7",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10300",
+                "iobufOffset": "0x13800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_7_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "xcvrCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_3",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40200"
+              },
+              "portNumber": 3
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_4",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40204"
+              },
+              "portNumber": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_7",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40208"
+              },
+              "portNumber": 7
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_8",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4020c"
+              },
+              "portNumber": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_11",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40210"
+              },
+              "portNumber": 11
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_12",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40214"
+              },
+              "portNumber": 12
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_15",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40218"
+              },
+              "portNumber": 15
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_16",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4021c"
+              },
+              "portNumber": 16
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_19",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40220"
+              },
+              "portNumber": 19
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_20",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40224"
+              },
+              "portNumber": 20
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_23",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40228"
+              },
+              "portNumber": 23
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_24",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4022c"
+              },
+              "portNumber": 24
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_27",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40230"
+              },
+              "portNumber": 27
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_28",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40234"
+              },
+              "portNumber": 28
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_31",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40238"
+              },
+              "portNumber": 31
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_32",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4023c"
+              },
+              "portNumber": 32
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_35",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40240"
+              },
+              "portNumber": 35
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_36",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40244"
+              },
+              "portNumber": 36
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_39",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40248"
+              },
+              "portNumber": 39
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_40",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4024c"
+              },
+              "portNumber": 40
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_43",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40250"
+              },
+              "portNumber": 43
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_44",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40254"
+              },
+              "portNumber": 44
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_47",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40258"
+              },
+              "portNumber": 47
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_48",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4025c"
+              },
+              "portNumber": 48
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_51",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40260"
+              },
+              "portNumber": 51
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_52",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40264"
+              },
+              "portNumber": 52
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_55",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40268"
+              },
+              "portNumber": 55
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_56",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4026c"
+              },
+              "portNumber": 56
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_59",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40270"
+              },
+              "portNumber": 59
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_60",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40274"
+              },
+              "portNumber": 60
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_63",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40278"
+              },
+              "portNumber": 63
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_B_DOM_XCVR_CTRL_PORT_64",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4027c"
+              },
+              "portNumber": 64
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "IOB_XCVR_CTRL_PORT_65",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x1030"
+              },
+              "portNumber": 65
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_1",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48200"
+              },
+              "portNumber": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_2",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48204"
+              },
+              "portNumber": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_5",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48208"
+              },
+              "portNumber": 5
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_6",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4820c"
+              },
+              "portNumber": 6
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_9",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48210"
+              },
+              "portNumber": 9
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_10",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48214"
+              },
+              "portNumber": 10
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_13",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48218"
+              },
+              "portNumber": 13
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_14",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4821c"
+              },
+              "portNumber": 14
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_17",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48220"
+              },
+              "portNumber": 17
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_18",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48224"
+              },
+              "portNumber": 18
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_21",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48228"
+              },
+              "portNumber": 21
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_22",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4822c"
+              },
+              "portNumber": 22
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_25",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48230"
+              },
+              "portNumber": 25
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_26",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48234"
+              },
+              "portNumber": 26
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_29",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48238"
+              },
+              "portNumber": 29
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_30",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4823c"
+              },
+              "portNumber": 30
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_33",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48240"
+              },
+              "portNumber": 33
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_34",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48244"
+              },
+              "portNumber": 34
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_37",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48248"
+              },
+              "portNumber": 37
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_38",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4824c"
+              },
+              "portNumber": 38
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_41",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48250"
+              },
+              "portNumber": 41
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_42",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48254"
+              },
+              "portNumber": 42
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_45",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48258"
+              },
+              "portNumber": 45
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_46",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4825c"
+              },
+              "portNumber": 46
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_49",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48260"
+              },
+              "portNumber": 49
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_50",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48264"
+              },
+              "portNumber": 50
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_53",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48268"
+              },
+              "portNumber": 53
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_54",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4826c"
+              },
+              "portNumber": 54
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_57",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48270"
+              },
+              "portNumber": 57
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_58",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48274"
+              },
+              "portNumber": 58
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_61",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x48278"
+              },
+              "portNumber": 61
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_T_DOM_XCVR_CTRL_PORT_62",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4827c"
+              },
+              "portNumber": 62
+            }
+          ],
+          "ledCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_1_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40410"
+              },
+              "portNumber": 1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_2_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40418"
+              },
+              "portNumber": 2,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_3_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40420"
+              },
+              "portNumber": 3,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_4_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40428"
+              },
+              "portNumber": 4,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_5_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40430"
+              },
+              "portNumber": 5,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_6_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40438"
+              },
+              "portNumber": 6,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_7_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40440"
+              },
+              "portNumber": 7,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_8_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40448"
+              },
+              "portNumber": 8,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_9_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40450"
+              },
+              "portNumber": 9,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_10_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40458"
+              },
+              "portNumber": 10,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_11_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40460"
+              },
+              "portNumber": 11,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_12_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40468"
+              },
+              "portNumber": 12,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_13_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40470"
+              },
+              "portNumber": 13,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_14_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40478"
+              },
+              "portNumber": 14,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_15_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40480"
+              },
+              "portNumber": 15,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_16_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40488"
+              },
+              "portNumber": 16,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_17_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40490"
+              },
+              "portNumber": 17,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_18_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40498"
+              },
+              "portNumber": 18,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_19_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a0"
+              },
+              "portNumber": 19,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_20_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a8"
+              },
+              "portNumber": 20,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_21_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b0"
+              },
+              "portNumber": 21,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_22_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b8"
+              },
+              "portNumber": 22,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_23_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c0"
+              },
+              "portNumber": 23,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_24_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c8"
+              },
+              "portNumber": 24,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_25_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d0"
+              },
+              "portNumber": 25,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_26_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d8"
+              },
+              "portNumber": 26,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_27_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e0"
+              },
+              "portNumber": 27,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_28_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e8"
+              },
+              "portNumber": 28,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_29_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f0"
+              },
+              "portNumber": 29,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_30_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f8"
+              },
+              "portNumber": 30,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_31_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40500"
+              },
+              "portNumber": 31,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_32_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40508"
+              },
+              "portNumber": 32,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_1_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40414"
+              },
+              "portNumber": 1,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_2_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4041c"
+              },
+              "portNumber": 2,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_3_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40424"
+              },
+              "portNumber": 3,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_4_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4042c"
+              },
+              "portNumber": 4,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_5_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40434"
+              },
+              "portNumber": 5,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_6_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4043c"
+              },
+              "portNumber": 6,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_7_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40444"
+              },
+              "portNumber": 7,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_8_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4044c"
+              },
+              "portNumber": 8,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_9_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40454"
+              },
+              "portNumber": 9,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_10_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4045c"
+              },
+              "portNumber": 10,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_11_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40464"
+              },
+              "portNumber": 11,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_12_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4046c"
+              },
+              "portNumber": 12,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_13_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40474"
+              },
+              "portNumber": 13,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_14_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4047c"
+              },
+              "portNumber": 14,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_15_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40484"
+              },
+              "portNumber": 15,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_16_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4048c"
+              },
+              "portNumber": 16,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_17_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40494"
+              },
+              "portNumber": 17,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_18_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4049c"
+              },
+              "portNumber": 18,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_19_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a4"
+              },
+              "portNumber": 19,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_20_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404ac"
+              },
+              "portNumber": 20,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_21_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b4"
+              },
+              "portNumber": 21,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_22_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404bc"
+              },
+              "portNumber": 22,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_23_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c4"
+              },
+              "portNumber": 23,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_24_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404cc"
+              },
+              "portNumber": 24,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_25_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d4"
+              },
+              "portNumber": 25,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_26_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404dc"
+              },
+              "portNumber": 26,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_27_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e4"
+              },
+              "portNumber": 27,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_28_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404ec"
+              },
+              "portNumber": 28,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_29_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f4"
+              },
+              "portNumber": 29,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_30_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404fc"
+              },
+              "portNumber": 30,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_31_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40504"
+              },
+              "portNumber": 31,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_32_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4050c"
+              },
+              "portNumber": 32,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_33_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48410"
+              },
+              "portNumber": 33,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_34_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48418"
+              },
+              "portNumber": 34,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_35_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48420"
+              },
+              "portNumber": 35,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_36_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48428"
+              },
+              "portNumber": 36,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_37_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48430"
+              },
+              "portNumber": 37,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_38_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48438"
+              },
+              "portNumber": 38,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_39_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48440"
+              },
+              "portNumber": 39,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_40_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48448"
+              },
+              "portNumber": 40,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_41_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48450"
+              },
+              "portNumber": 41,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_42_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48458"
+              },
+              "portNumber": 42,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_43_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48460"
+              },
+              "portNumber": 43,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_44_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48468"
+              },
+              "portNumber": 44,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_45_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48470"
+              },
+              "portNumber": 45,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_46_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48478"
+              },
+              "portNumber": 46,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_47_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48480"
+              },
+              "portNumber": 47,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_48_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48488"
+              },
+              "portNumber": 48,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_49_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48490"
+              },
+              "portNumber": 49,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_50_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48498"
+              },
+              "portNumber": 50,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_51_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484a0"
+              },
+              "portNumber": 51,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_52_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484a8"
+              },
+              "portNumber": 52,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_53_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484b0"
+              },
+              "portNumber": 53,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_54_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484b8"
+              },
+              "portNumber": 54,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_55_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484c0"
+              },
+              "portNumber": 55,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_56_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484c8"
+              },
+              "portNumber": 56,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_57_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484d0"
+              },
+              "portNumber": 57,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_58_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484d8"
+              },
+              "portNumber": 58,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_59_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484e0"
+              },
+              "portNumber": 59,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_60_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484e8"
+              },
+              "portNumber": 60,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_61_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484f0"
+              },
+              "portNumber": 61,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_62_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x484f8"
+              },
+              "portNumber": 62,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_63_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48500"
+              },
+              "portNumber": 63,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_64_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x48508"
+              },
+              "portNumber": 64,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_33_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48414"
+              },
+              "portNumber": 33,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_34_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4841c"
+              },
+              "portNumber": 34,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_35_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48424"
+              },
+              "portNumber": 35,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_36_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4842c"
+              },
+              "portNumber": 36,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_37_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48434"
+              },
+              "portNumber": 37,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_38_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4843c"
+              },
+              "portNumber": 38,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_39_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48444"
+              },
+              "portNumber": 39,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_40_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4844c"
+              },
+              "portNumber": 40,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_41_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48454"
+              },
+              "portNumber": 41,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_42_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4845c"
+              },
+              "portNumber": 42,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_43_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48464"
+              },
+              "portNumber": 43,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_44_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4846c"
+              },
+              "portNumber": 44,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_45_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48474"
+              },
+              "portNumber": 45,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_46_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4847c"
+              },
+              "portNumber": 46,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_47_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48484"
+              },
+              "portNumber": 47,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_48_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4848c"
+              },
+              "portNumber": 48,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_49_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48494"
+              },
+              "portNumber": 49,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_50_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4849c"
+              },
+              "portNumber": 50,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_51_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484a4"
+              },
+              "portNumber": 51,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_52_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484ac"
+              },
+              "portNumber": 52,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_53_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484b4"
+              },
+              "portNumber": 53,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_54_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484bc"
+              },
+              "portNumber": 54,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_55_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484c4"
+              },
+              "portNumber": 55,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_56_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484cc"
+              },
+              "portNumber": 56,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_57_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484d4"
+              },
+              "portNumber": 57,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_58_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484dc"
+              },
+              "portNumber": 58,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_59_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484e4"
+              },
+              "portNumber": 59,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_60_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484ec"
+              },
+              "portNumber": 60,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_61_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484f4"
+              },
+              "portNumber": 61,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_62_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x484fc"
+              },
+              "portNumber": 62,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_63_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x48504"
+              },
+              "portNumber": 63,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_64_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4850c"
+              },
+              "portNumber": 64,
+              "ledId": 2
+            }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "MCB_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            },
+            {
+              "pmUnitScopedName": "PIC_T_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x40000"
+            },
+            {
+              "pmUnitScopedName": "PIC_B_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x48000"
+            }
+          ]
+        }
+      ],
+      "i2cDeviceConfigs": [
+        {
+          "busName": "MCB_IOB_I2C_MASTER_2",
+          "address": "0x70",
+          "kernelDeviceName": "pca9546",
+          "pmUnitScopedName": "MCB_MUX",
+          "numOutgoingChannels": 4
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_3",
+          "address": "0x35",
+          "kernelDeviceName": "icecube_scmcpld",
+          "pmUnitScopedName": "SCM_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x60",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_1"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x61",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_2"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PWR_BRICK_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_9",
+          "address": "0x62",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_3"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_13",
+          "address": "0x4e",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x33",
+          "kernelDeviceName": "icecube_fancpld",
+          "pmUnitScopedName": "MCB_FAN_CPLD",
+          "isWatchdog": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x60",
+          "kernelDeviceName": "icecube_mcbcpld",
+          "pmUnitScopedName": "MCB_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_15",
+          "address": "0x53",
+          "kernelDeviceName": "24c64",
+          "pmUnitScopedName": "CHASSIS_EEPROM"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "LOAD_SWITCH_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_19",
+          "address": "0x40",
+          "kernelDeviceName": "bp4f_ina238",
+          "pmUnitScopedName": "MCB_VOLTAGE_MONITOR1"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_20",
+          "address": "0x41",
+          "kernelDeviceName": "bp4f_ina238",
+          "pmUnitScopedName": "MCB_VOLTAGE_MONITOR2"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_21",
+          "address": "0x44",
+          "kernelDeviceName": "bp4f_ina238",
+          "pmUnitScopedName": "MCB_VOLTAGE_MONITOR3"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_22",
+          "address": "0x45",
+          "kernelDeviceName": "bp4f_ina238",
+          "pmUnitScopedName": "MCB_VOLTAGE_MONITOR4"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_23",
+          "address": "0x11",
+          "kernelDeviceName": "ltc4287",
+          "pmUnitScopedName": "48V_HSC_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC1_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x37",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC2_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_18",
+          "address": "0x48",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_U18_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_18",
+          "address": "0x4a",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_U39_OUTLET_TSENSOR"
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RUNBMC_SLOT@0": {
+          "slotType": "RUNBMC_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_1"
+          ]
+        },
+        "COMESE_SLOT@0": {
+          "slotType": "COMESE_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_MUX@1",
+            "MCB_IOB_I2C_MASTER_18"
+          ]
+        },
+        "PICT_SLOT@0": {
+          "slotType": "PICT_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_26",
+            "PIC_T_DOM_I2C_MASTER_33",
+            "PIC_T_DOM_I2C_MASTER_34"
+          ]
+        },
+        "PICB_SLOT@0": {
+          "slotType": "PICB_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_27",
+            "PIC_B_DOM_I2C_MASTER_33",
+            "PIC_B_DOM_I2C_MASTER_34"
+          ]
+        }
+      }
+    },
+    "ICECUBE800BC_BMC": {
+      "pluggedInSlotType": "RUNBMC_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4a",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RUNBMC_THERMAL_SENSOR"
+        }
+      ]
+    },
+    "NETLAKE": {
+      "pluggedInSlotType": "COMESE_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x11",
+          "kernelDeviceName": "bp4f_tda38640",
+          "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x22",
+          "kernelDeviceName": "bp4f_tda38640",
+          "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x45",
+          "kernelDeviceName": "bp4f_tda38640",
+          "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x66",
+          "kernelDeviceName": "bp4f_tda38640",
+          "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x76",
+          "kernelDeviceName": "bp4f_xdpe15284",
+          "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
+        }
+      ]
+    },
+    "ICECUBE800BC_PIC_T": {
+      "pluggedInSlotType": "PICT_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x33",
+          "kernelDeviceName": "icecube_piccpld",
+          "pmUnitScopedName": "PIC_T_CPLD"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x66",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_T_XP3R3V_L_MONITOR"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x70",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_T_XP3R3V_R_MONITOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "PIC_T_ADC_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_T_TSENSOR_1"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_T_TSENSOR_2"
+        }
+      ]
+    },
+    "ICECUBE800BC_PIC_B": {
+      "pluggedInSlotType": "PICB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x33",
+          "kernelDeviceName": "icecube_piccpld",
+          "pmUnitScopedName": "PIC_B_CPLD"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x66",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_B_XP3R3V_L_MONITOR"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x70",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_B_XP3R3V_R_MONITOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "PIC_B_ADC_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_B_TSENSOR_1"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_B_TSENSOR_2"
+        }
+      ]
+    }
+  },
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/eeproms/MCB_EEPROM": "/[IDPROM]",
+    "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_EEPROM]",
+    "/run/devmap/eeproms/RUNBMC_EEPROM": "/RUNBMC_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/COME_EEPROM": "/COMESE_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/PIC_T_EEPROM": "/PICT_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/PIC_B_EEPROM": "/PICB_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/PMBUS_1": "/[PMBUS_1]",
+    "/run/devmap/sensors/PMBUS_2": "/[PMBUS_2]",
+    "/run/devmap/sensors/COME_INLET_TSENSOR": "/[COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/PWR_BRICK_INLET_TSENSOR": "/[PWR_BRICK_INLET_TSENSOR]",
+    "/run/devmap/sensors/PMBUS_3": "/[PMBUS_3]",
+    "/run/devmap/sensors/COME_OUTLET_TSENSOR": "/[COME_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_FAN_CPLD": "/[MCB_FAN_CPLD]",
+    "/run/devmap/sensors/LOAD_SWITCH_MONITOR": "/[LOAD_SWITCH_MONITOR]",
+    "/run/devmap/sensors/MCB_VOLTAGE_MONITOR1": "/[MCB_VOLTAGE_MONITOR1]",
+    "/run/devmap/sensors/MCB_VOLTAGE_MONITOR2": "/[MCB_VOLTAGE_MONITOR2]",
+    "/run/devmap/sensors/MCB_VOLTAGE_MONITOR3": "/[MCB_VOLTAGE_MONITOR3]",
+    "/run/devmap/sensors/MCB_VOLTAGE_MONITOR4": "/[MCB_VOLTAGE_MONITOR4]",
+    "/run/devmap/sensors/48V_HSC_MONITOR": "/[48V_HSC_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC1_MONITOR": "/[MCB_ADC1_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC2_MONITOR": "/[MCB_ADC2_MONITOR]",
+    "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
+    "/run/devmap/sensors/PIC_T_XP3R3V_L_MONITOR": "/PICT_SLOT@0/[PIC_T_XP3R3V_L_MONITOR]",
+    "/run/devmap/sensors/PIC_T_XP3R3V_R_MONITOR": "/PICT_SLOT@0/[PIC_T_XP3R3V_R_MONITOR]",
+    "/run/devmap/sensors/PIC_T_ADC_SENSOR": "/PICT_SLOT@0/[PIC_T_ADC_SENSOR]",
+    "/run/devmap/sensors/PIC_T_TSENSOR_1": "/PICT_SLOT@0/[PIC_T_TSENSOR_1]",
+    "/run/devmap/sensors/PIC_T_TSENSOR_2": "/PICT_SLOT@0/[PIC_T_TSENSOR_2]",
+    "/run/devmap/sensors/PIC_B_XP3R3V_L_MONITOR": "/PICB_SLOT@0/[PIC_B_XP3R3V_L_MONITOR]",
+    "/run/devmap/sensors/PIC_B_XP3R3V_R_MONITOR": "/PICB_SLOT@0/[PIC_B_XP3R3V_R_MONITOR]",
+    "/run/devmap/sensors/PIC_B_ADC_SENSOR": "/PICB_SLOT@0/[PIC_B_ADC_SENSOR]",
+    "/run/devmap/sensors/PIC_B_TSENSOR_1": "/PICB_SLOT@0/[PIC_B_TSENSOR_1]",
+    "/run/devmap/sensors/PIC_B_TSENSOR_2": "/PICB_SLOT@0/[PIC_B_TSENSOR_2]",
+    "/run/devmap/cplds/SCM_CPLD": "/[SCM_CPLD]",
+    "/run/devmap/cplds/MCB_CPLD": "/[MCB_CPLD]",
+    "/run/devmap/cplds/PIC_T_CPLD": "/PICT_SLOT@0/[PIC_T_CPLD]",
+    "/run/devmap/cplds/PIC_B_CPLD": "/PICB_SLOT@0/[PIC_B_CPLD]",
+    "/run/devmap/fpgas/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/fpgas/PIC_T_DOM_INFO_ROM": "/[PIC_T_DOM_INFO_ROM]",
+    "/run/devmap/fpgas/PIC_B_DOM_INFO_ROM": "/[PIC_B_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/inforoms/PIC_T_DOM_INFO_ROM": "/[PIC_T_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/PIC_B_DOM_INFO_ROM": "/[PIC_B_DOM_INFO_ROM]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_1": "/[MCB_IOB_I2C_MASTER_1]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_2": "/[MCB_IOB_I2C_MASTER_2]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_3": "/[MCB_IOB_I2C_MASTER_3]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_4": "/[MCB_IOB_I2C_MASTER_4]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_5": "/[MCB_IOB_I2C_MASTER_5]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_6": "/[MCB_IOB_I2C_MASTER_6]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_7": "/[MCB_IOB_I2C_MASTER_7]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_8": "/[MCB_IOB_I2C_MASTER_8]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_9": "/[MCB_IOB_I2C_MASTER_9]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_10": "/[MCB_IOB_I2C_MASTER_10]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_11": "/[MCB_IOB_I2C_MASTER_11]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_12": "/[MCB_IOB_I2C_MASTER_12]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_13": "/[MCB_IOB_I2C_MASTER_13]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_14": "/[MCB_IOB_I2C_MASTER_14]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_15": "/[MCB_IOB_I2C_MASTER_15]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_16": "/[MCB_IOB_I2C_MASTER_16]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_17": "/[MCB_IOB_I2C_MASTER_17]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_18": "/[MCB_IOB_I2C_MASTER_18]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_19": "/[MCB_IOB_I2C_MASTER_19]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_20": "/[MCB_IOB_I2C_MASTER_20]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_21": "/[MCB_IOB_I2C_MASTER_21]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_22": "/[MCB_IOB_I2C_MASTER_22]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_23": "/[MCB_IOB_I2C_MASTER_23]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_24": "/[MCB_IOB_I2C_MASTER_24]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_25": "/[MCB_IOB_I2C_MASTER_25]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_26": "/[MCB_IOB_I2C_MASTER_26]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_27": "/[MCB_IOB_I2C_MASTER_27]",
+    "/run/devmap/sensors/COME_VOLTAGE_MONITOR1": "/COMESE_SLOT@0/[COME_VOLTAGE_MONITOR1]",
+    "/run/devmap/sensors/COME_VOLTAGE_MONITOR2": "/COMESE_SLOT@0/[COME_VOLTAGE_MONITOR2]",
+    "/run/devmap/sensors/COME_VOLTAGE_MONITOR3": "/COMESE_SLOT@0/[COME_VOLTAGE_MONITOR3]",
+    "/run/devmap/sensors/COME_VOLTAGE_MONITOR4": "/COMESE_SLOT@0/[COME_VOLTAGE_MONITOR4]",
+    "/run/devmap/sensors/COME_VOLTAGE_MONITOR5": "/COMESE_SLOT@0/[COME_VOLTAGE_MONITOR5]",
+    "/run/devmap/sensors/COME_U18_INLET_TSENSOR": "/[COME_U18_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR": "/[COME_U39_OUTLET_TSENSOR]",
+    "/run/devmap/i2c-busses/XCVR_3": "/[PIC_B_DOM_I2C_MASTER_1]",
+    "/run/devmap/i2c-busses/XCVR_4": "/[PIC_B_DOM_I2C_MASTER_2]",
+    "/run/devmap/i2c-busses/XCVR_7": "/[PIC_B_DOM_I2C_MASTER_3]",
+    "/run/devmap/i2c-busses/XCVR_8": "/[PIC_B_DOM_I2C_MASTER_4]",
+    "/run/devmap/i2c-busses/XCVR_11": "/[PIC_B_DOM_I2C_MASTER_5]",
+    "/run/devmap/i2c-busses/XCVR_12": "/[PIC_B_DOM_I2C_MASTER_6]",
+    "/run/devmap/i2c-busses/XCVR_15": "/[PIC_B_DOM_I2C_MASTER_7]",
+    "/run/devmap/i2c-busses/XCVR_16": "/[PIC_B_DOM_I2C_MASTER_8]",
+    "/run/devmap/i2c-busses/XCVR_19": "/[PIC_B_DOM_I2C_MASTER_9]",
+    "/run/devmap/i2c-busses/XCVR_20": "/[PIC_B_DOM_I2C_MASTER_10]",
+    "/run/devmap/i2c-busses/XCVR_23": "/[PIC_B_DOM_I2C_MASTER_11]",
+    "/run/devmap/i2c-busses/XCVR_24": "/[PIC_B_DOM_I2C_MASTER_12]",
+    "/run/devmap/i2c-busses/XCVR_27": "/[PIC_B_DOM_I2C_MASTER_13]",
+    "/run/devmap/i2c-busses/XCVR_28": "/[PIC_B_DOM_I2C_MASTER_14]",
+    "/run/devmap/i2c-busses/XCVR_31": "/[PIC_B_DOM_I2C_MASTER_15]",
+    "/run/devmap/i2c-busses/XCVR_32": "/[PIC_B_DOM_I2C_MASTER_16]",
+    "/run/devmap/i2c-busses/XCVR_35": "/[PIC_B_DOM_I2C_MASTER_17]",
+    "/run/devmap/i2c-busses/XCVR_36": "/[PIC_B_DOM_I2C_MASTER_18]",
+    "/run/devmap/i2c-busses/XCVR_39": "/[PIC_B_DOM_I2C_MASTER_19]",
+    "/run/devmap/i2c-busses/XCVR_40": "/[PIC_B_DOM_I2C_MASTER_20]",
+    "/run/devmap/i2c-busses/XCVR_43": "/[PIC_B_DOM_I2C_MASTER_21]",
+    "/run/devmap/i2c-busses/XCVR_44": "/[PIC_B_DOM_I2C_MASTER_22]",
+    "/run/devmap/i2c-busses/XCVR_47": "/[PIC_B_DOM_I2C_MASTER_23]",
+    "/run/devmap/i2c-busses/XCVR_48": "/[PIC_B_DOM_I2C_MASTER_24]",
+    "/run/devmap/i2c-busses/XCVR_51": "/[PIC_B_DOM_I2C_MASTER_25]",
+    "/run/devmap/i2c-busses/XCVR_52": "/[PIC_B_DOM_I2C_MASTER_26]",
+    "/run/devmap/i2c-busses/XCVR_55": "/[PIC_B_DOM_I2C_MASTER_27]",
+    "/run/devmap/i2c-busses/XCVR_56": "/[PIC_B_DOM_I2C_MASTER_28]",
+    "/run/devmap/i2c-busses/XCVR_59": "/[PIC_B_DOM_I2C_MASTER_29]",
+    "/run/devmap/i2c-busses/XCVR_60": "/[PIC_B_DOM_I2C_MASTER_30]",
+    "/run/devmap/i2c-busses/XCVR_63": "/[PIC_B_DOM_I2C_MASTER_31]",
+    "/run/devmap/i2c-busses/XCVR_64": "/[PIC_B_DOM_I2C_MASTER_32]",
+    "/run/devmap/i2c-busses/PIC_B_DOM_I2C_MASTER_33": "/[PIC_B_DOM_I2C_MASTER_33]",
+    "/run/devmap/i2c-busses/PIC_B_DOM_I2C_MASTER_34": "/[PIC_B_DOM_I2C_MASTER_34]",
+    "/run/devmap/i2c-busses/XCVR_1": "/[PIC_T_DOM_I2C_MASTER_1]",
+    "/run/devmap/i2c-busses/XCVR_2": "/[PIC_T_DOM_I2C_MASTER_2]",
+    "/run/devmap/i2c-busses/XCVR_5": "/[PIC_T_DOM_I2C_MASTER_3]",
+    "/run/devmap/i2c-busses/XCVR_6": "/[PIC_T_DOM_I2C_MASTER_4]",
+    "/run/devmap/i2c-busses/XCVR_9": "/[PIC_T_DOM_I2C_MASTER_5]",
+    "/run/devmap/i2c-busses/XCVR_10": "/[PIC_T_DOM_I2C_MASTER_6]",
+    "/run/devmap/i2c-busses/XCVR_13": "/[PIC_T_DOM_I2C_MASTER_7]",
+    "/run/devmap/i2c-busses/XCVR_14": "/[PIC_T_DOM_I2C_MASTER_8]",
+    "/run/devmap/i2c-busses/XCVR_17": "/[PIC_T_DOM_I2C_MASTER_9]",
+    "/run/devmap/i2c-busses/XCVR_18": "/[PIC_T_DOM_I2C_MASTER_10]",
+    "/run/devmap/i2c-busses/XCVR_21": "/[PIC_T_DOM_I2C_MASTER_11]",
+    "/run/devmap/i2c-busses/XCVR_22": "/[PIC_T_DOM_I2C_MASTER_12]",
+    "/run/devmap/i2c-busses/XCVR_25": "/[PIC_T_DOM_I2C_MASTER_13]",
+    "/run/devmap/i2c-busses/XCVR_26": "/[PIC_T_DOM_I2C_MASTER_14]",
+    "/run/devmap/i2c-busses/XCVR_29": "/[PIC_T_DOM_I2C_MASTER_15]",
+    "/run/devmap/i2c-busses/XCVR_30": "/[PIC_T_DOM_I2C_MASTER_16]",
+    "/run/devmap/i2c-busses/XCVR_33": "/[PIC_T_DOM_I2C_MASTER_17]",
+    "/run/devmap/i2c-busses/XCVR_34": "/[PIC_T_DOM_I2C_MASTER_18]",
+    "/run/devmap/i2c-busses/XCVR_37": "/[PIC_T_DOM_I2C_MASTER_19]",
+    "/run/devmap/i2c-busses/XCVR_38": "/[PIC_T_DOM_I2C_MASTER_20]",
+    "/run/devmap/i2c-busses/XCVR_41": "/[PIC_T_DOM_I2C_MASTER_21]",
+    "/run/devmap/i2c-busses/XCVR_42": "/[PIC_T_DOM_I2C_MASTER_22]",
+    "/run/devmap/i2c-busses/XCVR_45": "/[PIC_T_DOM_I2C_MASTER_23]",
+    "/run/devmap/i2c-busses/XCVR_46": "/[PIC_T_DOM_I2C_MASTER_24]",
+    "/run/devmap/i2c-busses/XCVR_49": "/[PIC_T_DOM_I2C_MASTER_25]",
+    "/run/devmap/i2c-busses/XCVR_50": "/[PIC_T_DOM_I2C_MASTER_26]",
+    "/run/devmap/i2c-busses/XCVR_53": "/[PIC_T_DOM_I2C_MASTER_27]",
+    "/run/devmap/i2c-busses/XCVR_54": "/[PIC_T_DOM_I2C_MASTER_28]",
+    "/run/devmap/i2c-busses/XCVR_57": "/[PIC_T_DOM_I2C_MASTER_29]",
+    "/run/devmap/i2c-busses/XCVR_58": "/[PIC_T_DOM_I2C_MASTER_30]",
+    "/run/devmap/i2c-busses/XCVR_61": "/[PIC_T_DOM_I2C_MASTER_31]",
+    "/run/devmap/i2c-busses/XCVR_62": "/[PIC_T_DOM_I2C_MASTER_32]",
+    "/run/devmap/i2c-busses/XCVR_65": "/[PIC_T_DOM_I2C_MASTER_35]",
+    "/run/devmap/i2c-busses/PIC_T_DOM_I2C_MASTER_33": "/[PIC_T_DOM_I2C_MASTER_33]",
+    "/run/devmap/i2c-busses/PIC_T_DOM_I2C_MASTER_34": "/[PIC_T_DOM_I2C_MASTER_34]",
+    "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
+    "/run/devmap/xcvrs/xcvr_1": "/[PIC_T_DOM_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_2": "/[PIC_T_DOM_XCVR_CTRL_PORT_2]",
+    "/run/devmap/xcvrs/xcvr_3": "/[PIC_B_DOM_XCVR_CTRL_PORT_3]",
+    "/run/devmap/xcvrs/xcvr_4": "/[PIC_B_DOM_XCVR_CTRL_PORT_4]",
+    "/run/devmap/xcvrs/xcvr_5": "/[PIC_T_DOM_XCVR_CTRL_PORT_5]",
+    "/run/devmap/xcvrs/xcvr_6": "/[PIC_T_DOM_XCVR_CTRL_PORT_6]",
+    "/run/devmap/xcvrs/xcvr_7": "/[PIC_B_DOM_XCVR_CTRL_PORT_7]",
+    "/run/devmap/xcvrs/xcvr_8": "/[PIC_B_DOM_XCVR_CTRL_PORT_8]",
+    "/run/devmap/xcvrs/xcvr_9": "/[PIC_T_DOM_XCVR_CTRL_PORT_9]",
+    "/run/devmap/xcvrs/xcvr_10": "/[PIC_T_DOM_XCVR_CTRL_PORT_10]",
+    "/run/devmap/xcvrs/xcvr_11": "/[PIC_B_DOM_XCVR_CTRL_PORT_11]",
+    "/run/devmap/xcvrs/xcvr_12": "/[PIC_B_DOM_XCVR_CTRL_PORT_12]",
+    "/run/devmap/xcvrs/xcvr_13": "/[PIC_T_DOM_XCVR_CTRL_PORT_13]",
+    "/run/devmap/xcvrs/xcvr_14": "/[PIC_T_DOM_XCVR_CTRL_PORT_14]",
+    "/run/devmap/xcvrs/xcvr_15": "/[PIC_B_DOM_XCVR_CTRL_PORT_15]",
+    "/run/devmap/xcvrs/xcvr_16": "/[PIC_B_DOM_XCVR_CTRL_PORT_16]",
+    "/run/devmap/xcvrs/xcvr_17": "/[PIC_T_DOM_XCVR_CTRL_PORT_17]",
+    "/run/devmap/xcvrs/xcvr_18": "/[PIC_T_DOM_XCVR_CTRL_PORT_18]",
+    "/run/devmap/xcvrs/xcvr_19": "/[PIC_B_DOM_XCVR_CTRL_PORT_19]",
+    "/run/devmap/xcvrs/xcvr_20": "/[PIC_B_DOM_XCVR_CTRL_PORT_20]",
+    "/run/devmap/xcvrs/xcvr_21": "/[PIC_T_DOM_XCVR_CTRL_PORT_21]",
+    "/run/devmap/xcvrs/xcvr_22": "/[PIC_T_DOM_XCVR_CTRL_PORT_22]",
+    "/run/devmap/xcvrs/xcvr_23": "/[PIC_B_DOM_XCVR_CTRL_PORT_23]",
+    "/run/devmap/xcvrs/xcvr_24": "/[PIC_B_DOM_XCVR_CTRL_PORT_24]",
+    "/run/devmap/xcvrs/xcvr_25": "/[PIC_T_DOM_XCVR_CTRL_PORT_25]",
+    "/run/devmap/xcvrs/xcvr_26": "/[PIC_T_DOM_XCVR_CTRL_PORT_26]",
+    "/run/devmap/xcvrs/xcvr_27": "/[PIC_B_DOM_XCVR_CTRL_PORT_27]",
+    "/run/devmap/xcvrs/xcvr_28": "/[PIC_B_DOM_XCVR_CTRL_PORT_28]",
+    "/run/devmap/xcvrs/xcvr_29": "/[PIC_T_DOM_XCVR_CTRL_PORT_29]",
+    "/run/devmap/xcvrs/xcvr_30": "/[PIC_T_DOM_XCVR_CTRL_PORT_30]",
+    "/run/devmap/xcvrs/xcvr_31": "/[PIC_B_DOM_XCVR_CTRL_PORT_31]",
+    "/run/devmap/xcvrs/xcvr_32": "/[PIC_B_DOM_XCVR_CTRL_PORT_32]",
+    "/run/devmap/xcvrs/xcvr_33": "/[PIC_T_DOM_XCVR_CTRL_PORT_33]",
+    "/run/devmap/xcvrs/xcvr_34": "/[PIC_T_DOM_XCVR_CTRL_PORT_34]",
+    "/run/devmap/xcvrs/xcvr_35": "/[PIC_B_DOM_XCVR_CTRL_PORT_35]",
+    "/run/devmap/xcvrs/xcvr_36": "/[PIC_B_DOM_XCVR_CTRL_PORT_36]",
+    "/run/devmap/xcvrs/xcvr_37": "/[PIC_T_DOM_XCVR_CTRL_PORT_37]",
+    "/run/devmap/xcvrs/xcvr_38": "/[PIC_T_DOM_XCVR_CTRL_PORT_38]",
+    "/run/devmap/xcvrs/xcvr_39": "/[PIC_B_DOM_XCVR_CTRL_PORT_39]",
+    "/run/devmap/xcvrs/xcvr_40": "/[PIC_B_DOM_XCVR_CTRL_PORT_40]",
+    "/run/devmap/xcvrs/xcvr_41": "/[PIC_T_DOM_XCVR_CTRL_PORT_41]",
+    "/run/devmap/xcvrs/xcvr_42": "/[PIC_T_DOM_XCVR_CTRL_PORT_42]",
+    "/run/devmap/xcvrs/xcvr_43": "/[PIC_B_DOM_XCVR_CTRL_PORT_43]",
+    "/run/devmap/xcvrs/xcvr_44": "/[PIC_B_DOM_XCVR_CTRL_PORT_44]",
+    "/run/devmap/xcvrs/xcvr_45": "/[PIC_T_DOM_XCVR_CTRL_PORT_45]",
+    "/run/devmap/xcvrs/xcvr_46": "/[PIC_T_DOM_XCVR_CTRL_PORT_46]",
+    "/run/devmap/xcvrs/xcvr_47": "/[PIC_B_DOM_XCVR_CTRL_PORT_47]",
+    "/run/devmap/xcvrs/xcvr_48": "/[PIC_B_DOM_XCVR_CTRL_PORT_48]",
+    "/run/devmap/xcvrs/xcvr_49": "/[PIC_T_DOM_XCVR_CTRL_PORT_49]",
+    "/run/devmap/xcvrs/xcvr_50": "/[PIC_T_DOM_XCVR_CTRL_PORT_50]",
+    "/run/devmap/xcvrs/xcvr_51": "/[PIC_B_DOM_XCVR_CTRL_PORT_51]",
+    "/run/devmap/xcvrs/xcvr_52": "/[PIC_B_DOM_XCVR_CTRL_PORT_52]",
+    "/run/devmap/xcvrs/xcvr_53": "/[PIC_T_DOM_XCVR_CTRL_PORT_53]",
+    "/run/devmap/xcvrs/xcvr_54": "/[PIC_T_DOM_XCVR_CTRL_PORT_54]",
+    "/run/devmap/xcvrs/xcvr_55": "/[PIC_B_DOM_XCVR_CTRL_PORT_55]",
+    "/run/devmap/xcvrs/xcvr_56": "/[PIC_B_DOM_XCVR_CTRL_PORT_56]",
+    "/run/devmap/xcvrs/xcvr_57": "/[PIC_T_DOM_XCVR_CTRL_PORT_57]",
+    "/run/devmap/xcvrs/xcvr_58": "/[PIC_T_DOM_XCVR_CTRL_PORT_58]",
+    "/run/devmap/xcvrs/xcvr_59": "/[PIC_B_DOM_XCVR_CTRL_PORT_59]",
+    "/run/devmap/xcvrs/xcvr_60": "/[PIC_B_DOM_XCVR_CTRL_PORT_60]",
+    "/run/devmap/xcvrs/xcvr_61": "/[PIC_T_DOM_XCVR_CTRL_PORT_61]",
+    "/run/devmap/xcvrs/xcvr_62": "/[PIC_T_DOM_XCVR_CTRL_PORT_62]",
+    "/run/devmap/xcvrs/xcvr_63": "/[PIC_B_DOM_XCVR_CTRL_PORT_63]",
+    "/run/devmap/xcvrs/xcvr_64": "/[PIC_B_DOM_XCVR_CTRL_PORT_64]",
+    "/run/devmap/xcvrs/xcvr_65": "/[IOB_XCVR_CTRL_PORT_65]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1": "/[MCB_SPI_MASTER_3_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1": "/[MCB_SPI_MASTER_4_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1": "/[MCB_SPI_MASTER_5_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_6_DEVICE_1": "/[MCB_SPI_MASTER_6_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1": "/[MCB_SPI_MASTER_7_DEVICE_1]",
+    "/run/devmap/xcvrs/xcvr_io_1": "/[PIC_T_DOM_I2C_MASTER_1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_1": "/[PIC_T_DOM_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_io_2": "/[PIC_T_DOM_I2C_MASTER_2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_2": "/[PIC_T_DOM_XCVR_CTRL_PORT_2]",
+    "/run/devmap/xcvrs/xcvr_io_3": "/[PIC_B_DOM_I2C_MASTER_1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_3": "/[PIC_B_DOM_XCVR_CTRL_PORT_3]",
+    "/run/devmap/xcvrs/xcvr_io_4": "/[PIC_B_DOM_I2C_MASTER_2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_4": "/[PIC_B_DOM_XCVR_CTRL_PORT_4]",
+    "/run/devmap/xcvrs/xcvr_io_5": "/[PIC_T_DOM_I2C_MASTER_3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_5": "/[PIC_T_DOM_XCVR_CTRL_PORT_5]",
+    "/run/devmap/xcvrs/xcvr_io_6": "/[PIC_T_DOM_I2C_MASTER_4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_6": "/[PIC_T_DOM_XCVR_CTRL_PORT_6]",
+    "/run/devmap/xcvrs/xcvr_io_7": "/[PIC_B_DOM_I2C_MASTER_3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_7": "/[PIC_B_DOM_XCVR_CTRL_PORT_7]",
+    "/run/devmap/xcvrs/xcvr_io_8": "/[PIC_B_DOM_I2C_MASTER_4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_8": "/[PIC_B_DOM_XCVR_CTRL_PORT_8]",
+    "/run/devmap/xcvrs/xcvr_io_9": "/[PIC_T_DOM_I2C_MASTER_5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_9": "/[PIC_T_DOM_XCVR_CTRL_PORT_9]",
+    "/run/devmap/xcvrs/xcvr_io_10": "/[PIC_T_DOM_I2C_MASTER_6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_10": "/[PIC_T_DOM_XCVR_CTRL_PORT_10]",
+    "/run/devmap/xcvrs/xcvr_io_11": "/[PIC_B_DOM_I2C_MASTER_5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_11": "/[PIC_B_DOM_XCVR_CTRL_PORT_11]",
+    "/run/devmap/xcvrs/xcvr_io_12": "/[PIC_B_DOM_I2C_MASTER_6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_12": "/[PIC_B_DOM_XCVR_CTRL_PORT_12]",
+    "/run/devmap/xcvrs/xcvr_io_13": "/[PIC_T_DOM_I2C_MASTER_7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_13": "/[PIC_T_DOM_XCVR_CTRL_PORT_13]",
+    "/run/devmap/xcvrs/xcvr_io_14": "/[PIC_T_DOM_I2C_MASTER_8]",
+    "/run/devmap/xcvrs/xcvr_ctrl_14": "/[PIC_T_DOM_XCVR_CTRL_PORT_14]",
+    "/run/devmap/xcvrs/xcvr_io_15": "/[PIC_B_DOM_I2C_MASTER_7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_15": "/[PIC_B_DOM_XCVR_CTRL_PORT_15]",
+    "/run/devmap/xcvrs/xcvr_io_16": "/[PIC_B_DOM_I2C_MASTER_8]",
+    "/run/devmap/xcvrs/xcvr_ctrl_16": "/[PIC_B_DOM_XCVR_CTRL_PORT_16]",
+    "/run/devmap/xcvrs/xcvr_io_17": "/[PIC_T_DOM_I2C_MASTER_9]",
+    "/run/devmap/xcvrs/xcvr_ctrl_17": "/[PIC_T_DOM_XCVR_CTRL_PORT_17]",
+    "/run/devmap/xcvrs/xcvr_io_18": "/[PIC_T_DOM_I2C_MASTER_10]",
+    "/run/devmap/xcvrs/xcvr_ctrl_18": "/[PIC_T_DOM_XCVR_CTRL_PORT_18]",
+    "/run/devmap/xcvrs/xcvr_io_19": "/[PIC_B_DOM_I2C_MASTER_9]",
+    "/run/devmap/xcvrs/xcvr_ctrl_19": "/[PIC_B_DOM_XCVR_CTRL_PORT_19]",
+    "/run/devmap/xcvrs/xcvr_io_20": "/[PIC_B_DOM_I2C_MASTER_10]",
+    "/run/devmap/xcvrs/xcvr_ctrl_20": "/[PIC_B_DOM_XCVR_CTRL_PORT_20]",
+    "/run/devmap/xcvrs/xcvr_io_21": "/[PIC_T_DOM_I2C_MASTER_11]",
+    "/run/devmap/xcvrs/xcvr_ctrl_21": "/[PIC_T_DOM_XCVR_CTRL_PORT_21]",
+    "/run/devmap/xcvrs/xcvr_io_22": "/[PIC_T_DOM_I2C_MASTER_12]",
+    "/run/devmap/xcvrs/xcvr_ctrl_22": "/[PIC_T_DOM_XCVR_CTRL_PORT_22]",
+    "/run/devmap/xcvrs/xcvr_io_23": "/[PIC_B_DOM_I2C_MASTER_11]",
+    "/run/devmap/xcvrs/xcvr_ctrl_23": "/[PIC_B_DOM_XCVR_CTRL_PORT_23]",
+    "/run/devmap/xcvrs/xcvr_io_24": "/[PIC_B_DOM_I2C_MASTER_12]",
+    "/run/devmap/xcvrs/xcvr_ctrl_24": "/[PIC_B_DOM_XCVR_CTRL_PORT_24]",
+    "/run/devmap/xcvrs/xcvr_io_25": "/[PIC_T_DOM_I2C_MASTER_13]",
+    "/run/devmap/xcvrs/xcvr_ctrl_25": "/[PIC_T_DOM_XCVR_CTRL_PORT_25]",
+    "/run/devmap/xcvrs/xcvr_io_26": "/[PIC_T_DOM_I2C_MASTER_14]",
+    "/run/devmap/xcvrs/xcvr_ctrl_26": "/[PIC_T_DOM_XCVR_CTRL_PORT_26]",
+    "/run/devmap/xcvrs/xcvr_io_27": "/[PIC_B_DOM_I2C_MASTER_13]",
+    "/run/devmap/xcvrs/xcvr_ctrl_27": "/[PIC_B_DOM_XCVR_CTRL_PORT_27]",
+    "/run/devmap/xcvrs/xcvr_io_28": "/[PIC_B_DOM_I2C_MASTER_14]",
+    "/run/devmap/xcvrs/xcvr_ctrl_28": "/[PIC_B_DOM_XCVR_CTRL_PORT_28]",
+    "/run/devmap/xcvrs/xcvr_io_29": "/[PIC_T_DOM_I2C_MASTER_15]",
+    "/run/devmap/xcvrs/xcvr_ctrl_29": "/[PIC_T_DOM_XCVR_CTRL_PORT_29]",
+    "/run/devmap/xcvrs/xcvr_io_30": "/[PIC_T_DOM_I2C_MASTER_16]",
+    "/run/devmap/xcvrs/xcvr_ctrl_30": "/[PIC_T_DOM_XCVR_CTRL_PORT_30]",
+    "/run/devmap/xcvrs/xcvr_io_31": "/[PIC_B_DOM_I2C_MASTER_15]",
+    "/run/devmap/xcvrs/xcvr_ctrl_31": "/[PIC_B_DOM_XCVR_CTRL_PORT_31]",
+    "/run/devmap/xcvrs/xcvr_io_32": "/[PIC_B_DOM_I2C_MASTER_16]",
+    "/run/devmap/xcvrs/xcvr_ctrl_32": "/[PIC_B_DOM_XCVR_CTRL_PORT_32]",
+    "/run/devmap/xcvrs/xcvr_io_33": "/[PIC_T_DOM_I2C_MASTER_17]",
+    "/run/devmap/xcvrs/xcvr_ctrl_33": "/[PIC_T_DOM_XCVR_CTRL_PORT_33]",
+    "/run/devmap/xcvrs/xcvr_io_34": "/[PIC_T_DOM_I2C_MASTER_18]",
+    "/run/devmap/xcvrs/xcvr_ctrl_34": "/[PIC_T_DOM_XCVR_CTRL_PORT_34]",
+    "/run/devmap/xcvrs/xcvr_io_35": "/[PIC_B_DOM_I2C_MASTER_17]",
+    "/run/devmap/xcvrs/xcvr_ctrl_35": "/[PIC_B_DOM_XCVR_CTRL_PORT_35]",
+    "/run/devmap/xcvrs/xcvr_io_36": "/[PIC_B_DOM_I2C_MASTER_18]",
+    "/run/devmap/xcvrs/xcvr_ctrl_36": "/[PIC_B_DOM_XCVR_CTRL_PORT_36]",
+    "/run/devmap/xcvrs/xcvr_io_37": "/[PIC_T_DOM_I2C_MASTER_19]",
+    "/run/devmap/xcvrs/xcvr_ctrl_37": "/[PIC_T_DOM_XCVR_CTRL_PORT_37]",
+    "/run/devmap/xcvrs/xcvr_io_38": "/[PIC_T_DOM_I2C_MASTER_20]",
+    "/run/devmap/xcvrs/xcvr_ctrl_38": "/[PIC_T_DOM_XCVR_CTRL_PORT_38]",
+    "/run/devmap/xcvrs/xcvr_io_39": "/[PIC_B_DOM_I2C_MASTER_19]",
+    "/run/devmap/xcvrs/xcvr_ctrl_39": "/[PIC_B_DOM_XCVR_CTRL_PORT_39]",
+    "/run/devmap/xcvrs/xcvr_io_40": "/[PIC_B_DOM_I2C_MASTER_20]",
+    "/run/devmap/xcvrs/xcvr_ctrl_40": "/[PIC_B_DOM_XCVR_CTRL_PORT_40]",
+    "/run/devmap/xcvrs/xcvr_io_41": "/[PIC_T_DOM_I2C_MASTER_21]",
+    "/run/devmap/xcvrs/xcvr_ctrl_41": "/[PIC_T_DOM_XCVR_CTRL_PORT_41]",
+    "/run/devmap/xcvrs/xcvr_io_42": "/[PIC_T_DOM_I2C_MASTER_22]",
+    "/run/devmap/xcvrs/xcvr_ctrl_42": "/[PIC_T_DOM_XCVR_CTRL_PORT_42]",
+    "/run/devmap/xcvrs/xcvr_io_43": "/[PIC_B_DOM_I2C_MASTER_21]",
+    "/run/devmap/xcvrs/xcvr_ctrl_43": "/[PIC_B_DOM_XCVR_CTRL_PORT_43]",
+    "/run/devmap/xcvrs/xcvr_io_44": "/[PIC_B_DOM_I2C_MASTER_22]",
+    "/run/devmap/xcvrs/xcvr_ctrl_44": "/[PIC_B_DOM_XCVR_CTRL_PORT_44]",
+    "/run/devmap/xcvrs/xcvr_io_45": "/[PIC_T_DOM_I2C_MASTER_23]",
+    "/run/devmap/xcvrs/xcvr_ctrl_45": "/[PIC_T_DOM_XCVR_CTRL_PORT_45]",
+    "/run/devmap/xcvrs/xcvr_io_46": "/[PIC_T_DOM_I2C_MASTER_24]",
+    "/run/devmap/xcvrs/xcvr_ctrl_46": "/[PIC_T_DOM_XCVR_CTRL_PORT_46]",
+    "/run/devmap/xcvrs/xcvr_io_47": "/[PIC_B_DOM_I2C_MASTER_23]",
+    "/run/devmap/xcvrs/xcvr_ctrl_47": "/[PIC_B_DOM_XCVR_CTRL_PORT_47]",
+    "/run/devmap/xcvrs/xcvr_io_48": "/[PIC_B_DOM_I2C_MASTER_24]",
+    "/run/devmap/xcvrs/xcvr_ctrl_48": "/[PIC_B_DOM_XCVR_CTRL_PORT_48]",
+    "/run/devmap/xcvrs/xcvr_io_49": "/[PIC_T_DOM_I2C_MASTER_25]",
+    "/run/devmap/xcvrs/xcvr_ctrl_49": "/[PIC_T_DOM_XCVR_CTRL_PORT_49]",
+    "/run/devmap/xcvrs/xcvr_io_50": "/[PIC_T_DOM_I2C_MASTER_26]",
+    "/run/devmap/xcvrs/xcvr_ctrl_50": "/[PIC_T_DOM_XCVR_CTRL_PORT_50]",
+    "/run/devmap/xcvrs/xcvr_io_51": "/[PIC_B_DOM_I2C_MASTER_25]",
+    "/run/devmap/xcvrs/xcvr_ctrl_51": "/[PIC_B_DOM_XCVR_CTRL_PORT_51]",
+    "/run/devmap/xcvrs/xcvr_io_52": "/[PIC_B_DOM_I2C_MASTER_26]",
+    "/run/devmap/xcvrs/xcvr_ctrl_52": "/[PIC_B_DOM_XCVR_CTRL_PORT_52]",
+    "/run/devmap/xcvrs/xcvr_io_53": "/[PIC_T_DOM_I2C_MASTER_27]",
+    "/run/devmap/xcvrs/xcvr_ctrl_53": "/[PIC_T_DOM_XCVR_CTRL_PORT_53]",
+    "/run/devmap/xcvrs/xcvr_io_54": "/[PIC_T_DOM_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_54": "/[PIC_T_DOM_XCVR_CTRL_PORT_54]",
+    "/run/devmap/xcvrs/xcvr_io_55": "/[PIC_B_DOM_I2C_MASTER_27]",
+    "/run/devmap/xcvrs/xcvr_ctrl_55": "/[PIC_B_DOM_XCVR_CTRL_PORT_55]",
+    "/run/devmap/xcvrs/xcvr_io_56": "/[PIC_B_DOM_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_56": "/[PIC_B_DOM_XCVR_CTRL_PORT_56]",
+    "/run/devmap/xcvrs/xcvr_io_57": "/[PIC_T_DOM_I2C_MASTER_29]",
+    "/run/devmap/xcvrs/xcvr_ctrl_57": "/[PIC_T_DOM_XCVR_CTRL_PORT_57]",
+    "/run/devmap/xcvrs/xcvr_io_58": "/[PIC_T_DOM_I2C_MASTER_30]",
+    "/run/devmap/xcvrs/xcvr_ctrl_58": "/[PIC_T_DOM_XCVR_CTRL_PORT_58]",
+    "/run/devmap/xcvrs/xcvr_io_59": "/[PIC_B_DOM_I2C_MASTER_29]",
+    "/run/devmap/xcvrs/xcvr_ctrl_59": "/[PIC_B_DOM_XCVR_CTRL_PORT_59]",
+    "/run/devmap/xcvrs/xcvr_io_60": "/[PIC_B_DOM_I2C_MASTER_30]",
+    "/run/devmap/xcvrs/xcvr_ctrl_60": "/[PIC_B_DOM_XCVR_CTRL_PORT_60]",
+    "/run/devmap/xcvrs/xcvr_io_61": "/[PIC_T_DOM_I2C_MASTER_31]",
+    "/run/devmap/xcvrs/xcvr_ctrl_61": "/[PIC_T_DOM_XCVR_CTRL_PORT_61]",
+    "/run/devmap/xcvrs/xcvr_io_62": "/[PIC_T_DOM_I2C_MASTER_32]",
+    "/run/devmap/xcvrs/xcvr_ctrl_62": "/[PIC_T_DOM_XCVR_CTRL_PORT_62]",
+    "/run/devmap/xcvrs/xcvr_io_63": "/[PIC_B_DOM_I2C_MASTER_31]",
+    "/run/devmap/xcvrs/xcvr_ctrl_63": "/[PIC_B_DOM_XCVR_CTRL_PORT_63]",
+    "/run/devmap/xcvrs/xcvr_io_64": "/[PIC_B_DOM_I2C_MASTER_32]",
+    "/run/devmap/xcvrs/xcvr_ctrl_64": "/[PIC_B_DOM_XCVR_CTRL_PORT_64]",
+    "/run/devmap/xcvrs/xcvr_io_65": "/[PIC_T_DOM_I2C_MASTER_35]",
+    "/run/devmap/xcvrs/xcvr_ctrl_65": "/[IOB_XCVR_CTRL_PORT_65]"
+  },
+  "bspKmodsRpmName": "fboss_bsp_kmods",
+  "bspKmodsRpmVersion": "0.0.0-2",
+  "requiredKmodsToLoad": [
+    "i2c_i801",
+    "spidev",
+    "fboss_iob_pci"
+  ]
+}


### PR DESCRIPTION
Description
This PR is the preEVT first version of the IceCube platform configuration.

Motivation
1.Note: 
   Due to hardware limitation, there is no SMB card in the configuration file.It only has 5 slots.
![image (5).png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/image%20%285%29.png) 
   Due to hardware limitations, there is no cages of OSFP, so we cannot validate the xcvr symbolic links. The next step is to validate it once the hardware is finalized.
2.The i2c tree(version 0.7) is as follows:

[2OU_IceCUbe_I2C_Tree_V0.7_20250318.pdf](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/2OU_IceCUbe_I2C_Tree_V0.7_20250318.pdf) 


3. It can run platform manager and create the symbolic link successfully.



Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:

It can run platform manager successfully.
![image.png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/image.png)

It can create the symbolic link successfully.
 ![image (2).png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/image%20%282%29.png) 

![image (3).png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/image%20%283%29.png) 

![image (4).png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/image%20%284%29.png) 



[platform_test_log_3_25.txt](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17274/attachments/platform_test_log_3_25.txt) 
