### PR TITLE
MERU800BIA: Update fan_service minimum pwm

### DIFF
--- a/fboss/platform/configs/meru800bia/fan_service.json
+++ b/fboss/platform/configs/meru800bia/fan_service.json
@@ -4,7 +4,7 @@
   "pwmBoostOnNoQsfpAfterInSec": 0,
   "pwmBoostValue": 60,
   "pwmTransitionValue": 50,
-  "pwmLowerThreshold": 30,
+  "pwmLowerThreshold": 43,
   "pwmUpperThreshold": 100,
   "optics" : [
     {
@@ -32,19 +32,19 @@
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
       "normalUpTable": {
-        "15": 30,
+        "15": 43,
         "110": 100
       },
       "normalDownTable": {
-        "15": 30,
+        "15": 43,
         "110": 100
       },
       "failUpTable": {
-        "15": 30,
+        "15": 43,
         "110": 100
       },
       "failDownTable": {
-        "15": 30,
+        "15": 43,
         "110": 100
       }
     }


### PR DESCRIPTION
# Description

Update meru800bia fan_service to update minimum pwm to match that of the minimum pwm driven by the optics (PWM=43). This is to avoid any potential overheating caused by not having the qsfp_service running, which supplies the fan_service with the optics data.

# Test

## Running fan_service while qsfp_service is stopped
```
# systemctl stop qsfp_service
# systemctl restart fan_service

# FAN SERVICE LOGS
ControlLogic.cpp:100] Successfully fetched sensor data.
Bsp.cpp:250] Failed to read optics data from Qsfp for osfp_group_1, exception: apache::thrift::transport::TTransportException: AsyncSocketException: connect failed, type = Socket not open, errno = 111 (Connection refused): Connection refused
ControlLogic.cpp:110] Successfully fetched optics data.
ControlLogic.cpp:583] Processing Fans ...
ControlLogic.cpp:370] fan_1: is present in the host (through sysfs)
ControlLogic.cpp:169] fan_1: RPM read is 6185
ControlLogic.cpp:370] fan_2: is present in the host (through sysfs)
ControlLogic.cpp:169] fan_2: RPM read is 6198
ControlLogic.cpp:370] fan_3: is present in the host (through sysfs)
ControlLogic.cpp:169] fan_3: RPM read is 6211
ControlLogic.cpp:370] fan_4: is present in the host (through sysfs)
ControlLogic.cpp:169] fan_4: RPM read is 6185
ControlLogic.cpp:629] Processing Sensors ...
ControlLogic.cpp:238] SMB_BOARD_FRONT_TEMP: Sensor read value is 30
ControlLogic.cpp:221] SMB_BOARD_FRONT_TEMP: Calculated PWM is 43
ControlLogic.cpp:633] Processing Optics ...
ControlLogic.cpp:512] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 43.
ControlLogic.cpp:449] fan_1: Programmed with PWM 43 (raw value 110)
ControlLogic.cpp:449] fan_2: Programmed with PWM 43 (raw value 110)
ControlLogic.cpp:449] fan_3: Programmed with PWM 43 (raw value 110)
ControlLogic.cpp:449] fan_4: Programmed with PWM 43 (raw value 110)
```

## Running fan_service hw_tests
```
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from FanServiceHwTest
[ RUN      ] FanServiceHwTest.TransitionalPWM
I0407 23:24:11.518675  9471 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fan_service.json
I0407 23:24:11.519185  9471 ControlLogic.cpp:69] Upon fan_service start up, program all fan pwm with transitional value of 50
I0407 23:24:11.520153  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.521075  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.521999  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.522919  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 50 (raw value 128)
[       OK ] FanServiceHwTest.TransitionalPWM (4 ms)
[ RUN      ] FanServiceHwTest.FanControl
I0407 23:24:11.523156  9471 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fan_service.json
I0407 23:24:11.523374  9471 ControlLogic.cpp:69] Upon fan_service start up, program all fan pwm with transitional value of 50
I0407 23:24:11.524218  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.525144  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.526064  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 50 (raw value 128)
I0407 23:24:11.526982  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 50 (raw value 128)
I0407 23:24:17.301760  9471 Bsp.cpp:326] Got sensor data from sensor_service.  Item count: 64
I0407 23:24:17.301778  9471 ControlLogic.cpp:100] Successfully fetched sensor data.
E0407 23:24:22.435975  9471 Bsp.cpp:159] Transceiver id 0 has no sensor data. Ignoring.
E0407 23:24:22.435993  9471 Bsp.cpp:159] Transceiver id 1 has no sensor data. Ignoring.
E0407 23:24:22.435996  9471 Bsp.cpp:159] Transceiver id 2 has no sensor data. Ignoring.
E0407 23:24:22.435999  9471 Bsp.cpp:159] Transceiver id 3 has no sensor data. Ignoring.
E0407 23:24:22.436002  9471 Bsp.cpp:159] Transceiver id 4 has no sensor data. Ignoring.
E0407 23:24:22.436005  9471 Bsp.cpp:159] Transceiver id 5 has no sensor data. Ignoring.
E0407 23:24:22.436008  9471 Bsp.cpp:159] Transceiver id 6 has no sensor data. Ignoring.
E0407 23:24:22.436011  9471 Bsp.cpp:159] Transceiver id 7 has no sensor data. Ignoring.
E0407 23:24:22.436014  9471 Bsp.cpp:159] Transceiver id 8 has no sensor data. Ignoring.
E0407 23:24:22.436017  9471 Bsp.cpp:159] Transceiver id 9 has no sensor data. Ignoring.
E0407 23:24:22.436020  9471 Bsp.cpp:159] Transceiver id 11 has no sensor data. Ignoring.
E0407 23:24:22.436023  9471 Bsp.cpp:159] Transceiver id 12 has no sensor data. Ignoring.
E0407 23:24:22.436027  9471 Bsp.cpp:159] Transceiver id 15 has no sensor data. Ignoring.
E0407 23:24:22.436030  9471 Bsp.cpp:159] Transceiver id 17 has no sensor data. Ignoring.
E0407 23:24:22.436033  9471 Bsp.cpp:159] Transceiver id 19 has no sensor data. Ignoring.
E0407 23:24:22.436036  9471 Bsp.cpp:159] Transceiver id 20 has no sensor data. Ignoring.
E0407 23:24:22.436039  9471 Bsp.cpp:159] Transceiver id 22 has no sensor data. Ignoring.
E0407 23:24:22.436042  9471 Bsp.cpp:159] Transceiver id 23 has no sensor data. Ignoring.
E0407 23:24:22.436047  9471 Bsp.cpp:159] Transceiver id 25 has no sensor data. Ignoring.
E0407 23:24:22.436052  9471 Bsp.cpp:159] Transceiver id 26 has no sensor data. Ignoring.
E0407 23:24:22.436057  9471 Bsp.cpp:159] Transceiver id 28 has no sensor data. Ignoring.
E0407 23:24:22.436063  9471 Bsp.cpp:159] Transceiver id 29 has no sensor data. Ignoring.
E0407 23:24:22.436068  9471 Bsp.cpp:159] Transceiver id 30 has no sensor data. Ignoring.
E0407 23:24:22.436073  9471 Bsp.cpp:159] Transceiver id 31 has no sensor data. Ignoring.
E0407 23:24:22.436078  9471 Bsp.cpp:159] Transceiver id 32 has no sensor data. Ignoring.
E0407 23:24:22.436084  9471 Bsp.cpp:159] Transceiver id 33 has no sensor data. Ignoring.
E0407 23:24:22.436089  9471 Bsp.cpp:159] Transceiver id 34 has no sensor data. Ignoring.
E0407 23:24:22.436093  9471 Bsp.cpp:159] Transceiver id 35 has no sensor data. Ignoring.
E0407 23:24:22.436099  9471 Bsp.cpp:159] Transceiver id 36 has no sensor data. Ignoring.
E0407 23:24:22.436104  9471 Bsp.cpp:159] Transceiver id 37 has no sensor data. Ignoring.
I0407 23:24:22.436112  9471 Bsp.cpp:280] Got optics data from Qsfp. Data Size: 3. QsfpSvcTimestamp: 1744068247
I0407 23:24:22.436144  9471 ControlLogic.cpp:110] Successfully fetched optics data.
I0407 23:24:22.436149  9471 ControlLogic.cpp:583] Processing Fans ...
I0407 23:24:22.439148  9471 ControlLogic.cpp:370] fan_1: is present in the host (through sysfs)
I0407 23:24:22.447144  9471 ControlLogic.cpp:169] fan_1: RPM read is 6122
I0407 23:24:22.450140  9471 ControlLogic.cpp:370] fan_2: is present in the host (through sysfs)
I0407 23:24:22.458140  9471 ControlLogic.cpp:169] fan_2: RPM read is 6109
I0407 23:24:22.461308  9471 ControlLogic.cpp:370] fan_3: is present in the host (through sysfs)
I0407 23:24:22.469155  9471 ControlLogic.cpp:169] fan_3: RPM read is 6134
I0407 23:24:22.472162  9471 ControlLogic.cpp:370] fan_4: is present in the host (through sysfs)
I0407 23:24:22.480146  9471 ControlLogic.cpp:169] fan_4: RPM read is 6122
I0407 23:24:22.480152  9471 ControlLogic.cpp:629] Processing Sensors ...
E0407 23:24:22.480160  9471 ControlLogic.cpp:238] SMB_BOARD_FRONT_TEMP: Sensor read value is 28.5
I0407 23:24:22.480171  9471 ControlLogic.cpp:221] SMB_BOARD_FRONT_TEMP: Calculated PWM is 43
I0407 23:24:22.480176  9471 ControlLogic.cpp:633] Processing Optics ...
I0407 23:24:22.480182  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 23.472656. PWM is 43
I0407 23:24:22.480187  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 26.164062. PWM is 43
I0407 23:24:22.480191  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 27.09375. PWM is 43
I0407 23:24:22.480196  9471 ControlLogic.cpp:346] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 43
I0407 23:24:22.480203  9471 ControlLogic.cpp:512] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 43.
I0407 23:24:22.483031  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 47 (raw value 120)
I0407 23:24:22.486038  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 47 (raw value 120)
I0407 23:24:22.486958  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 47 (raw value 120)
I0407 23:24:22.489044  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 47 (raw value 120)
I0407 23:24:22.490870  9471 ControlLogic.cpp:470] fan_1: Setting LED to Good (value: 1)
I0407 23:24:22.492693  9471 ControlLogic.cpp:470] fan_2: Setting LED to Good (value: 1)
I0407 23:24:22.494140  9471 ControlLogic.cpp:470] fan_3: Setting LED to Good (value: 1)
I0407 23:24:22.495958  9471 ControlLogic.cpp:470] fan_4: Setting LED to Good (value: 1)
[       OK ] FanServiceHwTest.FanControl (10973 ms)
[ RUN      ] FanServiceHwTest.FanStatusesThrift
I0407 23:24:22.496321  9471 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fan_service.json
I0407 23:24:22.496595  9471 ControlLogic.cpp:69] Upon fan_service start up, program all fan pwm with transitional value of 50
I0407 23:24:22.497144  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 50 (raw value 128)
I0407 23:24:22.498054  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 50 (raw value 128)
I0407 23:24:22.498972  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 50 (raw value 128)
I0407 23:24:22.499890  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 50 (raw value 128)
I0407 23:24:28.486405  9471 Bsp.cpp:326] Got sensor data from sensor_service.  Item count: 64
I0407 23:24:28.486423  9471 ControlLogic.cpp:100] Successfully fetched sensor data.
E0407 23:24:34.480419  9471 Bsp.cpp:159] Transceiver id 0 has no sensor data. Ignoring.
E0407 23:24:34.480436  9471 Bsp.cpp:159] Transceiver id 1 has no sensor data. Ignoring.
E0407 23:24:34.480441  9471 Bsp.cpp:159] Transceiver id 2 has no sensor data. Ignoring.
E0407 23:24:34.480445  9471 Bsp.cpp:159] Transceiver id 3 has no sensor data. Ignoring.
E0407 23:24:34.480449  9471 Bsp.cpp:159] Transceiver id 4 has no sensor data. Ignoring.
E0407 23:24:34.480453  9471 Bsp.cpp:159] Transceiver id 5 has no sensor data. Ignoring.
E0407 23:24:34.480458  9471 Bsp.cpp:159] Transceiver id 6 has no sensor data. Ignoring.
E0407 23:24:34.480462  9471 Bsp.cpp:159] Transceiver id 7 has no sensor data. Ignoring.
E0407 23:24:34.480466  9471 Bsp.cpp:159] Transceiver id 8 has no sensor data. Ignoring.
E0407 23:24:34.480470  9471 Bsp.cpp:159] Transceiver id 9 has no sensor data. Ignoring.
E0407 23:24:34.480474  9471 Bsp.cpp:159] Transceiver id 11 has no sensor data. Ignoring.
E0407 23:24:34.480478  9471 Bsp.cpp:159] Transceiver id 12 has no sensor data. Ignoring.
E0407 23:24:34.480483  9471 Bsp.cpp:159] Transceiver id 15 has no sensor data. Ignoring.
E0407 23:24:34.480492  9471 Bsp.cpp:159] Transceiver id 17 has no sensor data. Ignoring.
E0407 23:24:34.480496  9471 Bsp.cpp:159] Transceiver id 19 has no sensor data. Ignoring.
E0407 23:24:34.480500  9471 Bsp.cpp:159] Transceiver id 20 has no sensor data. Ignoring.
E0407 23:24:34.480504  9471 Bsp.cpp:159] Transceiver id 22 has no sensor data. Ignoring.
E0407 23:24:34.480508  9471 Bsp.cpp:159] Transceiver id 23 has no sensor data. Ignoring.
E0407 23:24:34.480512  9471 Bsp.cpp:159] Transceiver id 25 has no sensor data. Ignoring.
E0407 23:24:34.480517  9471 Bsp.cpp:159] Transceiver id 26 has no sensor data. Ignoring.
E0407 23:24:34.480521  9471 Bsp.cpp:159] Transceiver id 28 has no sensor data. Ignoring.
E0407 23:24:34.480525  9471 Bsp.cpp:159] Transceiver id 29 has no sensor data. Ignoring.
E0407 23:24:34.480529  9471 Bsp.cpp:159] Transceiver id 30 has no sensor data. Ignoring.
E0407 23:24:34.480539  9471 Bsp.cpp:159] Transceiver id 31 has no sensor data. Ignoring.
E0407 23:24:34.480543  9471 Bsp.cpp:159] Transceiver id 32 has no sensor data. Ignoring.
E0407 23:24:34.480547  9471 Bsp.cpp:159] Transceiver id 33 has no sensor data. Ignoring.
E0407 23:24:34.480551  9471 Bsp.cpp:159] Transceiver id 34 has no sensor data. Ignoring.
E0407 23:24:34.480555  9471 Bsp.cpp:159] Transceiver id 35 has no sensor data. Ignoring.
E0407 23:24:34.480559  9471 Bsp.cpp:159] Transceiver id 36 has no sensor data. Ignoring.
E0407 23:24:34.480563  9471 Bsp.cpp:159] Transceiver id 37 has no sensor data. Ignoring.
I0407 23:24:34.480570  9471 Bsp.cpp:280] Got optics data from Qsfp. Data Size: 3. QsfpSvcTimestamp: 1744068267
I0407 23:24:34.480602  9471 ControlLogic.cpp:110] Successfully fetched optics data.
I0407 23:24:34.480607  9471 ControlLogic.cpp:583] Processing Fans ...
I0407 23:24:34.481768  9471 ControlLogic.cpp:370] fan_1: is present in the host (through sysfs)
I0407 23:24:34.486144  9471 ControlLogic.cpp:169] fan_1: RPM read is 6833
I0407 23:24:34.487147  9471 ControlLogic.cpp:370] fan_2: is present in the host (through sysfs)
I0407 23:24:34.491148  9471 ControlLogic.cpp:169] fan_2: RPM read is 6849
I0407 23:24:34.492132  9471 ControlLogic.cpp:370] fan_3: is present in the host (through sysfs)
I0407 23:24:34.496142  9471 ControlLogic.cpp:169] fan_3: RPM read is 6864
I0407 23:24:34.497145  9471 ControlLogic.cpp:370] fan_4: is present in the host (through sysfs)
I0407 23:24:34.501141  9471 ControlLogic.cpp:169] fan_4: RPM read is 6864
I0407 23:24:34.501146  9471 ControlLogic.cpp:629] Processing Sensors ...
E0407 23:24:34.501152  9471 ControlLogic.cpp:238] SMB_BOARD_FRONT_TEMP: Sensor read value is 28.5
I0407 23:24:34.501161  9471 ControlLogic.cpp:221] SMB_BOARD_FRONT_TEMP: Calculated PWM is 43
I0407 23:24:34.501165  9471 ControlLogic.cpp:633] Processing Optics ...
I0407 23:24:34.501170  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 23.628906. PWM is 43
I0407 23:24:34.501174  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 26.246094. PWM is 43
I0407 23:24:34.501178  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 27.238281. PWM is 43
I0407 23:24:34.501182  9471 ControlLogic.cpp:346] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 43
I0407 23:24:34.501187  9471 ControlLogic.cpp:512] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 43.
I0407 23:24:34.502098  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 47 (raw value 120)
I0407 23:24:34.503003  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 47 (raw value 120)
I0407 23:24:34.503921  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 47 (raw value 120)
I0407 23:24:34.504839  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 47 (raw value 120)
I0407 23:24:34.506653  9471 ControlLogic.cpp:470] fan_1: Setting LED to Good (value: 1)
I0407 23:24:34.508040  9471 ControlLogic.cpp:470] fan_2: Setting LED to Good (value: 1)
I0407 23:24:34.509855  9471 ControlLogic.cpp:470] fan_3: Setting LED to Good (value: 1)
I0407 23:24:34.511664  9471 ControlLogic.cpp:470] fan_4: Setting LED to Good (value: 1)
I0407 23:24:34.511674  9471 FanServiceHandler.cpp:11] FanServiceHandler Started
I0407 23:24:34.512171  9493 ThriftServer.cpp:863] Using thread manager (resource pools not enabled) on address/port [::1]:0: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
[       OK ] FanServiceHwTest.FanStatusesThrift (18868 ms)
[ RUN      ] FanServiceHwTest.ODSCounters
I0407 23:24:41.364583  9471 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/fan_service.json
I0407 23:24:41.364882  9471 ControlLogic.cpp:69] Upon fan_service start up, program all fan pwm with transitional value of 50
I0407 23:24:41.365834  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 50 (raw value 128)
I0407 23:24:41.366759  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 50 (raw value 128)
I0407 23:24:41.367678  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 50 (raw value 128)
I0407 23:24:41.368597  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 50 (raw value 128)
I0407 23:24:46.958708  9471 Bsp.cpp:326] Got sensor data from sensor_service.  Item count: 64
I0407 23:24:46.958728  9471 ControlLogic.cpp:100] Successfully fetched sensor data.
E0407 23:24:53.907686  9471 Bsp.cpp:159] Transceiver id 0 has no sensor data. Ignoring.
E0407 23:24:53.907706  9471 Bsp.cpp:159] Transceiver id 1 has no sensor data. Ignoring.
E0407 23:24:53.907711  9471 Bsp.cpp:159] Transceiver id 2 has no sensor data. Ignoring.
E0407 23:24:53.907715  9471 Bsp.cpp:159] Transceiver id 3 has no sensor data. Ignoring.
E0407 23:24:53.907720  9471 Bsp.cpp:159] Transceiver id 4 has no sensor data. Ignoring.
E0407 23:24:53.907724  9471 Bsp.cpp:159] Transceiver id 5 has no sensor data. Ignoring.
E0407 23:24:53.907728  9471 Bsp.cpp:159] Transceiver id 6 has no sensor data. Ignoring.
E0407 23:24:53.907732  9471 Bsp.cpp:159] Transceiver id 7 has no sensor data. Ignoring.
E0407 23:24:53.907736  9471 Bsp.cpp:159] Transceiver id 8 has no sensor data. Ignoring.
E0407 23:24:53.907740  9471 Bsp.cpp:159] Transceiver id 9 has no sensor data. Ignoring.
E0407 23:24:53.907744  9471 Bsp.cpp:159] Transceiver id 11 has no sensor data. Ignoring.
E0407 23:24:53.907748  9471 Bsp.cpp:159] Transceiver id 12 has no sensor data. Ignoring.
E0407 23:24:53.907753  9471 Bsp.cpp:159] Transceiver id 15 has no sensor data. Ignoring.
E0407 23:24:53.907763  9471 Bsp.cpp:159] Transceiver id 17 has no sensor data. Ignoring.
E0407 23:24:53.907767  9471 Bsp.cpp:159] Transceiver id 19 has no sensor data. Ignoring.
E0407 23:24:53.907771  9471 Bsp.cpp:159] Transceiver id 20 has no sensor data. Ignoring.
E0407 23:24:53.907775  9471 Bsp.cpp:159] Transceiver id 22 has no sensor data. Ignoring.
E0407 23:24:53.907780  9471 Bsp.cpp:159] Transceiver id 23 has no sensor data. Ignoring.
E0407 23:24:53.907784  9471 Bsp.cpp:159] Transceiver id 25 has no sensor data. Ignoring.
E0407 23:24:53.907788  9471 Bsp.cpp:159] Transceiver id 26 has no sensor data. Ignoring.
E0407 23:24:53.907792  9471 Bsp.cpp:159] Transceiver id 28 has no sensor data. Ignoring.
E0407 23:24:53.907796  9471 Bsp.cpp:159] Transceiver id 29 has no sensor data. Ignoring.
E0407 23:24:53.907800  9471 Bsp.cpp:159] Transceiver id 30 has no sensor data. Ignoring.
E0407 23:24:53.907804  9471 Bsp.cpp:159] Transceiver id 31 has no sensor data. Ignoring.
E0407 23:24:53.907814  9471 Bsp.cpp:159] Transceiver id 32 has no sensor data. Ignoring.
E0407 23:24:53.907820  9471 Bsp.cpp:159] Transceiver id 33 has no sensor data. Ignoring.
E0407 23:24:53.907824  9471 Bsp.cpp:159] Transceiver id 34 has no sensor data. Ignoring.
E0407 23:24:53.907829  9471 Bsp.cpp:159] Transceiver id 35 has no sensor data. Ignoring.
E0407 23:24:53.907833  9471 Bsp.cpp:159] Transceiver id 36 has no sensor data. Ignoring.
E0407 23:24:53.907837  9471 Bsp.cpp:159] Transceiver id 37 has no sensor data. Ignoring.
I0407 23:24:53.907845  9471 Bsp.cpp:280] Got optics data from Qsfp. Data Size: 3. QsfpSvcTimestamp: 1744068277
I0407 23:24:53.907876  9471 ControlLogic.cpp:110] Successfully fetched optics data.
I0407 23:24:53.907882  9471 ControlLogic.cpp:583] Processing Fans ...
I0407 23:24:53.909045  9471 ControlLogic.cpp:370] fan_1: is present in the host (through sysfs)
I0407 23:24:53.913142  9471 ControlLogic.cpp:169] fan_1: RPM read is 6122
I0407 23:24:53.914148  9471 ControlLogic.cpp:370] fan_2: is present in the host (through sysfs)
I0407 23:24:53.918132  9471 ControlLogic.cpp:169] fan_2: RPM read is 6122
I0407 23:24:53.919143  9471 ControlLogic.cpp:370] fan_3: is present in the host (through sysfs)
I0407 23:24:53.923141  9471 ControlLogic.cpp:169] fan_3: RPM read is 6147
I0407 23:24:53.924146  9471 ControlLogic.cpp:370] fan_4: is present in the host (through sysfs)
I0407 23:24:53.928132  9471 ControlLogic.cpp:169] fan_4: RPM read is 6109
I0407 23:24:53.928137  9471 ControlLogic.cpp:629] Processing Sensors ...
E0407 23:24:53.928144  9471 ControlLogic.cpp:238] SMB_BOARD_FRONT_TEMP: Sensor read value is 29
I0407 23:24:53.928151  9471 ControlLogic.cpp:221] SMB_BOARD_FRONT_TEMP: Calculated PWM is 43
I0407 23:24:53.928157  9471 ControlLogic.cpp:633] Processing Optics ...
I0407 23:24:53.928162  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 23.78125. PWM is 43
I0407 23:24:53.928166  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 26.296875. PWM is 43
I0407 23:24:53.928170  9471 ControlLogic.cpp:301] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 27.238281. PWM is 43
I0407 23:24:53.928174  9471 ControlLogic.cpp:346] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 43
I0407 23:24:53.928181  9471 ControlLogic.cpp:512] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 43.
I0407 23:24:53.929093  9471 ControlLogic.cpp:449] fan_1: Programmed with PWM 47 (raw value 120)
I0407 23:24:53.930000  9471 ControlLogic.cpp:449] fan_2: Programmed with PWM 47 (raw value 120)
I0407 23:24:53.930906  9471 ControlLogic.cpp:449] fan_3: Programmed with PWM 47 (raw value 120)
I0407 23:24:53.931826  9471 ControlLogic.cpp:449] fan_4: Programmed with PWM 47 (raw value 120)
I0407 23:24:53.933645  9471 ControlLogic.cpp:470] fan_1: Setting LED to Good (value: 1)
I0407 23:24:53.935040  9471 ControlLogic.cpp:470] fan_2: Setting LED to Good (value: 1)
I0407 23:24:53.936852  9471 ControlLogic.cpp:470] fan_3: Setting LED to Good (value: 1)
I0407 23:24:53.938663  9471 ControlLogic.cpp:470] fan_4: Setting LED to Good (value: 1)
[       OK ] FanServiceHwTest.ODSCounters (12574 ms)
[----------] 4 tests from FanServiceHwTest (42420 ms total)
```