### PR TITLE
Tahan: config: Adjusted sensor related thresholds

### DIFF
--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -2117,10 +2117,11 @@
   "chassisEepromDevicePath": "/SMB_FRU_SLOT@0/[IDPROM]",
   "numXcvrs": 33,
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "3.2.0-1",
+  "bspKmodsRpmVersion": "3.3.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",
-    "fboss_iob_pci"
+    "fboss_iob_pci",
+    "ledtrig_timer"
   ]
 }

--- a/fboss/platform/configs/tahan800bc/sensor_service.json
+++ b/fboss/platform/configs/tahan800bc/sensor_service.json
@@ -9,90 +9,90 @@
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE0_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE1_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE2_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE3_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE4_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE5_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE6_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "CPU_CORE7_TEMP",
           "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 90
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 100
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         },
         {
           "name": "SMB_E1S_SSD_TEMP",
@@ -109,8 +109,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U182_LM75B_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -119,9 +119,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.32,
             "maxAlarmVal": 1.26,
             "minAlarmVal": 1.14,
+            "upperCriticalVal": 1.32,
             "lowerCriticalVal": 1.08
           },
           "compute": "@/1000.0"
@@ -131,9 +131,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.98,
             "maxAlarmVal": 1.89,
             "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
             "lowerCriticalVal": 1.62
           },
           "compute": "@/1000.0"
@@ -143,9 +143,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.98,
             "maxAlarmVal": 0.9,
             "minAlarmVal": 0.65,
+            "upperCriticalVal": 0.98,
             "lowerCriticalVal": 0.6
           },
           "compute": "@/1000.0"
@@ -155,9 +155,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.825,
             "maxAlarmVal": 0.7875,
             "minAlarmVal": 0.7125,
+            "upperCriticalVal": 0.825,
             "lowerCriticalVal": 0.675
           },
           "compute": "@/1000.0"
@@ -167,9 +167,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.825,
             "maxAlarmVal": 0.7875,
             "minAlarmVal": 0.7125,
+            "upperCriticalVal": 0.825,
             "lowerCriticalVal": 0.675
           },
           "compute": "@/1000.0"
@@ -179,9 +179,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -191,9 +191,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in6_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -201,11 +201,11 @@
         {
           "name": "SMB_XP0R8V_TH5_VDDA",
           "sysfsPath": "/run/devmap/sensors/SMB_U206_ADC128D818_2/in7_input",
-          "type": 3,
+          "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.88,
             "maxAlarmVal": 0.84,
             "minAlarmVal": 0.76,
+            "upperCriticalVal": 0.88,
             "lowerCriticalVal": 0.72
           },
           "compute": "@/1000.0"
@@ -215,9 +215,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.65,
             "maxAlarmVal": 1.575,
             "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
             "lowerCriticalVal": 1.35
           },
           "compute": "@/1000.0"
@@ -227,9 +227,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.65,
             "maxAlarmVal": 1.575,
             "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
             "lowerCriticalVal": 1.35
           },
           "compute": "@/1000.0"
@@ -239,9 +239,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -251,9 +251,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -263,9 +263,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -275,9 +275,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.99,
             "maxAlarmVal": 0.945,
             "minAlarmVal": 0.855,
+            "upperCriticalVal": 0.99,
             "lowerCriticalVal": 0.81
           },
           "compute": "@/1000.0"
@@ -287,9 +287,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in6_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -297,11 +297,11 @@
         {
           "name": "SMB_XP3R3V_RIGHT",
           "sysfsPath": "/run/devmap/sensors/SMB_U207_ADC128D818_3/in7_input",
-          "type": 3,
+          "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -311,9 +311,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.21,
             "maxAlarmVal": 1.155,
             "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
             "lowerCriticalVal": 0.99
           },
           "compute": "@/1000.0"
@@ -323,9 +323,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 2.75,
             "maxAlarmVal": 2.625,
             "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
             "lowerCriticalVal": 2.25
           },
           "compute": "(15/11)*@/1000.0"
@@ -335,9 +335,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -347,9 +347,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.1,
             "maxAlarmVal": 1.05,
             "minAlarmVal": 0.95,
+            "upperCriticalVal": 1.1,
             "lowerCriticalVal": 0.9
           },
           "compute": "@/1000.0"
@@ -359,9 +359,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.32,
             "maxAlarmVal": 1.26,
             "minAlarmVal": 1.14,
+            "upperCriticalVal": 1.32,
             "lowerCriticalVal": 1.08
           },
           "compute": "@/1000.0"
