### PR TITLE
minipack3n: config: add support for 2nd source in platform configs

### DIFF
--- a/fboss/platform/configs/minipack3n/fw_util.json
+++ b/fboss/platform/configs/minipack3n/fw_util.json
@@ -25,6 +25,30 @@
           }
         }
       ],
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal",
+          "flashromExtraArgs": [
+            "--ifd",
+            "-i",
+            "bios",
+            "--noverify-all"
+          ]
+        }
+      },
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal",
+          "flashromExtraArgs": [
+            "--ifd",
+            "-i",
+            "bios",
+            "--noverify-all"
+          ]
+        }
+      },
       "postUpgrade": [
         {
           "commandType": "writeToPort",
@@ -50,7 +74,8 @@
             "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
             "chip": [
               "N25Q128..3E",
-              "W25Q128.V..M"
+              "W25Q128.V..M",
+              "MX25L12805D"
             ]
           }
         }
@@ -62,7 +87,8 @@
           "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
           "chip": [
             "N25Q128..3E",
-            "W25Q128.V..M"
+            "W25Q128.V..M",
+            "MX25L12805D"
           ]
         }
       },
@@ -73,7 +99,8 @@
           "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
           "chip": [
             "N25Q128..3E",
-            "W25Q128.V..M"
+            "W25Q128.V..M",
+            "MX25L12805D"
           ]
         }
       },
@@ -339,7 +366,8 @@
             "programmer_type": "linux_spi:dev=",
             "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
             "chip": [
-              "W25X20"
+              "W25X20",
+              "MX25L2005(C)/MX25L2006E"
             ]
           }
         }
@@ -359,7 +387,8 @@
           "programmer_type": "linux_spi:dev=",
           "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
           "chip": [
-            "W25X20"
+            "W25X20",
+            "MX25L2005(C)/MX25L2006E"
           ]
         }
       },
@@ -369,7 +398,8 @@
           "programmer_type": "linux_spi:dev=",
           "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
           "chip": [
-            "W25X20"
+            "W25X20",
+            "MX25L2005(C)/MX25L2006E"
           ]
         }
       },

--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -120,6 +120,48 @@
     "SMBus I801 adapter at 5000",
     "SMBus iSMT adapter at 20fffa7b000"
   ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x11",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x22",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x45",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x66",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x76",
+              "kernelDeviceName": "xdpe15284",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
+            }
+          ]
+        },
+        "productSubVersion": 1
+      }
+    ]
+  },
   "pmUnitConfigs": {
     "MINIPACK3N_MCB": {
       "pluggedInSlotType": "MCB_SLOT",

--- a/fboss/platform/configs/minipack3n/sensor_service.json
+++ b/fboss/platform/configs/minipack3n/sensor_service.json
@@ -986,28 +986,6 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU13_PVCCIN_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 2.2,
-            "maxAlarmVal": 2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "COME_PU13_P1V8_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 2.2,
-            "maxAlarmVal": 2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU13_PVCCIN_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
           "type": 3,
@@ -1037,24 +1015,6 @@
           "compute": "@/1000000"
         },
         {
-          "name": "COME_PU13_PVCCIN_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 1024
-          },
-          "compute": "@/1000000"
-        },
-        {
-          "name": "COME_PU13_P1V8_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 125
-          },
-          "compute": "@/1000000"
-        },
-        {
           "name": "COME_PU13_PVCCIN_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
           "type": 2,
@@ -1063,26 +1023,209 @@
             "maxAlarmVal": 12
           },
           "compute": "@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 2,
+          "productSubVersion": 1
         },
         {
-          "name": "COME_PU13_PVCCIN_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 130,
-            "maxAlarmVal": 94
-          },
-          "compute": "@/1000"
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 1,
+          "productSubVersion": 2
         },
         {
-          "name": "COME_PU13_P1V8_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 6,
-            "maxAlarmVal": 3
-          },
-          "compute": "@/1000"
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 2,
+          "productSubVersion": 2
         }
       ]
     },


### PR DESCRIPTION
### Summary:
- Updated configuration for platform_manager, sensor_service, and fw_util to support 2nd source components on the minipack3n platform.

### Description:
- platform_manager:
  - Added `VersionedPmUnitConfig` entries for productSubVersion 1 and 2.
- sensor_service:
  - Introduced `versionedSensors` to distinguish between COMe versions: 4.1.2, 4.2.1, and 4.2.2.
- fw_util:
  - Added 2nd source chip support for `scm_cpld` and `iob_fpga`.

### Motivation:
- Introduce configuration support for alternative (2nd source) chips with interchangeable compatibility, ensuring proper functionality across different DVT hardware variants.

### Test Plan:
platform_manager and sensor_service validation:
- Verified platform_manager and sensor_service on both EVT/DVT and 2nd source DVT devices.

fw_util tests:
1. Check firmware version:
   - `fw_util --config_file=fw_util.json --fw_action=version --fw_target_name=scm_cpld`
   - `fw_util --config_file=fw_util.json --fw_action=version --fw_target_name=iob_fpga`
2. Backup firmware:
   - `fw_util --config_file=fw_util.json --fw_action=read --fw_target_name=scm_cpld --fw_binary_file=scm_cpld.bin`
   - `fw_util --config_file=fw_util.json --fw_action=read --fw_target_name=iob_fpga --fw_binary_file=iob_fpga.bin`
3. Verify firmware image:
   - `fw_util --config_file=fw_util.json --fw_action=verify --fw_target_name=scm_cpld --fw_binary_file=scm_cpld.bin`
   - `fw_util --config_file=fw_util.json --fw_action=verify --fw_target_name=iob_fpga --fw_binary_file=iob_fpga.bin`
4. Program firmware:
   - `fw_util --config_file=fw_util.json --fw_action=program --fw_target_name=scm_cpld --fw_binary_file=scm_cpld.bin`
   - `fw_util --config_file=fw_util.json --fw_action=program --fw_target_name=iob_fpga --fw_binary_file=iob_fpga.bin`
5. Re-verify firmware after programming:
   - `fw_util --config_file=fw_util.json --fw_action=verify --fw_target_name=scm_cpld --fw_binary_file=scm_cpld.bin`
   - `fw_util --config_file=fw_util.json --fw_action=verify --fw_target_name=iob_fpga --fw_binary_file=iob_fpga.bin`

main source board tested log:
[main_source_board_tested_log.zip](https://github.com/user-attachments/files/22132691/main_source_board_tested_log.zip)

2nd source board tested log:
[2nd_source_board_tested_log.zip](https://github.com/user-attachments/files/22132690/2nd_source_board_tested_log.zip)