### PR TITLE
Enable missing unit tests in CMake

### DIFF
--- a/cmake/PlatformConfigLib.cmake
+++ b/cmake/PlatformConfigLib.cmake
@@ -77,6 +77,8 @@ target_link_libraries(platform_config_lib_config_lib_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(platform_config_lib_config_lib_test)
+
 add_library(platform_config_lib
   fboss/platform/config_lib/ConfigLib.cpp
   ${generated_header}
@@ -91,3 +93,5 @@ target_link_libraries(platform_config_lib
   Folly::folly
   platform_name_lib
 )
+
+gtest_discover_tests(platform_config_lib_config_lib_test)

--- a/cmake/PlatformDataCorralServiceTests.cmake
+++ b/cmake/PlatformDataCorralServiceTests.cmake
@@ -16,3 +16,5 @@ target_link_libraries(platform_data_corral_sw_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(platform_data_corral_sw_test)

--- a/cmake/PlatformHelpersTest.cmake
+++ b/cmake/PlatformHelpersTest.cmake
@@ -13,3 +13,5 @@ target_link_libraries(platform_helpers_platform_name_lib_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(platform_helpers_platform_name_lib_test)

--- a/cmake/PlatformPlatformManagerTest.cmake
+++ b/cmake/PlatformPlatformManagerTest.cmake
@@ -14,6 +14,8 @@ target_link_libraries(platform_manager_config_validator_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(platform_manager_config_validator_test)
+
 add_executable(platform_manager_i2c_explorer_test
   fboss/platform/platform_manager/tests/I2cExplorerTest.cpp
 )
@@ -24,6 +26,8 @@ target_link_libraries(platform_manager_i2c_explorer_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(platform_manager_i2c_explorer_test)
 
 add_executable(platform_manager_platform_explorer_test
   fboss/platform/platform_manager/tests/PlatformExplorerTest.cpp
@@ -38,6 +42,8 @@ target_link_libraries(platform_manager_platform_explorer_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(platform_manager_platform_explorer_test)
+
 add_executable(platform_manager_utils_test
   fboss/platform/platform_manager/tests/UtilsTest.cpp
 )
@@ -49,6 +55,8 @@ target_link_libraries(platform_manager_utils_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(platform_manager_utils_test)
+
 add_executable(platform_manager_data_store_test
   fboss/platform/platform_manager/tests/DataStoreTest.cpp
 )
@@ -59,6 +67,7 @@ target_link_libraries(platform_manager_data_store_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(platform_manager_data_store_test)
 add_executable(platform_manager_device_path_resolver_test
   fboss/platform/platform_manager/tests/DevicePathResolverTest.cpp
 )
@@ -80,3 +89,5 @@ target_link_libraries(platform_manager_presence_checker_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(platform_manager_presence_checker_test)

--- a/cmake/PlatformRackmon.cmake
+++ b/cmake/PlatformRackmon.cmake
@@ -94,3 +94,4 @@ target_include_directories(rackmon_test PRIVATE
 target_compile_definitions(rackmon_test PRIVATE __TEST__=1)
 
 install(TARGETS rackmon_test)
+gtest_discover_tests(rackmon_test)

--- a/cmake/PlatformSensorServiceTest.cmake
+++ b/cmake/PlatformSensorServiceTest.cmake
@@ -16,6 +16,8 @@ target_link_libraries(sensor_service_sw_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(sensor_service_sw_test)
+
 install(TARGETS sensor_service_sw_test)
 
 add_executable(sensor_service_utils_test
@@ -27,3 +29,5 @@ target_link_libraries(sensor_service_utils_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(sensor_service_utils_test)

--- a/cmake/PlatformWeutilTest.cmake
+++ b/cmake/PlatformWeutilTest.cmake
@@ -13,6 +13,8 @@ target_link_libraries(weutil_crc16_ccitt_test
   ${LIBGMOCK_LIBRARIES}
 )
 
+gtest_discover_tests(weutil_crc16_ccitt_test)
+
 add_executable(weutil_fboss_eeprom_parser_test
   fboss/platform/weutil/test/FbossEepromParserTest.cpp
 )
@@ -24,3 +26,5 @@ target_link_libraries(weutil_fboss_eeprom_parser_test
   ${GTEST}
   ${LIBGMOCK_LIBRARIES}
 )
+
+gtest_discover_tests(weutil_fboss_eeprom_parser_test)


### PR DESCRIPTION
These tests appear to be enabled in the BUCK files, but are missing from the CMake build system. Enable them so we can be sure they are executing and it is made obvious that they do not need to execute on a switch.