### PR TITLE
Tahan: config: Modified the shutdown sensor name to SMB_TH5_TEMP

### DIFF
--- a/fboss/platform/configs/tahan800bc/fan_service.json
+++ b/fboss/platform/configs/tahan800bc/fan_service.json
@@ -240,7 +240,7 @@
     "numOvertempSensorForShutdown": 1,
     "conditions": [
       {
-        "sensorName": "TAHAN_SMB_TH5_TEMP",
+        "sensorName": "SMB_TH5_TEMP",
         "overtempThreshold": 110.0,
         "slidingWindowSize": 1
       }


### PR DESCRIPTION
**Description**

This PR modified the shutdown sensor name to SMB_TH5_TEMP for tahan fan service.

**Motivation**

In this commit information on GitHub(https://github.com/facebook/fboss/commit/bf42c8bab7febb756b0b85a4873b5771ba03119f ), TAHAN_SMB_TH5_TEMP is changed to SMB_TH5_TEMP. Therefore, corresponding changes need to be made in the fan service.

**Test Plan**

1.The correctness of the format has been verified on jsonlint website.
2.Used jq cmd to pretty the format.
3.Test log as follows:

Before executing the shutdown command, lspci there is a TH5 ASIC:
![image](https://github.com/user-attachments/assets/6ad99377-6f08-4f79-9881-8189709d2d8a)

Run fan service and execution show down cmd(Note that I simulated the threshold at 35 degrees):
![image](https://github.com/user-attachments/assets/3b6bdd3a-634d-437d-947f-1283dfce6973)

After executing the shutdown command, lspci there is no TH5 ASIC:
![image](https://github.com/user-attachments/assets/24cca45a-a28c-495a-a812-acce0a27dc77)




[tahan_platform_test_log_6_6.txt](https://github.com/user-attachments/files/20622431/tahan_platform_test_log_6_6.txt)
[tahan_sensor_test_log_6_6.txt](https://github.com/user-attachments/files/20622432/tahan_sensor_test_log_6_6.txt)
[tahan_fan_test_log_6_6.txt](https://github.com/user-attachments/files/20622434/tahan_fan_test_log_6_6.txt)




