### PR TITLE
Platform_manager: fix platform name in config does not match the inferred platform name from bios

### DIFF
--- a/fboss/platform/helpers/PlatformNameLib.cpp
+++ b/fboss/platform/helpers/PlatformNameLib.cpp
@@ -39,6 +39,14 @@ std::string sanitizePlatformName(const std::string& platformNameFromBios) {
     return "MERU800BIA";
   }
 
+  if (platformNameUpper == "ICECUBE") {
+    return "ICECUBE800BC";
+  }
+
+  if (platformNameUpper == "ICETRAY") {
+    return "ICETRAY800BC";
+  }
+
   return platformNameUpper;
 }
 


### PR DESCRIPTION
### Description
The platform name in the config does not match the inferred platform name from the BIOS during platform manager startup.

![image](https://github.com/user-attachments/assets/44066849-1f86-4762-8e2d-5f5b77f6c323)
### Motivation
The platform alias transformation for a new project(icecube or icetray) is not supported in the current fboss code. The code fix is to add the transformation logic(ICECUBE-->ICECUBE800BC, ICETRAY-->ICETRAY800BC).
### Test Plan
Run platform_manager and check if the platform alias transformation is working.

![image](https://github.com/user-attachments/assets/8f371209-af11-4a36-8971-722849143652)
![image](https://github.com/user-attachments/assets/97af6b96-be85-4c17-b506-bb21909ac59b)
![image](https://github.com/user-attachments/assets/5bfab7af-a71f-44c0-8b3e-fac5452b1960)

[pm_verification_log.txt](https://github.com/user-attachments/files/20472157/pm_verification_log.txt)
