### PR TITLE
Icetray: config: platform service configurations support for EVT1

### DIFF
--- a/fboss/platform/configs/icetray/fan_service.json
+++ b/fboss/platform/configs/icetray/fan_service.json
@@ -1,0 +1,168 @@
+{
+  "pwmBoostOnNumDeadFan": 2,
+  "pwmBoostOnNumDeadSensor": 0,
+  "pwmBoostOnNoQsfpAfterInSec": 0,
+  "pwmBoostValue": 70,
+  "pwmTransitionValue": 70,
+  "pwmLowerThreshold": 60,
+  "pwmUpperThreshold": 100,
+  "watchdog": {
+    "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
+    "value": 0
+  },
+  "controlInterval": {
+    "sensorReadInterval": 5,
+    "pwmUpdateInterval": 5
+  },
+  "sensors": [
+    {
+      "sensorName": "CPU_UNCORE_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
+      "pidSetting": {
+        "kp": -4,
+        "ki": -0.06,
+        "kd": 0,
+        "setPoint": 97.0,
+        "posHysteresis": 0.0,
+        "negHysteresis": 8.0
+      }
+    },
+    {
+      "sensorName": "PIC_U12_INLET_LM75_1_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "30": 60,
+        "35": 70,
+        "37": 80,
+        "42": 90
+      },
+      "normalDownTable": {
+        "28": 60,
+        "33": 70,
+        "35": 80,
+        "40": 90
+      },
+      "failUpTable": {
+        "30": 70,
+        "35": 80,
+        "37": 90,
+        "42": 100
+      },
+      "failDownTable": {
+        "28": 70,
+        "33": 80,
+        "35": 90,
+        "40": 100
+      }
+    },
+    {
+      "sensorName": "POWER_BRICK1_TEMP1",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
+      "pidSetting": {
+        "kp": -8,
+        "ki": -0.06,
+        "kd": 0,
+        "setPoint": 105.0,
+        "posHysteresis": 0.0,
+        "negHysteresis": 3.0
+      }
+    },
+    {
+      "sensorName": "POWER_BRICK2_TEMP1",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
+      "pidSetting": {
+        "kp": -8,
+        "ki": -0.06,
+        "kd": 0,
+        "setPoint": 105.0,
+        "posHysteresis": 0.0,
+        "negHysteresis": 3.0
+      }
+    }
+  ],
+  "fans": [
+    {
+      "fanName": "FAN_1_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+      "pwmMin": 0,
+      "pwmMax": 40,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_2_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+      "pwmMin": 0,
+      "pwmMax": 40,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_3_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+      "pwmMin": 0,
+      "pwmMax": 40,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_4_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+      "pwmMin": 0,
+      "pwmMax": 40,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    }
+  ],
+  "zones": [
+    {
+      "zoneType": "ZONE_TYPE_MAX",
+      "zoneName": "zone1",
+      "sensorNames": [
+        "CPU_UNCORE_TEMP",
+        "PIC_U12_INLET_LM75_1_TEMP",
+        "POWER_BRICK1_TEMP1",
+        "POWER_BRICK2_TEMP1"
+      ],
+      "fanNames": [
+        "FAN_1_F",
+        "FAN_2_F",
+        "FAN_3_F",
+        "FAN_4_F"
+      ],
+      "slope": 10
+    }
+  ]
+}

--- a/fboss/platform/configs/icetray/fw_util.json
+++ b/fboss/platform/configs/icetray/fw_util.json
@@ -1,0 +1,402 @@
+{
+  "newFwConfigs": {
+    "bios": {
+      "preUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x15",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "internal",
+            "flashromExtraArgs": [
+              "--ifd",
+              "-i",
+              "bios",
+              "--noverify-all"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x16",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "version": {
+        "versionType": "sysfs",
+        "path": "/sys/devices/virtual/dmi/id/bios_version"
+      },
+      "priority": 1
+    },
+    "iob_fpga": {
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/MCB_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
+    "dom_fpga": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "66"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "9"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "66"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/PIC_DOM_INFO_ROM/fw_ver"
+      },
+      "priority": 3
+    },
+    "mcb_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/MCB_CPLD/fw_ver"
+      },
+      "priority": 4
+    },
+    "smb_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "7"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "7"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SMB_CPLD/fw_ver"
+      },
+      "priority": 5
+    },
+    "scm_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SCM_CPLD/fw_ver"
+      },
+      "priority": 6
+    },
+    "pic_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "66"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "66"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/PIC_CPLD/fw_ver"
+      },
+      "priority": 7
+    }
+  }
+}

--- a/fboss/platform/configs/icetray/led_manager.json
+++ b/fboss/platform/configs/icetray/led_manager.json
@@ -1,0 +1,90 @@
+{
+  "systemLedConfig": {
+    "presentLedColor": 3,
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",
+    "absentLedColor": 4,
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:amber:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:amber:status/brightness"
+    },
+    "PWR": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:amber:status/brightness"
+    },
+    "SMB": {
+      "presentLedColor": 3,
+      "presentLedSysfsPath": "/sys/class/leds/smb_led:blue:status/brightness",
+      "absentLedColor": 4,
+      "absentLedSysfsPath": "/sys/class/leds/smb_led:amber:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PWR",
+      "fruType": "PWR",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/hs_48v_pg",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "SMB",
+      "fruType": "SMB",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/smb_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}

