### PR TITLE
Dynamically determine and copy dependencies in package-fboss.py

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -436,7 +436,7 @@ class InstallSysDepsCmd(ProjectCmdBase):
         if manager == "rpm":
             packages = sorted(set(all_packages["rpm"]))
             if packages:
-                cmd_args = ["sudo", "dnf", "install", "-y"] + packages
+                cmd_args = ["sudo", "dnf", "install", "-y", "--skip-broken"] + packages
         elif manager == "deb":
             packages = sorted(set(all_packages["deb"]))
             if packages:

--- a/fboss/oss/scripts/docker-build.py
+++ b/fboss/oss/scripts/docker-build.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 
 OPT_ARG_SCRATCH_PATH = "--scratch-path"
@@ -25,7 +25,7 @@ FBOSS_CONTAINER_NAME = "FBOSS_BUILD_CONTAINER"
 CONTAINER_SCRATCH_PATH = "/var/FBOSS/tmp_bld_dir"
 
 
-def get_linux_type() -> tuple[Optional[str], Optional[str], Optional[str]]:
+def get_linux_type() -> Tuple[str, Optional[str], Optional[str]]:
     try:
         with open("/etc/os-release") as f:
             data = f.read()
@@ -206,7 +206,7 @@ def run_fboss_build(
     target: Optional[str],
     docker_output: bool,
     use_system_deps: bool,
-    env_vars: list[str],
+    env_vars: List[str],
     use_local: bool,
     num_jobs: Optional[int],
 ):

