### PR TITLE
Updated firmware target priority values in Darwin fw_util config file

### DIFF
--- a/fboss/platform/configs/darwin/fw_util.json
+++ b/fboss/platform/configs/darwin/fw_util.json
@@ -59,7 +59,7 @@
         "versionType": "full_command",
         "getVersionCmd": "cat /sys/devices/virtual/dmi/id/bios_version"
       },
-      "priority": 1
+      "priority": 7
     },
     "CPU_CPLD": {
       "preUpgrade": [
@@ -108,7 +108,7 @@
         "versionType": "full_command",
         "getVersionCmd": "cpu_cpld_ver=$((`cat /sys/bus/pci/devices/0000:ff:0b.3/fpga_ver`));cpu_cpld_subver=$((`cat /sys/bus/pci/devices/0000:ff:0b.3/fpga_sub_ver`));echo $cpu_cpld_ver'.'$cpu_cpld_subver"
       },
-      "priority": 2
+      "priority": 5
     },
     "SC_CPLD": {
       "preUpgrade": [
@@ -157,7 +157,7 @@
         "versionType": "full_command",
         "getVersionCmd": "sc_cpld_ver=$((`cat /sys/bus/i2c/drivers/blackhawk-cpld/*/cpld_ver | head -1`));sc_cpld_subver=$((`cat /sys/bus/i2c/drivers/blackhawk-cpld/*/cpld_sub_ver | head -1`));echo $sc_cpld_ver'.'$sc_cpld_subver"
       },
-      "priority": 7
+      "priority": 6
     },
     "SC_SCD": {
       "upgrade": [
@@ -178,7 +178,7 @@
         "versionType": "full_command",
         "getVersionCmd": "sc_fpga_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/fpga_ver`));sc_fpga_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/fpga_sub_ver`));echo $sc_fpga_ver'.'$sc_fpga_subver"
       },
-      "priority": 3
+      "priority": 4
     },
     "SC_SAT_CPLD0": {
       "preUpgrade": [
@@ -227,7 +227,7 @@
         "versionType": "full_command",
         "getVersionCmd": "sat0_cpld_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat0_cpld_ver`));sat0_cpld_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat0_cpld_sub_ver`));echo $sat0_cpld_ver'.'$sat0_cpld_subver"
       },
-      "priority": 4
+      "priority": 3
     },
     "SC_SAT_CPLD1": {
       "preUpgrade": [
@@ -276,14 +276,14 @@
         "versionType": "full_command",
         "getVersionCmd": "sat1_cpld_ver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat1_cpld_ver`));sat1_cpld_subver=$((`cat /sys/bus/pci/devices/0000:07:00.0/sat1_cpld_sub_ver`));echo $sat1_cpld_ver'.'$sat1_cpld_subver"
       },
-      "priority": 5
+      "priority": 2
     },
     "FAN_CPLD": {
       "version": {
         "versionType": "full_command",
         "getVersionCmd": "fanCpld_ver=$((`cat /sys/bus/i2c/drivers/rook-fan-cpld/*/*/*/cpld_ver`));fanCpld_subver=$((`cat /sys/bus/i2c/drivers/rook-fan-cpld/*/*/*/cpld_sub_ver`));echo $fanCpld_ver'.'$fanCpld_subver"
       },
-      "priority": 6
+      "priority": 1
     }
   }
 }

--- a/fboss/platform/configs/darwin48v/fw_util.json
+++ b/fboss/platform/configs/darwin48v/fw_util.json
@@ -77,7 +77,7 @@
         "versionType": "sysfs",
         "path": "/sys/devices/virtual/dmi/id/bios_version"
       },
-      "priority": 1
+      "priority": 7
     },
     "CPU_CPLD": {
       "preUpgrade": [
@@ -126,7 +126,7 @@
         "versionType": "sysfs",
         "path": "/run/devmap/cplds/ROOK_CPU_CPLD_INFO_ROM/fw_ver"
       },
-      "priority": 2
+      "priority": 5
     },
     "SC_CPLD": {
       "preUpgrade": [
@@ -175,7 +175,7 @@
         "versionType": "sysfs",
         "path": "/run/devmap/cplds/BLACKHAWK_CPLD/fw_ver"
       },
-      "priority": 7
+      "priority": 6
     },
     "SC_SCD": {
       "upgrade": [
@@ -196,7 +196,7 @@
         "versionType": "sysfs",
         "path": "/run/devmap/fpgas/SCD_FPGA_INFO_ROM/fw_ver"
       },
-      "priority": 3
+      "priority": 4
     },
     "SC_SAT_CPLD0": {
       "preUpgrade": [
@@ -245,7 +245,7 @@
         "versionType": "sysfs",
         "path": "/run/devmap/fpgas/SCD_FPGA/sat0_cpld_fw_ver"
       },
-      "priority": 4
+      "priority": 3
     },
     "SC_SAT_CPLD1": {
       "preUpgrade": [
@@ -294,14 +294,14 @@
         "versionType": "sysfs",
         "path": "/run/devmap/fpgas/SCD_FPGA/sat1_cpld_fw_ver"
       },
-      "priority": 5
+      "priority": 2
     },
     "FAN_CPLD": {
       "version": {
         "versionType": "sysfs",
         "path": "/run/devmap/cplds/FAN_CPLD/*/*/fw_ver"
       },
-      "priority": 6
+      "priority": 1
     }
   }
 }


### PR DESCRIPTION
### Summary
This change modifies the priority order for firmware targets to align with a leaf to root upgrade sequence. Previously, during CPU CPLD upgrades, the switchcard SCD SPI flash could unexpectedly unbind disrupting subsequent switchcard SCD upgrades. The revised priority structure is designed to prevent this issue.
### Testing
Tested firmware upgrade in a Darwin system