### PR TITLE
Janga: config: modified the bspKmodsRpmVersion to 3.2.0-1

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -2773,7 +2773,7 @@
   "chassisEepromDevicePath": "/SMB_FRU_SLOT@0/[IDPROM]",
   "numXcvrs": 46,
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "3.1.0-1",
+  "bspKmodsRpmVersion": "3.2.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",


### PR DESCRIPTION
**Description**
This PR is for janga platform service.

**Motivation**
The tag in the latest bsp repo is v3.2.0-1, so the configuration in platform needs to be modified synchronously.

![image](https://github.com/user-attachments/assets/310060d9-7092-4b16-886e-fea3b007c05b)

![image](https://github.com/user-attachments/assets/d27c4929-0d56-4386-a8b9-7e3318a1b43f)

![image](https://github.com/user-attachments/assets/ff121e4d-1088-4d69-a318-196177b45f99)

Test Plan
1.The correctness of the format has been verified on jsonlint website.
2.Used jq cmd to pretty the format.
3.Test log as follows:

....
I1020 23:09:28.407854 507125 PlatformExplorer.cpp:737] Reporting firmware version for JANGA_SMB_CPLD - version string:2.4.0
I1020 23:09:28.409411 507125 PlatformExplorer.cpp:737] Reporting firmware version for PWR_CPLD - version string:2.3.0
I1020 23:09:28.410858 507125 PlatformExplorer.cpp:737] Reporting firmware version for SMB_CPLD_1 - version string:2.4.0
I1020 23:09:28.410895 507125 PlatformExplorer.cpp:737] Reporting firmware version for SMB_DOM_INFO_ROM - version string:0.42
I1020 23:09:28.410918 507125 PlatformExplorer.cpp:737] Reporting firmware version for SMB_IOB_INFO_ROM - version string:0.51
I1020 23:09:28.411017 507125 PlatformExplorer.cpp:767] Reporting Production State: 2
I1020 23:09:28.411024 507125 PlatformExplorer.cpp:777] Reporting Production Sub-State: 5
I1020 23:09:28.411029 507125 PlatformExplorer.cpp:787] Reporting Variant Indicator: 20
I1020 23:09:28.411041 507125 ExplorationSummary.cpp:49] Successfully explored janga800bic...
W1020 23:09:28.411069 507125 Main.cpp:71] Skipping sd_notify since $NOTIFY_SOCKET is not set which does not imply systemd execution.
I1020 23:09:28.411074 507125 Main.cpp:78] Running PlatformManager thrift service...
I1020 23:09:28.411694 507125 ThriftServer.cpp:872] Using thread manager (resource pools not enabled) on address/port 5975: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
^C
.....

[janga_platform_test_log_5_28.txt](https://github.com/user-attachments/files/20497369/janga_platform_test_log_5_28.txt)








