### PR TITLE
tahansb: config: created data_corral_service FBOSS config for EVT1

### DIFF
--- a/fboss/platform/configs/tahansb/led_manager.json
+++ b/fboss/platform/configs/tahansb/led_manager.json
@@ -12,7 +12,7 @@
       "absentLedColor": 4,
       "absentLedSysfsPath": "/sys/class/leds/fan_led:amber:status/brightness"
     },
-    "PSU": {
+    "PWR": {
       "presentLedColor": 3,
       "presentLedSysfsPath": "/sys/class/leds/psu_led:blue:status/brightness",
       "absentLedColor": 4,

--- a/fboss/platform/configs/tahansb/led_manager.json
+++ b/fboss/platform/configs/tahansb/led_manager.json
@@ -1,0 +1,70 @@
+{
+  "systemLedConfig": {
+    "presentLedColor": 3,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",
+    "absentLedColor": 4,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:amber:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:amber:status/brightness"
+    },
+    "PSU": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:amber:status/brightness"
+    },
+    "SMB": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/smb_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/smb_led:amber:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Description**

This PR is for tahansb data_corral_service config file.

**Motivation**

Based on the TAHANSB EVT1 hardware specification, the present led color and presence status for following sorts of LEDs should be configured to FBOSS data_corral_service config file:

- System LED
- Fan Status LED
- Power Status LED
- SMB Status LED

![image](https://github.com/user-attachments/assets/bc39510b-3ef3-4a5f-bf4d-f0311abd5b6b)


**Test Plan**

1.The correctness of the format has been verified on this website https://jsonlint.com/
2. Used jq command to pretty the format
3. Compilation and config validation have passed

![image](https://github.com/user-attachments/assets/550f0342-e12c-406f-9a05-db3674455035)

Building Log:
[build.txt](https://github.com/user-attachments/files/20860060/build_20250623.txt)








