### PR TITLE
Updates and Changes 

### DIFF
--- a/common/fb303/cpp/FacebookBase2.h
+++ b/common/fb303/cpp/FacebookBase2.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <time.h>
+#include <unistd.h> // For getpid()
 
 #include <common/fb303/if/gen-cpp2/FacebookService.h>
 #include <folly/small_vector.h>
@@ -32,18 +33,17 @@ enum ThriftFuncAction {
 };
 
 class FacebookBase2 : virtual public cpp2::FacebookServiceSvIf {
-  time_t startTime;
+  time_t startTime = time(nullptr);
+  std::string name_;
 
  public:
-  explicit FacebookBase2(std::string name) {
-    startTime = time(nullptr);
-  }
+  explicit FacebookBase2(std::string name) : name_(std::move(name)) {}
 
   void setEventBaseManager(folly::EventBaseManager*) {}
 
   int64_t aliveSince() override {
     // crude implementation because QsfpCache depends on it
-    return (uint64_t)startTime;
+    return static_cast<int64_t>(startTime);
   }
 
   int64_t getPid() override {


### PR DESCRIPTION
This PR performs a minimal cleanup and modernization of the FacebookBase2 class defined under the fb303 module. The changes are non-functional and strictly scoped to improve readability, consistency, and adherence to modern C++ standards.

Direct Initialization of startTime: Replaced assignment inside the constructor with direct member initialization using time(nullptr) at the declaration site.

Using modern C++ practices such as member initialization lists and std::move improves performance and clarity.