@@ -371,9 +371,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.98,
             "maxAlarmVal": 1.89,
             "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
             "lowerCriticalVal": 1.62
           },
           "compute": "@/1000.0"
@@ -383,9 +383,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/in6_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -395,8 +395,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U208_ADC128D818_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75,
-            "maxAlarmVal": 70
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
           },
           "compute": "@/1000.0"
         },
@@ -405,9 +405,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -417,9 +417,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.98,
             "maxAlarmVal": 1.89,
             "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
             "lowerCriticalVal": 1.62
           },
           "compute": "@/1000.0"
@@ -429,9 +429,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -441,9 +441,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 2.75,
             "maxAlarmVal": 2.625,
             "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
             "lowerCriticalVal": 2.25
           },
           "compute": "(15/11)*@/1000.0"
@@ -453,9 +453,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.65,
             "maxAlarmVal": 1.575,
             "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
             "lowerCriticalVal": 1.35
           },
           "compute": "@/1000.0"
@@ -465,9 +465,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.21,
             "maxAlarmVal": 1.155,
             "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
             "lowerCriticalVal": 0.99
           },
           "compute": "@/1000.0"
@@ -477,8 +477,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U21_ADC128D818_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75,
-            "maxAlarmVal": 70
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
           },
           "compute": "@/1000.0"
         },
@@ -487,8 +487,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U279_ADM1272_1/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 50,
-            "maxAlarmVal": 40
+            "maxAlarmVal": 40,
+            "upperCriticalVal": 50
           },
           "compute": "2*@/1000.0"
         },
@@ -497,9 +497,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U279_ADM1272_1/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 56,
             "maxAlarmVal": 54,
             "minAlarmVal": 46,
+            "upperCriticalVal": 56,
             "lowerCriticalVal": 44
           },
           "compute": "@/1000.0"
@@ -509,9 +509,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U279_ADM1272_1/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 56,
             "maxAlarmVal": 54,
             "minAlarmVal": 46,
+            "upperCriticalVal": 56,
             "lowerCriticalVal": 44
           },
           "compute": "@/1000.0"
@@ -521,8 +521,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U279_ADM1272_1/power1_input",
           "type": 0,
           "thresholds": {
-            "upperCriticalVal": 2800,
-            "maxAlarmVal": 2160
+            "maxAlarmVal": 2160,
+            "upperCriticalVal": 2800
           },
           "compute": "2*@/1000000.0"
         },
@@ -531,8 +531,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U279_ADM1272_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 115,
-            "maxAlarmVal": 105
+            "maxAlarmVal": 105,
+            "upperCriticalVal": 115
           },
           "compute": "@/1000.0"
         },
@@ -541,8 +541,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U39_LM75B_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -551,8 +551,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U51_LM75B_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85,
-            "maxAlarmVal": 80
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
           },
           "compute": "@/1000.0"
         },
@@ -561,8 +561,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U57_LM75B_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 85,
-            "maxAlarmVal": 80
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
           },
           "compute": "@/1000.0"
         },
@@ -571,8 +571,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U67_LM75B_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -581,8 +581,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U69_LM75B_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -591,9 +591,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 13.2,
             "maxAlarmVal": 12.6,
             "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
             "lowerCriticalVal": 10.8
           },
           "compute": "11*@/1000.0"
@@ -603,9 +603,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 5.5,
             "maxAlarmVal": 5.25,
             "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
             "lowerCriticalVal": 4.5
           },
           "compute": "5.7*@/1000.0"
@@ -615,9 +615,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -627,9 +627,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 13.2,
             "maxAlarmVal": 12.6,
             "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
             "lowerCriticalVal": 10.8
           },
           "compute": "11*@/1000.0"
@@ -639,9 +639,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 5.5,
             "maxAlarmVal": 5.25,
             "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
             "lowerCriticalVal": 4.5
           },
           "compute": "5.7*@/1000.0"
@@ -651,9 +651,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 5.5,
             "maxAlarmVal": 5.25,
             "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
             "lowerCriticalVal": 4.5
           },
           "compute": "5.7*@/1000.0"
@@ -663,8 +663,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U6_ADC128D818_3/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75,
-            "maxAlarmVal": 70
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
           },
           "compute": "@/1000.0"
         },
@@ -673,8 +673,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U77_LM75B_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -683,9 +683,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in0_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -695,9 +695,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -707,9 +707,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -719,9 +719,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 13.2,
             "maxAlarmVal": 12.6,
             "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
             "lowerCriticalVal": 10.8
           },
           "compute": "11*@/1000.0"
