### PR TITLE
Darwin: add missing sensor compute attribute POS_3V3_ALW

### DIFF
--- a/fboss/platform/configs/darwin/sensor_service.json
+++ b/fboss/platform/configs/darwin/sensor_service.json
@@ -267,7 +267,8 @@
           "thresholds": {
             "upperCriticalVal": 3.795,
             "lowerCriticalVal": 2.8
-          }
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "POS_12V",


### PR DESCRIPTION
# Description

This fixes an issue where the sensor POS_3V3_ALW was throwing critical alarms due to a missing configuration with how the sensor value is computed.

```
POS_3V3_ALW 3273.000000 2025-01-28 14:29:21.0 PST
3.795000 2.800000
```

The new added `"compute": "@/1000.0"` will correctly calculate the sensor value.

# Testing
Value reported is within thresholds.