### PR TITLE
Glath05a-64o: add sensor_service support

### DIFF
--- a/fboss/platform/config_lib/ConfigLibTest.cpp
+++ b/fboss/platform/config_lib/ConfigLibTest.cpp
@@ -16,6 +16,7 @@ const std::string kMeru800bfa = "meru800bfa";
 const std::string kMorgan800cc = "morgan800cc";
 const std::string kJanga800bic = "janga800bic";
 const std::string kTahan800bc = "tahan800bc";
+const std::string kGlath05a_64o = "glath05a-64o";
 const std::string kSample = "sample";
 const std::string kNonExistentPlatform = "nonExistentPlatform";
 } // namespace
@@ -28,6 +29,7 @@ TEST(ConfigLibTest, Basic) {
   EXPECT_NO_THROW(ConfigLib().getSensorServiceConfig(kMorgan800cc));
   EXPECT_NO_THROW(ConfigLib().getSensorServiceConfig(kJanga800bic));
   EXPECT_NO_THROW(ConfigLib().getSensorServiceConfig(kTahan800bc));
+  EXPECT_NO_THROW(ConfigLib().getSensorServiceConfig(kGlath05a_64o));
   EXPECT_THROW(
       ConfigLib().getSensorServiceConfig(kNonExistentPlatform),
       std::out_of_range);

--- a/fboss/platform/configs/glath05a-64o/sensor_service.json
+++ b/fboss/platform/configs/glath05a-64o/sensor_service.json
@@ -1,0 +1,635 @@
+{
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "SCM",
+      "sensors": [
+        {
+          "name": "CPU_PACKAGE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SCM_ECB_VIN",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 10.5
+          },
+          "compute": "@/32000.0"
+        },
+        {
+          "name": "SCM_ECB_VOUT",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/32000.0"
+        },
+        {
+          "name": "SCM_ECB_IOUT",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0",
+      "pmUnitName": "SMB",
+      "sensors": [
+        {
+          "name": "FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN3_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN4_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN_BOARD_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FAN_TMP75/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_MGMT_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MGMT_TMP75/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105.0,
+            "maxAlarmVal": 95.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_SCM_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105.0,
+            "maxAlarmVal": 95.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_TH5_AIR_BEHIND_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105.0,
+            "maxAlarmVal": 95.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_LEFT_EDGE_PCB_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105.0,
+            "maxAlarmVal": 95.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_AIR_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 105.0,
+            "maxAlarmVal": 95.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_TH5_DIODE_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0,
+            "maxAlarmVal": 115.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_TH5_DIODE_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_MAX6581/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 125.0,
+            "maxAlarmVal": 115.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_RAA_TH5_CORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_RAA_TH5_CORE_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_RAA_TH5_CORE_VDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.0,
+            "lowerCriticalVal": 0.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V9_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V9_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V9_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V9_AVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.08,
+            "lowerCriticalVal": 0.675
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V9_AVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.08,
+            "lowerCriticalVal": 0.675
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V75_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V75_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V75_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V75_AVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.9375,
+            "lowerCriticalVal": 0.5625
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_TH5_0V75_AVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in4_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 0.9375,
+            "lowerCriticalVal": 0.5625
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_A_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_A_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_A_VOUT_3V3",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 4.125,
+            "lowerCriticalVal": 2.475
+          },
+          "compute": "1.2*@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_B_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 115.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_B_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_ISL_OPTICS_B_VOUT_3V3",
+          "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 4.125,
+            "lowerCriticalVal": 2.475
+          },
+          "compute": "1.2@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0/PSU_SLOT@0",
+      "pmUnitName": "PSU",
+      "sensors": [
+        {
+          "name": "PSU1_VIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in1_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU1_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 70.0,
+            "maxAlarmVal": 65.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 130.0,
+            "maxAlarmVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 120.0,
+            "maxAlarmVal": 112.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/curr2_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_PIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "PSU1_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0/PSU_SLOT@1",
+      "pmUnitName": "PSU",
+      "sensors": [
+        {
+          "name": "PSU2_VIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in1_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU2_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 70.0,
+            "maxAlarmVal": 65.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 130.0,
+            "maxAlarmVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 120.0,
+            "maxAlarmVal": 112.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/curr2_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_PIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "PSU2_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        }
+      ]
+    }
+  ]
+}

--- a/fboss/platform/configs/glath05a-64o/sensor_service.json
+++ b/fboss/platform/configs/glath05a-64o/sensor_service.json
@@ -108,20 +108,20 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
-            "lowerCriticalVal": 10.5
+            "upperCriticalVal": 14400.0,
+            "lowerCriticalVal": 10500.0
           },
-          "compute": "@/32000.0"
+          "compute": "@/32.0"
         },
         {
           "name": "SCM_ECB_VOUT",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
-            "lowerCriticalVal": 9.6
+            "upperCriticalVal": 14400.0,
+            "lowerCriticalVal": 9600.0
           },
-          "compute": "@/32000.0"
+          "compute": "@/32.0"
         },
         {
           "name": "SCM_ECB_IOUT",
@@ -266,20 +266,18 @@
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15.0,
-            "lowerCriticalVal": 9.0
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 15000.0,
+            "lowerCriticalVal": 9000.0
+          }
         },
         {
           "name": "SMB_RAA_TH5_CORE_VDD",
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.0,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1000.0,
+            "lowerCriticalVal": 600.0
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V9_TEMP1",
@@ -306,30 +304,27 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15.0,
-            "lowerCriticalVal": 9.0
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 15000.0,
+            "lowerCriticalVal": 9000.0
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V9_AVDD_0",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.675
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 675.0
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V9_AVDD_1",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.675
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 675.0
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V75_TEMP1",
@@ -356,30 +351,27 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15.0,
-            "lowerCriticalVal": 9.0
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 15000.0,
+            "lowerCriticalVal": 9000.0
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V75_AVDD_0",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9375,
-            "lowerCriticalVal": 0.5625
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 937.5,
+            "lowerCriticalVal": 562.5
+          }
         },
         {
           "name": "SMB_ISL_TH5_0V75_AVDD_1",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9375,
-            "lowerCriticalVal": 0.5625
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 937.5,
+            "lowerCriticalVal": 562.5
+          }
         },
         {
           "name": "SMB_ISL_OPTICS_A_TEMP",
@@ -396,20 +388,19 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15.0,
-            "lowerCriticalVal": 9.0
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 15000.0,
+            "lowerCriticalVal": 9000.0
+          }
         },
         {
           "name": "SMB_ISL_OPTICS_A_VOUT_3V3",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 4.125,
-            "lowerCriticalVal": 2.475
+            "upperCriticalVal": 4125.0,
+            "lowerCriticalVal": 2475.0
           },
