### PR TITLE
Ladakh800bcls: Platform: Add Ladakh800bcls platform config after bring up

### DIFF
--- a/fboss/platform/configs/ladakh800bcls/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bcls/platform_manager.json
@@ -1,6 +1,6 @@
 {
-  "platformName": "ANACAPA",
-  "rootPmUnitName": "ANACAPA_MCB",
+  "platformName": "LADAKH800BCLS",
+  "rootPmUnitName": "LADAKH800BCLS_MCB",
   "rootSlotType": "MCB_SLOT",
   "slotTypeConfigs": {
     "MCB_SLOT": {
@@ -66,7 +66,7 @@
   ],
   "versionedPmUnitConfigs": {},
   "pmUnitConfigs": {
-    "ANACAPA_MCB": {
+    "LADAKH800BCLS_MCB": {
       "pluggedInSlotType": "MCB_SLOT",
       "embeddedSensorConfigs": [
         {

--- a/fboss/platform/platform_manager/platform_manager_validators.thrift
+++ b/fboss/platform/platform_manager/platform_manager_validators.thrift
@@ -56,7 +56,7 @@ const list<string> ALLOWED_PMUNIT_NAMES = [
   "ICECUBE_MCB",
   "ICETEA_MCB",
   "TAHANSB_MCB",
-  "ANACAPA_MCB",
+  "LADAKH800BCLS_MCB",
   // The whole board is a PmUnit for these
   "TAHAN",
   "JANGA",


### PR DESCRIPTION
# Description

This PR is about Ladakh800bcls platform configurations for EVT1 phase.

# Motivation

## platform_manager

Based on Ladakh800bcls HW Design Specification EVT1, the following boards should be added.

<img width="473" height="301" alt="image" src="https://github.com/user-attachments/assets/f727f134-1a3d-4f65-a2df-745ca4f26dd6" />

1. SMB (Switch Main board) contains SMB CPLD, switch ASIC, clock and other peripheral circuit.
2. RTM (Retimer board) contains RTM CPLD, DOM FPGA,16x Retimers, Clock and other peripheral circuit.
3. MCB (Main Carrier board) contains MCB CPLD, COMe Module, RunBMC card and related logic components.

### bring up bugfix

1. RTM change kernel device
2. Add one i2c bus according to the FPGA spec
3. Fix error of i2c bus start offset on dom according to FPGA spec
4. Fix error of reading PMBUS sensor
5. Fix error of i2c address of FAN
6. Fix error of HSCB sensor address according to HW spec
7. Fix xcvr i2c bus number
8. Add tmp432 sensor `initRegSettings`

# Test Plan

1. Used `jq` command to pretty the format.
2. Compilation and config validation have passed.
```
I1028 23:21:17.308879 2308103 ConfigGenerator.cpp:113] Processing platform ladakh800bcls in /work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls
I1028 23:21:17.309004 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/bsp_tests.json"
I1028 23:21:17.312866 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/fan_service.json"
I1028 23:21:17.316480 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/fw_util.json"
I1028 23:21:17.319443 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/led_manager.json"
I1028 23:21:17.321964 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/sensor_service.json"
I1028 23:21:17.327983 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/showtech.json"
I1028 23:21:17.330609 2308103 ConfigGenerator.cpp:121] Processing config "/work/users/cheezhang/fboss/fboss/platform/configs/ladakh800bcls/platform_manager.json"
I1028 23:21:17.331477 2308103 ConfigValidator.cpp:557] Validating platform_manager config
I1028 23:21:17.331497 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot COMESE_SLOT...
I1028 23:21:17.331509 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot MCB_SLOT...
I1028 23:21:17.331516 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot RTM_L_SLOT...
I1028 23:21:17.331523 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot RTM_R_SLOT...
I1028 23:21:17.331530 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot RUNBMC_SLOT...
I1028 23:21:17.331538 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot SMB_L_SLOT...
I1028 23:21:17.331546 2308103 ConfigValidator.cpp:583] Validating SlotTypeConfig for Slot SMB_R_SLOT...
I1028 23:21:17.331553 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit BMC in Slot RUNBMC_SLOT...
I1028 23:21:17.331563 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit LADAKH800BCLS_MCB in Slot MCB_SLOT...
I1028 23:21:17.331655 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit NETLAKE in Slot COMESE_SLOT...
I1028 23:21:17.331671 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit RTM_L in Slot RTM_L_SLOT...
I1028 23:21:17.331683 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit RTM_R in Slot RTM_R_SLOT...
I1028 23:21:17.331695 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit SMB_L in Slot SMB_L_SLOT...
I1028 23:21:17.331708 2308103 ConfigValidator.cpp:600] Validating PmUnitConfig for PmUnit SMB_R in Slot SMB_R_SLOT...
I1028 23:21:17.331721 2308103 ConfigValidator.cpp:654] Validating Symbolic links...
I1028 23:21:17.335198 2308103 ConfigValidator.cpp:661] Validating Transceiver symbolic links...
I1028 23:21:17.335443 2308103 ConfigValidator.cpp:16] Validating sensor_service config
I1028 23:21:17.336406 2308103 CrossConfigValidator.cpp:25] Cross validating sensor_service config
I1028 23:21:17.337705 2308103 ConfigValidator.cpp:47] Validating fan_service config
I1028 23:21:17.337830 2308103 CrossConfigValidator.cpp:54] Cross validating fan_service config
I1028 23:21:17.337946 2308103 ConfigValidator.cpp:10] Validating data_corral_service config
I1028 23:21:17.337960 2308103 ConfigValidator.cpp:12] Validating the system LED config
I1028 23:21:17.337967 2308103 ConfigValidator.cpp:77] Validating the LED config for fruType: FAN
I1028 23:21:17.337973 2308103 ConfigValidator.cpp:77] Validating the LED config for fruType: PWR
I1028 23:21:17.337980 2308103 ConfigValidator.cpp:77] Validating the LED config for fruType: SMB
I1028 23:21:17.337990 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN1
I1028 23:21:17.337997 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN2
I1028 23:21:17.338003 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN3
I1028 23:21:17.338011 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN4
I1028 23:21:17.338018 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN5
I1028 23:21:17.338026 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: FAN6
I1028 23:21:17.338032 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: PWR
I1028 23:21:17.338043 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: SMB_L
I1028 23:21:17.338050 2308103 ConfigValidator.cpp:89] Validating the FRU config for fru: SMB_R
```

[build.log](https://github.com/user-attachments/files/23201896/build.log)

3. The platform_manager service is running successfully.

*To be verified with new name*

