### PR TITLE
Icetea: config: update the sensors and adjust the fan control parameters for EVT

### DIFF
--- a/fboss/platform/configs/icetea/fan_service.json
+++ b/fboss/platform/configs/icetea/fan_service.json
@@ -2,7 +2,7 @@
   "pwmBoostOnNumDeadFan": 2,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 0,
-  "pwmBoostValue": 70,
+  "pwmBoostValue": 100,
   "pwmTransitionValue": 70,
   "pwmLowerThreshold": 60,
   "pwmUpperThreshold": 100,
@@ -22,12 +22,12 @@
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
       "pidSetting": {
-        "kp": -4,
-        "ki": -0.06,
+        "kp": 2,
+        "ki": 0.6,
         "kd": 0,
-        "setPoint": 97.0,
-        "posHysteresis": 0.0,
-        "negHysteresis": 8.0
+        "setPoint": 95.0,
+        "posHysteresis": 2,
+        "negHysteresis": 0
       }
     },
     {
@@ -62,88 +62,88 @@
       }
     },
     {
-      "sensorName": "POWER_BRICK1_TEMP1",
+      "sensorName": "MCB_POWER_BRICK1_TEMP1",
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
       "pidSetting": {
-        "kp": -8,
-        "ki": -0.06,
+        "kp": 2,
+        "ki": 0.6,
         "kd": 0,
-        "setPoint": 105.0,
-        "posHysteresis": 0.0,
+        "setPoint": 102.0,
+        "posHysteresis": 3.0,
         "negHysteresis": 3.0
       }
     },
     {
-      "sensorName": "POWER_BRICK2_TEMP1",
+      "sensorName": "MCB_POWER_BRICK2_TEMP1",
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
       "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
       "pidSetting": {
-        "kp": -8,
-        "ki": -0.06,
+        "kp": 2,
+        "ki": 0.6,
         "kd": 0,
-        "setPoint": 105.0,
-        "posHysteresis": 0.0,
+        "setPoint": 102.0,
+        "posHysteresis": 3.0,
         "negHysteresis": 3.0
       }
     }
   ],
   "fans": [
     {
-      "fanName": "FAN_1_F",
+      "fanName": "FAN_1",
       "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
       "pwmMin": 0,
-      "pwmMax": 40,
+      "pwmMax": 64,
       "fanPresentVal": 1,
       "fanMissingVal": 0,
       "fanGoodLedVal": 1,
       "fanFailLedVal": 2,
-      "rpmMin": 1500
+      "rpmMin": 4100
     },
     {
-      "fanName": "FAN_2_F",
+      "fanName": "FAN_2",
       "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
       "pwmMin": 0,
-      "pwmMax": 40,
+      "pwmMax": 64,
       "fanPresentVal": 1,
       "fanMissingVal": 0,
       "fanGoodLedVal": 1,
       "fanFailLedVal": 2,
-      "rpmMin": 1500
+      "rpmMin": 4100
     },
     {
-      "fanName": "FAN_3_F",
+      "fanName": "FAN_3",
       "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
       "pwmMin": 0,
-      "pwmMax": 40,
+      "pwmMax": 64,
       "fanPresentVal": 1,
       "fanMissingVal": 0,
       "fanGoodLedVal": 1,
       "fanFailLedVal": 2,
-      "rpmMin": 1500
+      "rpmMin": 4100
     },
     {
-      "fanName": "FAN_4_F",
+      "fanName": "FAN_4",
       "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
       "pwmMin": 0,
-      "pwmMax": 40,
+      "pwmMax": 64,
       "fanPresentVal": 1,
       "fanMissingVal": 0,
       "fanGoodLedVal": 1,
       "fanFailLedVal": 2,
-      "rpmMin": 1500
+      "rpmMin": 4100
     }
   ],
   "zones": [
@@ -153,14 +153,14 @@
       "sensorNames": [
         "CPU_UNCORE_TEMP",
         "PIC_U12_INLET_LM75_1_TEMP",
-        "POWER_BRICK1_TEMP1",
-        "POWER_BRICK2_TEMP1"
+        "MCB_POWER_BRICK1_TEMP1",
+        "MCB_POWER_BRICK2_TEMP1"
       ],
       "fanNames": [
-        "FAN_1_F",
-        "FAN_2_F",
-        "FAN_3_F",
-        "FAN_4_F"
+        "FAN_1",
+        "FAN_2",
+        "FAN_3",
+        "FAN_4"
       ],
       "slope": 10
     }

