### PR TITLE
Update platform_manager.json config without versionedPmUnitConfigs and fix some the warnings

### DIFF
--- a/fboss/platform/configs/minipack3ba/platform_manager.json
+++ b/fboss/platform/configs/minipack3ba/platform_manager.json
@@ -1,6 +1,6 @@
 {
-  "platformName": "montblanc",
-  "rootPmUnitName": "MINIPACK3_MCB",
+  "platformName": "MINIPACK3BA",
+  "rootPmUnitName": "MINIPACK3BA_MCB",
   "rootSlotType": "MCB_SLOT",
   "slotTypeConfigs": {
     "MCB_SLOT": {
@@ -10,7 +10,7 @@
         "address": "0x53",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "MINIPACK3_MCB"
+      "pmUnitName": "MINIPACK3BA_MCB"
     },
     "SCM_SLOT": {
       "numOutgoingI2cBuses": 4,
@@ -19,7 +19,7 @@
         "address": "0x54",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "MINIPACK3_SCM"
+      "pmUnitName": "SCM"
     },
     "RUNBMC_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -28,7 +28,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "MINIPACK3_BMC"
+      "pmUnitName": "BMC"
     },
     "PDBLEFT_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -37,7 +37,7 @@
         "address": "0x55",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "MINIPACK3_PDB_L"
+      "pmUnitName": "PDB_L"
     },
     "PDBRIGHT_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -46,7 +46,7 @@
         "address": "0x55",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "MINIPACK3_PDB_R"
+      "pmUnitName": "PDB_R"
     },
     "PSU_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -64,7 +64,7 @@
         "address": "0x50",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "MINIPACK3_SMB"
+      "pmUnitName": "SMB"
     },
     "FCBBOTTOM_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -73,7 +73,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "MINIPACK3_FCB_B"
+      "pmUnitName": "FCB_B"
     },
     "FCBTOP_SLOT": {
       "numOutgoingI2cBuses": 2,
@@ -82,7 +82,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c64"
       },
-      "pmUnitName": "MINIPACK3_FCB_T"
+      "pmUnitName": "FCB_T"
     },
     "FAN_SLOT": {
       "numOutgoingI2cBuses": 0,
@@ -104,7 +104,7 @@
         "address": "0x51",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "MINIPACK3_3V3_L"
+      "pmUnitName": "3V3_L"
     },
     "OPTICR_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -113,278 +113,15 @@
         "address": "0x51",
         "kernelDeviceName": "24c02"
       },
-      "pmUnitName": "MINIPACK3_3V3_R"
+      "pmUnitName": "3V3_R"
     }
   },
   "i2cAdaptersFromCpu": [
     "SMBus I801 adapter at 5000",
     "SMBus iSMT adapter at 20fffa7b000"
   ],
