### PR TITLE
Janga: config: rack config

### DIFF
--- a/fboss/platform/configs/janga800bic/fan_service.json
+++ b/fboss/platform/configs/janga800bic/fan_service.json
@@ -2,9 +2,9 @@
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 100,
-  "pwmTransitionValue": 50,
-  "pwmLowerThreshold": 30,
+  "pwmBoostValue": 80,
+  "pwmTransitionValue": 55,
+  "pwmLowerThreshold": 20,
   "pwmUpperThreshold": 100,
   "shutdownCmd": "echo 0 > /run/devmap/cplds/JANGA_SMB_CPLD/j3a_pwr_en;echo 0 > /run/devmap/cplds/JANGA_SMB_CPLD/j3b_pwr_en",
   "controlInterval": {
@@ -24,7 +24,7 @@
           "kp": -4,
           "ki": -0.06,
           "kd": 0,
-          "setPoint": 67.0,
+          "setPoint": 76.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -32,7 +32,7 @@
           "kp": -4,
           "ki": -0.06,
           "kd": 0,
-          "setPoint": 67.0,
+          "setPoint": 76.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -40,7 +40,7 @@
           "kp": -4,
           "ki": -0.06,
           "kd": 0,
-          "setPoint": 67.0,
+          "setPoint": 76.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -48,7 +48,7 @@
           "kp": -4,
           "ki": -0.06,
           "kd": 0,
-          "setPoint": 67.0,
+          "setPoint": 76.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         }
@@ -57,38 +57,38 @@
   ],
   "sensors": [
     {
-      "sensorName": "SMB_INNER_LEFT_LM75_TEMP",
+      "sensorName": "SMB_U17_INNER_RIGHT_LM75_TEMP",
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
       "normalUpTable": {
-        "41": 55,
-        "42": 60,
-        "45": 70,
-        "48": 85,
-        "51": 100
+        "25": 30,
+        "30": 40,
+        "35": 50,
+        "40": 60,
+        "50": 100
       },
       "normalDownTable": {
-        "38": 55,
-        "41": 60,
-        "44": 70,
-        "47": 85,
+        "23": 30,
+        "28": 40,
+        "33": 50,
+        "38": 60,
         "48": 100
       },
       "failUpTable": {
-        "41": 55,
-        "42": 60,
-        "45": 70,
-        "48": 85,
-        "51": 100
+        "25": 80,
+        "30": 80,
+        "35": 80,
+        "40": 80,
+        "50": 80
       },
       "failDownTable": {
-        "38": 55,
-        "41": 60,
-        "44": 70,
-        "47": 85,
-        "48": 100
+        "23": 80,
+        "28": 80,
+        "33": 80,
+        "38": 80,
+        "48": 80
       }
     },
     {
@@ -96,14 +96,143 @@
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
-      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
-      "pidSetting": {
-        "kp": -4,
-        "ki": -0.06,
-        "kd": 0,
-        "setPoint": 97.0,
-        "posHysteresis": 0.0,
-        "negHysteresis": 5.0
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "80": 20,
+        "85": 30,
+        "90": 40,
+        "95": 50,
+        "99": 80
+      },
+      "normalDownTable": {
+        "78": 20,
+        "83": 30,
+        "88": 40,
+        "93": 50,
+        "97": 80
+      },
+      "failUpTable": {
+        "80": 80,
+        "85": 80,
+        "90": 80,
+        "95": 80,
+        "99": 80
+      },
+      "failDownTable": {
+        "78": 80,
+        "83": 80,
+        "88": 80,
+        "93": 80,
+        "97": 80
+      }
+    },
+    {
+      "sensorName": "SMB_E1S_SSD_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "55": 20,
+        "65": 30,
+        "75": 40,
+        "80": 80
+      },
+      "normalDownTable": {
+        "53": 20,
+        "63": 30,
+        "73": 40,
+        "78": 80
+      },
+      "failUpTable": {
+        "55": 80,
+        "65": 80,
+        "75": 80,
+        "80": 80
+      },
+      "failDownTable": {
+        "53": 80,
+        "63": 80,
+        "73": 80,
+        "78": 80
+      }
+    },
+    {
+      "sensorName": "PDB_PS1_12V_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "55": 20,
+        "65": 25,
+        "75": 30,
+        "85": 35,
+        "95": 40,
+        "100": 80
+      },
+      "normalDownTable": {
+        "53": 20,
+        "63": 25,
+        "73": 30,
+        "83": 35,
+        "93": 40,
+        "98": 80
+      },
+      "failUpTable": {
+        "55": 80,
+        "65": 80,
+        "75": 80,
+        "85": 80,
+        "95": 80,
+        "100": 80
+      },
+      "failDownTable": {
+        "53": 80,
+        "63": 80,
+        "73": 80,
+        "83": 80,
+        "93": 80,
+        "98": 80
+      }
+    },
+    {
+      "sensorName": "PDB_PS2_12V_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "55": 20,
+        "65": 25,
+        "75": 30,
+        "85": 35,
+        "95": 40,
+        "100": 80
+      },
+      "normalDownTable": {
+        "53": 20,
+        "63": 25,
+        "73": 30,
+        "83": 35,
+        "93": 40,
+        "98": 80
+      },
+      "failUpTable": {
+        "55": 80,
+        "65": 80,
+        "75": 80,
+        "85": 80,
+        "95": 80,
+        "100": 80
+      },
+      "failDownTable": {
+        "53": 80,
+        "63": 80,
+        "73": 80,
+        "83": 80,
+        "93": 80,
+        "98": 80
       }
     }
   ],
