### PR TITLE
Tahan: config: changed bsp kmods version to 3.1.0-1 in platform config

### DIFF
--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -2100,7 +2100,7 @@
   },
   "chassisEepromDevicePath": "/SMB_FRU_SLOT@0/[IDPROM]",
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "3.0.0-1",
+  "bspKmodsRpmVersion": "3.1.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",


### PR DESCRIPTION
### Description
This PR is for the tahan platform service to support the latest BSP version 3.1.0-1.

### Motivation
According to this BSP repository commit below, we need to adjust the BSP version to 3.1.0-1 in the platform config file.
<img width="490" alt="unnamed (2)" src="https://github.com/user-attachments/assets/c12e30cf-4878-482b-939e-7e5480298a91" />

### Test Plan
1. The correctness of the format has been verified on this jsonlint website.
2. Used jq command to pretty the format.
3. Test log as follows:

...
I0508 11:13:45.805033 1934 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_5 to /dev/i2c-33. DevicePath: /[SMB_DOM_I2C_MASTER_5]
I0508 11:13:45.807061 1934 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_6 to /dev/i2c-34. DevicePath: /[SMB_DOM_I2C_MASTER_6]
I0508 11:13:45.809138 1934 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_7 to /dev/i2c-35. DevicePath: /[SMB_DOM_I2C_MASTER_7]
I0508 11:13:45.811194 1934 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_8 to /dev/i2c-36. DevicePath: /[SMB_DOM_I2C_MASTER_8]
I0508 11:13:45.813261 1934 PlatformExplorer.cpp:688] Creating symlink from /run/devmap/xcvrs/xcvr_io_9 to /dev/i2c-37. DevicePath: /[SMB_DOM_I2C_MASTER_9]
I0508 11:13:45.816879 1934 PlatformExplorer.cpp:738] Reporting firmware version for PWR_CPLD - version string:2.1.0
I0508 11:13:45.818334 1934 PlatformExplorer.cpp:738] Reporting firmware version for SMB_CPLD_1 - version string:2.1.0
I0508 11:13:45.819890 1934 PlatformExplorer.cpp:738] Reporting firmware version for TAHAN_SMB_CPLD - version string:2.1.0
I0508 11:13:45.819924 1934 PlatformExplorer.cpp:738] Reporting firmware version for SMB_DOM_INFO_ROM - version string:0.38
I0508 11:13:45.819947 1934 PlatformExplorer.cpp:738] Reporting firmware version for SMB_IOB_INFO_ROM - version string:0.50
I0508 11:13:45.820042 1934 PlatformExplorer.cpp:768] Reporting Production State: 3
I0508 11:13:45.820049 1934 PlatformExplorer.cpp:778] Reporting Production Sub-State: 5
I0508 11:13:45.820054 1934 PlatformExplorer.cpp:788] Reporting Variant Indicator: 20
**I0508 11:13:45.820066 1934 ExplorationSummary.cpp:49] Successfully explored tahan800bc...**
W0508 11:13:45.820094 1934 Main.cpp:71] Skipping sd_notify since $NOTIFY_SOCKET is not set which does not imply systemd execution.
I0508 11:13:45.820099 1934 Main.cpp:78] Running PlatformManager thrift service...
I0508 11:13:45.820703 1934 ThriftServer.cpp:868] Using thread manager (resource pools not enabled) on address/port 5975: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false

[tahan_platform_5_8_test_log.txt](https://github.com/user-attachments/files/20117337/tahan_platform_5_8_test_log.txt)