@@ -731,9 +731,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -743,9 +743,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.98,
             "maxAlarmVal": 1.89,
             "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
             "lowerCriticalVal": 1.62
           },
           "compute": "@/1000.0"
@@ -755,9 +755,9 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/in6_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.63,
             "maxAlarmVal": 3.465,
             "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000.0"
@@ -767,8 +767,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_U7_ADC128D818_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 75,
-            "maxAlarmVal": 70
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
           },
           "compute": "@/1000.0"
         },
@@ -816,7 +816,7 @@
             "upperCriticalVal": 130,
             "lowerCriticalVal": 0
           },
-          "compute": "(1000/3650)*@/1000000"
+          "compute": "(1000/3650)*@/1000000.0"
         },
         {
           "name": "SMB_U327_TPS25990_COMe_P12V_IIN",
@@ -828,17 +828,17 @@
             "upperCriticalVal": 11,
             "lowerCriticalVal": 0
           },
-          "compute": "(1000/3650)*@/1000"
+          "compute": "(1000/3650)*@/1000.0"
         },
         {
           "name": "SMB_TH5_TEMP",
           "sysfsPath": "/run/devmap/sensors/TAHAN_SMB_CPLD/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 105,
-            "maxAlarmVal": 102
+            "maxAlarmVal": 102,
+            "upperCriticalVal": 105
           },
-          "compute": "@/1000"
+          "compute": "@/1000.0"
         }
       ]
     },
@@ -851,8 +851,8 @@
           "sysfsPath": "/run/devmap/sensors/PDB_TSENSOR_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 65,
-            "maxAlarmVal": 60
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 65
           },
           "compute": "@/1000.0"
         },
@@ -861,9 +861,9 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 56,
             "maxAlarmVal": 54,
             "minAlarmVal": 46,
+            "upperCriticalVal": 56,
             "lowerCriticalVal": 44
           },
           "compute": "@/1000.0"
@@ -873,9 +873,9 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
             "maxAlarmVal": 13.2,
             "minAlarmVal": 10.8,
+            "upperCriticalVal": 14.4,
             "lowerCriticalVal": 9.6
           },
           "compute": "@/1000.0"
@@ -885,8 +885,8 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110,
-            "maxAlarmVal": 107
+            "maxAlarmVal": 107,
+            "upperCriticalVal": 110
           },
           "compute": "@/1000.0"
         },
@@ -895,8 +895,8 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_1/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 80
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 100
           },
           "compute": "@/1000.0"
         },
@@ -905,9 +905,9 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 56,
             "maxAlarmVal": 54,
             "minAlarmVal": 46,
+            "upperCriticalVal": 56,
             "lowerCriticalVal": 44
           },
           "compute": "@/1000.0"
@@ -917,9 +917,9 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14.4,
             "maxAlarmVal": 13.2,
             "minAlarmVal": 10.8,
+            "upperCriticalVal": 14.4,
             "lowerCriticalVal": 9.6
           },
           "compute": "@/1000.0"
@@ -929,8 +929,8 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 110,
-            "maxAlarmVal": 107
+            "maxAlarmVal": 107,
+            "upperCriticalVal": 110
           },
           "compute": "@/1000.0"
         },
@@ -939,8 +939,8 @@
           "sysfsPath": "/run/devmap/sensors/PDB_PMBUS_2/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 100,
-            "maxAlarmVal": 80
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 100
           },
           "compute": "@/1000.0"
         }
