### PR TITLE
[meru800bfa] Add backported isl drivers to platform_manager.json

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -142,13 +142,13 @@
         {
           "busName": "INCOMING@1",
           "address": "0x50",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_R3R0_ANLG0"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x51",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_R3R0_ANLG1"
         },
         {
@@ -160,13 +160,13 @@
         {
           "busName": "INCOMING@1",
           "address": "0x52",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_R3R1_ANLG0"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x53",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_R3R1_ANLG1"
         },
         {


### PR DESCRIPTION
Changes the intended 4 isl drivers for meru800bfa to use the backported isl drivers.

Tested on a meru800bfa system:

```
ls /sys/bus/i2c/drivers/bp4a_isl68137/
11-0050  11-0051  11-0052  11-0053  bind  module  uevent  unbind
```

PM logs:
```
 Creating i2c device SMB_ISL68226_R3R0_ANLG0 (bp4a_isl68226) at i2c-11
Created i2c device SMB_ISL68226_R3R0_ANLG0 (bp4a_isl68226) at /sys/bus/i2c/devices/11-0050
 Creating i2c device SMB_ISL68226_R3R0_ANLG1 (bp4a_isl68226) at i2c-11
 Created i2c device SMB_ISL68226_R3R0_ANLG1 (bp4a_isl68226) at /sys/bus/i2c/devices/11-0051
 Creating i2c device SMB_ISL68226_R3R1_ANLG0 (bp4a_isl68226) at i2c-11
Created i2c device SMB_ISL68226_R3R1_ANLG0 (bp4a_isl68226) at /sys/bus/i2c/devices/11-0052
 Creating i2c device SMB_ISL68226_R3R1_ANLG1 (bp4a_isl68226) at i2c-11
 Created i2c device SMB_ISL68226_R3R1_ANLG1 (bp4a_isl68226) at /sys/bus/i2c/devices/11-0053
```