### PR TITLE
Meru800biac: add bsp mapping, platform mapping, qsfp_service, led_service

### DIFF
--- a/fboss/agent/platforms/common/PlatformMappingUtils.cpp
+++ b/fboss/agent/platforms/common/PlatformMappingUtils.cpp
@@ -148,6 +148,7 @@ std::unique_ptr<PlatformMapping> initPlatformMapping(PlatformType type) {
           : std::make_unique<Meru400biuPlatformMapping>(platformMappingStr);
     case PlatformType::PLATFORM_MERU800BIA:
     case PlatformType::PLATFORM_MERU800BIAB:
+    case PlatformType::PLATFORM_MERU800BIAC:
       return platformMappingStr.empty()
           ? std::make_unique<Meru800biaPlatformMapping>()
           : std::make_unique<Meru800biaPlatformMapping>(platformMappingStr);

--- a/fboss/agent/platforms/sai/SaiPlatform.cpp
+++ b/fboss/agent/platforms/sai/SaiPlatform.cpp
@@ -363,7 +363,8 @@ void SaiPlatform::initPorts() {
       saiPort = std::make_unique<SaiMeru400biuPlatformPort>(portId, this);
     } else if (
         platformMode == PlatformType::PLATFORM_MERU800BIA ||
-        platformMode == PlatformType::PLATFORM_MERU800BIAB) {
+        platformMode == PlatformType::PLATFORM_MERU800BIAB ||
+        platformMode == PlatformType::PLATFORM_MERU800BIAC) {
       saiPort = std::make_unique<SaiMeru800biaPlatformPort>(portId, this);
     } else if (platformMode == PlatformType::PLATFORM_MERU400BIA) {
       saiPort = std::make_unique<SaiMeru400biaPlatformPort>(portId, this);

--- a/fboss/agent/platforms/sai/SaiPlatformInit.cpp
+++ b/fboss/agent/platforms/sai/SaiPlatformInit.cpp
@@ -77,7 +77,8 @@ std::unique_ptr<SaiPlatform> chooseSaiPlatform(
         std::move(productInfo), localMac, platformMappingStr);
   } else if (
       productInfo->getType() == PlatformType::PLATFORM_MERU800BIA ||
-      productInfo->getType() == PlatformType::PLATFORM_MERU800BIAB) {
+      productInfo->getType() == PlatformType::PLATFORM_MERU800BIAB ||
+      productInfo->getType() == PlatformType::PLATFORM_MERU800BIAC) {
     return std::make_unique<SaiMeru800biaPlatform>(
         std::move(productInfo), localMac, platformMappingStr);
   } else if (productInfo->getType() == PlatformType::PLATFORM_MERU800BFA) {

--- a/fboss/led_service/LedManagerInit.cpp
+++ b/fboss/led_service/LedManagerInit.cpp
@@ -52,7 +52,8 @@ std::unique_ptr<LedManager> createLedManager() {
     return std::make_unique<Meru800bfaLedManager>();
   } else if (
       mode == PlatformType::PLATFORM_MERU800BIA ||
-      mode == PlatformType::PLATFORM_MERU800BIAB) {
+      mode == PlatformType::PLATFORM_MERU800BIAB ||
+      mode == PlatformType::PLATFORM_MERU800BIAC) {
     return std::make_unique<Meru800biaLedManager>();
   } else if (mode == PlatformType::PLATFORM_MORGAN800CC) {
     return std::make_unique<Morgan800ccLedManager>();

--- a/fboss/lib/bsp/bspmapping/Main.cpp
+++ b/fboss/lib/bsp/bspmapping/Main.cpp
@@ -31,6 +31,8 @@ const std::map<PlatformType, folly::StringPiece> kHardwareNameMap = {
      kPortMappingMeru800biaCsv},
     {facebook::fboss::PlatformType::PLATFORM_MERU800BIAB,
      kPortMappingMeru800biaCsv},
+    {facebook::fboss::PlatformType::PLATFORM_MERU800BIAC,
+     kPortMappingMeru800biaCsv},
     {facebook::fboss::PlatformType::PLATFORM_MERU800BFA,
      kPortMappingMeru800bfaCsv},
     {facebook::fboss::PlatformType::PLATFORM_JANGA800BIC,

--- a/fboss/lib/bsp/bspmapping/test/ParserTest.cpp
+++ b/fboss/lib/bsp/bspmapping/test/ParserTest.cpp
@@ -34,6 +34,10 @@ TEST(ParserTest, GetNameForTests) {
       "meru800biab");
   EXPECT_EQ(
       facebook::fboss::Parser::getNameFor(
+          facebook::fboss::PlatformType::PLATFORM_MERU800BIAC),
+      "meru800biac");
+  EXPECT_EQ(
+      facebook::fboss::Parser::getNameFor(
           facebook::fboss::PlatformType::PLATFORM_MERU800BFA),
       "meru800bfa");
   EXPECT_EQ(

--- a/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
+++ b/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
@@ -88,6 +88,7 @@ std::unique_ptr<WedgeManager> createWedgeManager() {
           PlatformType::PLATFORM_MERU400BIU>(platformMapping, threads);
     case PlatformType::PLATFORM_MERU800BIA:
     case PlatformType::PLATFORM_MERU800BIAB:
+    case PlatformType::PLATFORM_MERU800BIAC:
       return createBspWedgeManager<
           Meru800biaBspPlatformMapping,
           PlatformType::PLATFORM_MERU800BIA>(platformMapping, threads);


### PR DESCRIPTION
# Description

> NOTE: This is part of a series of PRs to add support for Meru800biac. The dependency chain of the PRs is as follows:
> 
> Meru800biac: define new platform #500 - Depends on #461 
> Meru800biac: add bsp mapping, platform mapping, qsfp_service, led_service #501 - Depends on #500

Meru800biac will use the same bsp mapping and platform mapping as Meru800bia
- Define reference to SaiMeru800biaPlatform
- Define reference to Meru800biaPlatformMapping
- Add support for qsfp_service and led_service 

# Testing
## qsfp_service
qsfp_service use the same config as meru800bia
```
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com systemd[1]: Started Start qsfp_service.                                                                                                                                                              │
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: firmware_upgrade_on_coldboot=true                                                                                                    │~
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: firmware_upgrade_on_link_down=false                                                                                                  │]
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: firmware_upgrade_on_tcvr_insert=true                                                                                                 │#
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: firmware_upgrade_supported=true                                                                                                      │
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: mode=meru800bia                                                                                                                      │[
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: remediation_enabled=false                                                                                                            │r
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: Overriding default flag from config: set_max_fec_sampling=true                                                                                                            │o
Jul 29 18:00:24 vpr405.sjc.aristanetworks.com run_qsfp_service.sh[6190]: I0729 18:00:24.145640  6190 PlatformProductInfo.cpp:356] Success parsing product info fields
...
```
[fboss2_show_interface_phy.txt](https://github.com/user-attachments/files/21495202/fboss2_show_interface_phy.txt)
[fboss2_show_port.txt](https://github.com/user-attachments/files/21495203/fboss2_show_port.txt)
[fboss2_show_transceiver.txt](https://github.com/user-attachments/files/21495204/fboss2_show_transceiver.txt)

## led_service
data_corral_service_hw_test - succedded
```
 /opt/fboss/bin/data_corral_service_hw_test --led_manager_config_file /opt/fboss/share/platform_configs/led_manager.json --weutil_config_file /opt/fboss/share/platform_configs/weutil.json
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from DataCorralServiceHwTest
[ RUN      ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck
I0729 14:53:11.634398  6579 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0729 14:53:11.634428  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0729 14:53:11.635579  6579 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0729 14:53:11.635585  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0729 14:53:11.636715  6579 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0729 14:53:11.636719  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0729 14:53:11.637736  6579 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0729 14:53:11.637740  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0729 14:53:11.638735  6579 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0729 14:53:11.638739  6579 FruPresenceExplorer.cpp:34] Detecting presence of PSU1 (via sysfs)
I0729 14:53:11.638754  6579 FruPresenceExplorer.cpp:49] Detected that PSU1 is present
I0729 14:53:11.638758  6579 FruPresenceExplorer.cpp:34] Detecting presence of PSU2 (via sysfs)
I0729 14:53:11.638768  6579 FruPresenceExplorer.cpp:49] Detected that PSU2 is present
I0729 14:53:11.638798  6579 LedManager.cpp:45] Programming PSU LED with true
I0729 14:53:11.638828  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0729 14:53:11.638845  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0729 14:53:11.638849  6579 LedManager.cpp:55] Programmed PSU LED with presence true
I0729 14:53:11.638854  6579 LedManager.cpp:45] Programming FAN LED with true
I0729 14:53:11.638869  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0729 14:53:11.638884  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0729 14:53:11.638888  6579 LedManager.cpp:55] Programmed FAN LED with presence true
I0729 14:53:11.638893  6579 LedManager.cpp:25] Programming system LED with true
I0729 14:53:11.638907  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0729 14:53:11.638921  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0729 14:53:11.638925  6579 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck (4 ms)
[ RUN      ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck
I0729 14:53:11.638990  6579 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0729 14:53:11.638994  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0729 14:53:11.639736  6579 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0729 14:53:11.639740  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0729 14:53:11.640736  6579 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0729 14:53:11.640740  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0729 14:53:11.641750  6579 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0729 14:53:11.641754  6579 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0729 14:53:11.642735  6579 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0729 14:53:11.642739  6579 FruPresenceExplorer.cpp:34] Detecting presence of PSU1 (via sysfs)
I0729 14:53:11.642750  6579 FruPresenceExplorer.cpp:49] Detected that PSU1 is present
I0729 14:53:11.642754  6579 FruPresenceExplorer.cpp:34] Detecting presence of PSU2 (via sysfs)
I0729 14:53:11.642765  6579 FruPresenceExplorer.cpp:49] Detected that PSU2 is present
I0729 14:53:11.642769  6579 LedManager.cpp:45] Programming PSU LED with true
I0729 14:53:11.642782  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0729 14:53:11.642794  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0729 14:53:11.642798  6579 LedManager.cpp:55] Programmed PSU LED with presence true
I0729 14:53:11.642802  6579 LedManager.cpp:45] Programming FAN LED with true
I0729 14:53:11.642814  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0729 14:53:11.642826  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0729 14:53:11.642830  6579 LedManager.cpp:55] Programmed FAN LED with presence true
I0729 14:53:11.642834  6579 LedManager.cpp:25] Programming system LED with true
I0729 14:53:11.642846  6579 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0729 14:53:11.642858  6579 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0729 14:53:11.642863  6579 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck (3 ms)
[ RUN      ] DataCorralServiceHwTest.getCachedFruid
I0729 14:53:11.643664  6586 ThriftServer.cpp:973] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions:
I0729 14:53:11.643903  6586 ThriftServer.cpp:1530] Resource pools configured: 2
I0729 14:53:11.646262  6589 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0729 14:53:11.646282  6589 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/weutil.json
[       OK ] DataCorralServiceHwTest.getCachedFruid (7322 ms)
[ RUN      ] DataCorralServiceHwTest.getUncachedFruid
I0729 14:53:18.965752  6607 ThriftServer.cpp:973] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions:
I0729 14:53:18.965931  6607 ThriftServer.cpp:1530] Resource pools configured: 2
I0729 14:53:18.966766  6610 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0729 14:53:18.966783  6610 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/weutil.json
[       OK ] DataCorralServiceHwTest.getUncachedFruid (5154 ms)
[ RUN      ] DataCorralServiceHwTest.testThrift
I0729 14:53:24.120037  6616 ThriftServer.cpp:973] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions:
I0729 14:53:24.120219  6616 ThriftServer.cpp:1530] Resource pools configured: 2
I0729 14:53:24.121087  6619 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0729 14:53:24.121103  6619 ConfigLib.cpp:33] Using config file: /opt/fboss/share/platform_configs/weutil.json
[       OK ] DataCorralServiceHwTest.testThrift (6652 ms)
[----------] 5 tests from DataCorralServiceHwTest (19137 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (19137 ms total)
[  PASSED  ] 5 tests.
```