### PR TITLE
Reduce number of jobs to 24 on qsfp actions build

### DIFF
--- a/.github/workflows/qsfp-build.yml
+++ b/.github/workflows/qsfp-build.yml
@@ -33,6 +33,8 @@ jobs:
           --no-docker-output
           --no-system-deps
           --local
+          --num-jobs
+          24
       - name: Package FBOSS binaries and library dependencies
         run: >
           sudo


### PR DESCRIPTION
Summary: The qsfp actions build is starting to OOM consistently. Adding the `--num-jobs` flag will allow us to reduce the parallelism and prevent this.

Differential Revision: D77599017