@@ -1155,11 +1155,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -1168,9 +1168,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1180,9 +1180,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -1192,8 +1192,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -1202,8 +1202,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -1212,8 +1212,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1222,8 +1222,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -1232,8 +1232,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -1242,9 +1242,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1254,20 +1254,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -1276,18 +1276,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1296,8 +1296,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -1306,8 +1306,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -1316,9 +1316,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1328,20 +1328,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -1350,18 +1350,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1370,8 +1370,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -1380,8 +1380,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -1390,8 +1390,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -1400,9 +1400,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1412,9 +1412,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -1424,9 +1424,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -1436,8 +1436,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -1446,8 +1446,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -1456,8 +1456,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -1466,8 +1466,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -1476,8 +1476,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -1486,8 +1486,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -1496,8 +1496,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -1506,8 +1506,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -1516,9 +1516,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1528,9 +1528,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -1540,9 +1540,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -1552,8 +1552,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -1562,8 +1562,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -1572,8 +1572,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -1582,8 +1582,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -1592,8 +1592,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -1606,11 +1606,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -1619,9 +1619,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1631,9 +1631,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -1643,8 +1643,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -1653,8 +1653,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -1663,8 +1663,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1673,8 +1673,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -1683,8 +1683,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -1693,9 +1693,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1705,20 +1705,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -1727,18 +1727,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1747,8 +1747,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -1757,8 +1757,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -1767,9 +1767,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1779,20 +1779,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -1801,18 +1801,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -1821,8 +1821,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -1831,8 +1831,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -1841,8 +1841,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -1851,9 +1851,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1863,9 +1863,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -1875,9 +1875,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -1887,8 +1887,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -1897,8 +1897,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -1907,8 +1907,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -1917,8 +1917,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -1927,8 +1927,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -1937,8 +1937,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -1947,8 +1947,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -1957,8 +1957,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -1967,9 +1967,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -1979,9 +1979,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -1991,9 +1991,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -2003,8 +2003,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -2013,8 +2013,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -2023,8 +2023,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -2033,8 +2033,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2043,8 +2043,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -2057,11 +2057,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -2070,9 +2070,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2082,9 +2082,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -2094,8 +2094,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -2104,8 +2104,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -2114,8 +2114,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2124,8 +2124,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -2134,8 +2134,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -2144,9 +2144,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2156,20 +2156,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -2178,18 +2178,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2198,8 +2198,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -2208,8 +2208,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -2218,9 +2218,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2230,20 +2230,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -2252,18 +2252,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2272,8 +2272,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -2282,8 +2282,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -2292,8 +2292,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -2302,9 +2302,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2314,9 +2314,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -2326,9 +2326,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -2338,8 +2338,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -2348,8 +2348,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -2358,8 +2358,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -2368,8 +2368,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2378,8 +2378,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2388,8 +2388,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -2398,8 +2398,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -2408,8 +2408,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -2418,9 +2418,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2430,9 +2430,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -2442,9 +2442,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -2454,8 +2454,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -2464,8 +2464,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -2474,8 +2474,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -2484,8 +2484,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2494,8 +2494,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -2508,11 +2508,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -2521,9 +2521,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2533,9 +2533,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -2545,8 +2545,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -2555,8 +2555,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -2565,8 +2565,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2575,8 +2575,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -2585,8 +2585,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -2595,9 +2595,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2607,20 +2607,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -2629,18 +2629,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2649,8 +2649,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -2659,8 +2659,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -2669,9 +2669,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2681,20 +2681,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -2703,18 +2703,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -2723,8 +2723,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -2733,8 +2733,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -2743,8 +2743,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -2753,9 +2753,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2765,9 +2765,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -2777,9 +2777,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -2789,8 +2789,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -2799,8 +2799,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -2809,8 +2809,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -2819,8 +2819,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2829,8 +2829,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2839,8 +2839,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -2849,8 +2849,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -2859,8 +2859,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -2869,9 +2869,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2881,9 +2881,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -2893,9 +2893,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -2905,8 +2905,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -2915,8 +2915,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -2925,8 +2925,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -2935,8 +2935,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -2945,8 +2945,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -2959,11 +2959,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -2972,9 +2972,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -2984,9 +2984,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -2996,8 +2996,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -3006,8 +3006,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -3016,8 +3016,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3026,8 +3026,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -3036,8 +3036,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -3046,9 +3046,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3058,20 +3058,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -3080,18 +3080,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3100,8 +3100,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -3110,8 +3110,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -3120,9 +3120,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3132,20 +3132,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -3154,18 +3154,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3174,8 +3174,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -3184,8 +3184,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -3194,8 +3194,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -3204,9 +3204,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3216,9 +3216,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -3228,9 +3228,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -3240,8 +3240,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -3250,8 +3250,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -3260,8 +3260,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -3270,8 +3270,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3280,8 +3280,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3290,8 +3290,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -3300,8 +3300,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -3310,8 +3310,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -3320,9 +3320,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3332,9 +3332,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -3344,9 +3344,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -3356,8 +3356,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -3366,8 +3366,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -3376,8 +3376,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -3386,8 +3386,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3396,8 +3396,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -3410,11 +3410,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -3423,9 +3423,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3435,9 +3435,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -3447,8 +3447,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -3457,8 +3457,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -3467,8 +3467,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3477,8 +3477,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -3487,8 +3487,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -3497,9 +3497,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3509,20 +3509,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -3531,18 +3531,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3551,8 +3551,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -3561,8 +3561,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -3571,9 +3571,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3583,20 +3583,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -3605,18 +3605,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3625,8 +3625,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -3635,8 +3635,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -3645,8 +3645,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -3655,9 +3655,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3667,9 +3667,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -3679,9 +3679,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -3691,8 +3691,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -3701,8 +3701,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -3711,8 +3711,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -3721,8 +3721,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3731,8 +3731,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3741,8 +3741,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -3751,8 +3751,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -3761,8 +3761,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -3771,9 +3771,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3783,9 +3783,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -3795,9 +3795,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -3807,8 +3807,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -3817,8 +3817,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -3827,8 +3827,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -3837,8 +3837,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -3847,8 +3847,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -3861,11 +3861,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -3874,9 +3874,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3886,9 +3886,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -3898,8 +3898,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -3908,8 +3908,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -3918,8 +3918,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -3928,8 +3928,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -3938,8 +3938,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -3948,9 +3948,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -3960,20 +3960,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -3982,18 +3982,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4002,8 +4002,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -4012,8 +4012,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -4022,9 +4022,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4034,20 +4034,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -4056,18 +4056,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4076,8 +4076,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -4086,8 +4086,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -4096,8 +4096,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -4106,9 +4106,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4118,9 +4118,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -4130,9 +4130,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -4142,8 +4142,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -4152,8 +4152,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -4162,8 +4162,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -4172,8 +4172,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4182,8 +4182,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4192,8 +4192,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -4202,8 +4202,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -4212,8 +4212,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -4222,9 +4222,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4234,9 +4234,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -4246,9 +4246,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -4258,8 +4258,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -4268,8 +4268,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -4278,8 +4278,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -4288,8 +4288,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4298,8 +4298,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -4312,11 +4312,11 @@
           "sensors": [
             {
               "name": "SMB_TH5_VDD_CORE_IOUT",
-              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr1_input",
+              "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -4325,9 +4325,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4337,9 +4337,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -4349,8 +4349,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -4359,8 +4359,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -4369,8 +4369,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4379,8 +4379,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -4389,8 +4389,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -4399,9 +4399,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4411,20 +4411,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -4433,18 +4433,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_RIGHT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4453,8 +4453,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -4463,8 +4463,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -4473,9 +4473,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4485,20 +4485,20 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
-              "compute": "3*@/1000.0"
+              "compute": "2*@/1000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_PIN",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -4507,18 +4507,18 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
-              "compute": "3*@/1000000.0"
+              "compute": "2*@/1000000.0"
             },
             {
               "name": "SMB_XP3R3V_LEFT_TEMP",
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4527,8 +4527,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -4537,8 +4537,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -4547,8 +4547,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -4557,9 +4557,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4569,9 +4569,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -4581,9 +4581,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -4593,8 +4593,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -4603,8 +4603,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -4613,8 +4613,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -4623,8 +4623,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4633,8 +4633,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4643,8 +4643,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -4653,8 +4653,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -4663,8 +4663,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -4673,9 +4673,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4685,9 +4685,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -4697,9 +4697,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in4_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -4709,8 +4709,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -4719,8 +4719,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -4729,8 +4729,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power4_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -4739,8 +4739,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             },
@@ -4749,8 +4749,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp2_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 125,
-                "maxAlarmVal": 115
+                "maxAlarmVal": 115,
+                "upperCriticalVal": 125
               },
               "compute": "@/1000.0"
             }