-  "versionedPmUnitConfigs": {
-    "NETLAKE": [
-      {
-        "pmUnitConfig": {
-          "pluggedInSlotType": "COMESE_SLOT",
-          "i2cDeviceConfigs": [
-            {
-              "busName": "INCOMING@0",
-              "address": "0x11",
-              "kernelDeviceName": "mp9941",
-              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x22",
-              "kernelDeviceName": "mp9941",
-              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x45",
-              "kernelDeviceName": "mp9941",
-              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x66",
-              "kernelDeviceName": "mp9941",
-              "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x76",
-              "kernelDeviceName": "mp2993",
-              "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
-            }
-          ]
-        },
-        "productSubVersion": 2
-      }
-    ],
-    "MINIPACK3_3V3_L": [
-      {
-        "pmUnitConfig": {
-          "pluggedInSlotType": "OPTICL_SLOT",
-          "i2cDeviceConfigs": [
-            {
-              "busName": "INCOMING@0",
-              "address": "0x23",
-              "kernelDeviceName": "mp2891",
-              "pmUnitScopedName": "3V3_L_MONITOR"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x48",
-              "kernelDeviceName": "tmp1075",
-              "pmUnitScopedName": "SMB_TSENSOR1"
-            }
-          ]
-        },
-        "productSubVersion": 10
-      }
-    ],
-    "MINIPACK3_3V3_R": [
-      {
-        "pmUnitConfig": {
-          "pluggedInSlotType": "OPTICR_SLOT",
-          "i2cDeviceConfigs": [
-            {
-              "busName": "INCOMING@0",
-              "address": "0x23",
-              "kernelDeviceName": "mp2891",
-              "pmUnitScopedName": "3V3_R_MONITOR"
-            },
-            {
-              "busName": "INCOMING@0",
-              "address": "0x48",
-              "kernelDeviceName": "tmp1075",
-              "pmUnitScopedName": "SMB_TSENSOR4"
-            }
-          ]
-        },
-        "productSubVersion": 10
-      }
-    ],
-    "MINIPACK3_SCM": [
-      {
-        "pmUnitConfig": {
-          "pluggedInSlotType": "SCM_SLOT",
-          "embeddedSensorConfigs": [
-            {
-              "pmUnitScopedName": "SCM_M2_SSD_TEMP",
-              "sysfsPath": "/sys/class/nvme/nvme0"
-            }
-          ],
-          "i2cDeviceConfigs": [
-            {
-              "busName": "INCOMING@0",
-              "address": "0x70",
-              "kernelDeviceName": "pca9548",
-              "pmUnitScopedName": "SCM_MUX_A",
-              "numOutgoingChannels": 8
-            },
-            {
-              "busName": "INCOMING@1",
-              "address": "0x70",
-              "kernelDeviceName": "pca9546",
-              "pmUnitScopedName": "SCM_MUX_B",
-              "numOutgoingChannels": 4
-            },
-            {
-              "busName": "INCOMING@2",
-              "address": "0x35",
-              "kernelDeviceName": "mp3_scmcpld",
-              "pmUnitScopedName": "SCM_CPLD",
-              "initRegSettings": [
-                {
-                  "regOffset": 177,
-                  "ioBuf": [2]
-                }
-              ]
-            },
-            {
-              "busName": "SCM_MUX_A@0",
-              "address": "0x44",
-              "kernelDeviceName": "lm25066",
-              "pmUnitScopedName": "SCM_SENSOR"
-            },
-            {
-              "busName": "SCM_MUX_A@1",
-              "address": "0x4c",
-              "kernelDeviceName": "lm75b",
-              "pmUnitScopedName": "SCM_TSENSOR1"
-            },
-            {
-              "busName": "SCM_MUX_A@1",
-              "address": "0x4d",
-              "kernelDeviceName": "lm75b",
-              "pmUnitScopedName": "SCM_TSENSOR2"
-            },
-            {
-              "busName": "SCM_MUX_A@2",
-              "address": "0x37",
-              "kernelDeviceName": "adc128d818",
-              "pmUnitScopedName": "SCM_VOLTAGE_MONITOR1",
-              "initRegSettings": [
-                {
-                  "regOffset": 11,
-                  "ioBuf": [2]
-                }
-              ]
-            },
-            {
-              "busName": "SCM_MUX_A@3",
-              "address": "0x4c",
-              "kernelDeviceName": "tps25990",
-              "pmUnitScopedName": "SCM_VOLTAGE_MONITOR2"
-            },
-            {
-              "busName": "INCOMING@3",
-              "address": "0x48",
-              "kernelDeviceName": "tmp75",
-              "pmUnitScopedName": "COME_TSENSOR1"
-            },
-            {
-              "busName": "INCOMING@3",
-              "address": "0x4a",
-              "kernelDeviceName": "tmp75",
-              "pmUnitScopedName": "COME_TSENSOR2"
-            }
-          ],
-          "outgoingSlotConfigs": {
-            "RUNBMC_SLOT@0": {
-              "slotType": "RUNBMC_SLOT",
-              "outgoingI2cBusNames": [
-                "SCM_MUX_A@7"
-              ]
-            },
-            "COMESE_SLOT@0": {
-              "slotType": "COMESE_SLOT",
-              "outgoingI2cBusNames": [
-                "SCM_MUX_B@1",
-                "INCOMING@3"
-              ]
-            }
-          }
-        },
-        "productSubVersion": 10
-      }
-    ],
-    "MINIPACK3_SMB": [
-      {
-        "pmUnitConfig": {
-          "pluggedInSlotType": "SMB_SLOT",
-          "i2cDeviceConfigs": [
-            {
-              "busName": "INCOMING@0",
-              "address": "0x21",
-              "kernelDeviceName": "mp2891",
-              "pmUnitScopedName": "SMB_VRM1"
-            },
-            {
-              "busName": "INCOMING@1",
-              "address": "0x1f",
-              "kernelDeviceName": "adc128d818",
-              "pmUnitScopedName": "SMB_VOLTAGE_MONITOR1",
-              "initRegSettings": [
-                {
-                  "regOffset": 11,
-                  "ioBuf": [2]
-                }
-              ]
-            },
-            {
-              "busName": "INCOMING@2",
-              "address": "0x35",
-              "kernelDeviceName": "adc128d818",
-              "pmUnitScopedName": "SMB_VOLTAGE_MONITOR2",
-              "initRegSettings": [
-                {
-                  "regOffset": 11,
-                  "ioBuf": [2]
-                }
-              ]
-            },
-            {
-              "busName": "INCOMING@3",
-              "address": "0x3e",
-              "kernelDeviceName": "mp3_smbcpld",
-              "pmUnitScopedName": "SMB_CPLD"
-            },
-            {
-              "busName": "INCOMING@4",
-              "address": "0x7d",
-              "kernelDeviceName": "mp2975",
-              "pmUnitScopedName": "SMB_VRM2"
-            },
-            {
-              "busName": "INCOMING@5",
-              "address": "0x7b",
-              "kernelDeviceName": "mp2975",
-              "pmUnitScopedName": "SMB_VRM3"
-            }
-          ],
-          "outgoingSlotConfigs": {
-            "OPTICL_SLOT@0": {
-              "slotType": "OPTICL_SLOT",
-              "outgoingI2cBusNames": [
-                "INCOMING@6"
-              ]
-            },
-            "OPTICR_SLOT@0": {
-              "slotType": "OPTICR_SLOT",
-              "outgoingI2cBusNames": [
-                "INCOMING@7"
-              ]
-            }
-          }
-        },
-        "productSubVersion": 10
-      }
-    ]
-  },
   "pmUnitConfigs": {
-    "MINIPACK3_MCB": {
+    "MINIPACK3BA_MCB": {
       "pluggedInSlotType": "MCB_SLOT",
       "embeddedSensorConfigs": [
         {
@@ -3053,7 +2790,7 @@
         }
       }
     },
-    "MINIPACK3_SCM": {
+    "SCM": {
       "pluggedInSlotType": "SCM_SLOT",
       "embeddedSensorConfigs": [
         {
@@ -3090,8 +2827,8 @@
         },
         {
           "busName": "SCM_MUX_A@0",
-          "address": "0x10",
-          "kernelDeviceName": "adm1278",
+          "address": "0x44",
+          "kernelDeviceName": "lm25066",
           "pmUnitScopedName": "SCM_SENSOR"
         },
         {
@@ -3153,7 +2890,7 @@
         }
       }
     },
-    "MINIPACK3_BMC": {
+    "BMC": {
       "pluggedInSlotType": "RUNBMC_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3164,7 +2901,7 @@
         }
       ]
     },
-    "MINIPACK3_PDB_L": {
+    "PDB_L": {
       "pluggedInSlotType": "PDBLEFT_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3190,7 +2927,7 @@
         }
       }
     },
-    "MINIPACK3_PDB_R": {
+    "PDB_R": {
       "pluggedInSlotType": "PDBRIGHT_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3227,7 +2964,7 @@
         }
       ]
     },
