### PR TITLE
updated fw_util config file for Darwin systems

### DIFF
--- a/fboss/platform/configs/darwin/fw_util.json
+++ b/fboss/platform/configs/darwin/fw_util.json
@@ -1,54 +1,284 @@
 {
   "newFwConfigs": {
-    "BIOS": {
+    "bios": {
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "spi_layout": "A00000:FFFFFF normal\n400000:9EFFFF fallback",
+            "programmer_type": "internal",
+            "flashromExtraArgs": [
+              "-i",
+              "normal",
+              "-i",
+              "fallback",
+              "--noverify-all"
+            ],
+            "chip": [
+              "MX25L12805D",
+              "N25Q128..3E"
+            ]
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal",
+          "flashromExtraArgs": [
+            "-i",
+            "normal",
+            "-i",
+            "fallback",
+            "--noverify-all"
+          ],
+          "chip": [
+            "MX25L12805D",
+            "N25Q128..3E"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal",
+          "flashromExtraArgs": [
+            "-i",
+            "normal",
+            "-i",
+            "fallback",
+            "--noverify-all"
+          ],
+          "chip": [
+            "MX25L12805D",
+            "N25Q128..3E"
+          ]
+        }
+      },
       "version": {
         "versionType": "full_command",
-        "getVersionCmd": "cat /sys/devices/virtual/dmi/id/bios_version | cut -d ':' -f 2 | cut -d '-' -f 3"
+        "getVersionCmd": "cat /sys/devices/virtual/dmi/id/bios_version"
       },
-      "priority": 1,
-      "sha1sum": "f821367de316fdcd28bdaae64a83d9d0876aeebe"
+      "priority": 1
     },
-    "CPU_CPLD": {
+    "cpu_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/scd_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr0_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr1_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/th3_jtag_sel",
+            "value": 0
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "jam",
+          "jamArgs": {
+            "jamExtraArgs": [
+              "-aprogram",
+              "-fcpu_cpld",
+              "-v"
+            ]
+          }
+        }
+      ],
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "cpu_cpld_ver=$((`cat /sys/bus/pci/devices/0000:ff:0b.3/fpga_ver`));cpu_cpld_subver=$((`cat /sys/bus/pci/devices/0000:ff:0b.3/fpga_sub_ver`));echo $cpu_cpld_ver'.'$cpu_cpld_subver"
       },
-      "priority": 2,
-      "sha1sum": "98ecb2d427085eda47a580144a622dfe8aa0c1ce"
+      "priority": 2
     },
-    "SC_CPLD": {
+    "sc_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/scd_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr0_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr1_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/th3_jtag_sel",
+            "value": 0
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "jam",
+          "jamArgs": {
+            "jamExtraArgs": [
+              "-aprogram",
+              "-fsc_cpld",
+              "-v"
+            ]
+          }
+        }
+      ],
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "sc_cpld_ver=$((`cat /sys/bus/i2c/drivers/blackhawk-cpld/*/cpld_ver | head -1`));sc_cpld_subver=$((`cat /sys/bus/i2c/drivers/blackhawk-cpld/*/cpld_sub_ver | head -1`));echo $sc_cpld_ver'.'$sc_cpld_subver"
       },
-      "priority": 7,
-      "sha1sum": "3729a09b9b83359b5b273f0fe59fb4fe9ff3dc71"
+      "priority": 7
     },
-    "SC_SCD": {
+    "sc_scd": {
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/SCD_SPI_MASTER_DEVICE1",
+            "chip": [
+              "MX25L1605A/MX25L1606E/MX25L1608E",
+              "GD25Q16(B)",
+              "IS25LP016"
+            ]
+          }
+        }
+      ],
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "sc_fpga_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/fpga_ver`));sc_fpga_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/fpga_sub_ver`));echo $sc_fpga_ver'.'$sc_fpga_subver"
       },
