### PR TITLE
Add led_service_hw_test CMake Target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1009,6 +1009,7 @@ add_dependencies(fboss_platform_services
   platform_manager_hw_test
   cross_config_validator_test
   fw_util_hw_test
+  led_service_hw_test
 )
 
 add_custom_target(qsfp_targets)

--- a/cmake/LedServiceHwTest.cmake
+++ b/cmake/LedServiceHwTest.cmake
@@ -1,0 +1,24 @@
+# CMake to build LedServiceHwTest in fboss/led_service/hw_test
+
+# In general, libraries and binaries in fboss/foo/bar are built by
+# cmake/FooBar.cmake
+
+add_executable(led_service_hw_test
+  fboss/led_service/hw_test/LedEnsemble.cpp
+  fboss/led_service/hw_test/LedServiceTest.cpp
+)
+
+target_link_libraries(led_service_hw_test
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+  fboss_common_init
+  error
+  fboss_types
+  led_manager_lib
+  common_file_utils
+  platform_utils
+  Folly::folly
+  FBThrift::thriftcpp2
+)
+
+install(TARGETS led_service_hw_test)

--- a/fboss/led_service/hw_test/BUCK
+++ b/fboss/led_service/hw_test/BUCK
@@ -14,12 +14,12 @@ cpp_binary(
     ],
     deps = [
         "fbsource//third-party/googletest:gtest",
-        "//common/init:init",
         "//fboss/agent:enum_utils",
         "//fboss/agent:fboss-error",
         "//fboss/agent:fboss-types",
         "//fboss/led_service:led_manager",
         "//fboss/lib:common_file_utils",
+        "//folly/init:init",
         "//folly/logging:logging",
         "//thrift/lib/cpp2/async:rocket_client_channel",
         "//thrift/lib/cpp2/protocol:protocol",

--- a/fboss/led_service/hw_test/LedServiceTest.cpp
+++ b/fboss/led_service/hw_test/LedServiceTest.cpp
@@ -10,9 +10,9 @@
 
 #include <gtest/gtest.h>
 
+#include <folly/init/Init.h>
 #include <thrift/lib/cpp2/async/RocketClientChannel.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
-#include "common/init/Init.h"
 #include "fboss/agent/EnumUtils.h"
 #include "fboss/led_service/LedManager.h"
 #include "fboss/led_service/hw_test/LedServiceTest.h"
@@ -385,7 +385,7 @@ int main(int argc, char* argv[]) {
   // Parse command line flags
   testing::InitGoogleTest(&argc, argv);
 
-  facebook::initFacebook(&argc, &argv);
+  folly::Init init(&argc, &argv);
 
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary:
We want to enable vendors to run LED hw tests in OSS.

This diff:
- adds proper cmake targets to build the binary necessary here.

- removes the dependency on `initFacebook` internal function, replacing with OSS equivalent `Folly::init`

Differential Revision: D78567148


