### PR TITLE
fboss: fan_service: Fix sensor incremental PID type config validate issue

### DIFF
--- a/fboss/platform/fan_service/ConfigValidator.cpp
+++ b/fboss/platform/fan_service/ConfigValidator.cpp
@@ -37,7 +37,8 @@ std::unordered_set<std::string> opticAggregationTypes = {
 
 std::unordered_set<std::string> sensorPwmCalcTypes = {
     constants::SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE(),
-    constants::SENSOR_PWM_CALC_TYPE_PID()};
+    constants::SENSOR_PWM_CALC_TYPE_PID(),
+    constants::SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID()};
 
 } // namespace
 


### PR DESCRIPTION
### Description
Run fan_service program with new sensor incremental PID type "**SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID**" will cause core dump. The root cause is the lack of support for the new sensor PID type in the ConfigValidator.cpp file. 
Error log:
![coredump](https://github.com/user-attachments/assets/5fbb1648-5208-4964-b44d-b6bb3a27bd75)

### Motivation
Add "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID" type support in the ConfigValidator.cpp file.

### Test log
The fan service can run normally without core dump.
Attach the test log: 
[coredump_fix.txt](https://github.com/user-attachments/files/20588278/coredump_fix.txt)

