### PR TITLE
Icetea: config: Bump BSP version to the latest 3.3.0-1

### DIFF
--- a/fboss/platform/configs/icetea/platform_manager.json
+++ b/fboss/platform/configs/icetea/platform_manager.json
@@ -2175,10 +2175,11 @@
   "chassisEepromDevicePath": "/[CHASSIS_IDPROM]",
   "numXcvrs": 33,
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "3.2.0-1",
+  "bspKmodsRpmVersion": "3.3.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",
-    "fboss_iob_pci"
+    "fboss_iob_pci",
+    "ledtrig_timer"
   ]
 }


### PR DESCRIPTION
# Description
This PR is for the icetea platform service to bump the latest BSP version 3.3.0-1.

# Motivation
 According to the latest BGP tag,  we need to adjust the BSP version to 3.3.0-1 in the platform config file.

# Test Plan

1. The correctness of the format has been verified on this jsonlint website.
2. Used jq command to pretty the format.
3. Test log as follows:
<img width="1473" height="304" alt="image" src="https://github.com/user-attachments/assets/b061cc35-2294-41f4-a928-5654a2536fbc" />

[platform_manager_log.txt](https://github.com/user-attachments/files/21791868/platform_manager_log.txt)