@@ -4772,8 +4772,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -4782,9 +4782,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4794,9 +4794,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -4806,8 +4806,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -4816,8 +4816,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -4826,8 +4826,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4836,8 +4836,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -4846,8 +4846,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -4856,8 +4856,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4866,8 +4866,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4876,8 +4876,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4886,8 +4886,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4896,9 +4896,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -4908,9 +4908,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
               "compute": "3*@/1000.0"
@@ -4920,8 +4920,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -4930,8 +4930,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
               "compute": "3*@/1000000.0"
             },
@@ -4940,8 +4940,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -4950,8 +4950,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -4960,8 +4960,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -4970,8 +4970,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4980,8 +4980,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -4990,8 +4990,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5000,8 +5000,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5010,9 +5010,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5022,9 +5022,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
               "compute": "3*@/1000.0"
@@ -5034,8 +5034,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -5044,8 +5044,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
               "compute": "3*@/1000000.0"
             },
@@ -5054,8 +5054,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5064,8 +5064,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -5074,8 +5074,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -5084,8 +5084,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5094,8 +5094,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5104,8 +5104,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5114,8 +5114,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -5124,8 +5124,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr7_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5134,8 +5134,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr8_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5144,9 +5144,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5156,9 +5156,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -5168,9 +5168,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -5180,8 +5180,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -5190,8 +5190,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -5200,8 +5200,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -5210,8 +5210,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5220,8 +5220,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -5230,8 +5230,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -5240,8 +5240,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5250,8 +5250,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5260,8 +5260,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5270,8 +5270,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -5280,8 +5280,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr7_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5290,8 +5290,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr8_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5300,9 +5300,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5312,9 +5312,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -5324,9 +5324,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -5336,8 +5336,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -5346,8 +5346,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -5356,8 +5356,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -5366,8 +5366,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             }
@@ -5389,8 +5389,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 850,
-                "maxAlarmVal": 830
+                "maxAlarmVal": 830,
+                "upperCriticalVal": 850
               },
               "compute": "@/1000.0"
             },
