### PR TITLE
meru800bfa: update fan_service to account for no qsfp data

### DIFF
--- a/fboss/platform/configs/meru800bfa/fan_service.json
+++ b/fboss/platform/configs/meru800bfa/fan_service.json
@@ -1,22 +1,22 @@
 {
-  "pwmBoostOnNumDeadFan" : 1,
-  "pwmBoostOnNumDeadSensor" : 0,
-  "pwmBoostOnNoQsfpAfterInSec" : 31,
-  "pwmBoostValue" : 60,
-  "pwmTransitionValue" : 50,
-  "pwmLowerThreshold" : 40,
-  "pwmUpperThreshold" : 100,
-  "optics" : [
+  "pwmBoostOnNumDeadFan": 1,
+  "pwmBoostOnNumDeadSensor": 0,
+  "pwmBoostOnNoQsfpAfterInSec": 31,
+  "pwmBoostValue": 65,
+  "pwmTransitionValue": 50,
+  "pwmLowerThreshold": 7,
+  "pwmUpperThreshold": 100,
+  "optics": [
     {
-      "opticName" : "osfp_group_1",
-      "access" : {
-        "accessType" : "ACCESS_TYPE_QSFP"
+      "opticName": "osfp_group_1",
+      "access": {
+        "accessType": "ACCESS_TYPE_QSFP"
       },
-      "portList" : [],
-      "aggregationType" : "OPTIC_AGGREGATION_TYPE_MAX",
-      "tempToPwmMaps" : {
-        "OPTIC_TYPE_800_GENERIC" : {
-          "5" : 35,
+      "portList": [],
+      "aggregationType": "OPTIC_AGGREGATION_TYPE_MAX",
+      "tempToPwmMaps": {
+        "OPTIC_TYPE_800_GENERIC": {
+          "5": 40,
           "67": 41,
           "68": 50,
           "69": 67,
@@ -26,7 +26,7 @@
       }
     }
   ],
-  "sensors" : [
+  "sensors": [
     {
       "sensorName": "SMB_INLET_TEMP",
       "access": {
@@ -34,19 +34,19 @@
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
       "normalUpTable": {
-        "15": 28,
+        "15": 40,
         "110": 80
       },
       "normalDownTable": {
-        "15": 28,
+        "15": 40,
         "110": 80
       },
       "failUpTable": {
-        "15": 28,
+        "15": 40,
         "110": 80
       },
       "failDownTable": {
-        "15": 28,
+        "15": 40,
         "110": 80
       }
     },
@@ -102,6 +102,33 @@
         "15": 7,
         "70": 10,
         "80": 100
+      }
+    },
+    {
+      "sensorName": "CPU_PACKAGE_TEMP",
+      "access": {
+        "accessType": "ACCESS_TYPE_THRIFT"
+      },
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "15": 40,
+        "80": 60,
+        "90": 100
+      },
+      "normalDownTable": {
+        "15": 40,
+        "80": 60,
+        "90": 100
+      },
+      "failUpTable": {
+        "15": 40,
+        "80": 60,
+        "90": 100
+      },
+      "failDownTable": {
+        "15": 40,
+        "80": 60,
+        "90": 100
       }
     }
   ],
@@ -271,7 +298,7 @@
         "R3_0_TEMP",
         "R3_1_TEMP"
       ],
-      "fanNames":[
+      "fanNames": [
         "fan_1",
         "fan_2",
         "fan_3",
@@ -283,6 +310,7 @@
       "zoneType": "ZONE_TYPE_MAX",
       "zoneName": "system_zone",
       "sensorNames": [
+        "CPU_PACKAGE_TEMP",
         "SMB_INLET_TEMP",
         "osfp_group_1"
       ],


### PR DESCRIPTION
# Description

- Fan service to enable boost mode after 31 seconds of no qsfp data (on the 2nd routine cycle without qsfp data).
- Increase boost pwm to 65%, to account for high ambient at 35C.
- Reduce global minimum pwm to 7%, this allows the asic_zone to run at lower speeds since they don't demand high fan speeds.
- Increase the minimum pwm on all the system_zone (optics and cpu) to 40%. This ensures that this zone runs the fans at a minimum speed of 40%.
- Add CPU_PACKAGE_TEMP sensor to the system_zone to allow high CPU temps to drive the fans faster.

# Testing

**Normal operation (qsfp_service is running)**
Observe:
- The system zone sensors & optics resolving to 40%
- The asic zone resolving to a much slower 7%
```
... 18:30:10.470894  7200 ControlLogic.cpp:602] Processing Sensors ...
... 18:30:10.470900  7200 ControlLogic.cpp:260] SMB_INLET_TEMP: Sensor read value is 25
... 18:30:10.470906  7200 ControlLogic.cpp:243] SMB_INLET_TEMP: Calculated PWM is 40
... 18:30:10.470909  7200 ControlLogic.cpp:260] R3_0_TEMP: Sensor read value is 57
... 18:30:10.470913  7200 ControlLogic.cpp:243] R3_0_TEMP: Calculated PWM is 7
... 18:30:10.470916  7200 ControlLogic.cpp:260] R3_1_TEMP: Sensor read value is 57.75
... 18:30:10.470919  7200 ControlLogic.cpp:243] R3_1_TEMP: Calculated PWM is 7
... 18:30:10.470923  7200 ControlLogic.cpp:260] CPU_PACKAGE_TEMP: Sensor read value is 50
... 18:30:10.470926  7200 ControlLogic.cpp:243] CPU_PACKAGE_TEMP: Calculated PWM is 40
... 18:30:10.470929  7200 ControlLogic.cpp:606] Processing Optics ...
... 18:30:10.470933  7200 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 39.16797. PWM is 40
... 18:30:10.470936  7200 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 39.632812. PWM is 40
... 18:30:10.470939  7200 ControlLogic.cpp:368] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 40
... 18:30:10.470944  7200 ControlLogic.cpp:503] asic_zone: Components: R3_0_TEMP,R3_1_TEMP. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 7.
... 18:30:10.471866  7200 ControlLogic.cpp:439] fan_1: Programmed with PWM 7 (raw value 18)
... 18:30:10.472772  7200 ControlLogic.cpp:439] fan_2: Programmed with PWM 7 (raw value 18)
... 18:30:10.473690  7200 ControlLogic.cpp:439] fan_3: Programmed with PWM 7 (raw value 18)
... 18:30:10.474606  7200 ControlLogic.cpp:439] fan_4: Programmed with PWM 7 (raw value 18)
... 18:30:10.474611  7200 ControlLogic.cpp:503] system_zone: Components: CPU_PACKAGE_TEMP,SMB_INLET_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 40.
```

**Boost mode (qsfp_service NOT running)**
Observe:
- All the fans running at 65%
```
... 18:31:33.715891  7200 ControlLogic.cpp:602] Processing Sensors ...
... 18:31:33.715896  7200 ControlLogic.cpp:260] SMB_INLET_TEMP: Sensor read value is 26
... 18:31:33.715902  7200 ControlLogic.cpp:243] SMB_INLET_TEMP: Calculated PWM is 40
... 18:31:33.715905  7200 ControlLogic.cpp:260] R3_0_TEMP: Sensor read value is 58
... 18:31:33.715909  7200 ControlLogic.cpp:243] R3_0_TEMP: Calculated PWM is 7
... 18:31:33.715912  7200 ControlLogic.cpp:260] R3_1_TEMP: Sensor read value is 58.75
... 18:31:33.715915  7200 ControlLogic.cpp:243] R3_1_TEMP: Calculated PWM is 7
... 18:31:33.715919  7200 ControlLogic.cpp:260] CPU_PACKAGE_TEMP: Sensor read value is 48
... 18:31:33.715922  7200 ControlLogic.cpp:243] CPU_PACKAGE_TEMP: Calculated PWM is 40
... 18:31:33.715925  7200 ControlLogic.cpp:606] Processing Optics ...
... 18:31:33.715928  7200 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 39.11328. PWM is 40
... 18:31:33.715932  7200 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 39.691406. PWM is 40
... 18:31:33.715935  7200 ControlLogic.cpp:368] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 40
... 18:31:33.715938  7200 ControlLogic.cpp:628] Boost mode enabled for optics update missing for 60s
... 18:31:33.715942  7200 ControlLogic.cpp:503] asic_zone: Components: R3_0_TEMP,R3_1_TEMP. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 65.
... 18:31:33.716861  7200 ControlLogic.cpp:439] fan_1: Programmed with PWM 10 (raw value 26)
... 18:31:33.717786  7200 ControlLogic.cpp:439] fan_2: Programmed with PWM 10 (raw value 26)
... 18:31:33.718705  7200 ControlLogic.cpp:439] fan_3: Programmed with PWM 10 (raw value 26)
... 18:31:33.719610  7200 ControlLogic.cpp:439] fan_4: Programmed with PWM 10 (raw value 26)
... 18:31:33.719616  7200 ControlLogic.cpp:503] system_zone: Components: CPU_PACKAGE_TEMP,SMB_INLET_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 65.
... 18:31:33.720536  7200 ControlLogic.cpp:439] fan_5: Programmed with PWM 43 (raw value 110)
... 18:31:33.721456  7200 ControlLogic.cpp:439] fan_6: Programmed with PWM 43 (raw value 110)
... 18:31:33.722375  7200 ControlLogic.cpp:439] fan_7: Programmed with PWM 43 (raw value 110)
... 18:31:33.722887  7200 ControlLogic.cpp:439] fan_8: Programmed with PWM 43 (raw value 110)
... 18:31:33.723803  7200 ControlLogic.cpp:439] fan_9: Programmed with PWM 43 (raw value 110)
... 18:31:33.724709  7200 ControlLogic.cpp:439] fan_10: Programmed with PWM 43 (raw value 110)
... 18:31:33.725625  7200 ControlLogic.cpp:439] fan_11: Programmed with PWM 43 (raw value 110)
... 18:31:33.726543  7200 ControlLogic.cpp:439] fan_12: Programmed with PWM 43 (raw value 110)
```