--- a/fboss/platform/configs/icetray/platform_manager.json
+++ b/fboss/platform/configs/icetray/platform_manager.json
@@ -1,0 +1,2250 @@
+{
+  "platformName": "ICETRAY",
+  "rootPmUnitName": "ICETRAY_MCB",
+  "rootSlotType": "MCB_SLOT",
+  "slotTypeConfigs": {
+    "MCB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "idpromConfig": {
+        "busName": "SMBus I801 adapter at 5000",
+        "address": "0x53",
+        "kernelDeviceName": "24c02"
+      },
+      "pmUnitName": "ICETRAY_MCB"
+    },
+    "RUNBMC_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x51",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "BMC"
+    },
+    "COMESE_SLOT": {
+      "numOutgoingI2cBuses": 2,
+      "idpromConfig": {
+        "busName": "INCOMING@1",
+        "address": "0x56",
+        "kernelDeviceName": "24c128"
+      },
+      "pmUnitName": "NETLAKE"
+    },
+    "FCB_SLOT": {
+      "numOutgoingI2cBuses": 5,
+      "idpromConfig": {
+        "busName": "INCOMING@4",
+        "address": "0x57",
+        "kernelDeviceName": "24c02"
+      },
+      "pmUnitName": "FCB"
+    },
+    "PIC_SLOT": {
+      "numOutgoingI2cBuses": 3,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "PIC"
+    },
+    "SMB_SLOT": {
+      "numOutgoingI2cBuses": 5,
+      "idpromConfig": {
+        "busName": "INCOMING@2",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "SMB"
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "SMBus I801 adapter at 5000",
+    "SMBus iSMT adapter at 20fffa7b000"
+  ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x11",
+              "kernelDeviceName": "mp9941",
+              "pmUnitScopedName": "COME_HWMON1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x22",
+              "kernelDeviceName": "mp9941",
+              "pmUnitScopedName": "COME_HWMON2"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x45",
+              "kernelDeviceName": "mp9941",
+              "pmUnitScopedName": "COME_HWMON3"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x66",
+              "kernelDeviceName": "mp9941",
+              "pmUnitScopedName": "COME_HWMON4"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x76",
+              "kernelDeviceName": "mp2993",
+              "pmUnitScopedName": "COME_HWMON5"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x48",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_U18_INLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_U39_OUTLET_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 2
+      }
+    ]
+  },
+  "pmUnitConfigs": {
+    "ICETRAY_MCB": {
+      "pluggedInSlotType": "MCB_SLOT",
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
+        }
+      ],
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "MCB_IOB",
+          "vendorId": "0x1d9b",
+          "deviceId": "0x0011",
+          "subSystemVendorId": "0x10ee",
+          "subSystemDeviceId": "0x0007",
+          "i2cAdapterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_1",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_2",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_3",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_4",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_5",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_6",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_7",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_8",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_9",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_10",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_11",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_12",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_13",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_14",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_15",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_16",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x4f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_17",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_18",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_19",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_20",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_21",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_22",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_23",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_24",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_25",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_26",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_27",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_IOB_I2C_MASTER_28",
+                "deviceName": "iob_i2c_master",
+                "csrOffset": "0x5b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_1",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_2",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_3",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_4",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_5",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_6",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_7",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_8",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_9",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_10",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_11",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_12",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_13",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_14",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_15",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_16",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x42f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_17",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_18",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43100"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_19",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43200"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_20",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43300"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_21",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43400"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_22",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43500"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_23",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43600"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_24",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43700"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_25",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43800"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_26",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43900"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_27",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43a00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_28",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43b00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_29",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43c00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_30",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43d00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_31",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43e00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_32",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x43f00"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_33",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x44000"
+              }
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_I2C_MASTER_34",
+                "deviceName": "dom1_i2c_master",
+                "csrOffset": "0x44100"
+              }
+            }
+          ],
+          "gpioChipConfigs": [
+            {
+              "pmUnitScopedName": "MCB_GPIO_CHIP_1",
+              "deviceName": "gpiochip",
+              "csrOffset": "0x0400"
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_1",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10000",
+                "iobufOffset": "0x12000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_1_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_2",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10080",
+                "iobufOffset": "0x12400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_2_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_3",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10100",
+                "iobufOffset": "0x12800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_3_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_4",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10180",
+                "iobufOffset": "0x12c00"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_4_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_5",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10200",
+                "iobufOffset": "0x13000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_5_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_6",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10280",
+                "iobufOffset": "0x13400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_6_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_7",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10300",
+                "iobufOffset": "0x13800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_7_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "xcvrCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_1",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40200"
+              },
+              "portNumber": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_2",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40204"
+              },
+              "portNumber": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_3",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40208"
+              },
+              "portNumber": 3
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_4",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4020c"
+              },
+              "portNumber": 4
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_5",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40210"
+              },
+              "portNumber": 5
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_6",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40214"
+              },
+              "portNumber": 6
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_7",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40218"
+              },
+              "portNumber": 7
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_8",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4021c"
+              },
+              "portNumber": 8
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_9",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40220"
+              },
+              "portNumber": 9
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_10",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40224"
+              },
+              "portNumber": 10
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_11",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40228"
+              },
+              "portNumber": 11
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_12",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4022c"
+              },
+              "portNumber": 12
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_13",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40230"
+              },
+              "portNumber": 13
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_14",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40234"
+              },
+              "portNumber": 14
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_15",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40238"
+              },
+              "portNumber": 15
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_16",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4023c"
+              },
+              "portNumber": 16
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_17",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40240"
+              },
+              "portNumber": 17
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_18",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40244"
+              },
+              "portNumber": 18
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_19",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40248"
+              },
+              "portNumber": 19
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_20",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4024c"
+              },
+              "portNumber": 20
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_21",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40250"
+              },
+              "portNumber": 21
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_22",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40254"
+              },
+              "portNumber": 22
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_23",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40258"
+              },
+              "portNumber": 23
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_24",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4025c"
+              },
+              "portNumber": 24
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_25",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40260"
+              },
+              "portNumber": 25
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_26",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40264"
+              },
+              "portNumber": 26
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_27",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40268"
+              },
+              "portNumber": 27
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_28",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4026c"
+              },
+              "portNumber": 28
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_29",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40270"
+              },
+              "portNumber": 29
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_30",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40274"
+              },
+              "portNumber": 30
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_31",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x40278"
+              },
+              "portNumber": 31
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "PIC_DOM_XCVR_CTRL_PORT_32",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x4027c"
+              },
+              "portNumber": 32
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "IOB_XCVR_CTRL_PORT_33",
+                "deviceName": "xcvr_ctrl",
+                "csrOffset": "0x1030"
+              },
+              "portNumber": 33
+            }
+          ],
+          "ledCtrlConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_1_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40410"
+              },
+              "portNumber": 1,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_2_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40418"
+              },
+              "portNumber": 2,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_3_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40420"
+              },
+              "portNumber": 3,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_4_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40428"
+              },
+              "portNumber": 4,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_5_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40430"
+              },
+              "portNumber": 5,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_6_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40438"
+              },
+              "portNumber": 6,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_7_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40440"
+              },
+              "portNumber": 7,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_8_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40448"
+              },
+              "portNumber": 8,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_9_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40450"
+              },
+              "portNumber": 9,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_10_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40458"
+              },
+              "portNumber": 10,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_11_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40460"
+              },
+              "portNumber": 11,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_12_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40468"
+              },
+              "portNumber": 12,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_13_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40470"
+              },
+              "portNumber": 13,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_14_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40478"
+              },
+              "portNumber": 14,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_15_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40480"
+              },
+              "portNumber": 15,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_16_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40488"
+              },
+              "portNumber": 16,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_17_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40490"
+              },
+              "portNumber": 17,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_18_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40498"
+              },
+              "portNumber": 18,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_19_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a0"
+              },
+              "portNumber": 19,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_20_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a8"
+              },
+              "portNumber": 20,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_21_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b0"
+              },
+              "portNumber": 21,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_22_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b8"
+              },
+              "portNumber": 22,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_23_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c0"
+              },
+              "portNumber": 23,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_24_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c8"
+              },
+              "portNumber": 24,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_25_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d0"
+              },
+              "portNumber": 25,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_26_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d8"
+              },
+              "portNumber": 26,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_27_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e0"
+              },
+              "portNumber": 27,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_28_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e8"
+              },
+              "portNumber": 28,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_29_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f0"
+              },
+              "portNumber": 29,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_30_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f8"
+              },
+              "portNumber": 30,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_31_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40500"
+              },
+              "portNumber": 31,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_32_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40508"
+              },
+              "portNumber": 32,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_33_LED_1",
+                "deviceName": "port_led",
+                "csrOffset": "0x40510"
+              },
+              "portNumber": 33,
+              "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_1_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40414"
+              },
+              "portNumber": 1,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_2_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4041c"
+              },
+              "portNumber": 2,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_3_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40424"
+              },
+              "portNumber": 3,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_4_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4042c"
+              },
+              "portNumber": 4,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_5_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40434"
+              },
+              "portNumber": 5,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_6_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4043c"
+              },
+              "portNumber": 6,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_7_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40444"
+              },
+              "portNumber": 7,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_8_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4044c"
+              },
+              "portNumber": 8,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_9_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40454"
+              },
+              "portNumber": 9,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_10_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4045c"
+              },
+              "portNumber": 10,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_11_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40464"
+              },
+              "portNumber": 11,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_12_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4046c"
+              },
+              "portNumber": 12,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_13_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40474"
+              },
+              "portNumber": 13,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_14_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4047c"
+              },
+              "portNumber": 14,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_15_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40484"
+              },
+              "portNumber": 15,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_16_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4048c"
+              },
+              "portNumber": 16,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_17_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40494"
+              },
+              "portNumber": 17,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_18_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4049c"
+              },
+              "portNumber": 18,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_19_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404a4"
+              },
+              "portNumber": 19,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_20_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404ac"
+              },
+              "portNumber": 20,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_21_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404b4"
+              },
+              "portNumber": 21,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_22_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404bc"
+              },
+              "portNumber": 22,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_23_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404c4"
+              },
+              "portNumber": 23,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_24_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404cc"
+              },
+              "portNumber": 24,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_25_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404d4"
+              },
+              "portNumber": 25,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_26_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404dc"
+              },
+              "portNumber": 26,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_27_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404e4"
+              },
+              "portNumber": 27,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_28_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404ec"
+              },
+              "portNumber": 28,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_29_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404f4"
+              },
+              "portNumber": 29,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_30_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x404fc"
+              },
+              "portNumber": 30,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_31_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x40504"
+              },
+              "portNumber": 31,
+              "ledId": 2
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_LED_PORT_32_LED_2",
+                "deviceName": "port_led",
+                "csrOffset": "0x4050c"
+              },
+              "portNumber": 32,
+              "ledId": 2
+            }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "MCB_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            },
+            {
+              "pmUnitScopedName": "PIC_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x40000"
+            }
+          ]
+        }
+      ],
+      "i2cDeviceConfigs": [
+        {
+          "busName": "MCB_IOB_I2C_MASTER_2",
+          "address": "0x70",
+          "kernelDeviceName": "pca9546",
+          "pmUnitScopedName": "MCB_MUX",
+          "numOutgoingChannels": 4
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_3",
+          "address": "0x35",
+          "kernelDeviceName": "icetray_scmcpld",
+          "pmUnitScopedName": "SCM_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x60",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "MCB_PMBUS_1"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x61",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "MCB_PMBUS_2"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PWR_BRICK_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_13",
+          "address": "0x4e",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x33",
+          "kernelDeviceName": "icetray_fancpld",
+          "pmUnitScopedName": "MCB_FAN_CPLD",
+          "isWatchdog": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x60",
+          "kernelDeviceName": "icetray_mcbcpld",
+          "pmUnitScopedName": "MCB_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_15",
+          "address": "0x53",
+          "kernelDeviceName": "24c64",
+          "pmUnitScopedName": "CHASSIS_IDPROM"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "MCB_LOAD_SWITCH_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_22",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_TSENSOR1"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_22",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_TSENSOR2"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC1_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x37",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC2_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RUNBMC_SLOT@0": {
+          "slotType": "RUNBMC_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_1"
+          ]
+        },
+        "COMESE_SLOT@0": {
+          "slotType": "COMESE_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_MUX@1",
+            "MCB_IOB_I2C_MASTER_18"
+          ]
+        },
+        "FCB_SLOT@0": {
+          "slotType": "FCB_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_9",
+            "MCB_IOB_I2C_MASTER_19",
+            "MCB_IOB_I2C_MASTER_20",
+            "MCB_IOB_I2C_MASTER_23",
+            "MCB_IOB_I2C_MASTER_27"
+          ]
+        },
+        "PIC_SLOT@0": {
+          "slotType": "PIC_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_27",
+            "PIC_DOM_I2C_MASTER_33",
+            "PIC_DOM_I2C_MASTER_34"
+          ]
+        },
+        "SMB_SLOT@0": {
+          "slotType": "SMB_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_7",
+            "MCB_IOB_I2C_MASTER_8",
+            "MCB_IOB_I2C_MASTER_10",
+            "MCB_IOB_I2C_MASTER_11",
+            "MCB_IOB_I2C_MASTER_12"
+          ]
+        }
+      }
+    },
+    "BMC": {
+      "pluggedInSlotType": "RUNBMC_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4a",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RUNBMC_THERMAL_SENSOR"
+        }
+      ]
+    },
+    "NETLAKE": {
+      "pluggedInSlotType": "COMESE_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x11",
+          "kernelDeviceName": "tda38640",
+          "pmUnitScopedName": "COME_HWMON1"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x22",
+          "kernelDeviceName": "tda38640",
+          "pmUnitScopedName": "COME_HWMON2"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x45",
+          "kernelDeviceName": "tda38640",
+          "pmUnitScopedName": "COME_HWMON3"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x66",
+          "kernelDeviceName": "tda38640",
+          "pmUnitScopedName": "COME_HWMON4"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x76",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "COME_HWMON5"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x48",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_U18_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x4a",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_U39_OUTLET_TSENSOR"
+        }
+      ]
+    },
+    "FCB": {
+      "pluggedInSlotType": "FCB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x70",
+          "kernelDeviceName": "pca9546",
+          "pmUnitScopedName": "FCB_MUX",
+          "numOutgoingChannels": 4
+        },
+        {
+          "busName": "FCB_MUX@0",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "FCB_TSENSOR1"
+        },
+        {
+          "busName": "FCB_MUX@1",
+          "address": "0x4b",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "FCB_TSENSOR2"
+        },
+        {
+          "busName": "FCB_MUX@2",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "FCB_TSENSOR3"
+        },
+        {
+          "busName": "FCB_MUX@3",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "FCB_TSENSOR4"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR1"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x41",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR2"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x44",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR3"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x45",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR4"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x11",
+          "kernelDeviceName": "ltc4287",
+          "pmUnitScopedName": "FCB_48V_HSC_MONITOR"
+        }
+      ]
+    },
+    "PIC": {
+      "pluggedInSlotType": "PIC_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x33",
+          "kernelDeviceName": "icetray_piccpld",
+          "pmUnitScopedName": "PIC_CPLD"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x66",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_XP3R3V_L_MONITOR"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x70",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PIC_XP3R3V_R_MONITOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "PIC_ADC_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_TSENSOR_1"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PIC_TSENSOR_2"
+        }
+      ]
+    },
+    "SMB": {
+      "pluggedInSlotType": "SMB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x74",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "SMB_MUX",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "SMB_MUX@0",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_0"
+        },
+        {
+          "busName": "SMB_MUX@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_1"
+        },
+        {
+          "busName": "SMB_MUX@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1"
+        },
+        {
+          "busName": "SMB_MUX@2",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_2"
+        },
+        {
+          "busName": "SMB_MUX@2",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_OUTLET_TH6_TSENSOR"
+        },
+        {
+          "busName": "SMB_MUX@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_3"
+        },
+        {
+          "busName": "SMB_MUX@3",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2"
+        },
+        {
+          "busName": "SMB_MUX@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_4"
+        },
+        {
+          "busName": "SMB_MUX@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_1"
+        },
+        {
+          "busName": "SMB_MUX@5",
+          "address": "0x6a",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_2"
+        },
+        {
+          "busName": "SMB_MUX@6",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_6"
+        },
+        {
+          "busName": "SMB_MUX@7",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_7"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x33",
+          "kernelDeviceName": "icetray_smbcpld",
+          "pmUnitScopedName": "SMB_CPLD"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x76",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SMB_VDDCORE"
+        }
+      ]
+    }
+  },
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/eeproms/MCB_EEPROM": "/[IDPROM]",
+    "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_IDPROM]",
+    "/run/devmap/eeproms/RUNBMC_EEPROM": "/RUNBMC_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/COME_EEPROM": "/COMESE_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/FCB_EEPROM": "/FCB_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/PIC_EEPROM": "/PIC_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/MCB_PMBUS_1": "/[MCB_PMBUS_1]",
+    "/run/devmap/sensors/MCB_PMBUS_2": "/[MCB_PMBUS_2]",
+    "/run/devmap/sensors/COME_INLET_TSENSOR": "/[COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/PWR_BRICK_INLET_TSENSOR": "/[PWR_BRICK_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_OUTLET_TSENSOR": "/[COME_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_FAN_CPLD": "/[MCB_FAN_CPLD]",
+    "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR": "/[MCB_LOAD_SWITCH_MONITOR]",
+    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR1": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR1]",
+    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR2": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR2]",
+    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR3": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR3]",
+    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR4": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR4]",
+    "/run/devmap/sensors/FCB_48V_HSC_MONITOR": "/FCB_SLOT@0/[FCB_48V_HSC_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC1_MONITOR": "/[MCB_ADC1_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC2_MONITOR": "/[MCB_ADC2_MONITOR]",
+    "/run/devmap/sensors/MCB_TSENSOR1": "/[MCB_TSENSOR1]",
+    "/run/devmap/sensors/MCB_TSENSOR2": "/[MCB_TSENSOR2]",
+    "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
+    "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR": "/PIC_SLOT@0/[PIC_XP3R3V_L_MONITOR]",
+    "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR": "/PIC_SLOT@0/[PIC_XP3R3V_R_MONITOR]",
+    "/run/devmap/sensors/PIC_ADC_SENSOR": "/PIC_SLOT@0/[PIC_ADC_SENSOR]",
+    "/run/devmap/sensors/PIC_TSENSOR_1": "/PIC_SLOT@0/[PIC_TSENSOR_1]",
+    "/run/devmap/sensors/PIC_TSENSOR_2": "/PIC_SLOT@0/[PIC_TSENSOR_2]",
+    "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_1]",
+    "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_OUTLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_2]",
+    "/run/devmap/sensors/SMB_ADC1_SENSOR": "/SMB_SLOT@0/[SMB_ADC1_SENSOR]",
+    "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
+    "/run/devmap/sensors/SMB_INLET_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TSENSOR]",
+    "/run/devmap/cplds/SCM_CPLD": "/[SCM_CPLD]",
+    "/run/devmap/cplds/MCB_CPLD": "/[MCB_CPLD]",
+    "/run/devmap/cplds/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
+    "/run/devmap/cplds/PIC_CPLD": "/PIC_SLOT@0/[PIC_CPLD]",
+    "/run/devmap/watchdogs/FAN_WATCHDOG": "/[MCB_FAN_CPLD]",
+    "/run/devmap/fpgas/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/fpgas/PIC_DOM_INFO_ROM": "/[PIC_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/inforoms/PIC_DOM_INFO_ROM": "/[PIC_DOM_INFO_ROM]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_1": "/[MCB_IOB_I2C_MASTER_1]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_2": "/[MCB_IOB_I2C_MASTER_2]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_3": "/[MCB_IOB_I2C_MASTER_3]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_4": "/[MCB_IOB_I2C_MASTER_4]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_5": "/[MCB_IOB_I2C_MASTER_5]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_6": "/[MCB_IOB_I2C_MASTER_6]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_7": "/[MCB_IOB_I2C_MASTER_7]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_8": "/[MCB_IOB_I2C_MASTER_8]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_9": "/[MCB_IOB_I2C_MASTER_9]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_10": "/[MCB_IOB_I2C_MASTER_10]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_11": "/[MCB_IOB_I2C_MASTER_11]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_12": "/[MCB_IOB_I2C_MASTER_12]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_13": "/[MCB_IOB_I2C_MASTER_13]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_14": "/[MCB_IOB_I2C_MASTER_14]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_15": "/[MCB_IOB_I2C_MASTER_15]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_16": "/[MCB_IOB_I2C_MASTER_16]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_17": "/[MCB_IOB_I2C_MASTER_17]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_18": "/[MCB_IOB_I2C_MASTER_18]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_19": "/[MCB_IOB_I2C_MASTER_19]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_20": "/[MCB_IOB_I2C_MASTER_20]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_21": "/[MCB_IOB_I2C_MASTER_21]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_22": "/[MCB_IOB_I2C_MASTER_22]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_23": "/[MCB_IOB_I2C_MASTER_23]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_24": "/[MCB_IOB_I2C_MASTER_24]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_25": "/[MCB_IOB_I2C_MASTER_25]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_26": "/[MCB_IOB_I2C_MASTER_26]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_27": "/[MCB_IOB_I2C_MASTER_27]",
+    "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_28": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
+    "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
+    "/run/devmap/sensors/COME_HWMON3": "/COMESE_SLOT@0/[COME_HWMON3]",
+    "/run/devmap/sensors/COME_HWMON4": "/COMESE_SLOT@0/[COME_HWMON4]",
+    "/run/devmap/sensors/COME_HWMON5": "/COMESE_SLOT@0/[COME_HWMON5]",
+    "/run/devmap/sensors/COME_U18_INLET_TSENSOR": "/COMESE_SLOT@0/[COME_U18_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR": "/COMESE_SLOT@0/[COME_U39_OUTLET_TSENSOR]",
+    "/run/devmap/i2c-busses/XCVR_1": "/[PIC_DOM_I2C_MASTER_1]",
+    "/run/devmap/i2c-busses/XCVR_2": "/[PIC_DOM_I2C_MASTER_2]",
+    "/run/devmap/i2c-busses/XCVR_3": "/[PIC_DOM_I2C_MASTER_3]",
+    "/run/devmap/i2c-busses/XCVR_4": "/[PIC_DOM_I2C_MASTER_4]",
+    "/run/devmap/i2c-busses/XCVR_5": "/[PIC_DOM_I2C_MASTER_5]",
+    "/run/devmap/i2c-busses/XCVR_6": "/[PIC_DOM_I2C_MASTER_6]",
+    "/run/devmap/i2c-busses/XCVR_7": "/[PIC_DOM_I2C_MASTER_7]",
+    "/run/devmap/i2c-busses/XCVR_8": "/[PIC_DOM_I2C_MASTER_8]",
+    "/run/devmap/i2c-busses/XCVR_9": "/[PIC_DOM_I2C_MASTER_9]",
+    "/run/devmap/i2c-busses/XCVR_10": "/[PIC_DOM_I2C_MASTER_10]",
+    "/run/devmap/i2c-busses/XCVR_11": "/[PIC_DOM_I2C_MASTER_11]",
+    "/run/devmap/i2c-busses/XCVR_12": "/[PIC_DOM_I2C_MASTER_12]",
+    "/run/devmap/i2c-busses/XCVR_13": "/[PIC_DOM_I2C_MASTER_13]",
+    "/run/devmap/i2c-busses/XCVR_14": "/[PIC_DOM_I2C_MASTER_14]",
+    "/run/devmap/i2c-busses/XCVR_15": "/[PIC_DOM_I2C_MASTER_15]",
+    "/run/devmap/i2c-busses/XCVR_16": "/[PIC_DOM_I2C_MASTER_16]",
+    "/run/devmap/i2c-busses/XCVR_17": "/[PIC_DOM_I2C_MASTER_17]",
+    "/run/devmap/i2c-busses/XCVR_18": "/[PIC_DOM_I2C_MASTER_18]",
+    "/run/devmap/i2c-busses/XCVR_19": "/[PIC_DOM_I2C_MASTER_19]",
+    "/run/devmap/i2c-busses/XCVR_20": "/[PIC_DOM_I2C_MASTER_20]",
+    "/run/devmap/i2c-busses/XCVR_21": "/[PIC_DOM_I2C_MASTER_21]",
+    "/run/devmap/i2c-busses/XCVR_22": "/[PIC_DOM_I2C_MASTER_22]",
+    "/run/devmap/i2c-busses/XCVR_23": "/[PIC_DOM_I2C_MASTER_23]",
+    "/run/devmap/i2c-busses/XCVR_24": "/[PIC_DOM_I2C_MASTER_24]",
+    "/run/devmap/i2c-busses/XCVR_25": "/[PIC_DOM_I2C_MASTER_25]",
+    "/run/devmap/i2c-busses/XCVR_26": "/[PIC_DOM_I2C_MASTER_26]",
+    "/run/devmap/i2c-busses/XCVR_27": "/[PIC_DOM_I2C_MASTER_27]",
+    "/run/devmap/i2c-busses/XCVR_28": "/[PIC_DOM_I2C_MASTER_28]",
+    "/run/devmap/i2c-busses/XCVR_29": "/[PIC_DOM_I2C_MASTER_29]",
+    "/run/devmap/i2c-busses/XCVR_30": "/[PIC_DOM_I2C_MASTER_30]",
+    "/run/devmap/i2c-busses/XCVR_31": "/[PIC_DOM_I2C_MASTER_31]",
+    "/run/devmap/i2c-busses/XCVR_32": "/[PIC_DOM_I2C_MASTER_32]",
+    "/run/devmap/i2c-busses/XCVR_33": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/i2c-busses/PIC_DOM_I2C_MASTER_33": "/[PIC_DOM_I2C_MASTER_33]",
+    "/run/devmap/i2c-busses/PIC_DOM_I2C_MASTER_34": "/[PIC_DOM_I2C_MASTER_34]",
+    "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
+    "/run/devmap/xcvrs/xcvr_1": "/[PIC_DOM_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_2": "/[PIC_DOM_XCVR_CTRL_PORT_2]",
+    "/run/devmap/xcvrs/xcvr_3": "/[PIC_DOM_XCVR_CTRL_PORT_3]",
+    "/run/devmap/xcvrs/xcvr_4": "/[PIC_DOM_XCVR_CTRL_PORT_4]",
+    "/run/devmap/xcvrs/xcvr_5": "/[PIC_DOM_XCVR_CTRL_PORT_5]",
+    "/run/devmap/xcvrs/xcvr_6": "/[PIC_DOM_XCVR_CTRL_PORT_6]",
+    "/run/devmap/xcvrs/xcvr_7": "/[PIC_DOM_XCVR_CTRL_PORT_7]",
+    "/run/devmap/xcvrs/xcvr_8": "/[PIC_DOM_XCVR_CTRL_PORT_8]",
+    "/run/devmap/xcvrs/xcvr_9": "/[PIC_DOM_XCVR_CTRL_PORT_9]",
+    "/run/devmap/xcvrs/xcvr_10": "/[PIC_DOM_XCVR_CTRL_PORT_10]",
+    "/run/devmap/xcvrs/xcvr_11": "/[PIC_DOM_XCVR_CTRL_PORT_11]",
+    "/run/devmap/xcvrs/xcvr_12": "/[PIC_DOM_XCVR_CTRL_PORT_12]",
+    "/run/devmap/xcvrs/xcvr_13": "/[PIC_DOM_XCVR_CTRL_PORT_13]",
+    "/run/devmap/xcvrs/xcvr_14": "/[PIC_DOM_XCVR_CTRL_PORT_14]",
+    "/run/devmap/xcvrs/xcvr_15": "/[PIC_DOM_XCVR_CTRL_PORT_15]",
+    "/run/devmap/xcvrs/xcvr_16": "/[PIC_DOM_XCVR_CTRL_PORT_16]",
+    "/run/devmap/xcvrs/xcvr_17": "/[PIC_DOM_XCVR_CTRL_PORT_17]",
+    "/run/devmap/xcvrs/xcvr_18": "/[PIC_DOM_XCVR_CTRL_PORT_18]",
+    "/run/devmap/xcvrs/xcvr_19": "/[PIC_DOM_XCVR_CTRL_PORT_19]",
+    "/run/devmap/xcvrs/xcvr_20": "/[PIC_DOM_XCVR_CTRL_PORT_20]",
+    "/run/devmap/xcvrs/xcvr_21": "/[PIC_DOM_XCVR_CTRL_PORT_21]",
+    "/run/devmap/xcvrs/xcvr_22": "/[PIC_DOM_XCVR_CTRL_PORT_22]",
+    "/run/devmap/xcvrs/xcvr_23": "/[PIC_DOM_XCVR_CTRL_PORT_23]",
+    "/run/devmap/xcvrs/xcvr_24": "/[PIC_DOM_XCVR_CTRL_PORT_24]",
+    "/run/devmap/xcvrs/xcvr_25": "/[PIC_DOM_XCVR_CTRL_PORT_25]",
+    "/run/devmap/xcvrs/xcvr_26": "/[PIC_DOM_XCVR_CTRL_PORT_26]",
+    "/run/devmap/xcvrs/xcvr_27": "/[PIC_DOM_XCVR_CTRL_PORT_27]",
+    "/run/devmap/xcvrs/xcvr_28": "/[PIC_DOM_XCVR_CTRL_PORT_28]",
+    "/run/devmap/xcvrs/xcvr_29": "/[PIC_DOM_XCVR_CTRL_PORT_29]",
+    "/run/devmap/xcvrs/xcvr_30": "/[PIC_DOM_XCVR_CTRL_PORT_30]",
+    "/run/devmap/xcvrs/xcvr_31": "/[PIC_DOM_XCVR_CTRL_PORT_31]",
+    "/run/devmap/xcvrs/xcvr_32": "/[PIC_DOM_XCVR_CTRL_PORT_32]",
+    "/run/devmap/xcvrs/xcvr_33": "/[IOB_XCVR_CTRL_PORT_33]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1": "/[MCB_SPI_MASTER_3_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1": "/[MCB_SPI_MASTER_4_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1": "/[MCB_SPI_MASTER_5_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_6_DEVICE_1": "/[MCB_SPI_MASTER_6_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1": "/[MCB_SPI_MASTER_7_DEVICE_1]",
+    "/run/devmap/xcvrs/xcvr_io_1": "/[PIC_DOM_I2C_MASTER_1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_1": "/[PIC_DOM_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_io_2": "/[PIC_DOM_I2C_MASTER_2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_2": "/[PIC_DOM_XCVR_CTRL_PORT_2]",
+    "/run/devmap/xcvrs/xcvr_io_3": "/[PIC_DOM_I2C_MASTER_3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_3": "/[PIC_DOM_XCVR_CTRL_PORT_3]",
+    "/run/devmap/xcvrs/xcvr_io_4": "/[PIC_DOM_I2C_MASTER_4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_4": "/[PIC_DOM_XCVR_CTRL_PORT_4]",
+    "/run/devmap/xcvrs/xcvr_io_5": "/[PIC_DOM_I2C_MASTER_5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_5": "/[PIC_DOM_XCVR_CTRL_PORT_5]",
+    "/run/devmap/xcvrs/xcvr_io_6": "/[PIC_DOM_I2C_MASTER_6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_6": "/[PIC_DOM_XCVR_CTRL_PORT_6]",
+    "/run/devmap/xcvrs/xcvr_io_7": "/[PIC_DOM_I2C_MASTER_7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_7": "/[PIC_DOM_XCVR_CTRL_PORT_7]",
+    "/run/devmap/xcvrs/xcvr_io_8": "/[PIC_DOM_I2C_MASTER_8]",
+    "/run/devmap/xcvrs/xcvr_ctrl_8": "/[PIC_DOM_XCVR_CTRL_PORT_8]",
+    "/run/devmap/xcvrs/xcvr_io_9": "/[PIC_DOM_I2C_MASTER_9]",
+    "/run/devmap/xcvrs/xcvr_ctrl_9": "/[PIC_DOM_XCVR_CTRL_PORT_9]",
+    "/run/devmap/xcvrs/xcvr_io_10": "/[PIC_DOM_I2C_MASTER_10]",
+    "/run/devmap/xcvrs/xcvr_ctrl_10": "/[PIC_DOM_XCVR_CTRL_PORT_10]",
+    "/run/devmap/xcvrs/xcvr_io_11": "/[PIC_DOM_I2C_MASTER_11]",
+    "/run/devmap/xcvrs/xcvr_ctrl_11": "/[PIC_DOM_XCVR_CTRL_PORT_11]",
+    "/run/devmap/xcvrs/xcvr_io_12": "/[PIC_DOM_I2C_MASTER_12]",
+    "/run/devmap/xcvrs/xcvr_ctrl_12": "/[PIC_DOM_XCVR_CTRL_PORT_12]",
+    "/run/devmap/xcvrs/xcvr_io_13": "/[PIC_DOM_I2C_MASTER_13]",
+    "/run/devmap/xcvrs/xcvr_ctrl_13": "/[PIC_DOM_XCVR_CTRL_PORT_13]",
+    "/run/devmap/xcvrs/xcvr_io_14": "/[PIC_DOM_I2C_MASTER_14]",
+    "/run/devmap/xcvrs/xcvr_ctrl_14": "/[PIC_DOM_XCVR_CTRL_PORT_14]",
+    "/run/devmap/xcvrs/xcvr_io_15": "/[PIC_DOM_I2C_MASTER_15]",
+    "/run/devmap/xcvrs/xcvr_ctrl_15": "/[PIC_DOM_XCVR_CTRL_PORT_15]",
+    "/run/devmap/xcvrs/xcvr_io_16": "/[PIC_DOM_I2C_MASTER_16]",
+    "/run/devmap/xcvrs/xcvr_ctrl_16": "/[PIC_DOM_XCVR_CTRL_PORT_16]",
+    "/run/devmap/xcvrs/xcvr_io_17": "/[PIC_DOM_I2C_MASTER_17]",
+    "/run/devmap/xcvrs/xcvr_ctrl_17": "/[PIC_DOM_XCVR_CTRL_PORT_17]",
+    "/run/devmap/xcvrs/xcvr_io_18": "/[PIC_DOM_I2C_MASTER_18]",
+    "/run/devmap/xcvrs/xcvr_ctrl_18": "/[PIC_DOM_XCVR_CTRL_PORT_18]",
+    "/run/devmap/xcvrs/xcvr_io_19": "/[PIC_DOM_I2C_MASTER_19]",
+    "/run/devmap/xcvrs/xcvr_ctrl_19": "/[PIC_DOM_XCVR_CTRL_PORT_19]",
+    "/run/devmap/xcvrs/xcvr_io_20": "/[PIC_DOM_I2C_MASTER_20]",
+    "/run/devmap/xcvrs/xcvr_ctrl_20": "/[PIC_DOM_XCVR_CTRL_PORT_20]",
+    "/run/devmap/xcvrs/xcvr_io_21": "/[PIC_DOM_I2C_MASTER_21]",
+    "/run/devmap/xcvrs/xcvr_ctrl_21": "/[PIC_DOM_XCVR_CTRL_PORT_21]",
+    "/run/devmap/xcvrs/xcvr_io_22": "/[PIC_DOM_I2C_MASTER_22]",
+    "/run/devmap/xcvrs/xcvr_ctrl_22": "/[PIC_DOM_XCVR_CTRL_PORT_22]",
+    "/run/devmap/xcvrs/xcvr_io_23": "/[PIC_DOM_I2C_MASTER_23]",
+    "/run/devmap/xcvrs/xcvr_ctrl_23": "/[PIC_DOM_XCVR_CTRL_PORT_23]",
+    "/run/devmap/xcvrs/xcvr_io_24": "/[PIC_DOM_I2C_MASTER_24]",
+    "/run/devmap/xcvrs/xcvr_ctrl_24": "/[PIC_DOM_XCVR_CTRL_PORT_24]",
+    "/run/devmap/xcvrs/xcvr_io_25": "/[PIC_DOM_I2C_MASTER_25]",
+    "/run/devmap/xcvrs/xcvr_ctrl_25": "/[PIC_DOM_XCVR_CTRL_PORT_25]",
+    "/run/devmap/xcvrs/xcvr_io_26": "/[PIC_DOM_I2C_MASTER_26]",
+    "/run/devmap/xcvrs/xcvr_ctrl_26": "/[PIC_DOM_XCVR_CTRL_PORT_26]",
+    "/run/devmap/xcvrs/xcvr_io_27": "/[PIC_DOM_I2C_MASTER_27]",
+    "/run/devmap/xcvrs/xcvr_ctrl_27": "/[PIC_DOM_XCVR_CTRL_PORT_27]",
+    "/run/devmap/xcvrs/xcvr_io_28": "/[PIC_DOM_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_28": "/[PIC_DOM_XCVR_CTRL_PORT_28]",
+    "/run/devmap/xcvrs/xcvr_io_29": "/[PIC_DOM_I2C_MASTER_29]",
+    "/run/devmap/xcvrs/xcvr_ctrl_29": "/[PIC_DOM_XCVR_CTRL_PORT_29]",
+    "/run/devmap/xcvrs/xcvr_io_30": "/[PIC_DOM_I2C_MASTER_30]",
+    "/run/devmap/xcvrs/xcvr_ctrl_30": "/[PIC_DOM_XCVR_CTRL_PORT_30]",
+    "/run/devmap/xcvrs/xcvr_io_31": "/[PIC_DOM_I2C_MASTER_31]",
+    "/run/devmap/xcvrs/xcvr_ctrl_31": "/[PIC_DOM_XCVR_CTRL_PORT_31]",
+    "/run/devmap/xcvrs/xcvr_io_32": "/[PIC_DOM_I2C_MASTER_32]",
+    "/run/devmap/xcvrs/xcvr_ctrl_32": "/[PIC_DOM_XCVR_CTRL_PORT_32]",
+    "/run/devmap/xcvrs/xcvr_io_33": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_33": "/[IOB_XCVR_CTRL_PORT_33]"
+  },
+  "chassisEepromDevicePath": "/[CHASSIS_IDPROM]",
+  "numXcvrs": 33,
+  "bspKmodsRpmName": "fboss_bsp_kmods",
+  "bspKmodsRpmVersion": "3.2.0-1",
+  "requiredKmodsToLoad": [
+    "i2c_i801",
+    "spidev",
+    "fboss_iob_pci"
+  ]
+}

