### PR TITLE
Fix intermittent failure of platform_manager.service after boot

### DIFF
--- a/fboss/platform/configs/minipack3ba/platform_manager.json
+++ b/fboss/platform/configs/minipack3ba/platform_manager.json
@@ -3609,6 +3609,7 @@
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
+    "fboss_iob_i2c",
     "ledtrig_timer"
   ]
 }

--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -3530,6 +3530,7 @@
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
+    "fboss_iob_i2c",
     "ledtrig_timer"
   ]
 }


### PR DESCRIPTION
The platform_manager.service may fail after boot, typically once every 100 to 700 test cycles.

[Abnormal]
  I0613 20:51:53.467280   845 PciExplorer.cpp:311] Creating device MCB_IOB_I2C_MASTER_1 in /sys/bus/pci/devices/0000:17:00.0 using /dev/fbiob_1d9b.0011.10ee.0007. Args - deviceName: iob_i2c_master instanceId: 1000, csrOffset: 0x4000, iobufOffset: 0x0
  I0613 20:51:53.467353   845 Utils.cpp:124] PciSubDevice MCB_IOB_I2C_MASTER_1 with deviceName iob_i2c_master and instId 1000 is not yet initialized at /sys/bus/pci/devices/0000:17:00.0. Waiting for at most 5s
  I0613 20:51:53.517542   845 PciExplorer.cpp:396] Successfully created device MCB_IOB_I2C_MASTER_1 at /sys/bus/pci/devices/0000:17:00.0/fboss_iob_pci.iob_i2c_master.1000 using /dev/fbiob_1d9b.0011.10ee.0007. Args - deviceName: iob_i2c_master instanceId: 1000, csrOffset: 0x4000, iobufOffset: 0x0
  E0613 20:51:53.518882   845 PlatformExplorer.cpp:811] Failed to explore PCISubDevice MCB_IOB_I2C_MASTER_1 at /. Details: Could not find any I2C buses in /sys/bus/pci/devices/0000:17:00.0/fboss_iob_pci.iob_i2c_master.1000
  I0613 20:51:53.518899   845 PciExplorer.cpp:311] Creating device MCB_IOB_I2C_MASTER_2 in /sys/bus/pci/devices/0000:17:00.0 using /dev/fbiob_1d9b.0011.10ee.0007. Args - deviceName: iob_i2c_master instanceId: 1001, csrOffset: 0x4100, iobufOffset: 0x0

[RootCase]
  The device requires time during registration to attach and initialize its driver.
  However, a check for the presence of the device node may occur before the driver is fully ready,
  resulting in a failed readiness check.

[Result]
  Per discussion, tao suggested adding the "fboss_iob_i2c" driver to "requiredKmodsToLoad"
  to preload the driver and avoid timing issues.

  After preload the driver, we ran tests on two DUTs without encountering any errors:
  DUT1 was tested over 1,400 cycles,
  and DUT2 was tested over 3,000 cycles.