### PR TITLE
tahansb: config: created weutil FBOSS config for EVT1

### DIFF
--- a/fboss/platform/configs/tahansb/weutil.json
+++ b/fboss/platform/configs/tahansb/weutil.json
@@ -1,0 +1,20 @@
+{
+  "chassisEepromName": "CHASSIS",
+  "fruEepromList": {
+    "CHASSIS": {
+      "path": "/run/devmap/eeproms/CHASSIS_EEPROM"
+    },
+    "COME": {
+      "path": "/run/devmap/eeproms/COME_EEPROM"
+    },
+    "MCB": {
+      "path": "/run/devmap/eeproms/MCB_EEPROM"
+    },
+    "RUNBMC": {
+      "path": "/run/devmap/eeproms/RUNBMC_EEPROM"
+    },
+    "SMB": {
+      "path": "/run/devmap/eeproms/SMB_EEPROM"
+    }
+  }
+}


### PR DESCRIPTION
**Description**

This PR is for tahansb weutil config file

**Motivation**

Based on the TAHANSB EVT1 hardware specification, five IDEEPROMs' Device Path should be added to FBOSS weutil config file:

- CHASSIS_EEPROM
- COME_EEPROM
- MCB_EEPROM
- RUNBMC_EEPROM
- SMB_EEPROM

![image](https://github.com/user-attachments/assets/e6f1ffeb-24d9-4507-8af5-95946e0c6107)


**Test Plan**

1.The correctness of the format has been verified on this website https://jsonlint.com/
2. Used jq command to pretty the format
3. Compilation and config validation have passed
![image](https://github.com/user-attachments/assets/a2b7a26b-bb5b-475d-96d3-f964710829da)

Building Log:
[build.txt](https://github.com/user-attachments/files/20751396/build.txt)