--- a/fboss/platform/configs/icetea/platform_manager.json
+++ b/fboss/platform/configs/icetea/platform_manager.json
@@ -895,7 +895,7 @@
             },
             {
               "fpgaIpBlockConfig": {
-                "pmUnitScopedName": "IOB_XCVR_CTRL_PORT_33",
+                "pmUnitScopedName": "MCB_IOB_XCVR_CTRL_PORT_33",
                 "deviceName": "xcvr_ctrl",
                 "csrOffset": "0x1030"
               },
@@ -1533,13 +1533,13 @@
           "busName": "MCB_IOB_I2C_MASTER_6",
           "address": "0x4d",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "COME_INLET_TSENSOR"
+          "pmUnitScopedName": "MCB_COME_INLET_TSENSOR"
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_6",
           "address": "0x4f",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "PWR_BRICK_INLET_TSENSOR"
+          "pmUnitScopedName": "MCB_PWR_BRICK_INLET_TSENSOR"
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
@@ -1571,7 +1571,7 @@
           "busName": "MCB_IOB_I2C_MASTER_22",
           "address": "0x4d",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "MCB_TSENSOR1"
+          "pmUnitScopedName": "MCB_TSENSOR"
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_24",
@@ -1664,31 +1664,31 @@
           "busName": "INCOMING@0",
           "address": "0x11",
           "kernelDeviceName": "mp9941",
-          "pmUnitScopedName": "COME_HWMON1"
+          "pmUnitScopedName": "COME_HWMON_1"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x22",
           "kernelDeviceName": "mp9941",
-          "pmUnitScopedName": "COME_HWMON2"
+          "pmUnitScopedName": "COME_HWMON_2"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x45",
           "kernelDeviceName": "mp9941",
-          "pmUnitScopedName": "COME_HWMON3"
+          "pmUnitScopedName": "COME_HWMON_3"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x66",
           "kernelDeviceName": "mp9941",
-          "pmUnitScopedName": "COME_HWMON4"
+          "pmUnitScopedName": "COME_HWMON_4"
         },
         {
           "busName": "INCOMING@0",
           "address": "0x76",
           "kernelDeviceName": "mp2993",
-          "pmUnitScopedName": "COME_HWMON5"
+          "pmUnitScopedName": "COME_HWMON_5"
         },
         {
           "busName": "INCOMING@1",
@@ -1718,49 +1718,49 @@
           "busName": "FCB_MUX@0",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "FCB_TSENSOR1"
+          "pmUnitScopedName": "FCB_TSENSOR_1"
         },
         {
           "busName": "FCB_MUX@1",
           "address": "0x4b",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "FCB_TSENSOR2"
+          "pmUnitScopedName": "FCB_TSENSOR_2"
         },
         {
           "busName": "FCB_MUX@2",
           "address": "0x4d",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "FCB_TSENSOR3"
+          "pmUnitScopedName": "FCB_TSENSOR_3"
         },
         {
           "busName": "FCB_MUX@3",
           "address": "0x4f",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "FCB_TSENSOR4"
+          "pmUnitScopedName": "FCB_TSENSOR_4"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x40",
           "kernelDeviceName": "ina238",
-          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR1"
+          "pmUnitScopedName": "FCB_FAN1_SENSOR"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x41",
           "kernelDeviceName": "ina238",
-          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR2"
+          "pmUnitScopedName": "FCB_FAN2_SENSOR"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x44",
           "kernelDeviceName": "ina238",
-          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR3"
+          "pmUnitScopedName": "FCB_FAN3_SENSOR"
         },
         {
           "busName": "INCOMING@2",
           "address": "0x45",
           "kernelDeviceName": "ina238",
-          "pmUnitScopedName": "FCB_VOLTAGE_MONITOR4"
+          "pmUnitScopedName": "FCB_FAN4_SENSOR"
         },
         {
           "busName": "INCOMING@3",
@@ -1833,13 +1833,13 @@
           "busName": "SMB_MUX@0",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_0"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_0"
         },
         {
           "busName": "SMB_MUX@1",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_1"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_1"
         },
         {
           "busName": "SMB_MUX@1",
@@ -1851,19 +1851,19 @@
           "busName": "SMB_MUX@2",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_2"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_2"
         },
         {
           "busName": "SMB_MUX@2",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_OUTLET_TH6_TSENSOR"
+          "pmUnitScopedName": "SMB_OUTLET_TH6_TSENSOR_1"
         },
         {
           "busName": "SMB_MUX@3",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_3"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_3"
         },
         {
           "busName": "SMB_MUX@3",
@@ -1875,31 +1875,31 @@
           "busName": "SMB_MUX@4",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_4"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_4"
         },
         {
           "busName": "SMB_MUX@5",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_1"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_5_1"
         },
         {
           "busName": "SMB_MUX@5",
           "address": "0x6a",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_2"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_5_2"
         },
         {
           "busName": "SMB_MUX@6",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_6"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_6"
         },
         {
           "busName": "SMB_MUX@7",
           "address": "0x70",
           "kernelDeviceName": "xdpe15284",
-          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_7"
+          "pmUnitScopedName": "SMB_ASIC_MONITOR_7"
         },
         {
           "busName": "INCOMING@1",
@@ -1939,7 +1939,7 @@
           "busName": "INCOMING@4",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_INLET_TSENSOR"
+          "pmUnitScopedName": "SMB_INLET_TSENSOR_2"
         },
         {
           "busName": "INCOMING@4",
@@ -1959,32 +1959,53 @@
     "/run/devmap/eeproms/FCB_EEPROM": "/FCB_SLOT@0/[IDPROM]",
     "/run/devmap/eeproms/PIC_EEPROM": "/PIC_SLOT@0/[IDPROM]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/COME_HWMON_1": "/COMESE_SLOT@0/[COME_HWMON_1]",
+    "/run/devmap/sensors/COME_HWMON_2": "/COMESE_SLOT@0/[COME_HWMON_2]",
+    "/run/devmap/sensors/COME_HWMON_3": "/COMESE_SLOT@0/[COME_HWMON_3]",
+    "/run/devmap/sensors/COME_HWMON_4": "/COMESE_SLOT@0/[COME_HWMON_4]",
+    "/run/devmap/sensors/COME_HWMON_5": "/COMESE_SLOT@0/[COME_HWMON_5]",
+    "/run/devmap/sensors/COME_U18_INLET_TSENSOR": "/COMESE_SLOT@0/[COME_U18_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR": "/COMESE_SLOT@0/[COME_U39_OUTLET_TSENSOR]",
     "/run/devmap/sensors/MCB_PMBUS_1": "/[MCB_PMBUS_1]",
     "/run/devmap/sensors/MCB_PMBUS_2": "/[MCB_PMBUS_2]",
-    "/run/devmap/sensors/COME_INLET_TSENSOR": "/[COME_INLET_TSENSOR]",
-    "/run/devmap/sensors/PWR_BRICK_INLET_TSENSOR": "/[PWR_BRICK_INLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_PWR_BRICK_INLET_TSENSOR": "/[MCB_PWR_BRICK_INLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_COME_INLET_TSENSOR": "/[MCB_COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_TSENSOR": "/[MCB_TSENSOR]",
     "/run/devmap/sensors/MCB_FAN_CPLD": "/[MCB_FAN_CPLD]",
     "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR": "/[MCB_LOAD_SWITCH_MONITOR]",
-    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR1": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR1]",
-    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR2": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR2]",
-    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR3": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR3]",
-    "/run/devmap/sensors/FCB_VOLTAGE_MONITOR4": "/FCB_SLOT@0/[FCB_VOLTAGE_MONITOR4]",
-    "/run/devmap/sensors/FCB_48V_HSC_MONITOR": "/FCB_SLOT@0/[FCB_48V_HSC_MONITOR]",
     "/run/devmap/sensors/MCB_ADC1_MONITOR": "/[MCB_ADC1_MONITOR]",
     "/run/devmap/sensors/MCB_ADC2_MONITOR": "/[MCB_ADC2_MONITOR]",
-    "/run/devmap/sensors/MCB_TSENSOR1": "/[MCB_TSENSOR1]",
+    "/run/devmap/sensors/FCB_TSENSOR_1": "/FCB_SLOT@0/[FCB_TSENSOR_1]",
+    "/run/devmap/sensors/FCB_TSENSOR_2": "/FCB_SLOT@0/[FCB_TSENSOR_2]",
+    "/run/devmap/sensors/FCB_TSENSOR_3": "/FCB_SLOT@0/[FCB_TSENSOR_3]",
+    "/run/devmap/sensors/FCB_TSENSOR_4": "/FCB_SLOT@0/[FCB_TSENSOR_4]",
+    "/run/devmap/sensors/FCB_FAN1_SENSOR": "/FCB_SLOT@0/[FCB_FAN1_SENSOR]",
+    "/run/devmap/sensors/FCB_FAN2_SENSOR": "/FCB_SLOT@0/[FCB_FAN2_SENSOR]",
+    "/run/devmap/sensors/FCB_FAN3_SENSOR": "/FCB_SLOT@0/[FCB_FAN3_SENSOR]",
+    "/run/devmap/sensors/FCB_FAN4_SENSOR": "/FCB_SLOT@0/[FCB_FAN4_SENSOR]",
+    "/run/devmap/sensors/FCB_48V_HSC_MONITOR": "/FCB_SLOT@0/[FCB_48V_HSC_MONITOR]",
     "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
     "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR": "/PIC_SLOT@0/[PIC_XP3R3V_L_MONITOR]",
     "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR": "/PIC_SLOT@0/[PIC_XP3R3V_R_MONITOR]",
     "/run/devmap/sensors/PIC_ADC_SENSOR": "/PIC_SLOT@0/[PIC_ADC_SENSOR]",
     "/run/devmap/sensors/PIC_TSENSOR_1": "/PIC_SLOT@0/[PIC_TSENSOR_1]",
     "/run/devmap/sensors/PIC_TSENSOR_2": "/PIC_SLOT@0/[PIC_TSENSOR_2]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_0": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_0]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_1": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_1]",
     "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_1]",
