### PR TITLE
Janga: config: remove the prefix bp4f in platform config

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -72,31 +72,31 @@
             {
               "busName": "INCOMING@1",
               "address": "0x11",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU31_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x22",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU32_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x45",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU41_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x66",
-              "kernelDeviceName": "bp4f_mp9941",
+              "kernelDeviceName": "mp9941",
               "pmUnitScopedName": "COME_PU42_TDA38640"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x76",
-              "kernelDeviceName": "bp4f_mp2993",
+              "kernelDeviceName": "mp2993",
               "pmUnitScopedName": "COME_PU4_XDPE15284"
             }
           ]
@@ -148,13 +148,13 @@
             {
               "busName": "INCOMING@3",
               "address": "0x2f",
-              "kernelDeviceName": "bp4f_mp2891",
+              "kernelDeviceName": "mp2891",
               "pmUnitScopedName": "SMB_U337_PMBUS_1"
             },
             {
               "busName": "INCOMING@3",
               "address": "0x21",
-              "kernelDeviceName": "bp4f_mp2891",
+              "kernelDeviceName": "mp2891",
               "pmUnitScopedName": "SMB_U177_PMBUS_2"
             },
             {
@@ -2097,7 +2097,7 @@
         {
           "busName": "SMB_IOB_I2C_MASTER_22",
           "address": "0x10",
-          "kernelDeviceName": "adm1272",
+          "kernelDeviceName": "bp4f_adm1272",
           "pmUnitScopedName": "SMB_U279_ADM1272_1"
         },
         {
@@ -2294,49 +2294,49 @@
         {
           "busName": "INCOMING@0",
           "address": "0x72",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U229_XDPE12284_1"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x6a",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U237_XDPE12284_2"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x76",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U210_XDPE12284_1"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x72",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U347_XDPE12284_2"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x70",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U92_XDPE12284_3"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x68",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U216_XDPE12284_4"
         },
         {
           "busName": "INCOMING@3",
           "address": "0x6a",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U86_XDPE12284_2"
         },
         {
           "busName": "INCOMING@3",
           "address": "0x70",
-          "kernelDeviceName": "bp4f_xdpe12284",
+          "kernelDeviceName": "xdpe12284",
           "pmUnitScopedName": "SMB_U343_XDPE12284_1"
         },
         {
@@ -2435,31 +2435,31 @@
         {
           "busName": "INCOMING@1",
           "address": "0x11",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU31_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x22",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU32_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x45",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU41_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x66",
-          "kernelDeviceName": "bp4f_tda38640",
+          "kernelDeviceName": "tda38640",
           "pmUnitScopedName": "COME_PU42_TDA38640"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x76",
-          "kernelDeviceName": "bp4f_xdpe15284",
+          "kernelDeviceName": "xdpe15284",
           "pmUnitScopedName": "COME_PU4_XDPE15284"
         }
       ]
@@ -2470,13 +2470,13 @@
         {
           "busName": "INCOMING@0",
           "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
+          "kernelDeviceName": "max31790",
           "pmUnitScopedName": "BCB_FAN_CPLD"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x5e",
-          "kernelDeviceName": "bp4f_max31790",
+          "kernelDeviceName": "max31790",
           "pmUnitScopedName": "BCB_FAN_CPLD_2"
         }
       ]


### PR DESCRIPTION
Description
1.This PR is for janga platform config file.Remove the prefix bp4f according to the github bsp new driver. Such as:
https://github.com/zhongedward/fboss.bsp.celestica/commit/131720f68e486a1c77e05fe2d4c2f817bd4c9a57

![image.png](https://dev.azure.com/celestica-hps/16458228-ffaa-4a71-971a-0cd833443086/_apis/git/repositories/8cd49794-7a39-425b-a1ae-ec7f5c69355a/pullRequests/17525/attachments/image.png) 
2.According to this PR https://github.com/facebookexternal/fboss.bsp.celestica/pull/484,should change adm1272 to bp4f_adm1272.
![image](https://github.com/user-attachments/assets/62bf5ce4-0a0a-4b34-8ae2-de5c95532c2d)

Motivation
1.In the PR has changed
bp4f_mp9941--->mp9941
bp4f_mp2993--->mp2993
bp4f_mp2891--->mp2891
bp4f_xdpe12284--->xdpe12284
bp4f_xdpe15284--->xdpe15284
bp4f_tda38640--->tda38640
bp4f_max31790--->max31790
adm1272--->bp4f_adm1272


Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:

....
I1014 21:08:37.767549 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_41 to /dev/i2c-71. DevicePath: /[SMB_DOM_I2C_MASTER_41]
I1014 21:08:37.769764 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_42 to /dev/i2c-72. DevicePath: /[SMB_DOM_I2C_MASTER_42]
I1014 21:08:37.771961 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_43 to /dev/i2c-73. DevicePath: /[SMB_DOM_I2C_MASTER_43]
I1014 21:08:37.774213 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_44 to /dev/i2c-74. DevicePath: /[SMB_DOM_I2C_MASTER_44]
I1014 21:08:37.776411 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_45 to /dev/i2c-75. DevicePath: /[SMB_DOM_I2C_MASTER_45]
I1014 21:08:37.778622 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_46 to /dev/i2c-76. DevicePath: /[SMB_DOM_I2C_MASTER_46]
I1014 21:08:37.780858 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_5 to /dev/i2c-35. DevicePath: /[SMB_DOM_I2C_MASTER_5]
I1014 21:08:37.783096 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_6 to /dev/i2c-36. DevicePath: /[SMB_DOM_I2C_MASTER_6]
I1014 21:08:37.785289 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_7 to /dev/i2c-37. DevicePath: /[SMB_DOM_I2C_MASTER_7]
I1014 21:08:37.787502 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_8 to /dev/i2c-38. DevicePath: /[SMB_DOM_I2C_MASTER_8]
I1014 21:08:37.789696 11377 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_9 to /dev/i2c-39. DevicePath: /[SMB_DOM_I2C_MASTER_9]
I1014 21:08:37.793525 11377 PlatformExplorer.cpp:738] Reporting firmware version for JANGA_SMB_CPLD - version string:2.4.0
I1014 21:08:37.795091 11377 PlatformExplorer.cpp:738] Reporting firmware version for PWR_CPLD - version string:2.3.0
I1014 21:08:37.796548 11377 PlatformExplorer.cpp:738] Reporting firmware version for SMB_CPLD_1 - version string:2.4.0
I1014 21:08:37.796593 11377 PlatformExplorer.cpp:738] Reporting firmware version for SMB_DOM_INFO_ROM - version string:0.42
I1014 21:08:37.796625 11377 PlatformExplorer.cpp:738] Reporting firmware version for SMB_IOB_INFO_ROM - version string:0.51
I1014 21:08:37.796735 11377 PlatformExplorer.cpp:768] Reporting Production State: 4
I1014 21:08:37.796742 11377 PlatformExplorer.cpp:778] Reporting Production Sub-State: 5
I1014 21:08:37.796749 11377 PlatformExplorer.cpp:788] Reporting Variant Indicator: 20
I1014 21:08:37.796766 11377 ExplorationSummary.cpp:49] Successfully explored janga800bic...
W1014 21:08:37.796806 11377 Main.cpp:71] Skipping sd_notify since $NOTIFY_SOCKET is not set which does not imply systemd execution.
I1014 21:08:37.796811 11377 Main.cpp:78] Running PlatformManager thrift service...
I1014 21:08:37.797448 11377 ThriftServer.cpp:861] Using thread manager (resource pools not enabled) on address/port 5975: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
^C
[root@localhost edward]# 
![image](https://github.com/user-attachments/assets/6e30f184-7e2d-459e-b697-1d5674f30c09)


[janga_platform_remove_bp4f_test_log_4_18.txt](https://github.com/user-attachments/files/19828122/janga_platform_remove_bp4f_test_log_4_18.txt)





