### PR TITLE
Darwin: Ignore eeproms at the end of PM exploration

### DIFF
--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -844,6 +844,15 @@ void PlatformExplorer::genHumanReadableEeproms() {
     if (devicePath == "/[SCM_IDPROM_P1]") {
       continue;
     }
+
+    // Ignore Darwin's I2cDeviceConfig eeproms as they don't support meta eeprom
+    // Darwin48v eeproms defined in I2cDeviceConfig aren't at offset 0
+    if (devicePath == "/RACKMON_SLOT@0/[FANSPINNER_EEPROM]" ||
+        devicePath == "/RACKMON_SLOT@0/[IDPROM]" ||
+        devicePath == "/[CHASSIS_EEPROM]") {
+      continue;
+    }
+
     writeEepromContent(devicePath, linkPath);
   }
 


### PR DESCRIPTION
# Definition

The following commit introduced a post exploration function to platform manager that seems to fetch information from the eeprom. The issue is that the function (genHumanReadableEeproms) assumes two things are correct, and if they are not, platform manager crashes.

1. The eeprom is programmed with a supported meta-eeprom version (versions >=4)
- This is not valid for Darwin as it predates meta-eeprom.

2. Any eeprom defined with an I2cDeviceConfig item has an offset of 0.
- Darwin48V makes use of eeproms defined using I2cDeviceConfig where the offset is not 0. Reference weutil.json for the correct offsets.

# Solution
Ignore eeprom paths that are problematic.

**Caveat:** This assumes no other platform has any of the following problematic device paths, which the moment there aren't. The condition can be made more robust by expanding it to check the platform's name:
- /RACKMON_SLOT@0/[FANSPINNER_EEPROM]
- /RACKMON_SLOT@0/[IDPROM]
- /[CHASSIS_EEPROM]"

# Testing
Platform manager completes successfully without crashing. Eeproms are seen in the end summary, but those are expected similar to how the behavior has always been.