-    "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_OUTLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_2": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_2]",
+    "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR_1": "/SMB_SLOT@0/[SMB_OUTLET_TH6_TSENSOR_1]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_3": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_3]",
     "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_2]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_4": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_4]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_5_1]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_5_2]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_6": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_6]",
+    "/run/devmap/sensors/SMB_ASIC_MONITOR_7": "/SMB_SLOT@0/[SMB_ASIC_MONITOR_7]",
     "/run/devmap/sensors/SMB_ADC1_SENSOR": "/SMB_SLOT@0/[SMB_ADC1_SENSOR]",
     "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
-    "/run/devmap/sensors/SMB_INLET_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_INLET_TSENSOR_2": "/SMB_SLOT@0/[SMB_INLET_TSENSOR_2]",
+    "/run/devmap/sensors/SMB_VDDCORE": "/SMB_SLOT@0/[SMB_VDDCORE]",
     "/run/devmap/cplds/SCM_CPLD": "/[SCM_CPLD]",
     "/run/devmap/cplds/MCB_CPLD": "/[MCB_CPLD]",
     "/run/devmap/cplds/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
@@ -2022,13 +2043,6 @@
     "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_26": "/[MCB_IOB_I2C_MASTER_26]",
     "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_27": "/[MCB_IOB_I2C_MASTER_27]",
     "/run/devmap/i2c-busses/MCB_IOB_I2C_MASTER_28": "/[MCB_IOB_I2C_MASTER_28]",
