### PR TITLE
Fix CentOS docker image build

### DIFF
--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN sudo dnf install -y autoconf automake binutils binutils-devel bzip2 \
 RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive fboss
 RUN dnf install bison flex -y
 RUN dnf group install "Development Tools" -y
-RUN dnf install openssl* -y
+RUN dnf install openssl openssl-devel openssl-libs -y
 RUN python3 -m pip install gitpython
 RUN python3 -m pip install meson
 RUN python3 -m pip install jinja2


### PR DESCRIPTION
In the past couple of days CentOS 9 changed some fips-provider packaging such that wildcarding the OpenSSL packages results in a conflict. Resolve this by explicitly listing the necessary OpenSSL packages.

This fixes the AGENT Service hourly build, among others.

    Step 19/23 : RUN dnf install openssl* -y
     ---> Running in 527efe96878c
    Last metadata expiration check: 0:02:41 ago on Wed Jul 23 17:32:02 2025.
    Package openssl-1:3.5.1-2.el9.x86_64 is already installed.
    Package openssl-devel-1:3.5.1-2.el9.x86_64 is already installed.
    Package openssl-libs-1:3.5.1-2.el9.x86_64 is already installed.
    Error:
     Problem: problem with installed package fips-provider-next-1.2.0-2.el9.x86_64
      - package fips-provider-next-1.2.0-2.el9.x86_64 from @System conflicts with openssl-fips-provider provided by openssl-fips-provider-1:3.5.1-2.el9.x86_64 from baseos
      - package fips-provider-next-1.2.0-2.el9.x86_64 from appstream conflicts with openssl-fips-provider provided by openssl-fips-provider-1:3.5.1-2.el9.x86_64 from baseos - cannot install the best candidate for the job (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages) The command '/bin/sh -c dnf install openssl* -y' returned a non-zero code: 1