### PR TITLE
Arista: update meru800bia and meru800bfa, VRM 3.3V reading

### DIFF
--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -573,7 +573,7 @@
             "upperCriticalVal": 3.96,
             "lowerCriticalVal": 2.64
           },
-          "compute": "@/1000.0"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_VRM_OSFP_TL_TEMP_3V3",
@@ -603,7 +603,7 @@
             "upperCriticalVal": 3.96,
             "lowerCriticalVal": 2.64
           },
-          "compute": "@/1000.0"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_VRM_OSFP_TR_TEMP_3V3",
@@ -633,7 +633,7 @@
             "upperCriticalVal": 3.96,
             "lowerCriticalVal": 2.64
           },
-          "compute": "@/1000.0"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_VRM_OSFP_BL_TEMP_3V3",
@@ -663,7 +663,7 @@
             "upperCriticalVal": 3.96,
             "lowerCriticalVal": 2.64
           },
-          "compute": "@/1000.0"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_VRM_OSFP_BR_TEMP_3V3",

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -363,7 +363,7 @@
             "upperCriticalVal": 3.96,
             "lowerCriticalVal": 2.64
           },
-          "compute": "@/1000.0"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_VRM3_TEMP",


### PR DESCRIPTION
 
# Description , meru800bia and meru800bfa some of their sensors 3.3V reading were off by 20%.
In one of the debug session with Meta, we notice the device voltage reading appear to be at the low end ... it still meet the min requirement. We investigate it on our end and confirm with the HW engineer, the reading were off by 20% due to a voltage divider in that particular circult.


This commit is to adjust those impacted sensors reading by 20%.

## UT:
**meru800bia** :  

### before:
    SensorData(
        name='SMB_VRM3_VOUT_OPTICS_3V3',
        value=2.749000072479248,
        timeStamp=1744670615,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1)])
### after:
    SensorData(
        name='SMB_VRM3_VOUT_OPTICS_3V3',
        value=3.3000001907348633,
        timeStamp=1744764963,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1)])        
      
         
        
 **meru800bfa:**
 
 ### before:
    SensorData(
        name='SMB_VRM_OSFP_BL_VOUT_3V3',
        value=2.7980000972747803,
        timeStamp=1744740910,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
     SensorData(
        name='SMB_VRM_OSFP_BR_VOUT_3V3',
        value=2.8010001182556152,
        timeStamp=1744740910,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
        SensorData(
        name='SMB_VRM_OSFP_TL_VOUT_3V3',
        value=2.7980000972747803,
        timeStamp=1744740910,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
         SensorData(
        name='SMB_VRM_OSFP_TR_VOUT_3V3',
        value=2.7980000972747803,
        timeStamp=1744740910,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
        
  ### after:
        SensorData(
        name='SMB_VRM_OSFP_BL_VOUT_3V3',
        value=3.357600212097168,
        timeStamp=1744752016,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
        SensorData(
        name='SMB_VRM_OSFP_BR_VOUT_3V3',
        value=3.3612000942230225,
        timeStamp=1744752016,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
         SensorData(
        name='SMB_VRM_OSFP_TL_VOUT_3V3',
        value=3.357600212097168,
        timeStamp=1744752016,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
        
        SensorData(
        name='SMB_VRM_OSFP_TR_VOUT_3V3',
        value=3.358800172805786,
        timeStamp=1744752016,
        thresholds=Thresholds(
            upperCriticalVal=3.96,
            lowerCriticalVal=2.64),
        sensorType=1),