@@ -5399,9 +5399,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5411,9 +5411,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.98,
                 "maxAlarmVal": 0.9,
                 "minAlarmVal": 0.65,
+                "upperCriticalVal": 0.98,
                 "lowerCriticalVal": 0.6
               },
               "compute": "@/1000.0"
@@ -5423,8 +5423,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 883,
-                "maxAlarmVal": 797
+                "maxAlarmVal": 797,
+                "upperCriticalVal": 883
               },
               "compute": "@/1000000.0"
             },
@@ -5433,8 +5433,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 833,
-                "maxAlarmVal": 747
+                "maxAlarmVal": 747,
+                "upperCriticalVal": 833
               },
               "compute": "@/1000000.0"
             },
@@ -5443,8 +5443,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U122_PMBUS_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5453,8 +5453,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -5463,8 +5463,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -5473,8 +5473,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5483,8 +5483,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5493,8 +5493,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5503,8 +5503,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5513,9 +5513,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5525,9 +5525,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
               "compute": "3*@/1000.0"
@@ -5537,8 +5537,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -5547,8 +5547,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
               "compute": "3*@/1000000.0"
             },
@@ -5557,8 +5557,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U20_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5567,8 +5567,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 35,
-                "maxAlarmVal": 31
+                "maxAlarmVal": 31,
+                "upperCriticalVal": 35
               },
               "compute": "@/1000.0"
             },
@@ -5577,8 +5577,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 130,
-                "maxAlarmVal": 110
+                "maxAlarmVal": 110,
+                "upperCriticalVal": 130
               },
               "compute": "@/1000.0"
             },
@@ -5587,8 +5587,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5597,8 +5597,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5607,8 +5607,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5617,8 +5617,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 32.5,
-                "maxAlarmVal": 27.5
+                "maxAlarmVal": 27.5,
+                "upperCriticalVal": 32.5
               },
               "compute": "@/1000.0"
             },
@@ -5627,9 +5627,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5639,9 +5639,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 3.63,
                 "maxAlarmVal": 3.465,
                 "minAlarmVal": 3.135,
+                "upperCriticalVal": 3.63,
                 "lowerCriticalVal": 2.97
               },
               "compute": "3*@/1000.0"
@@ -5651,8 +5651,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 500,
-                "maxAlarmVal": 410
+                "maxAlarmVal": 410,
+                "upperCriticalVal": 500
               },
               "compute": "@/1000000.0"
             },
@@ -5661,8 +5661,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 470,
-                "maxAlarmVal": 380
+                "maxAlarmVal": 380,
+                "upperCriticalVal": 470
               },
               "compute": "3*@/1000000.0"
             },
@@ -5671,8 +5671,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U229_XDPE12284_1/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5681,8 +5681,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -5691,8 +5691,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -5701,8 +5701,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5711,8 +5711,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5721,8 +5721,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5731,8 +5731,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -5741,8 +5741,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr7_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5751,8 +5751,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/curr8_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5761,9 +5761,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5773,9 +5773,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -5785,9 +5785,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -5797,8 +5797,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -5807,8 +5807,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -5817,8 +5817,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -5827,8 +5827,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U86_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             },
@@ -5837,8 +5837,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr1_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 15,
-                "maxAlarmVal": 11
+                "maxAlarmVal": 11,
+                "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
             },
@@ -5847,8 +5847,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr2_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 84,
-                "maxAlarmVal": 72
+                "maxAlarmVal": 72,
+                "upperCriticalVal": 84
               },
               "compute": "@/1000.0"
             },
@@ -5857,8 +5857,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr3_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5867,8 +5867,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr4_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5877,8 +5877,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr5_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 28,
-                "maxAlarmVal": 24
+                "maxAlarmVal": 24,
+                "upperCriticalVal": 28
               },
               "compute": "@/1000.0"
             },