-    "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
-    "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
-    "/run/devmap/sensors/COME_HWMON3": "/COMESE_SLOT@0/[COME_HWMON3]",
-    "/run/devmap/sensors/COME_HWMON4": "/COMESE_SLOT@0/[COME_HWMON4]",
-    "/run/devmap/sensors/COME_HWMON5": "/COMESE_SLOT@0/[COME_HWMON5]",
-    "/run/devmap/sensors/COME_U18_INLET_TSENSOR": "/COMESE_SLOT@0/[COME_U18_INLET_TSENSOR]",
-    "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR": "/COMESE_SLOT@0/[COME_U39_OUTLET_TSENSOR]",
     "/run/devmap/i2c-busses/XCVR_1": "/[PIC_DOM_I2C_MASTER_1]",
     "/run/devmap/i2c-busses/XCVR_2": "/[PIC_DOM_I2C_MASTER_2]",
     "/run/devmap/i2c-busses/XCVR_3": "/[PIC_DOM_I2C_MASTER_3]",
@@ -2097,7 +2111,7 @@
     "/run/devmap/xcvrs/xcvr_30": "/[PIC_DOM_XCVR_CTRL_PORT_30]",
     "/run/devmap/xcvrs/xcvr_31": "/[PIC_DOM_XCVR_CTRL_PORT_31]",
     "/run/devmap/xcvrs/xcvr_32": "/[PIC_DOM_XCVR_CTRL_PORT_32]",
-    "/run/devmap/xcvrs/xcvr_33": "/[IOB_XCVR_CTRL_PORT_33]",
+    "/run/devmap/xcvrs/xcvr_33": "/[MCB_IOB_XCVR_CTRL_PORT_33]",
     "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1": "/[MCB_SPI_MASTER_3_DEVICE_1]",
@@ -2170,7 +2184,7 @@
     "/run/devmap/xcvrs/xcvr_io_32": "/[PIC_DOM_I2C_MASTER_32]",
     "/run/devmap/xcvrs/xcvr_ctrl_32": "/[PIC_DOM_XCVR_CTRL_PORT_32]",
     "/run/devmap/xcvrs/xcvr_io_33": "/[MCB_IOB_I2C_MASTER_28]",