@@ -164,36 +293,14 @@
   },
   "fans": [
     {
-      "fanName": "FANTRAY1_FAN1",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan1_input",
-      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan1_present",
-      "pwmMin": 1,
-      "pwmMax": 255,
-      "fanPresentVal": 1,
-      "fanMissingVal": 0,
-      "fanGoodLedVal": 1,
-      "fanFailLedVal": 2,
-      "rpmMin": 1500
-    },
-    {
-      "fanName": "FANTRAY1_FAN2",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan2_input",
-      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan1_present",
-      "pwmMin": 1,
-      "pwmMax": 255,
-      "fanPresentVal": 1,
-      "fanMissingVal": 0,
-      "fanGoodLedVal": 1,
-      "fanFailLedVal": 2,
-      "rpmMin": 1500
-    },
-    {
-      "fanName": "FANTRAY1_FAN3",
+      "fanName": "FAN9_FRONT",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan3_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan2_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 9,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -203,10 +310,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY1_FAN4",
+      "fanName": "FAN9_REAR",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan4_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan2_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 9,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -216,10 +327,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY1_FAN5",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan5_input",
+      "fanName": "FAN10_FRONT",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan1_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan3_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 8,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -229,10 +344,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY1_FAN6",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan6_input",
+      "fanName": "FAN10_REAR",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan2_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan3_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 8,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -242,10 +361,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY1_FAN7",
+      "fanName": "FAN11_FRONT",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan7_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan4_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 11,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -255,10 +378,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY1_FAN8",
+      "fanName": "FAN11_REAR",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan8_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN/fan4_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 11,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -268,10 +395,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN1",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan1_input",
-      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan1_present",
+      "fanName": "FAN12_FRONT",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan5_input",
+      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 10,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -281,10 +412,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN2",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan2_input",
-      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan1_present",
+      "fanName": "FAN12_REAR",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/fan6_input",
+      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD/pwm3",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_1",
+        "lineIndex": 10,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -294,10 +429,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN3",
+      "fanName": "FAN13_FRONT",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan3_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan2_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 9,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -307,10 +446,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN4",
+      "fanName": "FAN13_REAR",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan4_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan2_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 9,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -320,10 +463,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN5",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan5_input",
+      "fanName": "FAN14_FRONT",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan1_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan3_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 8,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -333,10 +480,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN6",
-      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan6_input",
+      "fanName": "FAN14_REAR",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan2_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan3_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 8,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -346,10 +497,14 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN7",
+      "fanName": "FAN15_FRONT",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan7_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan4_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 11,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -359,10 +514,48 @@
       "rpmMin": 1500
     },
     {
-      "fanName": "FANTRAY2_FAN8",
+      "fanName": "FAN15_REAR",
       "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan8_input",
       "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
-      "presenceSysfsPath": "/run/devmap/sensors/BCB_FAN_2/fan4_present",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 11,
+        "desiredValue": 1
+      },
+      "pwmMin": 1,
+      "pwmMax": 255,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN16_FRONT",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan5_input",
+      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 10,
+        "desiredValue": 1
+      },
+      "pwmMin": 1,
+      "pwmMax": 255,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN16_REAR",
+      "rpmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/fan6_input",
+      "pwmSysfsPath": "/run/devmap/sensors/BCB_FAN_CPLD_2/pwm3",
+      "presenceGpio": {
+        "path": "/run/devmap/gpiochips/FCB_GPIO_CHIP_2",
+        "lineIndex": 10,
+        "desiredValue": 1
+      },
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
@@ -377,27 +570,30 @@
       "zoneType": "ZONE_TYPE_MAX",
       "zoneName": "zone1",
       "sensorNames": [
-        "SMB_INNER_LEFT_LM75_TEMP",
+        "SMB_U17_INNER_RIGHT_LM75_TEMP",
         "CPU_UNCORE_TEMP",
+        "SMB_E1S_SSD_TEMP",
+        "PDB_PS1_12V_TEMP",
+        "PDB_PS2_12V_TEMP",
         "qsfp_group_1"
       ],
       "fanNames": [
-        "FANTRAY1_FAN1",
-        "FANTRAY1_FAN2",
-        "FANTRAY1_FAN3",
-        "FANTRAY1_FAN4",
-        "FANTRAY1_FAN5",
-        "FANTRAY1_FAN6",
-        "FANTRAY1_FAN7",
-        "FANTRAY1_FAN8",
-        "FANTRAY2_FAN1",
-        "FANTRAY2_FAN2",
-        "FANTRAY2_FAN3",
-        "FANTRAY2_FAN4",
-        "FANTRAY2_FAN5",
-        "FANTRAY2_FAN6",
-        "FANTRAY2_FAN7",
-        "FANTRAY2_FAN8"
+        "FAN9_FRONT",
+        "FAN9_REAR",
+        "FAN10_FRONT",
+        "FAN10_REAR",
+        "FAN11_FRONT",
+        "FAN11_REAR",
+        "FAN12_FRONT",
+        "FAN12_REAR",
+        "FAN13_FRONT",
+        "FAN13_REAR",
+        "FAN14_FRONT",
+        "FAN14_REAR",
+        "FAN15_FRONT",
+        "FAN15_REAR",
+        "FAN16_FRONT",
+        "FAN16_REAR"
       ],
       "slope": 3
     }