-    "MINIPACK3_SMB": {
+    "SMB": {
       "pluggedInSlotType": "SMB_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3294,7 +3031,7 @@
         }
       }
     },
-    "MINIPACK3_FCB_T": {
+    "FCB_T": {
       "pluggedInSlotType": "FCBTOP_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3359,7 +3096,7 @@
         }
       }
     },
-    "MINIPACK3_FCB_B": {
+    "FCB_B": {
       "pluggedInSlotType": "FCBBOTTOM_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3427,36 +3164,36 @@
         {
           "busName": "INCOMING@0",
           "address": "0x11",
-          "kernelDeviceName": "tda38640",
+          "kernelDeviceName": "mp9941",
           "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x22",
-          "kernelDeviceName": "tda38640",
+          "kernelDeviceName": "mp9941",
           "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x45",
-          "kernelDeviceName": "tda38640",
+          "kernelDeviceName": "mp9941",
           "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x66",
-          "kernelDeviceName": "tda38640",
+          "kernelDeviceName": "mp9941",
           "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x76",
-          "kernelDeviceName": "xdpe15284",
+          "kernelDeviceName": "mp2993",
           "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
         }
       ]
     },
-    "MINIPACK3_3V3_L": {
+    "3V3_L": {
       "pluggedInSlotType": "OPTICL_SLOT",
       "i2cDeviceConfigs": [
         {
@@ -3473,7 +3210,7 @@
         }
       ]
     },
-    "MINIPACK3_3V3_R": {
+    "3V3_R": {
       "pluggedInSlotType": "OPTICR_SLOT",
       "i2cDeviceConfigs": [
         {

--- a/fboss/platform/configs/minipack3ba/sensor_service.json
+++ b/fboss/platform/configs/minipack3ba/sensor_service.json
@@ -2,7 +2,7 @@
   "pmUnitSensorsList": [
     {
       "slotPath": "/",
-      "pmUnitName": "MINIPACK3_MCB",
+      "pmUnitName": "MINIPACK3BA_MCB",
       "sensors": [
         {
           "name": "SMB_LEFT_U51_TEMP",
@@ -636,7 +636,7 @@
     },
     {
       "slotPath": "/SCM_SLOT@0/RUNBMC_SLOT@0",
-      "pmUnitName": "MINIPACK3_BMC",
+      "pmUnitName": "BMC",
       "sensors": [
         {
           "name": "RUNBMC_THERMAL_SENSOR",
@@ -890,6 +890,28 @@
           "compute": "@/1000"
         },
         {
+          "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.2,
+            "maxAlarmVal": 2,
+            "lowerCriticalVal": 1.4
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_XDPE15284_P1V8_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 2.2,
+            "maxAlarmVal": 2,
+            "lowerCriticalVal": 1.4
+          },
+          "compute": "@/1000"
+        },
+        {
           "name": "COME_PU4_XDPE15284_PVCCIN_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
           "type": 3,
@@ -919,6 +941,24 @@
           "compute": "@/1000000"
         },
         {
+          "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 1024
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU4_XDPE15284_P1V8_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 125
+          },
+          "compute": "@/1000000"
+        },
+        {
           "name": "COME_PU4_XDPE15284_PVCCIN_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
           "type": 2,
@@ -927,342 +967,32 @@
             "maxAlarmVal": 12
           },
           "compute": "@/1000"
-        }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 52.5
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 318.5
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 15
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 3.5,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 94
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 6,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 1,
-          "productSubVersion": 1
         },
         {
-          "sensors": [
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 125
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 94
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 6,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 1,
-          "productSubVersion": 2
+          "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 130,
+            "maxAlarmVal": 94
+          },
+          "compute": "@/1000"
         },
         {
-          "sensors": [
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_PIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 52.5
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 318.5
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 15
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IIN",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 3.5,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 94
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 6,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 4,
-          "productVersion": 1,
-          "productSubVersion": 1
-        },
-        {
-          "sensors": [
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 2.2,
-                "maxAlarmVal": 2,
-                "lowerCriticalVal": 1.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_POUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-              "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 125
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_PVCCIN_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 94
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "COME_PU4_XDPE15284_P1V8_IOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 6,
-                "maxAlarmVal": 3
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 4,
-          "productVersion": 1,
-          "productSubVersion": 2
+          "name": "COME_PU4_XDPE15284_P1V8_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 6,
+            "maxAlarmVal": 3
+          },
+          "compute": "@/1000"
         }
       ]
     },
     {
       "slotPath": "/FCBBOTTOM_SLOT@0",
-      "pmUnitName": "MINIPACK3_FCB_B",
+      "pmUnitName": "FCB_B",
       "sensors": [
         {
           "name": "FCB_B_U1_TEMP",
@@ -1288,7 +1018,7 @@
     },
     {
       "slotPath": "/FCBTOP_SLOT@0",
-      "pmUnitName": "MINIPACK3_FCB_T",
+      "pmUnitName": "FCB_T",
       "sensors": [
         {
           "name": "FCB_T_U1_TEMP",
@@ -1314,7 +1044,7 @@
     },
     {
       "slotPath": "/PDBLEFT_SLOT@0",
-      "pmUnitName": "MINIPACK3_PDB_L",
+      "pmUnitName": "PDB_L",
       "sensors": [
         {
           "name": "PDB_L_U1_TEMP",
@@ -1456,7 +1186,7 @@
     },
     {
       "slotPath": "/PDBRIGHT_SLOT@0",
-      "pmUnitName": "MINIPACK3_PDB_R",
+      "pmUnitName": "PDB_R",
       "sensors": [
         {
           "name": "PDB_R_U1_TEMP",
@@ -1598,7 +1328,7 @@
     },
     {
       "slotPath": "/SCM_SLOT@0",
-      "pmUnitName": "MINIPACK3_SCM",
+      "pmUnitName": "SCM",
       "sensors": [
         {
           "name": "COME_U18_INLET_SENSOR_TMP75_TEMP",
@@ -1807,150 +1537,22 @@
             "maxAlarmVal": 55
           },
           "compute": "@/1000"
-        }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 10
         },
         {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 0,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 1,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SCM_12V_HSC_IIN",
-              "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 9,
-                "maxAlarmVal": 8
-              },
-              "compute": "@/1000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 2,
-          "productSubVersion": 10
+          "name": "SCM_12V_HSC_IIN",
+          "sysfsPath": "/run/devmap/sensors/SCM_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 9,
+            "maxAlarmVal": 8
+          },
+          "compute": "@/1000"
         }
       ]
     },
     {
       "slotPath": "/SMB_SLOT@0",
-      "pmUnitName": "MINIPACK3_SMB",
+      "pmUnitName": "SMB",
       "sensors": [
         {
           "name": "SMB_XP3R3V_CLK",
@@ -2173,6 +1775,26 @@
           "compute": "@/1000"
         },
         {
+          "name": "SMB_VDDC_VRM_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 827,
+            "maxAlarmVal": 661.6
+          },
+          "compute": "@/1000"
+        },        
+        {
+          "name": "SMB_VDDC_VRM_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 750,
+            "maxAlarmVal": 675
+          },
+          "compute": "@/1000000"
+        },
+        {
           "name": "SMB_VDDC_VRM_VOUT",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
           "type": 1,
@@ -2216,7 +1838,72 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
           "type": 2,
           "compute": "@/1000"
+        }, 
+
+        {
+          "name": "SMB_0V9_R_VRM1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 63,
+            "maxAlarmVal": 56.7
+          },
+          "compute": "@/1000000"
         },
+        {
+          "name": "SMB_0V9_R_VRM1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.945,
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000"
+        }, 
+        {
+          "name": "SMB_0V9_R_VRM1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 70,
+            "maxAlarmVal": 63
+          },
+          "compute": "@/1000"
+        },         
+        {
+          "name": "SMB_0V75_R_VRM1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 27,
+            "maxAlarmVal": 24.3
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_0V75_R_VRM1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.7875,
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000"
+        },         
+        {
+          "name": "SMB_0V75_R_VRM1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 36,
+            "maxAlarmVal": 32.4
+          },
+          "compute": "@/1000"
+        },         
         {
           "name": "SMB_0V75_0V9_R_VRM1_TEMP",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
@@ -2240,7 +1927,7 @@
             "lowerCriticalVal": 10.8
           },
           "compute": "@/1000"
-        },
+        },        
         {
           "name": "SMB_0V75_0V9_L_VRM0_IIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
@@ -2248,2033 +1935,80 @@
           "compute": "@/1000"
         },
         {
+          "name": "SMB_0V9_L_VRM0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 63,
+            "maxAlarmVal": 56.7
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_0V9_L_VRM0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.945,
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_0V9_L_VRM0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 70,
+            "maxAlarmVal": 63
+          },
+          "compute": "@/1000"
+        },            
+        {
+          "name": "SMB_0V75_L_VRM0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 27,
+            "maxAlarmVal": 24.3
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_0V75_L_VRM0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.7875,
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000"
+        },            
+        {
+          "name": "SMB_0V75_L_VRM0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 36,
+            "maxAlarmVal": 32.4
+          },
+          "compute": "@/1000"
+        },        
+        {
           "name": "SMB_0V75_0V9_L_VRM0_TEMP",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
           "type": 3,
           "compute": "@/1000"
         }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr2_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr6_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in2_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 0,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 1,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_VDDC_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 750,
-                "maxAlarmVal": 675
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_VDDC_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM1/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 827,
-                "maxAlarmVal": 661.6
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_R_VRM1_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 70,
-                "maxAlarmVal": 63
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 36,
-                "maxAlarmVal": 32.4
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.945,
-                "maxAlarmVal": 0.927,
-                "minAlarmVal": 0.873,
-                "lowerCriticalVal": 0.855
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_VOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in4_input",
-              "type": 1,
-              "thresholds": {
-                "upperCriticalVal": 0.7875,
-                "maxAlarmVal": 0.7725,
-                "minAlarmVal": 0.7275,
-                "lowerCriticalVal": 0.7125
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_0V9_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 63,
-                "maxAlarmVal": 56.7
-              },
-              "compute": "@/1000000"
-            },
-            {
-              "name": "SMB_0V75_L_VRM0_POUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 27,
-                "maxAlarmVal": 24.3
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 2,
-          "productSubVersion": 20
-        }
       ]
     },
     {
       "slotPath": "/SMB_SLOT@0/OPTICL_SLOT@0",
-      "pmUnitName": "MINIPACK3_3V3_L",
+      "pmUnitName": "3V3_L",
       "sensors": [
         {
           "name": "SMB_3V3_L_U8_TEMP",
@@ -4321,315 +2055,36 @@
           "compute": "3*@/1000"
         },
         {
+          "name": "SMB_3V3_L_VRM_IOUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 250,
+            "maxAlarmVal": 214
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_3V3_L_VRM_POUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 825,
+            "maxAlarmVal": 706.2
+          },
+          "compute": "@/1000000"
+        },
+        {
           "name": "SMB_3V3_L_VRM_TEMP",
           "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
           "type": 3,
           "compute": "@/1000"
         }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_L_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_L_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 0,
-          "productSubVersion": 20
-        }
       ]
     },
     {
       "slotPath": "/SMB_SLOT@0/OPTICR_SLOT@0",
-      "pmUnitName": "MINIPACK3_3V3_R",
+      "pmUnitName": "3V3_R",
       "sensors": [
         {
           "name": "SMB_3V3_R_U8_TEMP",
@@ -4648,6 +2103,16 @@
           "thresholds": {
             "upperCriticalVal": 887,
             "maxAlarmVal": 760
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_3V3_R_VRM_POUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 825,
+            "maxAlarmVal": 706.2
           },
           "compute": "@/1000000"
         },
@@ -4676,309 +2141,20 @@
           "compute": "3*@/1000"
         },
         {
+          "name": "SMB_3V3_R_VRM_IOUT",
+          "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 250,
+            "maxAlarmVal": 214
+          },
+          "compute": "@/1000"
+        },
+        {
           "name": "SMB_3V3_R_VRM_TEMP",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
           "type": 3,
           "compute": "@/1000"
-        }
-      ],
-      "versionedSensors": [
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 10
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 0,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 2,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 3,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 2,
-          "productVersion": 4,
-          "productSubVersion": 20
-        },
-        {
-          "sensors": [
-            {
-              "name": "SMB_3V3_R_VRM_IOUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/curr1_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 250,
-                "maxAlarmVal": 214
-              },
-              "compute": "@/1000"
-            },
-            {
-              "name": "SMB_3V3_R_VRM_POUT",
-              "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/power2_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 825,
-                "maxAlarmVal": 706.2
-              },
-              "compute": "@/1000000"
-            }
-          ],
-          "productProductionState": 3,
-          "productVersion": 0,
-          "productSubVersion": 20
         }
       ]
     }


### PR DESCRIPTION
Update platform_manager.json config without versionedPmUnitConfigs to enable successful execution on MINIPACK3BA device
and fix some the warnings.

W1015 08:00:38.818906   762 PlatformExplorer.cpp:387] The PmUnit name in IDPROM -`MINIPACK3BA_MCB` is different from the one in config - `MINIPACK3_MCB`. NEEDS FIX.
W1015 08:00:46.411411   762 PlatformExplorer.cpp:387] The PmUnit name in IDPROM -`FCB_B` is different from the one in config - `MINIPACK3_FCB_B`. NEEDS FIX.
W1015 08:00:46.811580   762 PlatformExplorer.cpp:387] The PmUnit name in IDPROM -`FCB_T` is different from the one in config - `MINIPACK3_FCB_T`. NEEDS FIX.
W1015 08:00:46.841680   762 PlatformExplorer.cpp:387] The PmUnit name in IDPROM -`PDB_L` is different from the one in config - `MINIPACK3_PDB_L`. NEEDS FIX.
...

[minipack3ba-platform_manager_log_20250502.log](https://github.com/user-attachments/files/20008804/minipack3ba-platform_manager_log_20250502.log)