--- a/fboss/platform/configs/icetray/sensor_service.json
+++ b/fboss/platform/configs/icetray/sensor_service.json
@@ -1,0 +1,452 @@
+{
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "ICETRAY_MCB",
+      "sensors": [
+        {
+          "name": "CPU_UNCORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP1R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP3R3V_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP3R3V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP2R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP1R1V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP3R3V_I210",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP12R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "11*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP5R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R0V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.95,
+            "upperCriticalVal": 1.1,
+            "lowerCriticalVal": 0.9
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_STBY",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_MCB_PH",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R8V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R2V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.14,
+            "upperCriticalVal": 1.32,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP12R0V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13,
+            "minAlarmVal": 11,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "11*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP5R0V_USB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000"
+        },
+        {
+          "name": "POWER_BRICK1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "POWER_BRICK2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000"
+        }
+      ]
+    },
+    {
+      "slotPath": "/RUNBMC_SLOT@0",
+      "pmUnitName": "BMC",
+      "sensors": [
+        {
+          "name": "BMC_U9_THERMAL_SENSOR_TMP1075_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        }
+      ]
+    },
+    {
+      "slotPath": "/COMESE_SLOT@0",
+      "pmUnitName": "NETLAKE",
+      "sensors": [
+        {
+          "name": "COME_U18_INLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_U18_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_U39_OUTLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        }
+      ]
+    },
+    {
+      "slotPath": "/PIC_SLOT@0",
+      "pmUnitName": "PIC",
+      "sensors": [
+        {
+          "name": "PIC_U12_INLET_LM75_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_U13_INLET_LM75_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_PIC",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP5R0V_PIC",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP2R5V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP1R1V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_L",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_R",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        }
+      ]
+    }
+  ]
+}

--- a/fboss/platform/configs/icetray/weutil.json
+++ b/fboss/platform/configs/icetray/weutil.json
@@ -1,0 +1,26 @@
+{
+  "chassisEepromName": "CHASSIS",
+  "fruEepromList": {
+    "CHASSIS": {
+      "path": "/run/devmap/eeproms/CHASSIS_EEPROM"
+    },
+    "COME": {
+      "path": "/run/devmap/eeproms/COME_EEPROM"
+    },
+    "MCB": {
+      "path": "/run/devmap/eeproms/MCB_EEPROM"
+    },
+    "FCB": {
+      "path": "/run/devmap/eeproms/FCB_EEPROM"
+    },
+    "RUNBMC": {
+      "path": "/run/devmap/eeproms/RUNBMC_EEPROM"
+    },
+    "PIC": {
+      "path": "/run/devmap/eeproms/PIC_EEPROM"
+    },
+    "SMB": {
+      "path": "/run/devmap/eeproms/SMB_EEPROM"
+    }
+  }
+}


### PR DESCRIPTION
### Description
FBOSS platform service configurations support for the EVT1 phase.

### Motivation
Based on the Iceray EVT1 hardware specifications, the preliminary version configurations of platform_manager, fw_util, weutil, sensor_service, led_manager, and fan_service are provided for the EVT1 phase.

### Test Plan
1. The correctness of the format has been verified on this jsonlint website.
2. Used jq command to pretty the format.
3. Compilation and multiple services configs cross-check are passed.

![image](https://github.com/user-attachments/assets/7017de81-b9cd-4f78-b333-d1fce5a93b0e)

[Build_fboss_platform_services_log.txt](https://github.com/user-attachments/files/20895517/Build_fboss_platform_services_log.txt)

