### PR TITLE
Icecube: config: added the preEVT first version of weutil config 

### DIFF
--- a/fboss/platform/configs/icecube800bc/weutil.json
+++ b/fboss/platform/configs/icecube800bc/weutil.json
@@ -1,0 +1,23 @@
+{
+  "chassisEepromName": "CHASSIS",
+  "fruEepromList": {
+    "CHASSIS": {
+      "path": "/run/devmap/eeproms/CHASSIS_EEPROM"
+    },
+    "COME": {
+      "path": "/run/devmap/eeproms/COME_EEPROM"
+    },
+    "MCB": {
+      "path": "/run/devmap/eeproms/MCB_EEPROM"
+    },
+    "RUNBMC": {
+      "path": "/run/devmap/eeproms/RUNBMC_EEPROM"
+    },
+    "PIC_T": {
+      "path": "/run/devmap/eeproms/PIC_T_EEPROM"
+    },
+    "PIC_B": {
+      "path": "/run/devmap/eeproms/PIC_B_EEPROM"
+    }
+  }
+}


### PR DESCRIPTION
Description
This PR is the preEVT first version of the IceCube weutil configuration.

Motivation
1.Note:
Due to hardware limitation, there is no SMB card in the configuration file.It only has 6 eeproms.

![image](https://github.com/user-attachments/assets/bc2c85f0-bee9-4aa7-a8fb-36d39b85474a)

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:

[root@localhost edward]# LD_LIBRARY_PATH=./lib/ ./bin/weutil -config_file ./weutil.json --list
Name:CHASSIS Path:/run/devmap/eeproms/CHASSIS_EEPROM Offset:0
Name:COME Path:/run/devmap/eeproms/COME_EEPROM Offset:0
Name:MCB Path:/run/devmap/eeproms/MCB_EEPROM Offset:0
Name:PIC_B_EEPROM Path:/run/devmap/eeproms/PIC_B_EEPROM Offset:0
Name:PIC_T_EEPROM Path:/run/devmap/eeproms/PIC_T_EEPROM Offset:0
Name:RUNBMC Path:/run/devmap/eeproms/RUNBMC_EEPROM Offset:0
[root@localhost edward]#
[root@localhost edward]# LD_LIBRARY_PATH=./fboss_lib/ ./weutil --path /run/devmap/eeproms/CHASSIS_EEPROM --config_file weutil.json
Version: 6
Product Name: ICECUBE800BC
Product Part Number:
System Assembly Part Number: 0
Meta PCBA Part Number: 132100046
Meta PCB Part Number: 131100022
ODM/JDM PCBA Part Number: R3214G000203
ODM/JDM PCBA Serial Number: A023224420075
Production State: EVT
Production Sub-State: 0
Re-Spin/Variant Indicator: 0
Product Serial Number: F5000000000
System Manufacturer: CLS
System Manufacturing Date: 20250324
PCB Manufacturer: WUS
Assembled At: CTH
EEPROM location on Fabric: MCB
RMA: 0
Vendor Defined Field 1:
Vendor Defined Field 2:
Vendor Defined Field 3:
CRC16: 0xed3a (CRC Matched)
[root@localhost edward]# LD_LIBRARY_PATH=./fboss_lib/ ./weutil --path /run/devmap/eeproms/COME_EEPROM --config_file weutil.json
Version: 5
Product Name: NETLAKE
Product Part Number:
System Assembly Part Number:
Meta PCBA Part Number: 19-100257
Meta PCB Part Number: NA
ODM/JDM PCBA Part Number: B91.04M10.0003
ODM/JDM PCBA Serial Number: WK03442000UN01
Product Production State: 4
Product Version: 1
Product Sub-Version: 2
Product Serial Number:
System Manufacturer: WIWYNN
System Manufacturing Date: 20241022
PCB Manufacturer: WUS
Assembled At: WYTN
EEPROM location on Fabric: U20
X86 CPU MAC Base: 00:00:00:00:00:00
X86 CPU MAC Address Size: 0
BMC MAC Base: 00:00:00:00:00:00
BMC MAC Address Size: 0
Switch ASIC MAC Base: 00:00:00:00:00:00
Switch ASIC MAC Address Size: 0
META Reserved MAC Base: 00:00:00:00:00:00
META Reserved MAC Address Size: 0
CRC16: 0x3441 (CRC Mismatch. Expected 0x3713)
[root@localhost edward]#
....

[weutil_test_log_3_25.txt](https://github.com/user-attachments/files/19530961/weutil_test_log_3_25.txt)



