### PR TITLE
montblanc: config: Update configuration of COME 2nd source sensors to FBOSS Sensor Config

### DIFF
--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -1031,7 +1031,7 @@
           "sensors": [
             {
               "name": "COME_PU4_XDPE15284_PVCCIN_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
               "type": 1,
               "thresholds": {
                 "upperCriticalVal": 2.2,
@@ -1042,7 +1042,7 @@
             },
             {
               "name": "COME_PU4_XDPE15284_P1V8_VOUT",
-              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
               "type": 1,
               "thresholds": {
                 "upperCriticalVal": 2.2,


### PR DESCRIPTION
**Description**

This PR is about updating the configuration of Minipack3 COME 2nd source sensors to FBOSS Sensor's configurations

**Motivation**

The sensor service hw test failed on Minipack3 devices equipped with the 2nd source COME due to an unsuitable configuration in the Montblanc sensor service config file. 
In this PR, the configuration for the 2nd source COME sensors will be reverted to the original version, which is correct and functional.

**Test Plan**

The correctness of the format has been verified on this [jsonlint](https://jsonlint.com/) website.
Verified the updated configurations on the Minipack 3 machine configured with 2nd source COME:
- Run the platform manager/sensor service with the updated config file on the Minipack3 device
- Run fw_util check unit version information.
- Run the weutil check the unit eeprom data and product sub version.

Test log as follows:
1.There was a sensor discovery failure on the 2nd source COME device prior to updating the sensor configuration:
![image](https://github.com/user-attachments/assets/dc910e55-5e3f-4bab-ab05-9ee610f59938)

2.Sensor_service run successfully on the 2nd source COME device after updating the sensor configuration:
![image](https://github.com/user-attachments/assets/fbf449cc-c44c-446a-ad88-7b31e4eeca50)

[Minipack3_2nd_COMe_sensor_service_log-BeforeAndAfter.txt](https://github.com/user-attachments/files/20403800/Minipack3_2nd_COMe_sensor_service_log-BeforeAndAfter.txt)
[Minipack3_main_COMe_sensor_service_log.txt](https://github.com/user-attachments/files/20403804/Minipack3_main_COMe_sensor_service_log.txt)