-          "compute": "1.2*@/1000.0"
+          "compute": "1.2*@"
         },
         {
           "name": "SMB_ISL_OPTICS_B_TEMP",
@@ -426,20 +417,19 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15.0,
-            "lowerCriticalVal": 9.0
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 15000.0,
+            "lowerCriticalVal": 9000.0
+          }
         },
         {
           "name": "SMB_ISL_OPTICS_B_VOUT_3V3",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 4.125,
-            "lowerCriticalVal": 2.475
+            "upperCriticalVal": 4125.0,
+            "lowerCriticalVal": 2475.0
           },
-          "compute": "1.2@/1000.0"
+          "compute": "1.2*@"
         }
       ]
     },
@@ -450,18 +440,16 @@
         {
           "name": "PSU1_VIN",
           "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in1_input",
-          "type": 1,
-          "compute": "@/1000.0"
+          "type": 1
         },
         {
           "name": "PSU1_VOUT",
           "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14400.0,
+            "lowerCriticalVal": 9600.0
+          }
         },
         {
           "name": "PSU1_FAN1_RPM",
@@ -544,18 +532,16 @@
         {
           "name": "PSU2_VIN",
           "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in1_input",
-          "type": 1,
-          "compute": "@/1000.0"
+          "type": 1
         },
         {
           "name": "PSU2_VOUT",
           "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
-            "lowerCriticalVal": 9.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 14400.0,
+            "lowerCriticalVal": 9600.0
+          }
         },
         {
           "name": "PSU2_FAN1_RPM",

--- a/fboss/platform/configs/glath05a-64o/sensor_service.json
+++ b/fboss/platform/configs/glath05a-64o/sensor_service.json
@@ -108,20 +108,20 @@
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14400.0,
-            "lowerCriticalVal": 10500.0
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 10.5
           },
-          "compute": "@/32.0"
+          "compute": "@/32000.0"
         },
         {
           "name": "SCM_ECB_VOUT",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14400.0,
-            "lowerCriticalVal": 9600.0
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
           },
