### PR TITLE
Mount fboss in Docker container instead of copying

### DIFF
--- a/docs/static/code_snips/start_forwarding_stack_container.sh
+++ b/docs/static/code_snips/start_forwarding_stack_container.sh
@@ -1,3 +1,7 @@
+# Use stable commits
+rm -rf build/deps/github_hashes/
+tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
+
 # If you know your host has enough space for the build, just make the SDK
 # artifacts available by mounting them with the -v flag.
 #
@@ -12,11 +16,17 @@
 # this will mount lib/ and include/ to the container like so:
 # /path_to_sdk/lib/     -> /opt/sdk/lib/
 # /path_to_sdk/include/ -> /opt/sdk/include/
-sudo docker run -d -v /path_to_sdk:/opt/sdk:z -it \
---name=FBOSS_DOCKER_CONTAINER fboss_docker:latest bash
+sudo docker run -d \
+    -it --name=FBOSS_DOCKER_CONTAINER \
+    -v $PWD:/var/FBOSS/fboss:z \
+    -v /path_to_sdk:/opt/sdk:z \
+    fboss_docker:latest bash
 
 # A full FBOSS build may take significant space (>50GB of storage). You
 # can mount a volume with more storage for building by using the -v flag
-sudo docker run -d -v /path_to_sdk:/opt/sdk:z \
--v /opt/app/localbuild:/var/FBOSS/tmp_bld_dir:z -it \
---name=FBOSS_DOCKER_CONTAINER fboss_docker:latest bash
+sudo docker run -d \
+    -it --name=FBOSS_DOCKER_CONTAINER \
+    -v $PWD:/var/FBOSS/fboss:z \
+    -v /path_to_sdk:/opt/sdk:z \
+    -v /opt/app/localbuild:/var/FBOSS/tmp_bld_dir:z \
+    fboss_docker:latest bash

--- a/docs/static/code_snips/start_platform_stack_container.sh
+++ b/docs/static/code_snips/start_platform_stack_container.sh
@@ -1,7 +1,17 @@
+# Use stable commits
+rm -rf build/deps/github_hashes/
+tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
+
 # If you know your host has enough space for the build
-sudo docker run -d -it --name=FBOSS_DOCKER_CONTAINER fboss_docker:latest bash
+sudo docker run -d \
+    -it --name=FBOSS_DOCKER_CONTAINER \
+    -v $PWD:/var/FBOSS/fboss:z \
+    fboss_docker:latest bash
 
 # A full FBOSS build may take significant space (>50GB of storage). You
 # can mount a volume with more storage for building by using the -v flag
-sudo docker run -d -v /opt/app/localbuild:/var/FBOSS/tmp_bld_dir:z -it \
---name=FBOSS_DOCKER_CONTAINER fboss_docker:latest bash
+sudo docker run -d \
+    -it --name=FBOSS_DOCKER_CONTAINER \
+    -v $PWD:/var/FBOSS/fboss:z \
+    -v /opt/app/localbuild:/var/FBOSS/tmp_bld_dir:z \
+    fboss_docker:latest bash

--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -33,6 +33,8 @@ RUN dnf install gperf libcap-devel libmount-devel -y
 RUN dnf install gcc-toolset-12 -y
 RUN echo "source /opt/rh/gcc-toolset-12/enable" >> ~/.bashrc
 
+RUN rm -rf /var/FBOSS/fboss/*
+
 # The following libraries are needed for building Broadcom SDK
 RUN dnf install -y doxygen aspell libyaml-devel vim-common libnsl libnsl2-devel
 # Perl modules needed for Broadcom SDK build


### PR DESCRIPTION
Summary:
When building the fboss image, we used to copy the contents of the fboss repo on the host machine into the container. The user would have to re-build the image each time they make changes on their host machine in order to test them. We should instead mount the repository for ease of use and so that changes can persist on the host machine.

We still need to copy the fboss repo during image creation so we can use scripts for fetching dependencies, but this will be deleted afterwards so that the user will be using the mounted repository when entering the container.

Reviewed By: joseph5wu

Differential Revision: D81816484


