### PR TITLE
Add fw_util_hw_test to fboss_platform_services cmake target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,6 +1001,7 @@ add_dependencies(fboss_platform_services
   weutil_hw_test
   platform_manager_hw_test
   cross_config_validator_test
+  fw_util_hw_test
 )
 
 add_custom_target(qsfp_targets)

--- a/cmake/PlatformFwUtil.cmake
+++ b/cmake/PlatformFwUtil.cmake
@@ -36,4 +36,8 @@ target_link_libraries(fw_util
   fw_util_config-cpp2-types
 )
 
+add_executable(fw_util_hw_test
+    fboss/platform/fw_util/hw_test/FwUtilHwTest.cpp
+)
+
 install(TARGETS fw_util)


### PR DESCRIPTION
Summary: This diff adds fw_util_hw_test to the fboss_platform_services cmake target to ensure we include the binary in our manifold for OSS tests.

Differential Revision: D77043386


