### PR TITLE
config_lib: check sensor name of shutdownCondition is valid in fan_service config

### DIFF
--- a/fboss/platform/config_lib/CrossConfigValidator.cpp
+++ b/fboss/platform/config_lib/CrossConfigValidator.cpp
@@ -77,6 +77,15 @@ bool CrossConfigValidator::isValidFanServiceConfig(
       return false;
     }
   }
+  // add the sensor name validation check for shutdownCondition config
+  if (fanConfig.shutdownCondition()) {
+    for (const auto& condition : *fanConfig.shutdownCondition()->conditions()) {
+      if (!sensor_service::ConfigValidator().isValidSensorName(
+              *sensorConfig, *condition.sensorName())) {
+        return false;
+      }
+    }
+  }
   return true;
 }
 


### PR DESCRIPTION
### Description
This PR is to check if the sensor name in shutdownCondition is valid in the fan_service config.

### Motivation
The current cross-check code for fan service misses the sensor name check in shutdownCondition, which caused the issue not to be detected in the FBOSS building phase. (The sensor name “TAHAN_SMB_TH5_TEMP” in fan_service config is not defined in sensor_service config.)

<img width="863" height="163" alt="image" src="https://github.com/user-attachments/assets/da3a8fba-98d8-475e-a66c-29370d70f18b" />
<img width="1067" height="228" alt="image" src="https://github.com/user-attachments/assets/d5da619c-6270-4adf-8b89-1de8208a468d" />
<img width="812" height="187" alt="image" src="https://github.com/user-attachments/assets/c8cf933a-b4a1-49f9-bda2-14eb0eee82c5" />

### Test Plan
Run fboss_platform_services build and check; the configuration issue can be detected.

<img width="1295" height="641" alt="image" src="https://github.com/user-attachments/assets/361c83b5-a98b-4948-9d8b-2293db35bd25" />

Change the sensor name "TAHAN_SMB_TH5_TEMP" to "SMB_TH5_TEMP" in fan_service_config and run build again; we can see the fan_servcie cross-check is successful.

<img width="854" height="423" alt="image" src="https://github.com/user-attachments/assets/0ba81656-c952-4fdb-80e6-a75bcd4b9fee" />
