### PR TITLE
fboss: fan_service: add hysteresis in incremental PID logic

### DIFF
--- a/fboss/platform/fan_service/PidLogic.cpp
+++ b/fboss/platform/fan_service/PidLogic.cpp
@@ -59,9 +59,16 @@ int16_t PidLogic::calculatePwm(float measurement) {
 }
 
 int16_t IncrementalPidLogic::calculatePwm(float measurement) {
-  float pwmDelta = (*pidSetting_.kp() * (measurement - previousRead1_)) +
-      (*pidSetting_.ki() * (measurement - *pidSetting_.setPoint())) +
-      (*pidSetting_.kd() * (measurement - 2 * previousRead1_ + previousRead2_));
+  float pwmDelta{0};
+  float minVal = *pidSetting_.setPoint() - *pidSetting_.negHysteresis();
+  float maxVal = *pidSetting_.setPoint() + *pidSetting_.posHysteresis();
+
+  if ((measurement > maxVal) || (measurement < minVal)) {
+    pwmDelta = (*pidSetting_.kp() * (measurement - previousRead1_)) +
+        (*pidSetting_.ki() * (measurement - *pidSetting_.setPoint())) +
+        (*pidSetting_.kd() *
+         (measurement - 2 * previousRead1_ + previousRead2_));
+  }
   int16_t newPwm = lastPwm_ + pwmDelta;
 
   XLOG(DBG2) << fmt::format(


### PR DESCRIPTION
### Description
Thermal team tested and verified the new incremental PID algorithm and found that the Fan speed oscillation by 2.5% around setpoint. 
![image (37)](https://github.com/user-attachments/assets/b2268652-b07f-4957-80a3-a5d7392637f3)

The root cause is the min. Fan control step(2.5%PWM) of Fan CPLD limitation. Adding hysteresis can fix the issue of unstable fan speeds caused by the larger min. Fan control step.
<img width="653" alt="image (34)" src="https://github.com/user-attachments/assets/3058e4ce-9a3c-4961-bc8c-3dcf55e4c632" />

### Test Result
Thermal team has finished the test and the test result has been approved by Meta thermal.
![image (35)](https://github.com/user-attachments/assets/d732e49c-ae76-433f-a2a8-a8650f4e11c7)
<img width="681" alt="image" src="https://github.com/user-attachments/assets/d7ff2600-e0e3-43b0-b766-1f7dc9d3a88b" />