-    "/run/devmap/xcvrs/xcvr_ctrl_33": "/[IOB_XCVR_CTRL_PORT_33]"
+    "/run/devmap/xcvrs/xcvr_ctrl_33": "/[MCB_IOB_XCVR_CTRL_PORT_33]"
   },
   "chassisEepromDevicePath": "/[CHASSIS_IDPROM]",
   "numXcvrs": 33,

--- a/fboss/platform/configs/icetea/sensor_service.json
+++ b/fboss/platform/configs/icetea/sensor_service.json
@@ -5,92 +5,324 @@
       "pmUnitName": "ICETEA_MCB",
       "sensors": [
         {
-          "name": "CPU_UNCORE_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
-          "type": 3,
+          "name": "MCB_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+          "type": 4,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 42000,
+            "minAlarmVal": 4100,
+            "upperCriticalVal": 45000,
+            "lowerCriticalVal": 3690
+          }
+        },
+        {
+          "name": "MCB_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 42000,
+            "minAlarmVal": 4100,
+            "upperCriticalVal": 45000,
+            "lowerCriticalVal": 3690
+          }
+        },
+        {
+          "name": "MCB_FAN3_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 42000,
+            "minAlarmVal": 4100,
+            "upperCriticalVal": 45000,
+            "lowerCriticalVal": 3690
+          }
+        },
+        {
+          "name": "MCB_FAN4_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 42000,
+            "minAlarmVal": 4100,
+            "upperCriticalVal": 45000,
+            "lowerCriticalVal": 3690
+          }
+        },
+        {
+          "name": "MCB_POWER_BRICK1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 145,
+            "upperCriticalVal": 167
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE0_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "name": "MCB_POWER_BRICK1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE1_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
-          "type": 3,
+          "name": "MCB_POWER_BRICK1_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/in1_input",
+          "type": 1,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE2_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
-          "type": 3,
+          "name": "MCB_POWER_BRICK1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/in2_input",
+          "type": 1,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE3_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
-          "type": 3,
+          "name": "MCB_POWER_BRICK2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/curr1_input",
+          "type": 2,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 145,
+            "upperCriticalVal": 167
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE4_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "name": "MCB_POWER_BRICK2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE5_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
-          "type": 3,
+          "name": "MCB_POWER_BRICK2_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/in1_input",
+          "type": 1,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE6_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
-          "type": 3,
+          "name": "MCB_POWER_BRICK2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/in2_input",
+          "type": 1,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
           },
           "compute": "@/1000"
         },
         {
-          "name": "CPU_CORE7_TEMP",
-          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "name": "MCB_PU925_TPS25990_XP12R0V_COME_IIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 11
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_PU925_TPS25990_XP12R0V_COME_PIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 120,
+            "upperCriticalVal": 130
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "MCB_PU925_TPS25990_XP12R0V_COME_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_PU925_TPS25990_XP12R0V_COME_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_PU925_TPS25990_XP12R0V_COME_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_LOAD_SWITCH_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP12R0V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13,
+            "minAlarmVal": 11,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "11*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R0V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.95,
+            "upperCriticalVal": 1.1,
+            "lowerCriticalVal": 0.9
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R2V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.14,
+            "upperCriticalVal": 1.32,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP1R8V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_MCB_PH",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP3R3V_STBY",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "MCB_U130_ADC128D818_XP5R0V_USB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000"
+        },
+        {
+          "name": "MCB_U132_COME_INLET_LM75_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_INLET_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 90,
-            "upperCriticalVal": 100
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U165_PWR_BRICK_INLET_LM75_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_PWR_BRICK_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP12R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "11*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP1R1V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
           },
           "compute": "@/1000"
         },
@@ -105,6 +337,30 @@
             "lowerCriticalVal": 1.35
           },
           "compute": "@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP2R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000"