-      "priority": 3,
-      "sha1sum": "c5a6bf5c64371971103a2e31a1dded2fc7ecb1ca"
+      "priority": 3
     },
-    "SC_SAT_CPLD0": {
+    "sc_sat_cpld0": {
+      "preUpgrade": [
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/scd_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr0_jtag_sel",
+            "value": 1
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr1_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/th3_jtag_sel",
+            "value": 0
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "jam",
+          "jamArgs": {
+            "jamExtraArgs": [
+              "-aprogram",
+              "-fsc_sat_cpld",
+              "-v"
+            ]
+          }
+        }
+      ],
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "sat0_cpld_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat0_cpld_ver`));sat0_cpld_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat0_cpld_sub_ver`));echo $sat0_cpld_ver'.'$sat0_cpld_subver"
       },
-      "priority": 4,
-      "sha1sum": "faf75ec07bf6a974a921622dfed253a5712f3a11"
+      "priority": 4
     },
-    "SC_SAT_CPLD1": {
+    "sc_sat_cpld1": {
+      "preUpgrade": [
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/scd_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr0_jtag_sel",
+            "value": 0
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/sr1_jtag_sel",
+            "value": 1
+          }
+        },
+        {
+          "commandType": "jtag",
+          "jtagArgs": {
+            "path": "/run/devmap/cplds/BLACKHAWK_CPLD/th3_jtag_sel",
+            "value": 0
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "jam",
+          "jamArgs": {
+            "jamExtraArgs": [
+              "-aprogram",
+              "-fsc_sat_cpld",
+              "-v"
+            ]
+          }
+        }
+      ],
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "sat1_cpld_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat1_cpld_ver`));sat1_cpld_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat1_cpld_sub_ver`));echo $sat1_cpld_ver'.'$sat1_cpld_subver"
       },
-      "priority": 5,
-      "sha1sum": "faf75ec07bf6a974a921622dfed253a5712f3a11"
+      "priority": 5
     },
-    "FAN_CPLD": {
+    "fan_cpld": {
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "fanCpld_ver=$((`cat /sys/bus/i2c/drivers/rook-fan-cpld/*/*/*/cpld_ver`));fanCpld_subver=$((`cat /sys/bus/i2c/drivers/rook-fan-cpld/*/*/*/cpld_sub_ver`));echo $fanCpld_ver'.'$fanCpld_subver"

--- a/fboss/platform/configs/darwin48v/fw_util.json
+++ b/fboss/platform/configs/darwin48v/fw_util.json
@@ -186,7 +186,8 @@
             "programmer": "/run/devmap/flashes/SCD_SPI_MASTER_DEVICE1",
             "chip": [
               "MX25L1605A/MX25L1606E/MX25L1608E",
-              "GD25Q16(B)"
+              "GD25Q16(B)",
+              "IS25LP016"
             ]
           }
         }


### PR DESCRIPTION
### Summary of Changes
This pull request adds Darwin fw_util config file which is compliant with the recent fw_util refactoring.

The new fw_util configuration file is the same as the one for Darwin48V, with the exception of the two changes listed below:

- aconf programming doesn’t happen during BIOS upgrade. This change is made since aconf programming is a feature unique to Darwin48V
- Firmware versions are read through the `fw_util full_command` method which determines firmware versions by combining data from version and subversion sysfs entries. While newer BSPs initially replaced these with a single entry for the `fw_util sysfs` method compatibility, the original separate entries returned in BSP version `v0.7.11`. Thus, to ensure consistent firmware version reading after a BSP update on older Darwin systems, upgrade to version `v0.7.11` or higher

Additionally, the `ISSI IS25LP016D` chip is added as a supported SCD SPI flash for both Darwin and Darwin48V systems. Updating the `ISSI IS25LP016D` chip via flashrom requires rebuilding the flashrom binary with the `0004-ISSI_IS25LP016-support.patch` available in BSP `v0.7.11`.
### Testing
Tested by upgrading all the firmware targets through fw_util
