### PR TITLE
Added queue 7 to pump traffic

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
@@ -429,8 +429,9 @@ class AgentTrafficPfcTest : public AgentHwTest {
 
   void pumpTraffic(const int priority, bool scaleTest) {
     std::vector<PortID> portIds = portIdsForTest(scaleTest);
+    uint8_t queue = 7;
     pumpTraffic(
-        priority, std::nullopt, portIds, getDestinationIps(portIds.size()));
+        priority, queue, portIds, getDestinationIps(portIds.size()));
   }
 
   void stopTraffic(const std::vector<PortID>& portIds) {


### PR DESCRIPTION
The test was failing because PFC wasn't being triggered. The reason was we were dropping packets which prevented us from reaching PFC threshold. 

I discovered that the queue from which we are injecting packets gets stale. Root cause is because we had strict priority scheduler applied, higher indexed queues have a higher priority than lower indexed queues. And because we weren't specifying which queue to send packets to, we were defaulting to queue 0 which has the lowest priority and therefore packets from there would never be send to the destination queue. 

The fix is to explicitly send to queue 7.