+        },
+        {
+          "name": "MCB_U59_ADC128D818_XP3R3V_I210",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
         },
         {
           "name": "MCB_U59_ADC128D818_XP3R3V_MCB",
@@ -131,54 +387,6 @@
           "compute": "(5/3)*@/1000"
         },
         {
-          "name": "MCB_U59_ADC128D818_XP2R5V_OOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in3_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 2.625,
-            "minAlarmVal": 2.375,
-            "upperCriticalVal": 2.75,
-            "lowerCriticalVal": 2.25
-          },
-          "compute": "2*@/1000"
-        },
-        {
-          "name": "MCB_U59_ADC128D818_XP1R1V_OOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in4_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 1.155,
-            "minAlarmVal": 1.045,
-            "upperCriticalVal": 1.21,
-            "lowerCriticalVal": 0.99
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "MCB_U59_ADC128D818_XP3R3V_I210",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in5_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "upperCriticalVal": 3.63,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "(5/3)*@/1000"
-        },
-        {
-          "name": "MCB_U59_ADC128D818_XP12R0V_COME",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in6_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 13.6,
-            "minAlarmVal": 10.5,
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 10
-          },
-          "compute": "11*@/1000"
-        },
-        {
           "name": "MCB_U59_ADC128D818_XP5R0V_COME",
           "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in7_input",
           "type": 1,
@@ -191,118 +399,12 @@
           "compute": "5.7*@/1000"
         },
         {
-          "name": "MCB_U130_ADC128D818_XP1R0V_IOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in0_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 1.05,
-            "minAlarmVal": 0.95,
-            "upperCriticalVal": 1.1,
-            "lowerCriticalVal": 0.9
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP3R3V_STBY",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in1_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "upperCriticalVal": 3.63,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "(5/3)*@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP3R3V_MCB_PH",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in2_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "upperCriticalVal": 3.63,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "(5/3)*@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP1R8V_IOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in3_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 1.89,
-            "minAlarmVal": 1.71,
-            "upperCriticalVal": 1.98,
-            "lowerCriticalVal": 1.62
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP1R2V_IOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in4_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 1.26,
-            "minAlarmVal": 1.14,
-            "upperCriticalVal": 1.32,
-            "lowerCriticalVal": 1.08
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP3R3V_IOB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in5_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "upperCriticalVal": 3.63,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "(5/3)*@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP12R0V_SSD",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in6_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 13,
-            "minAlarmVal": 11,
-            "upperCriticalVal": 13.2,
-            "lowerCriticalVal": 10.8
-          },
-          "compute": "11*@/1000"
-        },
-        {
-          "name": "MCB_U130_ADC128D818_XP5R0V_USB",
-          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in7_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 5.25,
-            "minAlarmVal": 4.75,
-            "upperCriticalVal": 5.5,
-            "lowerCriticalVal": 4.5
-          },
-          "compute": "5.7*@/1000"
-        },
-        {
-          "name": "POWER_BRICK1_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_1/temp1_input",
+          "name": "MCB_U8_LM75_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 110
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "POWER_BRICK2_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/MCB_PMBUS_2/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "maxAlarmVal": 100,
-            "upperCriticalVal": 110
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         }
@@ -316,6 +418,10 @@
           "name": "BMC_U9_THERMAL_SENSOR_TMP1075_TEMP",
           "sysfsPath": "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR/temp1_input",
           "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
           "compute": "@/1000"
         }
       ]
@@ -325,15 +431,444 @@
       "pmUnitName": "NETLAKE",
       "sensors": [
         {
+          "name": "COME_PU31_MP9941_PVNN_PCH_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 13
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 125,
+            "upperCriticalVal": 135
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU31_MP9941_PVNN_PCH_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.6,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 20
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 125,
+            "upperCriticalVal": 135
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU32_MP9941_P1V05_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.61,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_P1V8_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 4,
+            "upperCriticalVal": 6
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_P1V8_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/power3_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 125
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU4_MP2993_P1V8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 110,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_P1V8_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2,
+            "upperCriticalVal": 2.4,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 225
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU4_MP2993_PVCCIN_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 117,
+            "upperCriticalVal": 130
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_PVCCIN_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/power2_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 318.5
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU4_MP2993_PVCCIN_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 110,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_PVCCIN_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2,
+            "upperCriticalVal": 2.4,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU4_MP2993_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_5/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 14,
+            "minAlarmVal": 9.5,
+            "upperCriticalVal": 15,
+            "lowerCriticalVal": 8.5
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 26
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 125,
+            "upperCriticalVal": 135
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU41_MP9941_1.2V_PVDDQ_ABC_CPU_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.45,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_IIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/curr1_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 5
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_PIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 125,
+            "upperCriticalVal": 135
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_VIN",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 15
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_PU42_MP9941_PVCCANA_CPU_1V_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON_4/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 1.15,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
           "name": "COME_U18_INLET_SENSOR_TMP75_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_U18_INLET_TSENSOR/temp1_input",
           "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
           "compute": "@/1000"
         },
         {
           "name": "COME_U39_OUTLET_SENSOR_TMP75_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_U39_OUTLET_TSENSOR/temp1_input",
           "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_UNCORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "CPU_CORE7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 100
+          },
           "compute": "@/1000"
         }
       ]
