### PR TITLE
Add required libraries to fix oss build of fboss

### DIFF
--- a/cmake/AgentPacket.cmake
+++ b/cmake/AgentPacket.cmake
@@ -62,4 +62,5 @@ target_link_libraries(packet_factory
   switch_config_cpp2
   Folly::folly
   sflow_structs
+  multiswitch_ctrl_cpp2
 )


### PR DESCRIPTION
Summary: When building fboss using getdeps.py, there are some dependencies missing that cause a build error. This diff adds them.

Differential Revision: D73962827