@@ -5887,8 +5887,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr6_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 48,
-                "maxAlarmVal": 36
+                "maxAlarmVal": 36,
+                "upperCriticalVal": 48
               },
               "compute": "@/1000.0"
             },
@@ -5897,8 +5897,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr7_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5907,8 +5907,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/curr8_input",
               "type": 2,
               "thresholds": {
-                "upperCriticalVal": 24,
-                "maxAlarmVal": 18
+                "maxAlarmVal": 18,
+                "upperCriticalVal": 24
               },
               "compute": "@/1000.0"
             },
@@ -5917,9 +5917,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in1_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 14.4,
                 "maxAlarmVal": 13.2,
                 "minAlarmVal": 10.8,
+                "upperCriticalVal": 14.4,
                 "lowerCriticalVal": 9.6
               },
               "compute": "@/1000.0"
@@ -5929,9 +5929,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.99,
                 "maxAlarmVal": 0.945,
                 "minAlarmVal": 0.855,
+                "upperCriticalVal": 0.99,
                 "lowerCriticalVal": 0.81
               },
               "compute": "@/1000.0"
@@ -5941,9 +5941,9 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/in3_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 0.825,
                 "maxAlarmVal": 0.7875,
                 "minAlarmVal": 0.7125,
+                "upperCriticalVal": 0.825,
                 "lowerCriticalVal": 0.675
               },
               "compute": "@/1000.0"
@@ -5953,8 +5953,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power1_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 145,
-                "maxAlarmVal": 120
+                "maxAlarmVal": 120,
+                "upperCriticalVal": 145
               },
               "compute": "@/1000000.0"
             },
@@ -5963,8 +5963,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power2_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 85,
-                "maxAlarmVal": 70
+                "maxAlarmVal": 70,
+                "upperCriticalVal": 85
               },
               "compute": "@/1000000.0"
             },
@@ -5973,8 +5973,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/power3_input",
               "type": 0,
               "thresholds": {
-                "upperCriticalVal": 40,
-                "maxAlarmVal": 30
+                "maxAlarmVal": 30,
+                "upperCriticalVal": 40
               },
               "compute": "@/1000000.0"
             },
@@ -5983,8 +5983,8 @@
               "sysfsPath": "/run/devmap/sensors/SMB_U92_XDPE12284_2/temp1_input",
               "type": 3,
               "thresholds": {
-                "upperCriticalVal": 115,
-                "maxAlarmVal": 105
+                "maxAlarmVal": 105,
+                "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
             }
@@ -6072,7 +6072,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
+                "maxAlarmVal": 100,
                 "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
@@ -6082,7 +6082,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
+                "maxAlarmVal": 100,
                 "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
@@ -6092,7 +6092,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 225
               },
               "compute": "@/1000000.0"
             },
@@ -6101,7 +6101,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 4096
+                "maxAlarmVal": 52.5
               },
               "compute": "@/1000000.0"
             },
@@ -6110,7 +6110,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 318.5
               },
               "compute": "@/1000000.0"
             },
@@ -6119,7 +6119,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 125
+                "maxAlarmVal": 15
               },
               "compute": "@/1000000.0"
             },
@@ -6168,8 +6168,6 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9,
                 "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
@@ -6204,9 +6202,6 @@
               "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
               "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
               "compute": "@/1000000.0"
             },
             {
@@ -6448,7 +6443,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp1_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
+                "maxAlarmVal": 100,
                 "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
@@ -6458,7 +6453,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/temp2_input",
               "type": 3,
               "thresholds": {
-                "maxAlarmVal": 115,
+                "maxAlarmVal": 100,
                 "upperCriticalVal": 115
               },
               "compute": "@/1000.0"
@@ -6468,7 +6463,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 225
               },
               "compute": "@/1000000.0"
             },
@@ -6477,7 +6472,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 4096
+                "maxAlarmVal": 52.5
               },
               "compute": "@/1000000.0"
             },
@@ -6486,7 +6481,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 1024
+                "maxAlarmVal": 318.5
               },
               "compute": "@/1000000.0"
             },
@@ -6495,7 +6490,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power4_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 125
+                "maxAlarmVal": 15
               },
               "compute": "@/1000000.0"
             },
@@ -6544,8 +6539,6 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/in1_input",
               "type": 1,
               "thresholds": {
-                "maxAlarmVal": 14,
-                "minAlarmVal": 9,
                 "upperCriticalVal": 15
               },
               "compute": "@/1000.0"