--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -2059,6 +2059,13 @@
       ],
       "i2cDeviceConfigs": [
         {
+          "busName": "SMB_IOB_I2C_MASTER_1",
+          "address": "0x12",
+          "kernelDeviceName": "pca9555",
+          "pmUnitScopedName": "FCB_GPIO_CHIP_1",
+          "isGpioChip": true
+        },
+        {
           "busName": "SMB_IOB_I2C_MASTER_4",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
@@ -2093,6 +2100,13 @@
           "address": "0x4c",
           "kernelDeviceName": "tps25990",
           "pmUnitScopedName": "SMB_U327_TPS25990_COME"
+        },
+        {
+          "busName": "SMB_IOB_I2C_MASTER_19",
+          "address": "0x12",
+          "kernelDeviceName": "pca9555",
+          "pmUnitScopedName": "FCB_GPIO_CHIP_2",
+          "isGpioChip": true
         },
         {
           "busName": "SMB_IOB_I2C_MASTER_22",
@@ -2654,6 +2668,8 @@
     "/run/devmap/xcvrs/xcvr_45": "/[SMB_DOM_XCVR_CTRL_PORT_45]",
     "/run/devmap/xcvrs/xcvr_46": "/[SMB_DOM_XCVR_CTRL_PORT_46]",
     "/run/devmap/gpiochips/SMB_GPIO_CHIP_1": "/[SMB_GPIO_CHIP_1]",
+    "/run/devmap/gpiochips/FCB_GPIO_CHIP_1": "/[FCB_GPIO_CHIP_1]",
+    "/run/devmap/gpiochips/FCB_GPIO_CHIP_2": "/[FCB_GPIO_CHIP_2]",
     "/run/devmap/flashes/SMB_SPI_MASTER_1_DEVICE_1": "/[SMB_SPI_MASTER_1_DEVICE_1]",
     "/run/devmap/flashes/SMB_SPI_MASTER_2_DEVICE_1": "/[SMB_SPI_MASTER_2_DEVICE_1]",
     "/run/devmap/flashes/SMB_SPI_MASTER_3_DEVICE_1": "/[SMB_SPI_MASTER_3_DEVICE_1]",


### PR DESCRIPTION
### Description
This PR is for Minerva rack Janga config. The platform manager config and fan service config files can be used on both rack and test fixture. The test fixture CPLD image need to update to V0.12. Attach the CPLD image and upgrade method here: 
[update_testfixtureCPLD.zip](https://github.com/user-attachments/files/20256126/update_testfixtureCPLD.zip)

### Limitation
The data in the fan service config file is draft. Quanta thermal team hasn't finalized the data.

### Test log
rack test log:
[janga_rack_log.zip](https://github.com/user-attachments/files/20256140/janga_rack_log.zip)
