### PR TITLE
Add support for reading the ONIE EEPROM format

### DIFF
--- a/fboss/platform/weutil/FbossEepromInterface.cpp
+++ b/fboss/platform/weutil/FbossEepromInterface.cpp
@@ -1,5 +1,7 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
+#include <cstring>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -18,6 +20,13 @@ namespace {
 constexpr int kHeaderSize = 4;
 // Field Type and Length are 1 byte each.
 constexpr int kEepromTypeLengthSize = 2;
+
+// ONIE TlvInfo format constants
+constexpr char kOnieTlvInfoIdString[] = "TlvInfo";
+constexpr int kOnieTlvInfoVersion = 0x01;
+constexpr int kOnieTlvInfoHdrLen = 11;
+constexpr int kOnieTlvInfoMaxLen = 2048;
+constexpr int kOnieCrcSize = 4;
 
 using entryType = FbossEepromInterface::entryType;
 using entryType::FIELD_BE_HEX;
@@ -77,6 +86,27 @@ const std::map<int, FbossEepromInterface::EepromFieldEntry> kV6Map = {
     {103, {"Vendor Defined Field 3", FIELD_BE_HEX}},
     {250, {"CRC16", FIELD_BE_HEX, 2}}};
 
+// ONIE TlvInfo format field dictionary (version 1000)
+const std::map<int, FbossEepromInterface::EepromFieldEntry> kOnieMap = {
+    {0x21, {"Product Name", FIELD_STRING}},
+    {0x22, {"Part Number", FIELD_STRING}},
+    {0x23, {"Serial Number", FIELD_STRING}},
+    {0x24, {"Base MAC Address", FIELD_MAC, 6}},
+    {0x25, {"Manufacture Date", FIELD_STRING}},
+    {0x26, {"Device Version", FIELD_BE_UINT, 1}},
+    {0x27, {"Label Revision", FIELD_STRING}},
+    {0x28, {"Platform Name", FIELD_STRING}},
+    {0x29, {"ONIE Version", FIELD_STRING}},
+    {0x2A, {"MAC Addresses", FIELD_BE_UINT, 2}},
+    {0x2B, {"Manufacturer", FIELD_STRING}},
+    {0x2C, {"Manufacture Country", FIELD_STRING}},
+    {0x2D, {"Vendor Name", FIELD_STRING}},
+    {0x2E, {"Diag Version", FIELD_STRING}},
+    {0x2F, {"Service Tag", FIELD_STRING}},
+    {0xFD, {"Vendor Extension", FIELD_BE_HEX}},
+    {0xFE, {"CRC-32", FIELD_BE_HEX, 4}},
+};
+
 } // namespace
 
 FbossEepromInterface::FbossEepromInterface(
@@ -87,6 +117,25 @@ FbossEepromInterface::FbossEepromInterface(
     throw std::runtime_error("Invalid EEPROM size");
   }
 
+  // Check if this is ONIE TlvInfo format
+  if (isOnieTlvInfoFormat(buffer)) {
+    version_ = kOnieEepromVersion;
+    fieldMap_ = kOnieMap;
+    parseEepromBlobTLVOnie(buffer);
+    return;
+  }
+
+  // Check for FBOSS EEPROM format signature (0xFBFB)
+  if (buffer[0] != 0xFB || buffer[1] != 0xFB) {
+    std::stringstream ss;
+    ss << "Invalid FBOSS EEPROM format: Expected signature 0xFBFB, got 0x"
+       << std::hex << std::uppercase << std::setfill('0') << std::setw(2)
+       << static_cast<int>(buffer[0]) << std::setw(2)
+       << static_cast<int>(buffer[1]);
+    throw std::runtime_error(ss.str());
+  }
+
+  // Parse Meta EEPROM format
   version_ = buffer.at(2);
   switch (version_) {
     case 5:
@@ -195,6 +244,9 @@ FbossEepromInterface FbossEepromInterface::createEepromInterface(int version) {
     case 6:
       result.fieldMap_ = kV6Map;
       break;
+    case kOnieEepromVersion:
+      result.fieldMap_ = kOnieMap;
+      break;
     default:
       throw std::runtime_error(
           "Invalid EEPROM version : " + std::to_string(version));
@@ -205,19 +257,30 @@ FbossEepromInterface FbossEepromInterface::createEepromInterface(int version) {
 std::vector<std::pair<std::string, std::string>>
 FbossEepromInterface::getContents() const {
   std::vector<std::pair<std::string, std::string>> contents;
-  contents.emplace_back("Version", std::to_string(getVersion()));
+
+  // Handle version display differently for ONIE format
+  if (version_ == kOnieEepromVersion) {
+    contents.emplace_back("Format", "ONIE TlvInfo");
+  } else {
+    contents.emplace_back("Version", std::to_string(getVersion()));
+  }
+
   for (const auto& [_, entry] : fieldMap_) {
     if (entry.fieldName == "NA") {
       continue;
     }
     if (entry.fieldType == FIELD_MAC) {
-      // Format
-      // (value): (00:00:00:00:00:00,222)
-      // (value1);(value2): (00:00:00:00:00:00);(222)
-      std::string value1 = entry.value.substr(0, entry.value.find(','));
-      std::string value2 = entry.value.substr(entry.value.find(',') + 1);
-      contents.emplace_back(entry.fieldName + " Base", value1);
-      contents.emplace_back(entry.fieldName + " Address Size", value2);
+      if (version_ == kOnieEepromVersion) {
+        // ONIE format: MAC is just the address, no size field
+        contents.emplace_back(entry.fieldName, entry.value);
+      } else {
+        // Meta format: MAC field is composite with base and size
+        // Format: (00:00:00:00:00:00,222)
+        std::string value1 = entry.value.substr(0, entry.value.find(','));
+        std::string value2 = entry.value.substr(entry.value.find(',') + 1);
+        contents.emplace_back(entry.fieldName + " Base", value1);
+        contents.emplace_back(entry.fieldName + " Address Size", value2);
+      }
     } else {
       contents.emplace_back(entry.fieldName, entry.value);
     }
@@ -230,71 +293,241 @@ int FbossEepromInterface::getVersion() const {
 }
 
 std::string FbossEepromInterface::getProductName() const {
-  return fieldMap_.at(1).value;
+  return fieldMap_.at(version_ < kOnieEepromVersion ? 1 : 0x21).value;
 }
 
 std::string FbossEepromInterface::getProductPartNumber() const {
-  return fieldMap_.at(2).value;
+  return fieldMap_.at(version_ < kOnieEepromVersion ? 2 : 0x22).value;
 }
 
 std::string FbossEepromInterface::getProductionState() const {
+  if (version_ >= kOnieEepromVersion) {
+    return "1"; // Production State not available in ONIE format
+  }
   return fieldMap_.at(8).value;
 }
 
 std::string FbossEepromInterface::getProductionSubState() const {
+  if (version_ >= kOnieEepromVersion) {
+    return "1"; // Production Sub-State not available in ONIE format
+  }
   return fieldMap_.at(9).value;
 }
 
 std::string FbossEepromInterface::getVariantVersion() const {
-  return fieldMap_.at(10).value;
+  return fieldMap_.at(version_ < kOnieEepromVersion ? 10 : 0x26).value;
 }
 
 std::string FbossEepromInterface::getProductSerialNumber() const {
-  return fieldMap_.at(11).value;
+  return fieldMap_.at(version_ < kOnieEepromVersion ? 11 : 0x23).value;
 }
 
 EepromContents FbossEepromInterface::getEepromContents() const {
   EepromContents result;
   result.version() = version_;
   try {
-    result.productName() = fieldMap_.at(1).value;
-    result.productPartNumber() = fieldMap_.at(2).value;
-    result.systemAssemblyPartNumber() = fieldMap_.at(3).value;
-    result.metaPCBAPartNumber() = fieldMap_.at(4).value;
-    result.metaPCBPartNumber() = fieldMap_.at(5).value;
-    result.odmJdmPCBAPartNumber() = fieldMap_.at(6).value;
-    result.odmJdmPCBASerialNumber() = fieldMap_.at(7).value;
-    result.productionState() = fieldMap_.at(8).value;
-    result.productionSubState() = fieldMap_.at(9).value;
-    result.variantIndicator() = fieldMap_.at(10).value;
-    result.productSerialNumber() = fieldMap_.at(11).value;
-    result.systemManufacturer() = fieldMap_.at(12).value;
-    result.systemManufacturingDate() = fieldMap_.at(13).value;
-    result.pcbManufacturer() = fieldMap_.at(14).value;
-    result.assembledAt() = fieldMap_.at(15).value;
-    result.eepromLocationOnFabric() = fieldMap_.at(16).value;
-    result.x86CpuMac() = fieldMap_.at(17).value;
-    result.bmcMac() = fieldMap_.at(18).value;
-    result.switchAsicMac() = fieldMap_.at(19).value;
-    result.metaReservedMac() = fieldMap_.at(20).value;
-    result.crc16() = fieldMap_.at(250).value;
+    result.productName() = getProductName();
+    result.productPartNumber() = getProductPartNumber();
+    result.productionState() = getProductionState();
+    result.productionSubState() = getProductionSubState();
+    result.variantIndicator() = getVariantVersion();
+    result.productSerialNumber() = getProductSerialNumber();
+    if (version_ < kOnieEepromVersion) {
+      result.systemAssemblyPartNumber() = fieldMap_.at(3).value;
+      result.metaPCBAPartNumber() = fieldMap_.at(4).value;
+      result.metaPCBPartNumber() = fieldMap_.at(5).value;
+      result.odmJdmPCBAPartNumber() = fieldMap_.at(6).value;
+      result.odmJdmPCBASerialNumber() = fieldMap_.at(7).value;
+      result.systemManufacturer() = fieldMap_.at(12).value;
+      result.systemManufacturingDate() = fieldMap_.at(13).value;
+      result.pcbManufacturer() = fieldMap_.at(14).value;
+      result.assembledAt() = fieldMap_.at(15).value;
+      result.eepromLocationOnFabric() = fieldMap_.at(16).value;
+      result.x86CpuMac() = fieldMap_.at(17).value;
+      result.bmcMac() = fieldMap_.at(18).value;
+      result.switchAsicMac() = fieldMap_.at(19).value;
+      result.metaReservedMac() = fieldMap_.at(20).value;
+      result.crc16() = fieldMap_.at(250).value;
 
-    // V6 unique fields
-    if (version_ == 6) {
-      result.rma() = fieldMap_.at(21).value;
-      result.vendorDefinedField1() = fieldMap_.at(101).value;
-      result.vendorDefinedField2() = fieldMap_.at(102).value;
-      result.vendorDefinedField3() = fieldMap_.at(103).value;
+      // V6 unique fields
+      if (version_ == 6) {
+        result.rma() = fieldMap_.at(21).value;
+        result.vendorDefinedField1() = fieldMap_.at(101).value;
+        result.vendorDefinedField2() = fieldMap_.at(102).value;
+        result.vendorDefinedField3() = fieldMap_.at(103).value;
+      }
+    } else { // ONIE EEPROM format
+      result.systemAssemblyPartNumber() = "NA";
+      result.metaPCBAPartNumber() = "NA";
+      result.metaPCBPartNumber() = "NA";
+      result.odmJdmPCBAPartNumber() = "NA";
+      result.odmJdmPCBASerialNumber() = "NA";
+      result.systemManufacturer() = fieldMap_.at(0x2D).value;
+      result.systemManufacturingDate() = "NA";
+      result.pcbManufacturer() = fieldMap_.at(0x2B).value;
+      result.assembledAt() = fieldMap_.at(0x2C).value;
+      result.eepromLocationOnFabric() = "NA";
+      // TODO: figure out how to allocate the MAC addresses across those
+      // fields. The number of MAC addresses we have is defined by field 0x2A.
+      result.x86CpuMac() = fieldMap_.at(0x24).value;
+      result.bmcMac() = fieldMap_.at(0x24).value;
+      result.switchAsicMac() = fieldMap_.at(0x24).value;
+      result.metaReservedMac() = "NA";
+
+      result.rma() = fieldMap_.at(0x2F).value; // unsure
+      result.vendorDefinedField1() = fieldMap_.at(0xFD).value;
+      result.vendorDefinedField2() = fieldMap_.at(0x2E).value; // unsure
+      result.crc16() = fieldMap_.at(0xFE).value; // even though it's a CRC32...
     }
   } catch (const std::out_of_range&) {
     auto availableKeys = fieldMap_ | std::views::keys;
     std::string joinedKeys = folly::join(", ", availableKeys);
-    throw std::runtime_error(fmt::format(
-        "Invalid FbossEepromInterface structure. Version: {}, Available keys: [{}]",
-        version_,
-        joinedKeys));
+    throw std::runtime_error(
+        fmt::format(
+            "Invalid FbossEepromInterface structure. Version: {}, Available keys: [{}]",
+            version_,
+            joinedKeys));
   }
   return result;
+}
+
+void FbossEepromInterface::parseEepromBlobTLVOnie(
+    const std::vector<uint8_t>& buffer) {
+  // Validate ONIE header
+  if (!isOnieTlvInfoFormat(buffer)) {
+    throw std::runtime_error("Invalid ONIE TlvInfo format");
+  }
+
+  // Get total length from header
+  uint16_t totalLen = (buffer[9] << 8) | buffer[10];
+  int tlvEnd = kOnieTlvInfoHdrLen + totalLen;
+
+  // Start parsing TLVs after the header
+  int cursor = kOnieTlvInfoHdrLen;
+
+  while (cursor < buffer.size() && cursor < tlvEnd) {
+    // Check if we have at least 2 bytes for TLV header
+    if (cursor + 2 > buffer.size()) {
+      break;
+    }
+
+    int itemCode = static_cast<int>(buffer[cursor]);
+    int itemLength = static_cast<int>(buffer[cursor + 1]);
+
+    // Check if we have enough bytes for the value
+    if (cursor + 2 + itemLength > buffer.size()) {
+      break;
+    }
+
+    unsigned char* itemDataPtr =
+        const_cast<unsigned char*>(&buffer[cursor + 2]);
+    std::string value;
+
+    // Parse based on known ONIE TLV codes
+    switch (itemCode) {
+      case 0x21: // Product Name
+      case 0x22: // Part Number
+      case 0x23: // Serial Number
+      case 0x25: // Manufacture Date
+      case 0x27: // Label Revision
+      case 0x28: // Platform Name
+      case 0x29: // ONIE Version
+      case 0x2B: // Manufacturer
+      case 0x2C: // Manufacture Country
+      case 0x2D: // Vendor Name
+      case 0x2E: // Diag Version
+      case 0x2F: // Service Tag
+        value = ParserUtils::parseString(itemLength, itemDataPtr);
+        break;
+      case 0x24: // Base MAC Address
+        value = ParserUtils::parseOnieMac(itemLength, itemDataPtr);
+        break;
+      case 0x26: // Device Version
+      case 0x2A: // MAC Addresses
+        value = ParserUtils::parseBeUint(itemLength, itemDataPtr);
+        break;
+      case 0xFD: // Vendor Extension
+      case 0xFE: // CRC-32
+        value = ParserUtils::parseBeHex(itemLength, itemDataPtr);
+        break;
+      default:
+        std::cout << " Unknown field code " << itemCode << " at position "
+                  << cursor << std::endl;
+        throw std::runtime_error(
+            "Invalid field code in ONIE EEPROM at :" + std::to_string(cursor));
+        break;
+    }
+
+    fieldMap_.at(itemCode).value = value;
+
+    // Handle CRC-32 validation
+    if (itemCode == 0xFE) { // CRC-32 code
+      uint32_t crcProgrammed = std::stoul(value, nullptr, 16);
+      // Calculate CRC over data including CRC TLV header but excluding CRC
+      // value cursor points to start of CRC TLV, so include TLV header (2
+      // bytes) but exclude CRC value (4 bytes)
+      uint32_t crcCalculated = calculateCrc32(buffer.data(), cursor + 2);
+      if (crcProgrammed == crcCalculated) {
+        value.append(" (CRC Matched)");
+      } else {
+        std::stringstream ss;
+        ss << "0x" << std::hex << crcCalculated;
+        value.append(" (CRC Mismatch. Expected " + ss.str() + ")");
+      }
+      fieldMap_.at(itemCode).value = value;
+      break; // CRC is the last field
+    }
+
+    cursor += 2 + itemLength;
+  }
+}
+
+bool FbossEepromInterface::isOnieTlvInfoFormat(
+    const std::vector<uint8_t>& buffer) {
+  // Check if we have enough bytes for the ONIE header
+  if (buffer.size() < kOnieTlvInfoHdrLen) {
+    return false;
+  }
+
+  // Check for "TlvInfo\x00" signature (8 bytes)
+  if (std::memcmp(buffer.data(), kOnieTlvInfoIdString, 7) != 0 ||
+      buffer[7] != 0x00) {
+    return false;
+  }
+
+  // Check version byte (should be 0x01)
+  if (buffer[8] != kOnieTlvInfoVersion) {
+    return false;
+  }
+
+  // Check total length field (bytes 9-10)
+  uint16_t totalLen = (buffer[9] << 8) | buffer[10];
+  if (totalLen > (kOnieTlvInfoMaxLen - kOnieTlvInfoHdrLen)) {
+    return false;
+  }
+
+  return true;
+}
+
+uint32_t FbossEepromInterface::calculateCrc32(
+    const uint8_t* buffer,
+    size_t len) {
+  // Standard CRC-32 polynomial (IEEE 802.3)
+  const uint32_t polynomial = 0xEDB88320;
+  uint32_t crc = 0xFFFFFFFF;
+
+  for (size_t i = 0; i < len; i++) {
+    crc ^= buffer[i];
+    for (int j = 0; j < 8; j++) {
+      if (crc & 1) {
+        crc = (crc >> 1) ^ polynomial;
+      } else {
+        crc >>= 1;
+      }
+    }
+  }
+
+  return ~crc;
 }
 
 } // namespace facebook::fboss::platform

--- a/fboss/platform/weutil/FbossEepromInterface.h
+++ b/fboss/platform/weutil/FbossEepromInterface.h
@@ -49,8 +49,16 @@ class FbossEepromInterface {
   FbossEepromInterface() = default;
   void parseEepromBlobTLV(const std::vector<uint8_t>& buffer);
 
+  // ONIE TlvInfo format parsing methods
+  void parseEepromBlobTLVOnie(const std::vector<uint8_t>& buffer);
+  bool isOnieTlvInfoFormat(const std::vector<uint8_t>& buffer);
+  uint32_t calculateCrc32(const uint8_t* buffer, size_t len);
+
   std::map<int, EepromFieldEntry> fieldMap_{};
   int version_{0};
 };
+
+// Use version 1000 for ONIE format (first 1000 versions reserved for FBOSS)
+constexpr int kOnieEepromVersion = 1000;
 
 } // namespace facebook::fboss::platform

--- a/fboss/platform/weutil/ParserUtils.cpp
+++ b/fboss/platform/weutil/ParserUtils.cpp
@@ -163,6 +163,11 @@ std::string ParserUtils::parseMac(int len, unsigned char* ptr) {
   return retVal;
 }
 
+// For ONIE format, Parse MAC with the format XX:XX:XX:XX:XX:XX (no size field)
+std::string ParserUtils::parseOnieMac(int len, unsigned char* ptr) {
+  return parseMacHelper(len, ptr, true);
+}
+
 std::string ParserUtils::parseDate(int len, unsigned char* ptr) {
   std::string retVal;
   if (len != 4) {

--- a/fboss/platform/weutil/ParserUtils.h
+++ b/fboss/platform/weutil/ParserUtils.h
@@ -16,6 +16,7 @@ class ParserUtils {
   static std::string parseBeHex(int len, unsigned char* ptr);
   static std::string parseString(int len, unsigned char* ptr);
   static std::string parseMac(int len, unsigned char* ptr);
+  static std::string parseOnieMac(int len, unsigned char* ptr);
   static std::string parseDate(int len, unsigned char* ptr);
   static uint16_t calculateCrc16(const uint8_t* buffer, size_t len);
 };

--- a/fboss/platform/weutil/test/FbossEepromInterfaceTest.cpp
+++ b/fboss/platform/weutil/test/FbossEepromInterfaceTest.cpp
@@ -84,6 +84,62 @@ EepromData kEepromV6 = {
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     0xff};
 
+// ONIE TlvInfo format test data
+// clang-format off
+EepromData eepromOnie = {
+    // Header: "TlvInfo\x00" + version(0x01) + total_length(0x0050 = 80 bytes)
+    0x54, 0x6c, 0x76, 0x49, 0x6e, 0x66, 0x6f, 0x00, 0x01, 0x00, 0x50,
+    // Product Name TLV (0x21, length=11, "TestProduct")
+    0x21, 0x0b,
+    0x54, 0x65, 0x73, 0x74, 0x50, 0x72, 0x6f, 0x64, 0x75, 0x63, 0x74,
+    // Part Number TLV (0x22, length=7, "PN12345")
+    0x22, 0x07, 0x50, 0x4e, 0x31, 0x32, 0x33, 0x34, 0x35,
+    // Serial Number TLV (0x23, length=9, "SN1234567")
+    0x23, 0x09, 0x53, 0x4e, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37,
+    // Base MAC Address TLV (0x24, length=6, 00:11:22:33:44:55)
+    0x24, 0x06, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+    // MAC Addresses TLV (0x2A, length=2, 256 addresses)
+    0x2a, 0x02, 0x01, 0x00,
+    // Manufacturer TLV (0x2B, length=7, "TestMfg")
+    0x2b, 0x07, 0x54, 0x65, 0x73, 0x74, 0x4d, 0x66, 0x67,
+    // CRC-32 TLV (0xFE, length=4, placeholder CRC)
+    0xfe, 0x04, 0x12, 0x34, 0x56, 0x78
+};
+
+// Real device ONIE EEPROM data from Nexthop NH-4010
+EepromData eepromOnieReal = {
+    // Header: "TlvInfo\x00" + version(0x01) + total_length(0x0076 = 118 bytes)
+    0x54, 0x6c, 0x76, 0x49, 0x6e, 0x66, 0x6f, 0x00, 0x01, 0x00, 0x76,
+    // Product Name TLV (0x21, length=7, "NH-4010")
+    0x21, 0x07, 0x4e, 0x48, 0x2d, 0x34, 0x30, 0x31, 0x30,
+    // Part Number TLV (0x22, length=12, "950-00001-01")
+    0x22, 0x0c,
+    0x39, 0x35, 0x30, 0x2d, 0x30, 0x30, 0x30, 0x30, 0x31, 0x2d, 0x30, 0x31,
+    // Serial Number TLV (0x23, length=14, "NH-FSJ25160005")
+    0x23, 0x0e,
+    0x4e, 0x48, 0x2d, 0x46, 0x53, 0x4a, 0x32,
+    0x35, 0x31, 0x36, 0x30, 0x30, 0x30, 0x35,
+    // Base MAC Address TLV (0x24, length=6, E8:E4:9D:00:18:28)
+    0x24, 0x06, 0xe8, 0xe4, 0x9d, 0x00, 0x18, 0x28,
+    // Device Version TLV (0x26, length=1, 1)
+    0x26, 0x01, 0x01,
+    // Label Revision TLV (0x27, length=2, "P1")
+    0x27, 0x02, 0x50, 0x31,
+    // Platform Name TLV (0x28, length=22, "x86_64-nexthop_4010-r0")
+    0x28, 0x16, 0x78, 0x38, 0x36, 0x5f, 0x36, 0x34, 0x2d, 0x6e, 0x65, 0x78,
+    0x74, 0x68, 0x6f, 0x70, 0x5f, 0x34, 0x30, 0x31, 0x30, 0x2d, 0x72, 0x30,
+    // Manufacturer TLV (0x2B, length=7, "Nexthop")
+    0x2b, 0x07, 0x4e, 0x65, 0x78, 0x74, 0x68, 0x6f, 0x70,
+    // Vendor TLV (0x2D, length=7, "Nexthop")
+    0x2d, 0x07, 0x4e, 0x65, 0x78, 0x74, 0x68, 0x6f, 0x70,
+    // Service Tag TLV (0x2F, length=14, "www.nexthop.ai")
+    0x2f, 0x0e, 0x77, 0x77, 0x77, 0x2e, 0x6e, 0x65,
+    0x78, 0x74, 0x68, 0x6f, 0x70, 0x2e, 0x61, 0x69,
+    // CRC-32 TLV (0xFE, length=4, 0xB06FDC7B)
+    0xfe, 0x04, 0xb0, 0x6f, 0xdc, 0x7b,
+};
+// clang-format on
+
 FbossEepromInterface createFbossEepromInterface(const EepromData& data) {
   folly::test::TemporaryDirectory tmpDir = folly::test::TemporaryDirectory();
   std::string fileName = tmpDir.path().string() + "/eepromContent";
@@ -219,6 +275,68 @@ TEST(FbossEepromInterfaceTest, V5ObjWrongCrc) {
   EepromContents expectedObj = createEepromContents(5, false);
 
   EXPECT_EQ(actualObj, expectedObj);
+}
+
+TEST(FbossEepromOnieTest, OnieFormat) {
+  std::vector<std::pair<std::string, std::string>> expectedContentsDummy = {
+      {"Format", "ONIE TlvInfo"},
+      {"Product Name", "TestProduct"},
+      {"Part Number", "PN12345"},
+      {"Serial Number", "SN1234567"},
+      {"Base MAC Address", "00:11:22:33:44:55"},
+      {"Manufacture Date", ""},
+      {"Device Version", ""},
+      {"Label Revision", ""},
+      {"Platform Name", ""},
+      {"ONIE Version", ""},
+      {"MAC Addresses", "256"},
+      {"Manufacturer", "TestMfg"},
+      {"Manufacture Country", ""},
+      {"Vendor Name", ""},
+      {"Diag Version", ""},
+      {"Service Tag", ""},
+      {"Vendor Extension", ""},
+      {"CRC-32", "0x12345678 (CRC Mismatch. Expected 0x7e83c97f)"},
+  };
+  std::vector<std::pair<std::string, std::string>> expectedContentsNH4010 = {
+      {"Format", "ONIE TlvInfo"},
+      {"Product Name", "NH-4010"},
+      {"Part Number", "950-00001-01"},
+      {"Serial Number", "NH-FSJ25160005"},
+      {"Base MAC Address", "e8:e4:9d:00:18:28"},
+      {"Manufacture Date", ""},
+      {"Device Version", "1"},
+      {"Label Revision", "P1"},
+      {"Platform Name", "x86_64-nexthop_4010-r0"},
+      {"ONIE Version", ""},
+      {"MAC Addresses", ""},
+      {"Manufacturer", "Nexthop"},
+      {"Manufacture Country", ""},
+      {"Vendor Name", "Nexthop"},
+      {"Diag Version", ""},
+      {"Service Tag", "www.nexthop.ai"},
+      {"Vendor Extension", ""},
+      {"CRC-32", "0xb06fdc7b (CRC Matched)"},
+  };
+
+  std::vector<
+      std::pair<EepromData, std::vector<std::pair<std::string, std::string>>>>
+      testCases = {
+          {eepromOnie, expectedContentsDummy},
+          {eepromOnieReal, expectedContentsNH4010},
+      };
+
+  for (auto& [eepromData, expectedContents] : testCases) {
+    folly::test::TemporaryDirectory tmpDir = folly::test::TemporaryDirectory();
+    std::string fileName = tmpDir.path().string() + "/eepromContent";
+    folly::writeFile(eepromData, fileName.c_str());
+    FbossEepromInterface interface(fileName, 0);
+    auto parsedContents = interface.getContents();
+    ASSERT_EQ(expectedContents.size(), parsedContents.size());
+    for (size_t i = 0; i < expectedContents.size(); i++) {
+      EXPECT_EQ(parsedContents[i], expectedContents[i]);
+    }
+  }
 }
 
 } // namespace facebook::fboss::platform


### PR DESCRIPTION
# Summary

FBOSS has its own EEPROM format. In our labs our devices will quickly switch back and forth between SONiC and FBOSS, and it's not practical to have to rewrite the EEPROM each time. It's better to have FBOSS support the ONIE EEPROM format.

# Test plan

- Added new unit tests. They pass, obviously.
- Tested `platform_manager` on a real NH-4010 device.