### PR TITLE
Tahan: config: modified the bspKmodsRpmVersion to 3.2.0-1

### DIFF
--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -2117,7 +2117,7 @@
   "chassisEepromDevicePath": "/SMB_FRU_SLOT@0/[IDPROM]",
   "numXcvrs": 33,
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "3.1.0-1",
+  "bspKmodsRpmVersion": "3.2.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",


### PR DESCRIPTION
**Description**
This PR is for tahan platform service.

**Motivation**
The tag in the latest bsp repo is v3.2.0-1, so the configuration in platform needs to be modified synchronously.

![image](https://github.com/user-attachments/assets/157a9fe6-9735-4760-b043-d39797dfd988)

![image](https://github.com/user-attachments/assets/038b1f79-0ceb-44e6-8156-e23051483653)

![image](https://github.com/user-attachments/assets/7490fffb-a1bc-4788-b92d-6d7085c04d7e)

**Test Plan**
1.The correctness of the format has been verified on this website.
2.Used jq cmd to pretty the format.
3.Test log as follows:

...
I0528 14:38:59.299581 48847 PlatformExplorer.cpp:737] Reporting firmware version for TAHAN_SMB_CPLD - version string:2.1.0
I0528 14:38:59.299616 48847 PlatformExplorer.cpp:737] Reporting firmware version for SMB_DOM_INFO_ROM - version string:0.38
I0528 14:38:59.299639 48847 PlatformExplorer.cpp:737] Reporting firmware version for SMB_IOB_INFO_ROM - version string:0.50
I0528 14:38:59.299737 48847 PlatformExplorer.cpp:767] Reporting Production State: 3
I0528 14:38:59.299744 48847 PlatformExplorer.cpp:777] Reporting Production Sub-State: 5
I0528 14:38:59.299749 48847 PlatformExplorer.cpp:787] Reporting Variant Indicator: 20
I0528 14:38:59.299760 48847 ExplorationSummary.cpp:49] Successfully explored tahan800bc...
W0528 14:38:59.299788 48847 Main.cpp:71] Skipping sd_notify since $NOTIFY_SOCKET is not set which does not imply systemd execution.
I0528 14:38:59.299793 48847 Main.cpp:78] Running PlatformManager thrift service...
I0528 14:38:59.300417 48847 ThriftServer.cpp:872] Using thread manager (resource pools not enabled) on address/port 5975: runtime: thriftFlagNotSet, , thrift flag: false, enable gflag: false, disable gflag: false
^C
...

[tahan_platform_test_log_5_28.txt](https://github.com/user-attachments/files/20497520/tahan_platform_test_log_5_28.txt)