-          "compute": "@/32.0"
+          "compute": "@/32000.0"
         },
         {
           "name": "SCM_ECB_IOUT",
@@ -266,12 +266,13 @@
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15000.0,
-            "lowerCriticalVal": 9000.0
-          }
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
         },
         {
-          "name": "SMB_RAA_TH5_CORE_VDD",
+          "name": "SMB_RAA_TH5_CORE_VDD_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_TH5_CORE/in3_input",
           "type": 1,
           "thresholds": {
@@ -304,12 +305,13 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15000.0,
-            "lowerCriticalVal": 9000.0
-          }
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
         },
         {
-          "name": "SMB_ISL_TH5_0V9_AVDD_0",
+          "name": "SMB_ISL_TH5_0V9_AVDD_0_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in3_input",
           "type": 1,
           "thresholds": {
@@ -318,7 +320,7 @@
           }
         },
         {
-          "name": "SMB_ISL_TH5_0V9_AVDD_1",
+          "name": "SMB_ISL_TH5_0V9_AVDD_1_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V9_ANALOG/in4_input",
           "type": 1,
           "thresholds": {
@@ -351,12 +353,13 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15000.0,
-            "lowerCriticalVal": 9000.0
-          }
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
         },
         {
-          "name": "SMB_ISL_TH5_0V75_AVDD_0",
+          "name": "SMB_ISL_TH5_0V75_AVDD_0_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in3_input",
           "type": 1,
           "thresholds": {
@@ -365,7 +368,7 @@
           }
         },
         {
-          "name": "SMB_ISL_TH5_0V75_AVDD_1",
+          "name": "SMB_ISL_TH5_0V75_AVDD_1_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_TH5_0V75_ANALOG/in4_input",
           "type": 1,
           "thresholds": {
@@ -388,19 +391,20 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15000.0,
-            "lowerCriticalVal": 9000.0
-          }
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "SMB_ISL_OPTICS_A_VOUT_3V3",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_A/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 4125.0,
-            "lowerCriticalVal": 2475.0
+            "upperCriticalVal": 4.125,
+            "lowerCriticalVal": 2.475
           },
-          "compute": "1.2*@"
+          "compute": "1.2*@/1000.0"
         },
         {
           "name": "SMB_ISL_OPTICS_B_TEMP",
@@ -417,19 +421,20 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 15000.0,
-            "lowerCriticalVal": 9000.0
-          }
+            "upperCriticalVal": 15.0,
+            "lowerCriticalVal": 9.0
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "SMB_ISL_OPTICS_B_VOUT_3V3",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OPTICS_B/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 4125.0,
-            "lowerCriticalVal": 2475.0
+            "upperCriticalVal": 4.125,
+            "lowerCriticalVal": 2.475
           },
-          "compute": "1.2*@"
+          "compute": "1.2@/1000.0"
         }
       ]
     },
@@ -440,16 +445,18 @@
         {
           "name": "PSU1_VIN",
           "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in1_input",
-          "type": 1
+          "type": 1,
+          "compute": "@/1000.0"
         },
         {
           "name": "PSU1_VOUT",
           "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14400.0,
-            "lowerCriticalVal": 9600.0
-          }
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "PSU1_FAN1_RPM",
@@ -532,16 +539,18 @@
         {
           "name": "PSU2_VIN",
           "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in1_input",
-          "type": 1
+          "type": 1,
+          "compute": "@/1000.0"
         },
         {
           "name": "PSU2_VOUT",
           "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14400.0,
-            "lowerCriticalVal": 9600.0
-          }
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
         },
         {
           "name": "PSU2_FAN1_RPM",
@@ -615,6 +624,25 @@
           "type": 0,
           "compute": "@/1000000.0"
         }
+      ]
+    }
+  ],
+  "powerConsumptionConfigs": [
+    {
+      "name": "PSU1",
+      "powerSensorName": "PSU1_PIN"
+    },
+    {
+      "name": "PSU2",
+      "powerSensorName": "PSU2_PIN"
+    }
+  ],
+  "temperatureConfigs": [
+    {
+      "name": "ASIC",
+      "temperatureSensorNames": [
+        "SMB_TH5_DIODE_1_TEMP",
+        "SMB_TH5_DIODE_2_TEMP"
       ]
     }
   ]


### PR DESCRIPTION
# Description 

> 
> **NOTE:** This is part of a series of PRs to add support for Glath05a-64o. The dependency chain of the PRs is as follows:
> 
> Glath05a-64o: define new platform #461
> Glath05a-64o: platform manager #462 – Depends on #461
> Glath05a-64o: add sensor_service support #467 – Depends on #462
> Glath05a-64o: weutil config #468 – Depends on #462
> Glath05a-64o: add fan_service config #469 – Depends on #467
> Glath05a-64o: fw_util support #470 – Depends on #461
> Glath05a-64o: bsp mapping #471 – Depends on #461
> Glath05a-64o: platform mapping #472 – Depends on #471
> Glath05a-64o: led service #473 – Depends on #472

- Add sensor_service for glath05a-64o

# Testing

