### PR TITLE
Montblanc: config: added overtemp support in configs

### DIFF
--- a/fboss/platform/configs/montblanc/fan_service.json
+++ b/fboss/platform/configs/montblanc/fan_service.json
@@ -6,6 +6,7 @@
   "pwmTransitionValue": 45,
   "pwmLowerThreshold": 25,
   "pwmUpperThreshold": 70,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD/th5_pwr_en",
   "watchdog": {
     "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
@@ -121,6 +122,16 @@
       }
     }
   ],
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 1,
+    "conditions": [
+      {
+        "sensorName": "SMB_TH5_TEMP",
+        "overtempThreshold": 110.0,
+        "slidingWindowSize": 1
+      }
+    ]
+  },
   "fans": [
     {
       "fanName": "FAN_1_F",

--- a/fboss/platform/configs/montblanc/platform_manager.json
+++ b/fboss/platform/configs/montblanc/platform_manager.json
@@ -347,7 +347,7 @@
             },
             {
               "busName": "INCOMING@3",
-              "address": "0x3e",
+              "address": "0x33",
               "kernelDeviceName": "mp3_smbcpld",
               "pmUnitScopedName": "SMB_CPLD"
             },
@@ -3262,7 +3262,7 @@
         },
         {
           "busName": "INCOMING@3",
-          "address": "0x3e",
+          "address": "0x33",
           "kernelDeviceName": "mp3_smbcpld",
           "pmUnitScopedName": "SMB_CPLD"
         },


### PR DESCRIPTION
Description
This PR added overtemp config for montblanc fan service and platform service.

Motivation
1.Added SMB_TH5_TEMP node to the fan service config. Threshold is 110 degrees and will run shoutdown cmd to shut down the TH5 ASIC in case of over-temperature.
![image](https://github.com/user-attachments/assets/472c9354-0026-4ff1-9797-a4b45fde5d3f)

2.If run the shutdown cmd "echo 0 > /run/devmap/cplds/SMB_CPLD/th5_pwr_en", Only shut down the TH5 ASIC not the entire system.

Test Plan
1.The correctness of the format has been verified on this website https://jsonlint.com/ 
2.Used jq cmd to pretty the format.
3.Test log as follows:

Note: For testing I set the threshold to 15 degrees trigger threshold.

Read the SMB_TH5_TEMP in sensor service:
![image](https://github.com/user-attachments/assets/5484179e-5813-456d-a6c7-d0f0e3152a76)

Overtemp run shutdown cmd in fan service:
![image](https://github.com/user-attachments/assets/682e04bd-d02a-4f80-a766-56f7731c2efa)

Nomal lspci:

![image](https://github.com/user-attachments/assets/8e3774bc-cc37-4a07-8abd-ed4491f97b1f)

After shutdown cat sysfs node th5_pwr_en:

![image](https://github.com/user-attachments/assets/05f0eab8-6f4b-4bc2-9081-b02791b7e8a3)

After shudown lspci:
![image](https://github.com/user-attachments/assets/53c58a8e-0315-44d8-8780-a6d156922ed9)


[mp3_fan_test_log_4_24.txt](https://github.com/user-attachments/files/19885230/mp3_fan_test_log_4_24.txt)
[mp3_cat_th5_pwr_en_log_4_24.txt](https://github.com/user-attachments/files/19885232/mp3_cat_th5_pwr_en_log_4_24.txt)
[mp3_lspci_log_4_24.txt](https://github.com/user-attachments/files/19885234/mp3_lspci_log_4_24.txt)
[mp3_platform_log_4_24.txt](https://github.com/user-attachments/files/19885237/mp3_platform_log_4_24.txt)
