### PR TITLE
montblanc: config: adapt to two adm12xx devices for SCM board

### DIFF
--- a/fboss/platform/configs/montblanc/platform_manager.json
+++ b/fboss/platform/configs/montblanc/platform_manager.json
@@ -3091,7 +3091,7 @@
         {
           "busName": "SCM_MUX_A@0",
           "address": "0x10",
-          "kernelDeviceName": "adm1278",
+          "kernelDeviceName": "bp4f_adm1278",
           "pmUnitScopedName": "SCM_SENSOR"
         },
         {


### PR DESCRIPTION
**Description**
Updated platform manager configuration file to support new device adm1281.

**Motivation**
1.Updated the Platform PM config file to adapt new device amd1281.
2.Compatibility with different adm12xx devices using BSP driver PR#484.

**Test Plan**
1. Run the jq to format the json file.
2. Download the latest fboss platform manager binary.
3. It is correct to run the Platform Manager using the configuration files on the main and second source devices.

[Montblanc-platform_manager_PVT_main_source_adm1281_log_20250418.txt](https://github.com/user-attachments/files/19810355/Montblanc-platform_manager_PVT_main_source_adm1281_log_20250418.txt)
[Montblanc-platform_manager_PVT_2nd_source_log_20250418.txt](https://github.com/user-attachments/files/19810357/Montblanc-platform_manager_PVT_2nd_source_log_20250418.txt)
