### PR TITLE
[meru800biab] Remove unnecessary references

### DIFF
--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -303,7 +303,7 @@ std::optional<std::string> PlatformExplorer::getPmUnitNameFromSlot(
     See: https://github.com/facebookexternal/fboss.bsp.arista/pull/31/files
     */
     if ((platformConfig_.platformName().value() == "meru800bfa" ||
-         platformConfig_.platformName().value() == "meru800bia" ) &&
+         platformConfig_.platformName().value() == "meru800bia") &&
         (!(idpromConfig.busName()->starts_with("INCOMING")) &&
          *idpromConfig.address() == "0x50")) {
       try {

--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -303,8 +303,7 @@ std::optional<std::string> PlatformExplorer::getPmUnitNameFromSlot(
     See: https://github.com/facebookexternal/fboss.bsp.arista/pull/31/files
     */
     if ((platformConfig_.platformName().value() == "meru800bfa" ||
-         platformConfig_.platformName().value() == "meru800bia" ||
-         platformConfig_.platformName().value() == "meru800biab") &&
+         platformConfig_.platformName().value() == "meru800bia" ) &&
         (!(idpromConfig.busName()->starts_with("INCOMING")) &&
          *idpromConfig.address() == "0x50")) {
       try {


### PR DESCRIPTION
Platform logic has been changed so that meru800biab uses meru800bia configs - https://github.com/facebook/fboss/pull/381 

This PR simply updates the codebase to remove unnecessary meru800biab references, which happens to only be in one place, as the other references are needed for the agent/qsfp_service to distinguish between products.

Tested that there are no issues on platform_manager and qsfp_service.