### PR TITLE
Tahan: config: remove the prefix bp4f in platform config

### DIFF
--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -2098,7 +2098,7 @@
     "/run/devmap/xcvrs/xcvr_ctrl_33": "/[SMB_DOM_XCVR_CTRL_PORT_33]"
   },
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "2.4.0-1",
+  "bspKmodsRpmVersion": "3.0.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",

--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -72,31 +72,31 @@
             {
               "busName": "INCOMING@1",
               "address": "0x11",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU31_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x22",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU32_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x45",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU41_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x66",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU42_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x76",
-              "kernelDeviceName": "bp4f_mp2993",
+              "kernelDeviceName": "mp2993",
               "pmUnitScopedName": "COME_PU4_XDPE15284"
             }
           ]
@@ -112,7 +112,7 @@
             {
               "busName": "INCOMING@0",
               "address": "0x21",
-              "kernelDeviceName": "bp4f_mp2891",
+              "kernelDeviceName": "mp2891",
               "pmUnitScopedName": "SMB_U122_PMBUS_1"
             },
             {
@@ -1760,25 +1760,25 @@
         {
           "busName": "INCOMING@2",
           "address": "0x68",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U20_XDPE12284_1"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x6a",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U86_XDPE12284_2"
         },
         {
           "busName": "INCOMING@3",
           "address": "0x72",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U229_XDPE12284_1"
         },
         {
           "busName": "INCOMING@3",
           "address": "0x70",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U92_XDPE12284_2"
         }
       ]
@@ -1812,31 +1812,31 @@
         {
           "busName": "INCOMING@1",
           "address": "0x11",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU31_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x22",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU32_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x45",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU41_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x66",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU42_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x76",
-          "kernelDeviceName": "bp4f_xdpe15284",
+          "kernelDeviceName": "xdpe15284",
           "pmUnitScopedName": "COME_PU4_XDPE15284"
         }
       ]
@@ -1870,13 +1870,13 @@
         {
           "busName": "INCOMING@0",
           "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
+          "kernelDeviceName": "max31790",
           "pmUnitScopedName": "SMB_BCB_FAN_CPLD"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
+          "kernelDeviceName": "max31790",
           "pmUnitScopedName": "SMB_BCB_FAN_CPLD_2"
         }
       ]


### PR DESCRIPTION
Description
This PR is for tahan platform config file.Remove the prefix bp4f according to the github bsp new driver.


![image](https://github.com/user-attachments/assets/82a1ad59-5a3d-4a82-9e8d-3840718e2792)

Motivation
1.In the PR has changed
bp4f_mp9941--->mp9941
bp4f_mp2993--->mp2993
bp4f_mp2891--->mp2891
bp4f_xdpe12284--->xdpe12284
bp4f_xdpe15284--->xdpe15284
bp4f_tda38640--->tda38640
bp4f_max31790--->max31790

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:

......
I1014 20:06:44.390344  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_31 to /dev/i2c-59. DevicePath: /[SMB_DOM_I2C_MASTER_31]
I1014 20:06:44.392534  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_32 to /dev/i2c-60. DevicePath: /[SMB_DOM_I2C_MASTER_32]
I1014 20:06:44.394731  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_33 to /dev/i2c-61. DevicePath: /[SMB_DOM_I2C_MASTER_33]
I1014 20:06:44.396946  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_4 to /dev/i2c-32. DevicePath: /[SMB_DOM_I2C_MASTER_4]
I1014 20:06:44.399150  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_5 to /dev/i2c-33. DevicePath: /[SMB_DOM_I2C_MASTER_5]
I1014 20:06:44.401336  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_6 to /dev/i2c-34. DevicePath: /[SMB_DOM_I2C_MASTER_6]
I1014 20:06:44.403533  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_7 to /dev/i2c-35. DevicePath: /[SMB_DOM_I2C_MASTER_7]
I1014 20:06:44.405769  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_8 to /dev/i2c-36. DevicePath: /[SMB_DOM_I2C_MASTER_8]
I1014 20:06:44.407987  8513 PlatformExplorer.cpp:687] Creating symlink from /run/devmap/xcvrs/xcvr_io_9 to /dev/i2c-37. DevicePath: /[SMB_DOM_I2C_MASTER_9]
I1014 20:06:44.411734  8513 PlatformExplorer.cpp:737] Reporting firmware version for PWR_CPLD - version string:2.3.0
I1014 20:06:44.413189  8513 PlatformExplorer.cpp:737] Reporting firmware version for SMB_CPLD_1 - version string:2.3.0
I1014 20:06:44.414948  8513 PlatformExplorer.cpp:737] Reporting firmware version for TAHAN_SMB_CPLD - version string:2.3.0
I1014 20:06:44.414982  8513 PlatformExplorer.cpp:737] Reporting firmware version for SMB_DOM_INFO_ROM - version string:0.38
I1014 20:06:44.415006  8513 PlatformExplorer.cpp:737] Reporting firmware version for SMB_IOB_INFO_ROM - version string:0.50
I1014 20:06:44.415098  8513 ExplorationSummary.cpp:49] Successfully explored TAHAN800BC....
W1014 20:06:44.415162  8513 Main.cpp:71] Skipping sd_notify since $NOTIFY_SOCKET is not set which does not imply systemd execution.
I1014 20:06:44.415167  8513 Main.cpp:78] Running PlatformManager thrift service...
I1014 20:06:44.415776  8513 ThriftServer.cpp:861] Using thread manager (resource pools not enabled) on address/port 5975: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
.....


[tahan_platform_test_log_4_2.txt](https://github.com/user-attachments/files/19562522/tahan_platform_test_log_4_2.txt)

