### PR TITLE
MERU800BIA/BFA: Initialize PSUs with write-protect

### DIFF
--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -4104,7 +4104,9 @@
           "initRegSettings": [
             {
               "regOffset": 16,
-              "ioBuf": [-128]
+              "ioBuf": [
+                -128
+              ]
             }
           ]
         }

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -4100,7 +4100,13 @@
           "busName": "INCOMING@0",
           "address": "0x58",
           "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PSU_PMBUS"
+          "pmUnitScopedName": "PSU_PMBUS",
+          "initRegSettings": [
+            {
+              "regOffset": 16,
+              "ioBuf": [-128]
+            }
+          ]
         }
       ],
       "outgoingSlotConfigs": {},

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -1489,7 +1489,9 @@
           "initRegSettings": [
             {
               "regOffset": 16,
-              "ioBuf": [-128]
+              "ioBuf": [
+                -128
+              ]
             }
           ]
         }

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -1485,7 +1485,13 @@
           "busName": "INCOMING@0",
           "address": "0x58",
           "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PSU_PMBUS"
+          "pmUnitScopedName": "PSU_PMBUS",
+          "initRegSettings": [
+            {
+              "regOffset": 16,
+              "ioBuf": [-128]
+            }
+          ]
         }
       ],
       "outgoingSlotConfigs": {},


### PR DESCRIPTION
# Description

Some registers when read, cause the psu to raise an error through the status_cml register at 0x7e. This is normal for some PSUs with unsupported registers. However, problems arise when the write-protect is disabled, the linux pmbus driver sees the status register reporting an error and decides to ignore the valid values it reads.

# Motivation

While this issue shouldn't hit because the WP register is enabled by default when the PSU turns on, this change ensures that WP is enabled in the rare cases where a WP may have been disabled manually or by another process prior to setting up fboss on the system.

# Testing
Manually disabled WP and confirmed platform manager enables it again. All expected psu sensors are read successfully.