### PR TITLE
[meru] Update platform_manager configs to load adc rail driver

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -4741,7 +4741,7 @@
   },
   "chassisEepromDevicePath": "/SMB_SLOT@0/[IDPROM]",
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.9-1",
+  "bspKmodsRpmVersion": "0.7.10-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -88,6 +88,13 @@
               "deviceName": "fpga_info_iob",
               "csrOffset": "0x100"
             }
+          ],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SCM_ADC",
+              "deviceName": "adc",
+              "csrOffset": "0x7300"
+            }
           ]
         }
       ],

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -87,6 +87,13 @@
               "deviceName": "fpga_info_iob",
               "csrOffset": "0x100"
             }
+          ],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SCM_ADC",
+              "deviceName": "adc",
+              "csrOffset": "0x7300"
+            }
           ]
         }
       ],
@@ -1455,6 +1462,13 @@
               "pmUnitScopedName": "SMB_FPGA_INFO_ROM",
               "deviceName": "fpga_info_iob",
               "csrOffset": "0x100"
+            }
+          ],
+          "miscCtrlConfigs": [
+            {
+              "pmUnitScopedName": "SMB_ADC",
+              "deviceName": "adc",
+              "csrOffset": "0x7300"
             }
           ]
         }

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -1706,7 +1706,7 @@
   },
   "chassisEepromDevicePath": "/SMB_SLOT@0/[IDPROM]",
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.9-1",
+  "bspKmodsRpmVersion": "0.7.10-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",


### PR DESCRIPTION
Loads the adc rail driver for meru800bia scm and smb and meru800bfa scm.

Tested that platform manager successfully loads the driver for all applicable devices and that all voltage readings are correctly showing up in `sensors`.