### PR TITLE
Darwin: sync led_manager config

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,22 +1,22 @@
 {
   "systemLedConfig": {
     "presentLedColor": 1,
-    "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
     "absentLedColor": 2,
-    "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PEM": {
       "presentLedColor": 1,
-      "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
       "absentLedColor": 2,
-      "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },
   "fruConfigs": [
@@ -66,6 +66,16 @@
       "presenceDetection": {
         "sysfsFileHandle": {
           "presenceFilePath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/fpgas/SCD_FPGA/rackmon_present",
           "desiredValue": 1
         }
       }


### PR DESCRIPTION
# Description

This is part of a series of PRs to sync Darwin configs.

This is the third PR in the series. Depends on https://github.com/facebook/fboss/pull/378

**NOTE:** the details below are identical for all PRs in the series.


## Platform Manager
This PR includes changes from previous PRs updated with recent changes to be in sync: #329 #267 

**Summary of all changes**
- Initialize the qsfp ports (1-32) and generate the necessary symlinks.
- Port leds support using scd-leds-darwin. See PR introducing the driver for more details.
- Added infoRom support
- Syncing the config with PM updates to keep it valid. E.g. Removed outdated attributes: bspKmodsToReload, sharedKmodsToReload, and upstreamKmodsToLoad .

## Sensor_service changes
- Sync Darwin sensor_service config to include all sensors.
- Match pmUnitNames generated used by PM
- Added missing compute attribute for POS_3V3_ALW

## Led manager config
- Sync Darwin led_manager paths to follow the same /sys/class/leds used on all other platforms.
- Add missing rackmon fan as a FRU associated with the FAN led.

# Testing

This testing section, while it includes general tests, focuses on changes introduced by this PR when compared to the outdated #329 #267.

## PM Init of Xcvrs
Ports on Darwin reflect the expected values through the scd-xcvr driver 
```
# ls /run/devmap/xcvrs/
xcvr_1   xcvr_17  xcvr_24  xcvr_31  xcvr_ctrl_1   xcvr_ctrl_17  xcvr_ctrl_24  xcvr_ctrl_31  xcvr_io_1   xcvr_io_17  xcvr_io_24  xcvr_io_31
xcvr_10  xcvr_18  xcvr_25  xcvr_32  xcvr_ctrl_10  xcvr_ctrl_18  xcvr_ctrl_25  xcvr_ctrl_32  xcvr_io_10  xcvr_io_18  xcvr_io_25  xcvr_io_32
xcvr_11  xcvr_19  xcvr_26  xcvr_4   xcvr_ctrl_11  xcvr_ctrl_19  xcvr_ctrl_26  xcvr_ctrl_4   xcvr_io_11  xcvr_io_19  xcvr_io_26  xcvr_io_4
xcvr_12  xcvr_2   xcvr_27  xcvr_5   xcvr_ctrl_12  xcvr_ctrl_2   xcvr_ctrl_27  xcvr_ctrl_5   xcvr_io_12  xcvr_io_2   xcvr_io_27  xcvr_io_5
xcvr_13  xcvr_20  xcvr_28  xcvr_6   xcvr_ctrl_13  xcvr_ctrl_20  xcvr_ctrl_28  xcvr_ctrl_6   xcvr_io_13  xcvr_io_20  xcvr_io_28  xcvr_io_6
xcvr_14  xcvr_21  xcvr_29  xcvr_7   xcvr_ctrl_14  xcvr_ctrl_21  xcvr_ctrl_29  xcvr_ctrl_7   xcvr_io_14  xcvr_io_21  xcvr_io_29  xcvr_io_7
xcvr_15  xcvr_22  xcvr_3   xcvr_8   xcvr_ctrl_15  xcvr_ctrl_22  xcvr_ctrl_3   xcvr_ctrl_8   xcvr_io_15  xcvr_io_22  xcvr_io_3   xcvr_io_8
xcvr_16  xcvr_23  xcvr_30  xcvr_9   xcvr_ctrl_16  xcvr_ctrl_23  xcvr_ctrl_30  xcvr_ctrl_9   xcvr_io_16  xcvr_io_23  xcvr_io_30  xcvr_io_9
```

Port 1 is expected to be present
```
# cat /run/devmap/xcvrs/xcvr_ctrl_1/xcvr1_present
0 <-- 0 is present
```

Testing with a non-existing xcvr
```
# cat /run/devmap/xcvrs/xcvr_ctrl_5/xcvr5_present
1  <---- 1 is absent
```

## Port Leds
Verified that the green led is on at first, and turning on yellow leds turns off the green led:
E.g. Setting Port 1 LED to yellow `# echo 1 > port1_led1\:yellow\:status/brightness`
![image](https://github.com/user-attachments/assets/fc678155-c581-4d16-ba55-a81d5df0bc75)
![image](https://github.com/user-attachments/assets/bc0228cd-3e0c-4c4a-8b73-d5fc42e8421a)

## Led Manager Testing
```
Jan 31 00:49:20 ...: I0131 00:49:20.856894  5161 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
Jan 31 00:49:20 ...: I0131 00:49:20.856950  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.857852  5161 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.857892  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.858802  5161 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
Jan 31 00:49:20 ...: I0131 00:49:20.858819  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.859799  5161 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
Jan 31 00:49:20 ...: I0131 00:49:20.859815  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.860829  5161 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
Jan 31 00:49:20 ...: I0131 00:49:20.860845  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN5 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861801  5161 FruPresenceExplorer.cpp:49] Detected that FAN5 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861817  5161 FruPresenceExplorer.cpp:34] Detecting presence of FAN6 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861846  5161 FruPresenceExplorer.cpp:49] Detected that FAN6 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861852  5161 FruPresenceExplorer.cpp:34] Detecting presence of PEM1 (via sysfs)
Jan 31 00:49:20 ...: I0131 00:49:20.861869  5161 FruPresenceExplorer.cpp:49] Detected that PEM1 is present
Jan 31 00:49:20 ...: I0131 00:49:20.861877  5161 LedManager.cpp:45] Programming PEM LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861911  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861936  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861944  5161 LedManager.cpp:55] Programmed PEM LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.861950  5161 LedManager.cpp:45] Programming FAN LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.861972  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861993  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.861999  5161 LedManager.cpp:55] Programmed FAN LED with presence true
Jan 31 00:49:20 ...: I0131 00:49:20.862005  5161 LedManager.cpp:25] Programming system LED with true
Jan 31 00:49:20 ...: I0131 00:49:20.862026  5161 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862047  5161 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
Jan 31 00:49:20 ...: I0131 00:49:20.862054  5161 LedManager.cpp:34] Programmed system LED with true
```
![Screenshot 2025-03-25 at 2 56 06 PM](https://github.com/user-attachments/assets/d007b2af-ee33-429d-99ca-78c048b2ca70)



## General Tests
The following sw_tests passed:
- async_logger_test
- fan_service_sw_test
- fsdb_client_test
- platform_config_lib_config_lib_test
- platform_data_corral_sw_test
- platform_helpers_platform_name_lib_test
- platform_manager_config_validator_test
- platform_manager_data_store_test
- platform_manager_device_path_resolver_test
- platform_manager_i2c_explorer_test
- platform_manager_platform_explorer_test
- platform_manager_presence_checker_test
- platform_manager_utils_test
- rackmon_test
- sensor_service_sw_test
- sensor_service_utils_test
- thrift_cow_visitor_tests
- thrift_node_tests
- weutil_crc16_ccitt_test
- weutil_fboss_eeprom_parser_test


The following hw_tests passed:
- data_corral_service_hw_test
- sensor_service_hw_test
- fan_service_hw_test
- weutil_hw_test