@@ -343,24 +878,134 @@
       "pmUnitName": "PIC",
       "sensors": [
         {
-          "name": "PIC_U12_INLET_LM75_1_TEMP",
-          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_1/temp1_input",
-          "type": 3,
+          "name": "PIC_PU8_XP3R3V_OSFP_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR/curr2_input",
+          "type": 2,
           "thresholds": {
-            "maxAlarmVal": 80,
-            "upperCriticalVal": 85
+            "maxAlarmVal": 203,
+            "upperCriticalVal": 220
           },
           "compute": "@/1000"
         },
         {
-          "name": "PIC_U13_INLET_LM75_2_TEMP",
-          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_2/temp1_input",
+          "name": "PIC_PU8_XP3R3V_OSFP_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PIC_PU8_XP3R3V_OSFP_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 80,
-            "upperCriticalVal": 85
+            "upperCriticalVal": 150
           },
           "compute": "@/1000"
+        },
+        {
+          "name": "PIC_PU8_XP3R3V_OSFP_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_L_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_PU19_XP3R3V_OSFP_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR/curr2_input",
+          "type": 2,
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_PU19_XP3R3V_OSFP_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PIC_PU19_XP3R3V_OSFP_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 150
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_PU19_XP3R3V_OSFP_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PIC_XP3R3V_R_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP1R1V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP2R5V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_DOM",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_L",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_R",
+          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000"
         },
         {
           "name": "PIC_U1_ADC128D818_XP3R3V_PIC",
@@ -387,44 +1032,346 @@
           "compute": "5.7*@/1000"
         },
         {
-          "name": "PIC_U1_ADC128D818_XP3R3V_DOM",
-          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in3_input",
-          "type": 1,
+          "name": "PIC_U12_INLET_LM75_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_1/temp1_input",
+          "type": 3,
           "thresholds": {
-            "maxAlarmVal": 3.465,
-            "minAlarmVal": 3.135,
-            "upperCriticalVal": 3.63,
-            "lowerCriticalVal": 2.97
-          },
-          "compute": "(5/3)*@/1000"
-        },
-        {
-          "name": "PIC_U1_ADC128D818_XP2R5V_DOM",
-          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in4_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 2.625,
-            "minAlarmVal": 2.375,
-            "upperCriticalVal": 2.75,
-            "lowerCriticalVal": 2.25
-          },
-          "compute": "2*@/1000"
-        },
-        {
-          "name": "PIC_U1_ADC128D818_XP1R1V_DOM",
-          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in5_input",
-          "type": 1,
-          "thresholds": {
-            "maxAlarmVal": 1.155,
-            "minAlarmVal": 1.045,
-            "upperCriticalVal": 1.21,
-            "lowerCriticalVal": 0.99
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         },
         {
-          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_L",
-          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in6_input",
+          "name": "PIC_U13_INLET_LM75_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PIC_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        }
+      ]
+    },
+    {
+      "slotPath": "/FCB_SLOT@0",
+      "pmUnitName": "FCB",
+      "sensors": [
+        {
+          "name": "FCB_FAN1_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN1_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN1_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN1_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "FCB_FAN1_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN1_SENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN1_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN2_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN2_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN2_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN2_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "FCB_FAN2_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN2_SENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN2_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN3_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN3_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN3_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN3_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "FCB_FAN3_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN3_SENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN3_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN3_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN4_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN4_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN4_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN4_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "FCB_FAN4_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN4_SENSOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_FAN4_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/FCB_FAN4_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_LM75_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_LM75_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_LM75_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_TSENSOR_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_LM75_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_TSENSOR_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_XP48R0V_HOTSWAP_IOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_48V_HSC_MONITOR/curr1_input",
+          "type": 2,
+          "compute": "2.4*@/1000"
+        },
+        {
+          "name": "FCB_XP48R0V_HOTSWAP_PIN",
+          "sysfsPath": "/run/devmap/sensors/FCB_48V_HSC_MONITOR/power1_input",
+          "type": 0,
+          "compute": "2.4*@/1000000"
+        },
+        {
+          "name": "FCB_XP48R0V_HOTSWAP_TEMP",
+          "sysfsPath": "/run/devmap/sensors/FCB_48V_HSC_MONITOR/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_XP48R0V_HOTSWAP_VIN",
+          "sysfsPath": "/run/devmap/sensors/FCB_48V_HSC_MONITOR/in1_input",
+          "type": 1,
+          "compute": "@/1000"
+        },
+        {
+          "name": "FCB_XP48R0V_HOTSWAP_VOUT",
+          "sysfsPath": "/run/devmap/sensors/FCB_48V_HSC_MONITOR/in2_input",
+          "type": 1,
+          "compute": "@/1000"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0",
+      "pmUnitName": "SMB",
+      "sensors": [
+        {
+          "name": "SMB_U21_ADC128D818_XP0R75V_TH6_PT_RESCAL",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.772,
+            "minAlarmVal": 0.728,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP0R8V_TH6_VDDA",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.824,
+            "minAlarmVal": 0.776,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP0R9V_TH6_PVDD_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.936,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP1R2V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.236,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP1R5V_TH6_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP1R8V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP1R8V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.854,
+            "minAlarmVal": 1.746,
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U21_ADC128D818_XP3R3V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in0_input",
           "type": 1,
           "thresholds": {
             "maxAlarmVal": 3.465,
@@ -435,8 +1382,92 @@
           "compute": "(5/3)*@/1000"
         },
         {
-          "name": "PIC_U1_ADC128D818_XP3R3V_OSFP_R",
-          "sysfsPath": "/run/devmap/sensors/PIC_ADC_SENSOR/in7_input",
+          "name": "SMB_U22_ADC128D818_XP0R9V_TH6_PVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.936,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP0R9V_TH6_PVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.936,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP0R9V_TH6_PVDD_3",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.936,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP1R2V_TH6_VDDHTX",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.236,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP1R5V_TH6_PVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.56,
+            "minAlarmVal": 1.44,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP1R8V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP1R8V_SMB",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.908,
+            "minAlarmVal": 1.692,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U22_ADC128D818_XP3R3V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in2_input",
           "type": 1,
           "thresholds": {
             "maxAlarmVal": 3.465,
@@ -445,6 +1476,719 @@
             "lowerCriticalVal": 2.97
           },
           "compute": "(5/3)*@/1000"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 105
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 105
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U30_RIGHT_TMP432_2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U30_RIGHT_TMP432_2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 105
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U30_RIGHT_TMP432_2_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U7_TOP_LEFT_LM75_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_U8_BOT_RIGHT_LM75_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_INLET_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.816,
+            "minAlarmVal": 0.792,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.816,
+            "minAlarmVal": 0.792,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.816,
+            "minAlarmVal": 0.792,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R72V_PB_TRVDD_3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.816,
+            "minAlarmVal": 0.792,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.772,
+            "minAlarmVal": 0.728,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R75V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.772,
+            "minAlarmVal": 0.728,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_0/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_5_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_5_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_5_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_7_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_7_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_PT_VDDC_7_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_TH6_VDDC_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 1100
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_TH6_VDDC_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/power1_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_TH6_VDDC_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/power2_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R8V_TH6_VDDC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R8V_TH6_VDDC_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/power3_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/temp1_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP0R9V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/power4_input",
+          "type": 0,
+          "compute": "@/1000000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/temp2_input",
+          "type": 3,
+          "compute": "@/1000"
+        },
+        {
+          "name": "SMB_XP1R5V_TH6_RVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_MONITOR_5_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000"
         }
       ]
     }


### PR DESCRIPTION
# Description

Update the configurations for `platform_manager`, `sensor_service`, and `fan_service` to align with the latest sensors list and fan control requirements provided by the hardware team.

# Motivation

The hardware team has recently updated the monitoring sensors list and fan control parameters. It is essential to reflect these updates in the FBoss configurations.

# Test Plan

1. Used jq command to pretty the format.
2. Compilation and config validation have passed.
3. Run platform_manager and check logs.
    <img width="1242" height="362" alt="image" src="https://github.com/user-attachments/assets/0d432334-b094-4e33-b4be-ea02cd12ba15" />
[platform_manager_log.txt](https://github.com/user-attachments/files/22074782/platform_manager_log.txt)
4. Run sensor_service and check logs.
    <img width="1569" height="657" alt="image" src="https://github.com/user-attachments/assets/927e4e9a-698d-469e-ba43-58183bb96859" />
[sensor_service_log.txt](https://github.com/user-attachments/files/22074827/sensor_service_log.txt)
[sensor_service_hw_test_log.txt](https://github.com/user-attachments/files/22074829/sensor_service_hw_test_log.txt)
5. Run fan_service and check logs.
   <img width="1144" height="465" alt="image" src="https://github.com/user-attachments/assets/ba7f8294-b78e-4f71-b185-ff7770fb4193" />
[fan_service_log.txt](https://github.com/user-attachments/files/22074858/fan_service_log.txt)
[fan_service_hw_tes_log.txt](https://github.com/user-attachments/files/22074861/fan_service_hw_tes_log.txt)
