### PR TITLE
Glath05a-64o: weutil config

### DIFF
--- a/fboss/platform/config_lib/ConfigLibTest.cpp
+++ b/fboss/platform/config_lib/ConfigLibTest.cpp
@@ -16,6 +16,7 @@ const std::string kMeru800bfa = "meru800bfa";
 const std::string kMorgan800cc = "morgan800cc";
 const std::string kJanga800bic = "janga800bic";
 const std::string kTahan800bc = "tahan800bc";
+const std::string kGlath05a_64o = "glath05a-64o";
 const std::string kSample = "sample";
 const std::string kNonExistentPlatform = "nonExistentPlatform";
 } // namespace
@@ -63,6 +64,7 @@ TEST(ConfigLibTest, Basic) {
   EXPECT_NO_THROW(ConfigLib().getWeutilConfig(kJanga800bic));
   EXPECT_NO_THROW(ConfigLib().getWeutilConfig(kTahan800bc));
   EXPECT_NO_THROW(ConfigLib().getWeutilConfig(kMontblanc));
+  EXPECT_NO_THROW(ConfigLib().getWeutilConfig(kGlath05a_64o));
   EXPECT_THROW(
       ConfigLib().getWeutilConfig(kNonExistentPlatform), std::runtime_error);
 

--- a/fboss/platform/configs/glath05a-64o/weutil.json
+++ b/fboss/platform/configs/glath05a-64o/weutil.json
@@ -1,0 +1,13 @@
+{
+  "chassisEepromName": "SMB",
+  "fruEepromList": {
+    "SCM": {
+      "path": "/run/devmap/eeproms/MERU_SCM_EEPROM",
+      "offset": 15360
+    },
+    "SMB": {
+      "path": "/run/devmap/eeproms/GLATH05A-64O_SMB_EEPROM",
+      "offset": 15360
+    }
+  }
+}


### PR DESCRIPTION
# Description 

> 
> **NOTE:** This is part of a series of PRs to add support for Glath05a-64o. The dependency chain of the PRs is as follows:
> 
> Glath05a-64o: define new platform #461
> Glath05a-64o: platform manager #462 – Depends on #461
> Glath05a-64o: add sensor_service support #467 – Depends on #462
> Glath05a-64o: weutil config #468 – Depends on #462
> Glath05a-64o: add fan_service config #469 – Depends on #467
> Glath05a-64o: fw_util support #470 – Depends on #461
> Glath05a-64o: bsp mapping #471 – Depends on #461
> Glath05a-64o: platform mapping #472 – Depends on #471
> Glath05a-64o: led service #473 – Depends on #472

Add weutil config for glath05a-64o

# Testing
```
# weutil --eeprom scm --config_file=/opt/fboss/share/platform_configs/weutil.json
Version: 6
Product Name: SCM
Product Part Number: 
System Assembly Part Number: 
Meta PCBA Part Number: 
Meta PCB Part Number: 
ODM/JDM PCBA Part Number: XXXXXXX
ODM/JDM PCBA Serial Number: 
Production State: PVT
Production Sub-State: 2
Re-Spin/Variant Indicator: 0
Product Serial Number: XXXXXXX
System Manufacturer: 
System Manufacturing Date: XXXXXXX
PCB Manufacturer: 
Assembled At: 
EEPROM location on Fabric: 
X86 CPU MAC Base: XXXXXXX
X86 CPU MAC Address Size: 1
BMC MAC Base: XXXXXXX
BMC MAC Address Size: 1
RMA: 
Vendor Defined Field 1: 
Vendor Defined Field 2: 
Vendor Defined Field 3: 
CRC16: 0xeb6d (CRC Mismatch. Expected 0x772c)
```

```
# weutil --eeprom smb --config_file=/opt/fboss/share/platform_configs/weutil.json
Version: 6
Product Name: GLATH05A-64O
Product Part Number: 
System Assembly Part Number: 
Meta PCBA Part Number: 
Meta PCB Part Number: 
ODM/JDM PCBA Part Number: 
ODM/JDM PCBA Serial Number: 
Production State: MP
Production Sub-State: 1
Re-Spin/Variant Indicator: 0
Product Serial Number: XXXXXXX
System Manufacturer: 
System Manufacturing Date: XXXXXXX
PCB Manufacturer: 
Assembled At: 
EEPROM location on Fabric: 
Switch ASIC MAC Base: XXXXXXX
Switch ASIC MAC Address Size: 149
RMA: 
Vendor Defined Field 1: 
Vendor Defined Field 2: 
Vendor Defined Field 3: 
CRC16: 0x426e (CRC Matched)
```

```
# /opt/fboss/bin/weutil_hw_test
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from WeutilTest
[ RUN      ] WeutilTest.getWedgeInfo
I0612 00:09:03.188037  8720 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
I0612 00:09:03.188084  8720 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
I0612 00:09:03.188094  8720 ConfigLib.cpp:27] The inferred platform is glath05a-64o
[       OK ] WeutilTest.getWedgeInfo (1889 ms)
[ RUN      ] WeutilTest.getEepromPaths
I0612 00:09:05.077824  8720 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
I0612 00:09:05.077843  8720 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
I0612 00:09:05.077848  8720 ConfigLib.cpp:27] The inferred platform is glath05a-64o
I0612 00:09:05.077863  8720 PlatformNameLib.cpp:78] Platform name read from cache: GLATH05A-64O
I0612 00:09:05.077867  8720 ConfigLib.cpp:27] The inferred platform is glath05a-64o
[       OK ] WeutilTest.getEepromPaths (0 ms)
[----------] 2 tests from WeutilTest (1889 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (1889 ms total)
[  PASSED  ] 2 tests.
```