@@ -6580,9 +6573,6 @@
               "name": "COMe_PU41_TDA38640_1.2V_PVDDQ_ABC_CPU_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU41_TDA38640/power2_input",
               "type": 0,
-              "thresholds": {
-                "maxAlarmVal": 1024
-              },
               "compute": "@/1000000.0"
             },
             {
@@ -6834,7 +6824,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 2046
+                "maxAlarmVal": 225
               },
               "compute": "@/1000000.0"
             },
@@ -6842,12 +6832,18 @@
               "name": "COMe_PU4_MP2993_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
               "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 318.5
+              },
               "compute": "@/1000000.0"
             },
             {
               "name": "COMe_PU4_MP2993_P1V8_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
               "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 15
+              },
               "compute": "@/1000000.0"
             },
             {
@@ -6946,7 +6942,8 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.6
+                "upperCriticalVal": 1.6,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },
@@ -7165,7 +7162,7 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power1_input",
               "type": 0,
               "thresholds": {
-                "maxAlarmVal": 2046
+                "maxAlarmVal": 225
               },
               "compute": "@/1000000.0"
             },
@@ -7173,12 +7170,18 @@
               "name": "COMe_PU4_MP2993_PVCCIN_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power2_input",
               "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 318.5
+              },
               "compute": "@/1000000.0"
             },
             {
               "name": "COMe_PU4_MP2993_P1V8_POUT",
               "sysfsPath": "/run/devmap/sensors/COME_PU4_XDPE15284/power3_input",
               "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 15
+              },
               "compute": "@/1000000.0"
             },
             {
@@ -7277,7 +7280,8 @@
               "sysfsPath": "/run/devmap/sensors/COME_PU31_TDA38640/in2_input",
               "type": 1,
               "thresholds": {
-                "upperCriticalVal": 1.6
+                "upperCriticalVal": 1.6,
+                "lowerCriticalVal": 0
               },
               "compute": "@/1000.0"
             },


### PR DESCRIPTION
# Description

This PR is for tahan sensor service config file.

# Motivation

This PR includes the following changes:

1.  **Sensor Threshold Adjustment:** The sensor thresholds for the SMB and COME boards have been updated to match the latest hardware sensor table.
2.  **Bug Fix:** Resolved an issue where the `SMB_XP3R3V_LEFT_VOUT` and `SMB_XP3R3V_RIGHT_VOUT` sensor readings were exceeding their configured thresholds.
3.  **Version Bump:** Increased the `bspKmodsRpmVersion` to `3.3.0-1` in `platform_manager.json`.
4.  **Code Formatting:** Rearranged the order of threshold fields for all sensors to maintain a consistent order: `maxAlarmVal`, `minAlarmVal`, `upperCriticalVal`, `lowerCriticalVal`. Also applied standard formatting to the file for better readability.


# Test Plan

1.The correctness of the format has been verified on this jsonlint website.
2.Used jq command to pretty the format.
3.Compilation and multiple services configs cross-check passed.

In main source machine tested pass:
LD_LIBRARY_PATH=./lib/ ./sensor_service_hw_test --config_file sensor_service.json --logging=DBG5
<img width="1902" height="436" alt="image" src="https://github.com/user-attachments/assets/f54c7bc1-aac0-4d1c-97bf-9c5ce7a2a28a" />




In 2nd source machine tested pass:
LD_LIBRARY_PATH=./lib/ ./sensor_service_hw_test --config_file sensor_service.json --logging=DBG5
<img width="1872" height="476" alt="image" src="https://github.com/user-attachments/assets/c3e6eb43-0c05-4315-8247-aac84a3405b7" />



Test log:

[tahan_main_pm_test_log_8_27.txt](https://github.com/user-attachments/files/22071919/tahan_main_pm_test_log_8_27.txt)
[tahan_main_fan_test_log_9_1.txt](https://github.com/user-attachments/files/22071923/tahan_main_fan_test_log_9_1.txt)
[tahan_main_sensor_test_log_8_29.txt](https://github.com/user-attachments/files/22071928/tahan_main_sensor_test_log_8_29.txt)

[tahan_2nd_pm_test_log_8_28.txt](https://github.com/user-attachments/files/22071931/tahan_2nd_pm_test_log_8_28.txt)
[tahan_2nd_fan_test_log_9_1.txt](https://github.com/user-attachments/files/22071932/tahan_2nd_fan_test_log_9_1.txt)
[tahan_2nd_sensor_test_log_8_29_2th.txt](https://github.com/user-attachments/files/22071934/tahan_2nd_sensor_test_log_8_29_2th.txt)

