### PR TITLE
Reduce number of jobs to 18 on fake agent actions build

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -36,7 +36,7 @@ jobs:
           --env-var
           BUILD_SAI_FAKE
           --num-jobs
-          22
+          18
       - name: Package FBOSS binaries and library dependencies
         run: >
           sudo


### PR DESCRIPTION
Summary: The fake agent actions build is starting to OOM consistently. Reducing the parallelism will prevent this.

Differential Revision: D77629400