--- a/fboss/oss/scripts/package-fboss.py
+++ b/fboss/oss/scripts/package-fboss.py
@@ -19,6 +19,7 @@ def parse_args():
     parser.add_argument(
         OPT_ARG_SCRATCH_PATH,
         type=str,
+        required=True,
         help=(
             "use this path for build and install files e.g. "
             + OPT_ARG_SCRATCH_PATH
@@ -48,14 +49,10 @@ class PackageFboss:
 
     DEVTOOLS_LIBRARY_PATH = "/opt/rh/devtoolset-8/root/usr/lib64"
 
-    NAME_TO_EXECUTABLES = {
-        FBOSS: (BIN, [], BUILD),
-        "gflags": (LIB, [], INSTALLED),
-        "glog": (LIB, [], INSTALLED),
-        "libevent": (LIB, [], INSTALLED),
-        "libgpiod": (LIB, [], INSTALLED),
-        "libsodium": (LIB, [], INSTALLED),
-        "python": (LIB, [], INSTALLED),
+    # Project names and binaries we want packaged.
+    # If unspecified, all binaries for a given project will be copied over.
+    NAME_TO_BINARIES = {
+        FBOSS: [],
     }
 
     def __init__(self):
@@ -116,8 +113,11 @@ class PackageFboss:
         for file_name in src_files:
             full_file_name = os.path.join(run_scripts_path, file_name)
             script_pkg_path = os.path.join(tmp_dir_name, PackageFboss.BIN)
-            print(f"Copying {full_file_name} to {script_pkg_path}")
-            shutil.copy(full_file_name, script_pkg_path)
+            try:
+                shutil.copy(full_file_name, script_pkg_path)
+                print(f"Copied {full_file_name} to {script_pkg_path}")
+            except IsADirectoryError:
+                print(f"Skipping directory: {full_file_name}")
 
     def _copy_run_configs(self, tmp_dir_name):
         run_configs_path = self.get_fboss_subdirectory("fboss/oss/scripts/run_configs")
@@ -211,31 +211,35 @@ class PackageFboss:
     def _copy_binaries(self, tmp_dir_name):
         print("Copying binaries...")
 
-        for name, metadata in list(PackageFboss.NAME_TO_EXECUTABLES.items()):
-            executable_type, executables, location = metadata
-            installed_dirs = self._get_dir_for(name, location)
-            for installed_dir in installed_dirs:
-                bin_pkg_path = os.path.join(tmp_dir_name, executable_type)
-                # Get the matching executable_type dir in the installed dir
-                if name == PackageFboss.FBOSS:
-                    # FBOSS binaries are specifically located under {scratch}/build/fboss/...
-                    executable_path = glob.glob(installed_dir + "*")[0]
-                else:
-                    # Shared libraries are located under {scratch}/installed/...
-                    executable_path = glob.glob(
-                        os.path.join(installed_dir, executable_type) + "*"
-                    )[0]
-                # If module does not have executables listed, then copy all
-                if not executables:
-                    executables = os.listdir(executable_path)
+        self._update_ld_library_path()
 
-                for e in executables:
-                    abs_path = os.path.join(executable_path, e)
-                    print(f"Copying {abs_path} to {bin_pkg_path}")
+        for name, binaries in PackageFboss.NAME_TO_BINARIES.items():
+            bin_pkg_path = os.path.join(tmp_dir_name, PackageFboss.BIN)
+            lib_pkg_path = os.path.join(tmp_dir_name, PackageFboss.LIB)
+
+            # find the project directory: {scratch}/build/{name}
+            project_dirs = self._get_dir_for(name, PackageFboss.BUILD)
+            for project_dir in project_dirs:
+                if not binaries:
+                    binaries = os.listdir(project_dir)
+
+                for bin in binaries:
+                    bin_abs_path = os.path.join(project_dir, bin)
                     try:
-                        shutil.copy(abs_path, bin_pkg_path)
+                        shutil.copy(bin_abs_path, bin_pkg_path)
+                        print(f"Copied {bin_abs_path} to {bin_pkg_path}")
                     except OSError:
-                        print("Skipping non-existent " + abs_path)
+                        print(f"Skipping binary {bin_abs_path}")
+                        continue
+
+                    # retrieve dependencies using ldd
+                    dependencies = self._get_dependency_paths(bin_abs_path)
+                    for lib_abs_path in dependencies:
+                        try:
+                            shutil.copy(lib_abs_path, lib_pkg_path)
+                            print(f"Copied {lib_abs_path} to {lib_pkg_path}")
+                        except OSError:
+                            print(f"Skipping library {lib_abs_path}")
 
         self._copy_run_scripts(tmp_dir_name)
         self._copy_run_configs(tmp_dir_name)
@@ -243,6 +247,62 @@ class PackageFboss:
         self._copy_known_bad_tests(tmp_dir_name)
         self._copy_unsupported_tests(tmp_dir_name)
         self._copy_production_features(tmp_dir_name)
+
+    def _update_ld_library_path(self) -> None:
+        find_cmd = [
+            "find",
+            f"{self.scratch_path}/{PackageFboss.INSTALLED}",
+            "-type",
+            "d",
+            "-regex",
+            ".*/\\(lib\\|lib64\\)",
+        ]
+        try:
+            output = subprocess.check_output(find_cmd).decode("utf-8").strip()
+            lib_paths = ":".join(output.splitlines())
+            if os.environ.get("LD_LIBRARY_PATH") is not None:
+                os.environ["LD_LIBRARY_PATH"] = (
+                    f"{lib_paths}:{os.environ['LD_LIBRARY_PATH']}"
+                )
+            else:
+                os.environ["LD_LIBRARY_PATH"] = lib_paths
+        except subprocess.CalledProcessError:
+            print("Unable to update LD_LIBRARY_PATH, libs may be missing!")
+
+    def _get_dependency_paths(self, path_to_binary: str) -> {str}:
+        """
+        Get full paths to dependencies identified by ldd for a given binary.
+        """
+
+        dependencies = set()
+
+        try:
+            output = subprocess.check_output(["file", path_to_binary])
+            if b"executable" not in output and b"shared object" not in output:
+                return dependencies
+
+            output = subprocess.check_output(["ldd", path_to_binary]).decode("utf-8")
+        except subprocess.CalledProcessError:
+            print(f"Could not run ldd on path {path_to_binary}")
+            return dependencies
+
+        for line in output.splitlines():
+            if not line.strip():
+                continue
+
+            # ldd output can take multiple forms:
+            # /lib64/ld-linux-x86-64.so.2 (0x00007f4c1e7d2000)
+            # libudev.so.1 => /lib64/libudev.so.1 (0x00007f4c1bc48000)
+            parts = line.split("=>")
+            if len(parts) > 1:
+                lib_path = parts[1].split("(")[0].strip()
+            else:
+                lib_path = parts[0].split("(")[0].strip()
+
+            if not lib_path.startswith("/lib"):
+                dependencies.add(lib_path)
+
+        return dependencies
 
     def _compress_binaries(self):
         print("Compressing FBOSS Binaries...")


### PR DESCRIPTION
Summary: We want to copy libraries identified by ldd rather than the hardcoded mapping we have right now in package-fboss.py. These need to be packaged alongside the binaries as they are dynamically linked.

Differential Revision: D72731449
