### PR TITLE
Update FBOSS documentation to add RPM package installation information

### DIFF
--- a/docs/docs/platform/bsp_development_requirements.md
+++ b/docs/docs/platform/bsp_development_requirements.md
@@ -229,7 +229,7 @@ The BSP utility files must be installed in a vendor-specific directory structure
 ```
 
 Where:
-- `<vendor>` is extracted from the RPM name (e.g., "fboss", "arista", "cisco", "nexthop")
+- `<vendor>` is extracted from the RPM name
 - `<kernel-version>` is the target kernel version (e.g., "6.4.3-0_fbk1_755_ga25447393a1d")
 
 The Platform Manager uses this path structure to locate and manage BSP components


### PR DESCRIPTION
#### Why I did it

FBOSS documentation had information about BSP source structure including RPM package but did not have information about install location of the contents of the RPM package.

#### How I did it

- Update FBOSS documentation to add RPM package installation information.

#### How to verify it

N/A
