### PR TITLE
icecube: fixup HwParityErrorTest.verifyParityError of sai_test

### DIFF
--- a/fboss/agent/hw/sai/hw_test/HwTestTamUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestTamUtils.cpp
@@ -15,7 +15,8 @@ void triggerBcmXgsParityError(HwSwitchEnsemble* ensemble) {
   auto asic = ensemble->getPlatform()->getAsic()->getAsicType();
   ensemble->runDiagCommand("\n", out);
   if (asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK4 ||
-      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK5) {
+      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK5 ||
+      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK6) {
     ensemble->runDiagCommand("ser inject pt=L2_ENTRY_SINGLEm\n", out);
     ensemble->runDiagCommand("ser LOG\n", out);
   } else {

--- a/fboss/agent/hw/sai/hw_test/HwTestTamUtilsThriftHandler.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestTamUtilsThriftHandler.cpp
@@ -27,7 +27,8 @@ void triggerBcmXgsParityError(const HwSwitch* hw) {
       std::make_unique<ClientInformation>(clientInfo));
 
   if (asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK4 ||
-      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK5) {
+      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK5 ||
+      asic == cfg::AsicType::ASIC_TYPE_TOMAHAWK6) {
     diagCmdServer->diagCmd(
         std::make_unique<fbstring>("ser inject pt=L2_ENTRY_SINGLEm\n"),
         std::make_unique<ClientInformation>(clientInfo));


### PR DESCRIPTION
### **Description**
This PR is to fixup the testcase HwParityErrorTest.verifyParityError of sai_test for the icecube platform

### **Motivation**
Resolve the issue where HwParityErrorTest.verifyParityError failed with "/var/FBOSS/th6_0905/fboss/agent/hw/test/HwParityErrorTest.cpp:38: Failure
Expected: (getCorrectedParityErrorCount()) > (0), actual: 0 vs 0"
<img width="616" height="204" alt="image" src="https://github.com/user-attachments/assets/96d194d6-6de5-41dc-b512-0e8249ea96a3" />

### **Test Plan**
rerun the testcase and get passed
LD_LIBRARY_PATH=/opt/fboss/lib/ ./sai_test-sai_impl --gtest_filter=HwParityErrorTest.verifyParityError --logging DBG4
<img width="496" height="85" alt="image" src="https://github.com/user-attachments/assets/aae8099d-91c2-4f0c-9e18-bbf9dcf32b63" />
testlog:
[HwParityErrorTest.verifyParityError.log](https://github.com/user-attachments/files/22248288/HwParityErrorTest.verifyParityError.log)