```
Jun 11 17:45:47 systemd[1]: Started Start sensor_service.
Jun 11 17:45:47 ... 17:45:47.180069  5907 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
Jun 11 17:45:47 ... 17:45:47.180109  5907 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/sensor_service.json
Jun 11 17:45:47 ... 17:45:47.180658  5907 SensorServiceImpl.cpp:90] Reading SensorData for 4 PMUnits
Jun 11 17:45:47 ... 17:45:47.180672  5907 SensorServiceImpl.cpp:95] Processing SCM PMUnit: 13 sensors
Jun 11 17:45:47 ... 17:45:47.190193  5907 SensorServiceImpl.cpp:95] Processing SMB PMUnit: 31 sensors
Jun 11 17:45:47 ... 17:45:47.284218  5907 SensorServiceImpl.cpp:95] Processing PSU PMUnit: 11 sensors
Jun 11 17:45:47 ... 17:45:47.295164  5907 SensorServiceImpl.cpp:95] Processing PSU PMUnit: 11 sensors
Jun 11 17:45:47 ... 17:45:47.306159  5907 SensorServiceImpl.cpp:126] Summary: Processed 66 Sensors. 0 Failures.
```

```
# /opt/fboss/bin/sensor_service_sw_test
Running main() from gmock_main.cc
[==========] Running 6 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 4 tests from SensorServiceImplTest
[ RUN      ] SensorServiceImplTest.fetchAndCheckSensorDataSuccess
I0612 00:23:41.102912  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.102940  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
I0612 00:23:41.103439  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 0 Failures.
[       OK ] SensorServiceImplTest.fetchAndCheckSensorDataSuccess (1 ms)
[ RUN      ] SensorServiceImplTest.fetchAndCheckSensorDataFailure
I0612 00:23:41.103998  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.104009  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
E0612 00:23:41.104018  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR1 from path:/tmp/b972-3cea-066c-5a56/mock_fru_sensor_1_path:temp1, error:File does not exist
E0612 00:23:41.104027  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR2 from path:/tmp/b972-3cea-066c-5a56/mock_fru_sensor_2_path:fan1, error:File does not exist
E0612 00:23:41.104035  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR3 from path:/tmp/b972-3cea-066c-5a56/mock_fru_sensor_3_path:vin, error:File does not exist
I0612 00:23:41.104041  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 3 Failures.
[       OK ] SensorServiceImplTest.fetchAndCheckSensorDataFailure (0 ms)
[ RUN      ] SensorServiceImplTest.fetchAndCheckSensorDataSuccesAndThenFailure
I0612 00:23:41.104422  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.104430  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
I0612 00:23:41.104775  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 0 Failures.
I0612 00:23:41.104822  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.104828  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
E0612 00:23:41.104836  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR1 from path:/tmp/25eb-8647-3c46-8911/mock_fru_sensor_1_path:temp1, error:File does not exist
E0612 00:23:41.104844  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR2 from path:/tmp/25eb-8647-3c46-8911/mock_fru_sensor_2_path:fan1, error:File does not exist
E0612 00:23:41.104858  8831 SensorServiceImpl.cpp:189] Could not read data for MOCK_FRU_SENSOR3 from path:/tmp/25eb-8647-3c46-8911/mock_fru_sensor_3_path:vin, error:File does not exist
I0612 00:23:41.104865  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 3 Failures.
[       OK ] SensorServiceImplTest.fetchAndCheckSensorDataSuccesAndThenFailure (0 ms)
[ RUN      ] SensorServiceImplTest.getSomeSensors
I0612 00:23:41.105320  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.105329  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
I0612 00:23:41.105656  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 0 Failures.
[       OK ] SensorServiceImplTest.getSomeSensors (0 ms)
[----------] 4 tests from SensorServiceImplTest (3 ms total)

[----------] 2 tests from SensorServiceThriftHandlerTest
[ RUN      ] SensorServiceThriftHandlerTest.getSensorValuesByNameWithEmptySensorName
I0612 00:23:41.106035  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.106044  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
I0612 00:23:41.106366  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 0 Failures.
[       OK ] SensorServiceThriftHandlerTest.getSensorValuesByNameWithEmptySensorName (0 ms)
[ RUN      ] SensorServiceThriftHandlerTest.getSensorValuesByNameWithNonEmptySensorName
I0612 00:23:41.106719  8831 SensorServiceImpl.cpp:90] Reading SensorData for 1 PMUnits
I0612 00:23:41.106727  8831 SensorServiceImpl.cpp:95] Processing MOCK PMUnit: 3 sensors
I0612 00:23:41.107048  8831 SensorServiceImpl.cpp:126] Summary: Processed 3 Sensors. 0 Failures.
[       OK ] SensorServiceThriftHandlerTest.getSensorValuesByNameWithNonEmptySensorName (0 ms)
[----------] 2 tests from SensorServiceThriftHandlerTest (1 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 2 test suites ran. (4 ms total)
[  PASSED  ] 6 tests.
```

