### PR TITLE
IceCube: Config Update and Fixup AgentCoppEapolTest/*EapolToHighPriQ

### DIFF
--- a/fboss/oss/link_test_configs/vendor/icecube800bc.materialized_JSON
+++ b/fboss/oss/link_test_configs/vendor/icecube800bc.materialized_JSON
@@ -18,10 +18,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2001,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/1/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -30,12 +32,16 @@
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
         "expectedLLDPValues": {
-        "2": "eth1/1/1"
+          "2": "eth1/2/1"
         },
-        "lookupClasses": [],
-        "profileID": 52,
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -48,10 +54,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2002,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/1/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -59,11 +67,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/2/5"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -76,10 +90,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2003,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/2/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -88,12 +104,16 @@
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
         "expectedLLDPValues": {
-          "2": "eth1/2/1"  
+          "2": "eth1/1/1"
         },
-        "lookupClasses": [],
-        "profileID": 52,
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -106,10 +126,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2004,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/2/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -117,11 +139,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/1/5"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -137,7 +165,9 @@
         "speed": 800000,
         "name": "eth1/3/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -145,11 +175,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/4/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -165,7 +201,9 @@
         "speed": 800000,
         "name": "eth1/3/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -173,11 +211,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/4/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -193,7 +237,9 @@
         "speed": 800000,
         "name": "eth1/4/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -201,11 +247,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/3/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -221,7 +273,9 @@
         "speed": 800000,
         "name": "eth1/4/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -229,11 +283,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/3/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -249,7 +309,9 @@
         "speed": 800000,
         "name": "eth1/5/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -257,11 +319,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/6/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -277,7 +345,9 @@
         "speed": 800000,
         "name": "eth1/5/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -285,11 +355,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/6/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -305,7 +381,9 @@
         "speed": 800000,
         "name": "eth1/6/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -313,11 +391,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/5/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -333,7 +417,9 @@
         "speed": 800000,
         "name": "eth1/6/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -341,11 +427,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/5/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -361,7 +453,9 @@
         "speed": 800000,
         "name": "eth1/7/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -369,11 +463,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/8/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -389,7 +489,9 @@
         "speed": 800000,
         "name": "eth1/7/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -397,11 +499,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/8/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -417,7 +525,9 @@
         "speed": 800000,
         "name": "eth1/8/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -425,11 +535,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/7/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -445,7 +561,9 @@
         "speed": 800000,
         "name": "eth1/8/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -453,11 +571,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/7/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -473,7 +597,9 @@
         "speed": 800000,
         "name": "eth1/9/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -481,11 +607,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/10/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -501,7 +633,9 @@
         "speed": 800000,
         "name": "eth1/9/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -509,11 +643,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/10/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -529,7 +669,9 @@
         "speed": 800000,
         "name": "eth1/10/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -537,11 +679,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/9/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -557,7 +705,9 @@
         "speed": 800000,
         "name": "eth1/10/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -565,11 +715,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/9/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -585,7 +741,9 @@
         "speed": 800000,
         "name": "eth1/11/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -593,11 +751,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/12/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -613,7 +777,9 @@
         "speed": 800000,
         "name": "eth1/11/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -621,11 +787,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/12/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -641,7 +813,9 @@
         "speed": 800000,
         "name": "eth1/12/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -649,11 +823,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/11/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -669,7 +849,9 @@
         "speed": 800000,
         "name": "eth1/12/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -677,11 +859,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/11/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -697,7 +885,9 @@
         "speed": 800000,
         "name": "eth1/13/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -705,11 +895,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/14/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -725,7 +921,9 @@
         "speed": 800000,
         "name": "eth1/13/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -733,11 +931,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/14/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -753,7 +957,9 @@
         "speed": 800000,
         "name": "eth1/14/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -761,11 +967,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/13/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -781,7 +993,9 @@
         "speed": 800000,
         "name": "eth1/14/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -789,11 +1003,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/13/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -809,7 +1029,9 @@
         "speed": 800000,
         "name": "eth1/15/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -817,11 +1039,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/16/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -837,7 +1065,9 @@
         "speed": 800000,
         "name": "eth1/15/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -845,11 +1075,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/16/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -865,7 +1101,9 @@
         "speed": 800000,
         "name": "eth1/16/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -873,11 +1111,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/15/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -893,7 +1137,9 @@
         "speed": 800000,
         "name": "eth1/16/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -901,11 +1147,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/15/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -921,7 +1173,9 @@
         "speed": 800000,
         "name": "eth1/17/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -929,11 +1183,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/18/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -949,7 +1209,9 @@
         "speed": 800000,
         "name": "eth1/17/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -957,11 +1219,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/18/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -977,7 +1245,9 @@
         "speed": 800000,
         "name": "eth1/18/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -985,11 +1255,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/17/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1005,7 +1281,9 @@
         "speed": 800000,
         "name": "eth1/18/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1013,11 +1291,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/17/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1033,7 +1317,9 @@
         "speed": 800000,
         "name": "eth1/19/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1041,11 +1327,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/20/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1061,7 +1353,9 @@
         "speed": 800000,
         "name": "eth1/19/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1069,11 +1363,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/20/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1089,7 +1389,9 @@
         "speed": 800000,
         "name": "eth1/20/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1097,11 +1399,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/19/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1117,7 +1425,9 @@
         "speed": 800000,
         "name": "eth1/20/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1125,11 +1435,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/19/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1145,7 +1461,9 @@
         "speed": 800000,
         "name": "eth1/21/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1153,11 +1471,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/22/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1173,7 +1497,9 @@
         "speed": 800000,
         "name": "eth1/21/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1181,11 +1507,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/22/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1201,7 +1533,9 @@
         "speed": 800000,
         "name": "eth1/22/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1209,11 +1543,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/21/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1229,7 +1569,9 @@
         "speed": 800000,
         "name": "eth1/22/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1237,11 +1579,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/21/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1257,7 +1605,9 @@
         "speed": 800000,
         "name": "eth1/23/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1265,11 +1615,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/24/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1285,7 +1641,9 @@
         "speed": 800000,
         "name": "eth1/23/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1293,11 +1651,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/24/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1313,7 +1677,9 @@
         "speed": 800000,
         "name": "eth1/24/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1321,11 +1687,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/23/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1341,7 +1713,9 @@
         "speed": 800000,
         "name": "eth1/24/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1349,11 +1723,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/23/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1369,7 +1749,9 @@
         "speed": 800000,
         "name": "eth1/25/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1377,11 +1759,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/26/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1397,7 +1785,9 @@
         "speed": 800000,
         "name": "eth1/25/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1405,11 +1795,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/26/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1425,7 +1821,9 @@
         "speed": 800000,
         "name": "eth1/26/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1433,11 +1831,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/25/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1453,7 +1857,9 @@
         "speed": 800000,
         "name": "eth1/26/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1461,11 +1867,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/25/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1481,7 +1893,9 @@
         "speed": 800000,
         "name": "eth1/27/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1489,11 +1903,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/28/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1509,7 +1929,9 @@
         "speed": 800000,
         "name": "eth1/27/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1517,11 +1939,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/28/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1537,7 +1965,9 @@
         "speed": 800000,
         "name": "eth1/28/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1545,11 +1975,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/27/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1565,7 +2001,9 @@
         "speed": 800000,
         "name": "eth1/28/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1573,11 +2011,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/27/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1593,7 +2037,9 @@
         "speed": 800000,
         "name": "eth1/29/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1601,11 +2047,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/30/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1621,7 +2073,9 @@
         "speed": 800000,
         "name": "eth1/29/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1629,11 +2083,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/30/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1649,7 +2109,9 @@
         "speed": 800000,
         "name": "eth1/30/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1657,11 +2119,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/29/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1677,7 +2145,9 @@
         "speed": 800000,
         "name": "eth1/30/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1685,11 +2155,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/29/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1705,7 +2181,9 @@
         "speed": 800000,
         "name": "eth1/31/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1713,11 +2191,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/32/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1733,7 +2217,9 @@
         "speed": 800000,
         "name": "eth1/31/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1741,11 +2227,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/32/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1761,7 +2253,9 @@
         "speed": 800000,
         "name": "eth1/32/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1769,11 +2263,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/31/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1789,7 +2289,9 @@
         "speed": 800000,
         "name": "eth1/32/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1797,11 +2299,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/31/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1817,7 +2325,9 @@
         "speed": 800000,
         "name": "eth1/33/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1825,11 +2335,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/34/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1845,7 +2361,9 @@
         "speed": 800000,
         "name": "eth1/33/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1853,11 +2371,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/34/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1873,7 +2397,9 @@
         "speed": 800000,
         "name": "eth1/34/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1881,11 +2407,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/33/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1901,7 +2433,9 @@
         "speed": 800000,
         "name": "eth1/34/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1909,11 +2443,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/33/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1929,7 +2469,9 @@
         "speed": 800000,
         "name": "eth1/35/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1937,11 +2479,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/36/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1957,7 +2505,9 @@
         "speed": 800000,
         "name": "eth1/35/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1965,11 +2515,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/36/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -1985,7 +2541,9 @@
         "speed": 800000,
         "name": "eth1/36/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -1993,11 +2551,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/35/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2013,7 +2577,9 @@
         "speed": 800000,
         "name": "eth1/36/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2021,11 +2587,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/35/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2041,7 +2613,9 @@
         "speed": 800000,
         "name": "eth1/37/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2049,11 +2623,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/38/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2069,7 +2649,9 @@
         "speed": 800000,
         "name": "eth1/37/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2077,11 +2659,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/38/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2097,7 +2685,9 @@
         "speed": 800000,
         "name": "eth1/38/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2105,11 +2695,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/37/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2125,7 +2721,9 @@
         "speed": 800000,
         "name": "eth1/38/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2133,11 +2731,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/37/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2153,7 +2757,9 @@
         "speed": 800000,
         "name": "eth1/39/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2161,11 +2767,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/40/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2181,7 +2793,9 @@
         "speed": 800000,
         "name": "eth1/39/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2189,11 +2803,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/40/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2209,7 +2829,9 @@
         "speed": 800000,
         "name": "eth1/40/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2217,11 +2839,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/39/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2237,7 +2865,9 @@
         "speed": 800000,
         "name": "eth1/40/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2245,11 +2875,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/39/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2265,7 +2901,9 @@
         "speed": 800000,
         "name": "eth1/41/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2273,11 +2911,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/42/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2293,7 +2937,9 @@
         "speed": 800000,
         "name": "eth1/41/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2301,11 +2947,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/42/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2321,7 +2973,9 @@
         "speed": 800000,
         "name": "eth1/42/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2329,11 +2983,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/41/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2349,7 +3009,9 @@
         "speed": 800000,
         "name": "eth1/42/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2357,11 +3019,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/41/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2374,10 +3042,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2085,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/43/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2385,11 +3055,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/44/1"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2402,10 +3078,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2086,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/43/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2413,11 +3091,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/44/5"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2430,10 +3114,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2087,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/44/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2441,11 +3127,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/43/1"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2458,10 +3150,12 @@
         "parserType": 1,
         "routable": true,
         "ingressVlan": 2088,
-        "speed": 800000,
+        "speed": 400000,
         "name": "eth1/44/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2469,11 +3163,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
-        "profileID": 52,
+        "expectedLLDPValues": {
+          "2": "eth1/43/5"
+        },
+        "lookupClasses": [
+          
+        ],
+        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2489,7 +3189,9 @@
         "speed": 800000,
         "name": "eth1/45/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2497,11 +3199,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/46/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2517,7 +3225,9 @@
         "speed": 800000,
         "name": "eth1/45/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2525,11 +3235,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/46/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2545,7 +3261,9 @@
         "speed": 800000,
         "name": "eth1/46/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2553,11 +3271,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/45/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2573,7 +3297,9 @@
         "speed": 800000,
         "name": "eth1/46/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2581,11 +3307,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/45/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2601,7 +3333,9 @@
         "speed": 800000,
         "name": "eth1/47/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2609,11 +3343,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/48/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2629,7 +3369,9 @@
         "speed": 800000,
         "name": "eth1/47/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2637,11 +3379,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/48/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2657,7 +3405,9 @@
         "speed": 800000,
         "name": "eth1/48/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2665,11 +3415,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/47/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2685,7 +3441,9 @@
         "speed": 800000,
         "name": "eth1/48/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2693,11 +3451,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/47/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2713,7 +3477,9 @@
         "speed": 800000,
         "name": "eth1/49/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2721,11 +3487,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/50/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2741,7 +3513,9 @@
         "speed": 800000,
         "name": "eth1/49/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2749,11 +3523,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/50/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2769,7 +3549,9 @@
         "speed": 800000,
         "name": "eth1/50/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2777,11 +3559,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/49/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2797,7 +3585,9 @@
         "speed": 800000,
         "name": "eth1/50/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2805,11 +3595,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/49/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2825,7 +3621,9 @@
         "speed": 800000,
         "name": "eth1/51/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2833,11 +3631,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/52/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2853,7 +3657,9 @@
         "speed": 800000,
         "name": "eth1/51/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2861,11 +3667,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/52/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2881,7 +3693,9 @@
         "speed": 800000,
         "name": "eth1/52/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2889,11 +3703,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/51/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2909,7 +3729,9 @@
         "speed": 800000,
         "name": "eth1/52/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2917,11 +3739,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/51/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2937,7 +3765,9 @@
         "speed": 800000,
         "name": "eth1/53/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2945,11 +3775,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/54/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2965,7 +3801,9 @@
         "speed": 800000,
         "name": "eth1/53/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -2973,11 +3811,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/54/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -2993,7 +3837,9 @@
         "speed": 800000,
         "name": "eth1/54/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3001,11 +3847,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/53/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3021,7 +3873,9 @@
         "speed": 800000,
         "name": "eth1/54/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3029,11 +3883,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/53/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3049,7 +3909,9 @@
         "speed": 800000,
         "name": "eth1/55/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3057,11 +3919,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/56/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3077,7 +3945,9 @@
         "speed": 800000,
         "name": "eth1/55/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3085,11 +3955,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/56/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3105,7 +3981,9 @@
         "speed": 800000,
         "name": "eth1/56/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3113,11 +3991,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/55/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3133,7 +4017,9 @@
         "speed": 800000,
         "name": "eth1/56/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3141,11 +4027,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/55/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3161,7 +4053,9 @@
         "speed": 800000,
         "name": "eth1/57/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3169,11 +4063,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/58/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3189,7 +4089,9 @@
         "speed": 800000,
         "name": "eth1/57/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3197,11 +4099,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/58/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3217,7 +4125,9 @@
         "speed": 800000,
         "name": "eth1/58/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3225,11 +4135,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/57/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3245,7 +4161,9 @@
         "speed": 800000,
         "name": "eth1/58/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3253,11 +4171,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/57/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3273,7 +4197,9 @@
         "speed": 800000,
         "name": "eth1/59/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3281,11 +4207,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/60/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3301,7 +4233,9 @@
         "speed": 800000,
         "name": "eth1/59/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3309,11 +4243,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/60/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3329,7 +4269,9 @@
         "speed": 800000,
         "name": "eth1/60/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3337,11 +4279,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/59/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3357,7 +4305,9 @@
         "speed": 800000,
         "name": "eth1/60/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3365,11 +4315,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/59/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3385,7 +4341,9 @@
         "speed": 800000,
         "name": "eth1/61/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3393,11 +4351,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/62/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3413,7 +4377,9 @@
         "speed": 800000,
         "name": "eth1/61/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3421,11 +4387,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/62/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3441,7 +4413,9 @@
         "speed": 800000,
         "name": "eth1/62/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3449,11 +4423,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/61/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3469,7 +4449,9 @@
         "speed": 800000,
         "name": "eth1/62/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3477,11 +4459,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/61/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3497,7 +4485,9 @@
         "speed": 800000,
         "name": "eth1/63/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3505,11 +4495,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/64/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3525,7 +4521,9 @@
         "speed": 800000,
         "name": "eth1/63/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3533,11 +4531,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/64/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3553,7 +4557,9 @@
         "speed": 800000,
         "name": "eth1/64/1",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3561,11 +4567,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/63/1"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3581,7 +4593,9 @@
         "speed": 800000,
         "name": "eth1/64/5",
         "description": "",
-        "queues_DEPRECATED": [],
+        "queues_DEPRECATED": [
+          
+        ],
         "pause": {
           "tx": false,
           "rx": false
@@ -3589,11 +4603,17 @@
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {},
-        "lookupClasses": [],
+        "expectedLLDPValues": {
+          "2": "eth1/63/5"
+        },
+        "lookupClasses": [
+          
+        ],
         "profileID": 52,
         "portType": 0,
-        "expectedNeighborReachability": [],
+        "expectedNeighborReachability": [
+          
+        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -3605,910 +4625,1170 @@
         "id": 10,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "default",
         "id": 4094,
         "recordStats": true,
         "routable": false,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2001",
         "id": 2001,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2002",
         "id": 2002,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2003",
         "id": 2003,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2004",
         "id": 2004,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2005",
         "id": 2005,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2006",
         "id": 2006,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2007",
         "id": 2007,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2008",
         "id": 2008,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2009",
         "id": 2009,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2010",
         "id": 2010,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2011",
         "id": 2011,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2012",
         "id": 2012,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2013",
         "id": 2013,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2014",
         "id": 2014,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2015",
         "id": 2015,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2016",
         "id": 2016,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2017",
         "id": 2017,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2018",
         "id": 2018,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2019",
         "id": 2019,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2020",
         "id": 2020,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2021",
         "id": 2021,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2022",
         "id": 2022,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2023",
         "id": 2023,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2024",
         "id": 2024,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2025",
         "id": 2025,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2026",
         "id": 2026,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2027",
         "id": 2027,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2028",
         "id": 2028,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2029",
         "id": 2029,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2030",
         "id": 2030,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2031",
         "id": 2031,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2032",
         "id": 2032,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2033",
         "id": 2033,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2034",
         "id": 2034,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2035",
         "id": 2035,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2036",
         "id": 2036,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2037",
         "id": 2037,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2038",
         "id": 2038,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2039",
         "id": 2039,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2040",
         "id": 2040,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2041",
         "id": 2041,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2042",
         "id": 2042,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2043",
         "id": 2043,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2044",
         "id": 2044,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2045",
         "id": 2045,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2046",
         "id": 2046,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2047",
         "id": 2047,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2048",
         "id": 2048,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2049",
         "id": 2049,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2050",
         "id": 2050,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2051",
         "id": 2051,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2052",
         "id": 2052,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2053",
         "id": 2053,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2054",
         "id": 2054,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2055",
         "id": 2055,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2056",
         "id": 2056,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2057",
         "id": 2057,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2058",
         "id": 2058,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2059",
         "id": 2059,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2060",
         "id": 2060,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2061",
         "id": 2061,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2062",
         "id": 2062,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2063",
         "id": 2063,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2064",
         "id": 2064,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2065",
         "id": 2065,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2066",
         "id": 2066,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2067",
         "id": 2067,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2068",
         "id": 2068,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2069",
         "id": 2069,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2070",
         "id": 2070,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2071",
         "id": 2071,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2072",
         "id": 2072,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2073",
         "id": 2073,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2074",
         "id": 2074,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2075",
         "id": 2075,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2076",
         "id": 2076,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2077",
         "id": 2077,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2078",
         "id": 2078,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2079",
         "id": 2079,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2080",
         "id": 2080,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2081",
         "id": 2081,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2082",
         "id": 2082,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2083",
         "id": 2083,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2084",
         "id": 2084,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2085",
         "id": 2085,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2086",
         "id": 2086,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2087",
         "id": 2087,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2088",
         "id": 2088,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2089",
         "id": 2089,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2090",
         "id": 2090,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2091",
         "id": 2091,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2092",
         "id": 2092,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2093",
         "id": 2093,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2094",
         "id": 2094,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2095",
         "id": 2095,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2096",
         "id": 2096,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2097",
         "id": 2097,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2098",
         "id": 2098,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2099",
         "id": 2099,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2100",
         "id": 2100,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2101",
         "id": 2101,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2102",
         "id": 2102,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2103",
         "id": 2103,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2104",
         "id": 2104,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2105",
         "id": 2105,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2106",
         "id": 2106,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2107",
         "id": 2107,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2108",
         "id": 2108,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2109",
         "id": 2109,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2110",
         "id": 2110,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2111",
         "id": 2111,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2112",
         "id": 2112,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2113",
         "id": 2113,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2114",
         "id": 2114,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2115",
         "id": 2115,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2116",
         "id": 2116,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2117",
         "id": 2117,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2118",
         "id": 2118,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2119",
         "id": 2119,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2120",
         "id": 2120,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2121",
         "id": 2121,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2122",
         "id": 2122,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2123",
         "id": 2123,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2124",
         "id": 2124,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2125",
         "id": 2125,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2126",
         "id": 2126,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2127",
         "id": 2127,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       },
       {
         "name": "vlan2128",
         "id": 2128,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": []
+        "ipAddresses": [
+          
+        ]
       }
     ],
     "vlanPorts": [
@@ -7094,9 +8374,15 @@
     "arpRefreshSeconds": 20,
     "arpAgerInterval": 5,
     "proactiveArp": false,
-    "staticRoutesWithNhops": [],
-    "staticRoutesToNull": [],
-    "staticRoutesToCPU": [],
+    "staticRoutesWithNhops": [
+      
+    ],
+    "staticRoutesToNull": [
+      
+    ],
+    "staticRoutesToCPU": [
+      
+    ],
     "acls": [
       {
         "dscp": 48,
@@ -7196,7 +8482,9 @@
     ],
     "maxNeighborProbes": 300,
     "staleEntryInterval": 10,
-    "aggregatePorts": [],
+    "aggregatePorts": [
+      
+    ],
     "clientIdToAdminDistance": {
       "0": 20,
       "1": 1,
@@ -7206,7 +8494,9 @@
       "700": 255,
       "786": 10
     },
-    "sFlowCollectors": [],
+    "sFlowCollectors": [
+      
+    ],
     "cpuQueues": [
       {
         "id": 9,
@@ -7280,7 +8570,8 @@
           },
           {
             "matcher": "cpuPolicing-CPU-Port-Mcast-v6",
-            "action": {}
+            "action": {
+            }
           },
           {
             "matcher": "cpuPolicing-high-NetworkControl-linkLocal-v6",
@@ -7415,8 +8706,12 @@
             1,
             2
           ],
-          "mplsFields": [],
-          "udfGroups": []
+          "mplsFields": [
+            
+          ],
+          "udfGroups": [
+            
+          ]
         },
         "algorithm": 1
       },
@@ -7431,9 +8726,15 @@
             1,
             2
           ],
-          "transportFields": [],
-          "mplsFields": [],
-          "udfGroups": []
+          "transportFields": [
+            
+          ],
+          "mplsFields": [
+            
+          ],
+          "udfGroups": [
+            
+          ]
         },
         "algorithm": 1
       }
@@ -7472,7 +8773,9 @@
         }
       ]
     },
-    "mirrors": [],
+    "mirrors": [
+      
+    ],
     "trafficCounters": [
       {
         "name": "ttld-prod-private",
@@ -7510,56 +8813,92 @@
         ]
       }
     ],
-    "qosPolicies": [],
-    "defaultPortQueues": [],
-    "staticMplsRoutesWithNhops": [],
-    "staticMplsRoutesToNull": [],
-    "staticMplsRoutesToCPU": [],
-    "staticIp2MplsRoutes": [],
-    "portQueueConfigs": {},
+    "qosPolicies": [
+      
+    ],
+    "defaultPortQueues": [
+      
+    ],
+    "staticMplsRoutesWithNhops": [
+      
+    ],
+    "staticMplsRoutesToNull": [
+      
+    ],
+    "staticMplsRoutesToCPU": [
+      
+    ],
+    "staticIp2MplsRoutes": [
+      
+    ],
+    "portQueueConfigs": {
+      
+    },
     "switchSettings": {
       "l2LearningMode": 0,
       "qcmEnable": false,
       "ptpTcEnable": false,
       "l2AgeTimerSeconds": 300,
       "maxRouteCounterIDs": 0,
-      "blockNeighbors": [],
-      "macAddrsToBlock": [],
+      "blockNeighbors": [
+        
+      ],
+      "macAddrsToBlock": [
+        
+      ],
       "switchType": 0,
-      "exactMatchTableConfigs": [],
-      "switchIdToSwitchType_DEPRECATED": {},
+      "exactMatchTableConfigs": [
+        
+      ],
+      "switchIdToSwitchType_DEPRECATED": {
+        
+      },
       "switchDrainState": 0,
       "switchIdToSwitchInfo": {
         "0": {
-          "switchType": 0,
-          "asicType": 18,
-          "switchIndex": 0,
-          "portIdRange": {
-            "minimum": 0,
-            "maximum": 2047
-          },
-          "firmwareNameToFirmwareInfo": {}
+            "switchType": 0,
+            "asicType": 18,
+            "switchIndex": 0,
+            "portIdRange": {
+              "minimum": 0,
+              "maximum": 2047
+            },
+            "firmwareNameToFirmwareInfo": {
+              
+            }
         }
       },
-      "vendorMacOuis": [],
-      "metaMacOuis": []
+      "vendorMacOuis": [
+        
+      ],
+      "metaMacOuis": [
+        
+      ]
     },
     "sdkVersion": {
       "asicSdk": "sdk",
       "saiSdk": "sai"
     },
-    "dsfNodes": {},
-    "defaultVoqConfig": [],
-    "mirrorOnDropReports": []
+    "dsfNodes": {
+      
+    },
+    "defaultVoqConfig": [
+      
+    ],
+    "mirrorOnDropReports": [
+      
+    ]
   },
   "platform": {
     "chip": {
       "asicConfig": {
         "common": {
-          "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x20317645\n                TX_LANE_MAP: 0x64750231\n                RX_POLARITY_FLIP: 0x38\n                TX_POLARITY_FLIP: 0xC6\n            ?\n                PC_PM_ID: 2\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x20317654\n                TX_LANE_MAP: 0x46572031\n                RX_POLARITY_FLIP: 0x38\n                TX_POLARITY_FLIP: 0xCA\n            ?\n                PC_PM_ID: 3\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x45671302\n                TX_LANE_MAP: 0x13027564\n                RX_POLARITY_FLIP: 0x1C\n                TX_POLARITY_FLIP: 0x53\n            ?\n                PC_PM_ID: 4\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x54671302\n                TX_LANE_MAP: 0x13205746\n                RX_POLARITY_FLIP: 0x1C\n                TX_POLARITY_FLIP: 0xE3\n            ?\n                PC_PM_ID: 8\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107456\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0x3D\n                TX_POLARITY_FLIP: 0x3E\n            ?\n                PC_PM_ID: 7\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107465\n                TX_LANE_MAP: 0x74651023\n                RX_POLARITY_FLIP: 0x3E\n                TX_POLARITY_FLIP: 0x3E\n            ?\n                PC_PM_ID: 6\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56470123\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x7C\n                TX_POLARITY_FLIP: 0x7C\n            ?\n                PC_PM_ID: 5\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x74560312\n                TX_LANE_MAP: 0x30125647\n                RX_POLARITY_FLIP: 0xE8\n                TX_POLARITY_FLIP: 0xCC\n            ?\n                PC_PM_ID: 9\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x74560312\n                TX_LANE_MAP: 0x30125647\n                RX_POLARITY_FLIP: 0x93\n                TX_POLARITY_FLIP: 0x33\n            ?\n                PC_PM_ID: 10\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57462031\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x8C\n                TX_POLARITY_FLIP: 0xA3\n            ?\n                PC_PM_ID: 11\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026475\n                TX_LANE_MAP: 0x74651032\n                RX_POLARITY_FLIP: 0x31\n                TX_POLARITY_FLIP: 0xC5\n            ?\n                PC_PM_ID: 12\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026457\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0x32\n                TX_POLARITY_FLIP: 0xC9\n            ?\n                PC_PM_ID: 16\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56741032\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x83\n                TX_POLARITY_FLIP: 0x53\n            ?\n                PC_PM_ID: 15\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x65741032\n                TX_LANE_MAP: 0x23106574\n                RX_POLARITY_FLIP: 0x43\n                TX_POLARITY_FLIP: 0x63\n            ?\n                PC_PM_ID: 14\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x23014756\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0xC2\n                TX_POLARITY_FLIP: 0xC6\n            ?\n                PC_PM_ID: 13\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x23014765\n                TX_LANE_MAP: 0x74651032\n                RX_POLARITY_FLIP: 0xC1\n                TX_POLARITY_FLIP: 0xCA\n            ?\n                PC_PM_ID: 17\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x31204675\n                TX_LANE_MAP: 0x74651023\n                RX_POLARITY_FLIP: 0xCE\n                TX_POLARITY_FLIP: 0x39\n            ?\n                PC_PM_ID: 18\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x31204657\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0xCD\n                TX_POLARITY_FLIP: 0x35\n            ?\n                PC_PM_ID: 19\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x75640213\n                TX_LANE_MAP: 0x32106574\n                RX_POLARITY_FLIP: 0xB3\n                TX_POLARITY_FLIP: 0xAC\n            ?\n                PC_PM_ID: 20\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57640213\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x73\n                TX_POLARITY_FLIP: 0x9C\n            ?\n                PC_PM_ID: 24\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107456\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0x3D\n                TX_POLARITY_FLIP: 0x3A\n            ?\n                PC_PM_ID: 23\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107465\n                TX_LANE_MAP: 0x74651023\n                RX_POLARITY_FLIP: 0x3E\n                TX_POLARITY_FLIP: 0x36\n            ?\n                PC_PM_ID: 22\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56470123\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x7C\n                TX_POLARITY_FLIP: 0x6C\n            ?\n                PC_PM_ID: 21\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x74560312\n                TX_LANE_MAP: 0x30125647\n                RX_POLARITY_FLIP: 0xE8\n                TX_POLARITY_FLIP: 0xCC\n            ?\n                PC_PM_ID: 25\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x74560312\n                TX_LANE_MAP: 0x30125647\n                RX_POLARITY_FLIP: 0x93\n                TX_POLARITY_FLIP: 0x33\n            ?\n                PC_PM_ID: 26\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57462031\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x8C\n                TX_POLARITY_FLIP: 0xB3\n            ?\n                PC_PM_ID: 27\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026475\n                TX_LANE_MAP: 0x74651032\n                RX_POLARITY_FLIP: 0x31\n                TX_POLARITY_FLIP: 0xCD\n            ?\n                PC_PM_ID: 28\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026457\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0x32\n                TX_POLARITY_FLIP: 0xCD\n            ?\n                PC_PM_ID: 32\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x54671302\n                TX_LANE_MAP: 0x13205746\n                RX_POLARITY_FLIP: 0xEC\n                TX_POLARITY_FLIP: 0x1F\n            ?\n                PC_PM_ID: 31\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x45671302\n                TX_LANE_MAP: 0x13027564\n                RX_POLARITY_FLIP: 0xEC\n                TX_POLARITY_FLIP: 0xAF\n            ?\n                PC_PM_ID: 30\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x20317654\n                TX_LANE_MAP: 0x46572031\n                RX_POLARITY_FLIP: 0x37\n                TX_POLARITY_FLIP: 0xF5\n            ?\n                PC_PM_ID: 29\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x20317645\n                TX_LANE_MAP: 0x64750231\n                RX_POLARITY_FLIP: 0x37\n                TX_POLARITY_FLIP: 0xF9\n            ?\n                PC_PM_ID: 33\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x45763120\n                TX_LANE_MAP: 0x31027564\n                RX_POLARITY_FLIP: 0x23\n                TX_POLARITY_FLIP: 0x90\n            ?\n                PC_PM_ID: 34\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x54763120\n                TX_LANE_MAP: 0x31205746\n                RX_POLARITY_FLIP: 0x23\n                TX_POLARITY_FLIP: 0xA0\n            ?\n                PC_PM_ID: 35\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x02136745\n                TX_LANE_MAP: 0x64750213\n                RX_POLARITY_FLIP: 0xC4\n                TX_POLARITY_FLIP: 0x5\n            ?\n                PC_PM_ID: 36\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x02136754\n                TX_LANE_MAP: 0x46572013\n                RX_POLARITY_FLIP: 0xC4\n                TX_POLARITY_FLIP: 0xB\n            ?\n                PC_PM_ID: 40\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57640213\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x73\n                TX_POLARITY_FLIP: 0x8C\n            ?\n                PC_PM_ID: 39\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x75640213\n                TX_LANE_MAP: 0x32106574\n                RX_POLARITY_FLIP: 0xB3\n                TX_POLARITY_FLIP: 0x8C\n            ?\n                PC_PM_ID: 38\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x31204657\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0xCD\n                TX_POLARITY_FLIP: 0x31\n            ?\n                PC_PM_ID: 37\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x12035674\n                TX_LANE_MAP: 0x47561230\n                RX_POLARITY_FLIP: 0x39\n                TX_POLARITY_FLIP: 0x33\n            ?\n                PC_PM_ID: 41\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x12035674\n                TX_LANE_MAP: 0x47561230\n                RX_POLARITY_FLIP: 0xD4\n                TX_POLARITY_FLIP: 0xCC\n            ?\n                PC_PM_ID: 42\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x23014756\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0xC2\n                TX_POLARITY_FLIP: 0xC6\n            ?\n                PC_PM_ID: 43\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x65741032\n                TX_LANE_MAP: 0x23106574\n                RX_POLARITY_FLIP: 0x43\n                TX_POLARITY_FLIP: 0x63\n            ?\n                PC_PM_ID: 44\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56741032\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x83\n                TX_POLARITY_FLIP: 0x53\n            ?\n                PC_PM_ID: 48\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026457\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0x32\n                TX_POLARITY_FLIP: 0xC9\n            ?\n                PC_PM_ID: 47\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x13026475\n                TX_LANE_MAP: 0x74651032\n                RX_POLARITY_FLIP: 0x31\n                TX_POLARITY_FLIP: 0xC5\n            ?\n                PC_PM_ID: 46\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57462031\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x8C\n                TX_POLARITY_FLIP: 0xA3\n            ?\n                PC_PM_ID: 45\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x75462031\n                TX_LANE_MAP: 0x23106574\n                RX_POLARITY_FLIP: 0x4C\n                TX_POLARITY_FLIP: 0x93\n            ?\n                PC_PM_ID: 49\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x65470123\n                TX_LANE_MAP: 0x32106574\n                RX_POLARITY_FLIP: 0xBC\n                TX_POLARITY_FLIP: 0x5C\n            ?\n                PC_PM_ID: 50\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56470123\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x7C\n                TX_POLARITY_FLIP: 0x6C\n            ?\n                PC_PM_ID: 51\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107465\n                TX_LANE_MAP: 0x74651023\n                RX_POLARITY_FLIP: 0x3E\n                TX_POLARITY_FLIP: 0x36\n            ?\n                PC_PM_ID: 52\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x32107456\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0x3D\n                TX_POLARITY_FLIP: 0x3A\n            ?\n                PC_PM_ID: 56\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x57640213\n                TX_LANE_MAP: 0x32015647\n                RX_POLARITY_FLIP: 0x73\n                TX_POLARITY_FLIP: 0x9C\n            ?\n                PC_PM_ID: 55\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x75640213\n                TX_LANE_MAP: 0x32106574\n                RX_POLARITY_FLIP: 0xB3\n                TX_POLARITY_FLIP: 0xAC\n            ?\n                PC_PM_ID: 54\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x31204657\n                TX_LANE_MAP: 0x47560123\n                RX_POLARITY_FLIP: 0xCD\n                TX_POLARITY_FLIP: 0x35\n            ?\n                PC_PM_ID: 53\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x12035674\n                TX_LANE_MAP: 0x47561230\n                RX_POLARITY_FLIP: 0x39\n                TX_POLARITY_FLIP: 0x33\n            ?\n                PC_PM_ID: 57\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x12035674\n                TX_LANE_MAP: 0x47561230\n                RX_POLARITY_FLIP: 0xD4\n                TX_POLARITY_FLIP: 0xCC\n            ?\n                PC_PM_ID: 58\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x23014756\n                TX_LANE_MAP: 0x47560132\n                RX_POLARITY_FLIP: 0xC2\n                TX_POLARITY_FLIP: 0xC2\n            ?\n                PC_PM_ID: 59\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x65741032\n                TX_LANE_MAP: 0x23106574\n                RX_POLARITY_FLIP: 0x43\n                TX_POLARITY_FLIP: 0x43\n            ?\n                PC_PM_ID: 60\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x56741032\n                TX_LANE_MAP: 0x23015647\n                RX_POLARITY_FLIP: 0x83\n                TX_POLARITY_FLIP: 0x43\n            ?\n                PC_PM_ID: 64\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x02136754\n                TX_LANE_MAP: 0x46572013\n                RX_POLARITY_FLIP: 0xCB\n                TX_POLARITY_FLIP: 0x34\n            ?\n                PC_PM_ID: 63\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x02136745\n                TX_LANE_MAP: 0x64750213\n                RX_POLARITY_FLIP: 0xCB\n                TX_POLARITY_FLIP: 0x3A\n            ?\n                PC_PM_ID: 62\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x54763120\n                TX_LANE_MAP: 0x31205746\n                RX_POLARITY_FLIP: 0xD3\n                TX_POLARITY_FLIP: 0x5C\n            ?\n                PC_PM_ID: 61\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x45763120\n                TX_LANE_MAP: 0x31027564\n                RX_POLARITY_FLIP: 0xD3\n                TX_POLARITY_FLIP: 0x6C\n            ?\n                PC_PM_ID: 65\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n                TX_LANE_MAP_AUTO: 0\n                RX_POLARITY_FLIP_AUTO: 0\n                TX_POLARITY_FLIP_AUTO: 0\n                RX_LANE_MAP: 0x3210\n                TX_LANE_MAP: 0x3210\n                RX_POLARITY_FLIP: 0x0\n                TX_POLARITY_FLIP: 0x0\n...\n---\ndevice:\n    0:\n        PC_PORT_PHYS_MAP:\n            ?\n                PORT_ID: 1\n            :\n                PC_PHYS_PORT_ID: 1\n            ?\n                PORT_ID: 2\n            :\n                PC_PHYS_PORT_ID: 5\n            ?\n                PORT_ID: 3\n            :\n                PC_PHYS_PORT_ID: 9\n            ?\n                PORT_ID: 4\n            :\n                PC_PHYS_PORT_ID: 13\n            ?\n                PORT_ID: 18\n            :\n                PC_PHYS_PORT_ID: 17\n            ?\n                PORT_ID: 19\n            :\n                PC_PHYS_PORT_ID: 21\n            ?\n                PORT_ID: 20\n            :\n                PC_PHYS_PORT_ID: 25\n            ?\n                PORT_ID: 21\n            :\n                PC_PHYS_PORT_ID: 29\n            ?\n                PORT_ID: 36\n            :\n                PC_PHYS_PORT_ID: 33\n            ?\n                PORT_ID: 37\n            :\n                PC_PHYS_PORT_ID: 37\n            ?\n                PORT_ID: 38\n            :\n                PC_PHYS_PORT_ID: 41\n            ?\n                PORT_ID: 39\n            :\n                PC_PHYS_PORT_ID: 45\n            ?\n                PORT_ID: 54\n            :\n                PC_PHYS_PORT_ID: 49\n            ?\n                PORT_ID: 55\n            :\n                PC_PHYS_PORT_ID: 53\n            ?\n                PORT_ID: 56\n            :\n                PC_PHYS_PORT_ID: 57\n            ?\n                PORT_ID: 57\n            :\n                PC_PHYS_PORT_ID: 61\n            ?\n                PORT_ID: 72\n            :\n                PC_PHYS_PORT_ID: 65\n            ?\n                PORT_ID: 73\n            :\n                PC_PHYS_PORT_ID: 69\n            ?\n                PORT_ID: 74\n            :\n                PC_PHYS_PORT_ID: 73\n            ?\n                PORT_ID: 75\n            :\n                PC_PHYS_PORT_ID: 77\n            ?\n                PORT_ID: 90\n            :\n                PC_PHYS_PORT_ID: 81\n            ?\n                PORT_ID: 91\n            :\n                PC_PHYS_PORT_ID: 85\n            ?\n                PORT_ID: 92\n            :\n                PC_PHYS_PORT_ID: 89\n            ?\n                PORT_ID: 93\n            :\n                PC_PHYS_PORT_ID: 93\n            ?\n                PORT_ID: 108\n            :\n                PC_PHYS_PORT_ID: 97\n            ?\n                PORT_ID: 109\n            :\n                PC_PHYS_PORT_ID: 101\n            ?\n                PORT_ID: 110\n            :\n                PC_PHYS_PORT_ID: 105\n            ?\n                PORT_ID: 111\n            :\n                PC_PHYS_PORT_ID: 109\n            ?\n                PORT_ID: 126\n            :\n                PC_PHYS_PORT_ID: 113\n            ?\n                PORT_ID: 127\n            :\n                PC_PHYS_PORT_ID: 117\n            ?\n                PORT_ID: 128\n            :\n                PC_PHYS_PORT_ID: 121\n            ?\n                PORT_ID: 129\n            :\n                PC_PHYS_PORT_ID: 125\n            ?\n                PORT_ID: 144\n            :\n                PC_PHYS_PORT_ID: 129\n            ?\n                PORT_ID: 145\n            :\n                PC_PHYS_PORT_ID: 133\n            ?\n                PORT_ID: 146\n            :\n                PC_PHYS_PORT_ID: 137\n            ?\n                PORT_ID: 147\n            :\n                PC_PHYS_PORT_ID: 141\n            ?\n                PORT_ID: 162\n            :\n                PC_PHYS_PORT_ID: 145\n            ?\n                PORT_ID: 163\n            :\n                PC_PHYS_PORT_ID: 149\n            ?\n                PORT_ID: 164\n            :\n                PC_PHYS_PORT_ID: 153\n            ?\n                PORT_ID: 165\n            :\n                PC_PHYS_PORT_ID: 157\n            ?\n                PORT_ID: 180\n            :\n                PC_PHYS_PORT_ID: 161\n            ?\n                PORT_ID: 181\n            :\n                PC_PHYS_PORT_ID: 165\n            ?\n                PORT_ID: 182\n            :\n                PC_PHYS_PORT_ID: 169\n            ?\n                PORT_ID: 183\n            :\n                PC_PHYS_PORT_ID: 173\n            ?\n                PORT_ID: 198\n            :\n                PC_PHYS_PORT_ID: 177\n            ?\n                PORT_ID: 199\n            :\n                PC_PHYS_PORT_ID: 181\n            ?\n                PORT_ID: 200\n            :\n                PC_PHYS_PORT_ID: 185\n            ?\n                PORT_ID: 201\n            :\n                PC_PHYS_PORT_ID: 189\n            ?\n                PORT_ID: 216\n            :\n                PC_PHYS_PORT_ID: 193\n            ?\n                PORT_ID: 217\n            :\n                PC_PHYS_PORT_ID: 197\n            ?\n                PORT_ID: 218\n            :\n                PC_PHYS_PORT_ID: 201\n            ?\n                PORT_ID: 219\n            :\n                PC_PHYS_PORT_ID: 205\n            ?\n                PORT_ID: 234\n            :\n                PC_PHYS_PORT_ID: 209\n            ?\n                PORT_ID: 235\n            :\n                PC_PHYS_PORT_ID: 213\n            ?\n                PORT_ID: 236\n            :\n                PC_PHYS_PORT_ID: 217\n            ?\n                PORT_ID: 237\n            :\n                PC_PHYS_PORT_ID: 221\n            ?\n                PORT_ID: 252\n            :\n                PC_PHYS_PORT_ID: 225\n            ?\n                PORT_ID: 253\n            :\n                PC_PHYS_PORT_ID: 229\n            ?\n                PORT_ID: 254\n            :\n                PC_PHYS_PORT_ID: 233\n            ?\n                PORT_ID: 255\n            :\n                PC_PHYS_PORT_ID: 237\n            ?\n                PORT_ID: 270\n            :\n                PC_PHYS_PORT_ID: 241\n            ?\n                PORT_ID: 271\n            :\n                PC_PHYS_PORT_ID: 245\n            ?\n                PORT_ID: 272\n            :\n                PC_PHYS_PORT_ID: 249\n            ?\n                PORT_ID: 273\n            :\n                PC_PHYS_PORT_ID: 253\n            ?\n                PORT_ID: 288\n            :\n                PC_PHYS_PORT_ID: 257\n            ?\n                PORT_ID: 289\n            :\n                PC_PHYS_PORT_ID: 261\n            ?\n                PORT_ID: 290\n            :\n                PC_PHYS_PORT_ID: 265\n            ?\n                PORT_ID: 291\n            :\n                PC_PHYS_PORT_ID: 269\n            ?\n                PORT_ID: 306\n            :\n                PC_PHYS_PORT_ID: 273\n            ?\n                PORT_ID: 307\n            :\n                PC_PHYS_PORT_ID: 277\n            ?\n                PORT_ID: 308\n            :\n                PC_PHYS_PORT_ID: 281\n            ?\n                PORT_ID: 309\n            :\n                PC_PHYS_PORT_ID: 285\n            ?\n                PORT_ID: 324\n            :\n                PC_PHYS_PORT_ID: 289\n            ?\n                PORT_ID: 325\n            :\n                PC_PHYS_PORT_ID: 293\n            ?\n                PORT_ID: 326\n            :\n                PC_PHYS_PORT_ID: 297\n            ?\n                PORT_ID: 327\n            :\n                PC_PHYS_PORT_ID: 301\n            ?\n                PORT_ID: 342\n            :\n                PC_PHYS_PORT_ID: 305\n            ?\n                PORT_ID: 343\n            :\n                PC_PHYS_PORT_ID: 309\n            ?\n                PORT_ID: 344\n            :\n                PC_PHYS_PORT_ID: 313\n            ?\n                PORT_ID: 345\n            :\n                PC_PHYS_PORT_ID: 317\n            ?\n                PORT_ID: 360\n            :\n                PC_PHYS_PORT_ID: 321\n            ?\n                PORT_ID: 361\n            :\n                PC_PHYS_PORT_ID: 325\n            ?\n                PORT_ID: 362\n            :\n                PC_PHYS_PORT_ID: 329\n            ?\n                PORT_ID: 363\n            :\n                PC_PHYS_PORT_ID: 333\n            ?\n                PORT_ID: 378\n            :\n                PC_PHYS_PORT_ID: 337\n            ?\n                PORT_ID: 379\n            :\n                PC_PHYS_PORT_ID: 341\n            ?\n                PORT_ID: 380\n            :\n                PC_PHYS_PORT_ID: 345\n            ?\n                PORT_ID: 381\n            :\n                PC_PHYS_PORT_ID: 349\n            ?\n                PORT_ID: 396\n            :\n                PC_PHYS_PORT_ID: 353\n            ?\n                PORT_ID: 397\n            :\n                PC_PHYS_PORT_ID: 357\n            ?\n                PORT_ID: 398\n            :\n                PC_PHYS_PORT_ID: 361\n            ?\n                PORT_ID: 399\n            :\n                PC_PHYS_PORT_ID: 365\n            ?\n                PORT_ID: 414\n            :\n                PC_PHYS_PORT_ID: 369\n            ?\n                PORT_ID: 415\n            :\n                PC_PHYS_PORT_ID: 373\n            ?\n                PORT_ID: 416\n            :\n                PC_PHYS_PORT_ID: 377\n            ?\n                PORT_ID: 417\n            :\n                PC_PHYS_PORT_ID: 381\n            ?\n                PORT_ID: 432\n            :\n                PC_PHYS_PORT_ID: 385\n            ?\n                PORT_ID: 433\n            :\n                PC_PHYS_PORT_ID: 389\n            ?\n                PORT_ID: 434\n            :\n                PC_PHYS_PORT_ID: 393\n            ?\n                PORT_ID: 435\n            :\n                PC_PHYS_PORT_ID: 397\n            ?\n                PORT_ID: 450\n            :\n                PC_PHYS_PORT_ID: 401\n            ?\n                PORT_ID: 451\n            :\n                PC_PHYS_PORT_ID: 405\n            ?\n                PORT_ID: 452\n            :\n                PC_PHYS_PORT_ID: 409\n            ?\n                PORT_ID: 453\n            :\n                PC_PHYS_PORT_ID: 413\n            ?\n                PORT_ID: 468\n            :\n                PC_PHYS_PORT_ID: 417\n            ?\n                PORT_ID: 469\n            :\n                PC_PHYS_PORT_ID: 421\n            ?\n                PORT_ID: 470\n            :\n                PC_PHYS_PORT_ID: 425\n            ?\n                PORT_ID: 471\n            :\n                PC_PHYS_PORT_ID: 429\n            ?\n                PORT_ID: 486\n            :\n                PC_PHYS_PORT_ID: 433\n            ?\n                PORT_ID: 487\n            :\n                PC_PHYS_PORT_ID: 437\n            ?\n                PORT_ID: 488\n            :\n                PC_PHYS_PORT_ID: 441\n            ?\n                PORT_ID: 489\n            :\n                PC_PHYS_PORT_ID: 445\n            ?\n                PORT_ID: 504\n            :\n                PC_PHYS_PORT_ID: 449\n            ?\n                PORT_ID: 505\n            :\n                PC_PHYS_PORT_ID: 453\n            ?\n                PORT_ID: 506\n            :\n                PC_PHYS_PORT_ID: 457\n            ?\n                PORT_ID: 507\n            :\n                PC_PHYS_PORT_ID: 461\n            ?\n                PORT_ID: 522\n            :\n                PC_PHYS_PORT_ID: 465\n            ?\n                PORT_ID: 523\n            :\n                PC_PHYS_PORT_ID: 469\n            ?\n                PORT_ID: 524\n            :\n                PC_PHYS_PORT_ID: 473\n            ?\n                PORT_ID: 525\n            :\n                PC_PHYS_PORT_ID: 477\n            ?\n                PORT_ID: 540\n            :\n                PC_PHYS_PORT_ID: 481\n            ?\n                PORT_ID: 541\n            :\n                PC_PHYS_PORT_ID: 485\n            ?\n                PORT_ID: 542\n            :\n                PC_PHYS_PORT_ID: 489\n            ?\n                PORT_ID: 543\n            :\n                PC_PHYS_PORT_ID: 493\n            ?\n                PORT_ID: 558\n            :\n                PC_PHYS_PORT_ID: 497\n            ?\n                PORT_ID: 559\n            :\n                PC_PHYS_PORT_ID: 501\n            ?\n                PORT_ID: 560\n            :\n                PC_PHYS_PORT_ID: 505\n            ?\n                PORT_ID: 561\n            :\n                PC_PHYS_PORT_ID: 509\n...\n---\ndevice:\n    0:\n        PC_PORT:\n            ?\n                PORT_ID: [[1, 4],\n                          [18, 21],\n                          [36, 39],\n                          [54, 57],\n                          [72, 75],\n                          [90, 93],\n                          [108, 111],\n                          [126, 129],\n                          [144, 147],\n                          [162, 165],\n                          [180, 183],\n                          [198, 201],\n                          [216, 219],\n                          [234, 237],\n                          [252, 255],\n                          [270, 273],\n                          [288, 291],\n                          [306, 309],\n                          [324, 327],\n                          [342, 345],\n                          [360, 363],\n                          [378, 381],\n                          [396, 399],\n                          [414, 417],\n                          [432, 435],\n                          [450, 453],\n                          [468, 471],\n                          [486, 489],\n                          [504, 507],\n                          [522, 525],\n                          [540, 543],\n                          [558, 561]]\n            :\n                ENABLE: 1\n                SPEED: 800000\n                NUM_LANES: 4\n                FEC_MODE: PC_FEC_RS544_2XN_IEEE\n                MAX_FRAME_SIZE: 9416\n                LINK_TRAINING: 1\n...\n---\ndevice:\n    0:\n        DEVICE_CONFIG:\n            AUTOLOAD_BOARD_SETTINGS: 0\n...\n---\nbcm_device:\n    0:\n        global:\n            pktio_mode: 1\n            vlan_flooding_l2mc_num_reserved: 0\n            ipv6_lpm_128b_enable: 1\n            shared_block_mask_section: uc_bc\n            skip_protocol_default_entries: 1\n            # LTSW uses value 1 for ALPM combined mode\n            l3_alpm_template: 1\n            l3_alpm_hit_skip: 1\n            sai_feat_tail_timestamp : 0\n            sai_port_phy_time_sync_en : 0\n            sai_field_group_auto_prioritize: 1\n            #l3_intf_vlan_split_egress for MTU at L3IF\n            l3_intf_vlan_split_egress : 1\n            pfc_deadlock_seq_control : 1\n            sai_tunnel_support: 1\n            bcm_tunnel_term_compatible_mode: 1\n            l3_ecmp_member_first_lkup_mem_size: 32768\n            #enable port queue drop stats\n            sai_stats_support_mask: 0\n            #disable vxlan tunnel stats\n            sai_stats_disable_mask: 0x200\n            #For PPIU Mode, Set resources for counters in global mode counters like ACL, etc\n            global_flexctr_ing_action_num_reserved: 20\n            global_flexctr_ing_pool_num_reserved: 8\n            global_flexctr_ing_op_profile_num_reserved: 20\n            global_flexctr_ing_group_num_reserved: 2\n            global_flexctr_egr_action_num_reserved: 8\n            global_flexctr_egr_pool_num_reserved: 5\n            global_flexctr_egr_op_profile_num_reserved: 10\n            global_flexctr_egr_group_num_reserved: 1\n            l3_alpm_large_vrf_mode: 1\n            l3_ecmp_member_secondary_mem_size: 8192\n            stat_custom_receive0_management_mode: 1\n...\n---\ndevice:\n    0:\n        # Per pipe flex counter configuration. Enable PPIU Mode\n        CTR_EFLEX_CONFIG:\n            CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 1\n            CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n            CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 1\n            CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n\n        # IFP mode\n        FP_CONFIG:\n            FP_ING_OPERMODE: GLOBAL_PIPE_AWARE\n\n        #CTR COS_ENABLE\n        CTR_ING_COS_Q_CONFIG:\n            COS_ENABLE: 0\n...\n"
+          "yamlConfig": "---\ndevice:\n  0:\n    PC_PM_CORE:\n      ?\n        PC_PM_ID: 1\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x20317645\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x64750231\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x38\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC6\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 2\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x20317654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x46572031\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x38\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 3\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45671302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13027564\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x1C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x53\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 4\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54671302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13205746\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x1C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xE3\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 5\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74560312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30125647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xE8\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 6\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56470123\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x7C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x7C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 7\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107465\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651023\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3E\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x3E\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 8\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x3E\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 9\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74560312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30125647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x93\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x33\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 10\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57462031\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x8C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA3\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 11\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026475\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x31\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC5\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 12\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026457\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x32\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 13\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23014765\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC1\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 14\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23014756\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC2\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC6\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 15\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x43\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x63\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 16\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x83\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x53\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 17\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x31204675\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651023\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCE\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x39\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 18\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x31204657\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x35\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 19\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 20\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x73\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x9C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 21\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74560312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30125647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xE8\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 22\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56470123\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x7C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x6C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 23\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107465\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651023\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3E\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x36\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 24\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x3A\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 25\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74560312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30125647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x93\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x33\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 26\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57462031\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x8C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xB3\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 27\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026475\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x31\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 28\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026457\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x32\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 29\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x20317645\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x64750231\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x37\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xF9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 30\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x20317654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x46572031\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x37\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xF5\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 31\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45671302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13027564\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xEC\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAF\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 32\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54671302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13205746\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xEC\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x1F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 33\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45763120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x31027564\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x23\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x90\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 34\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54763120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x31205746\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x23\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA0\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 35\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02136745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x64750213\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC4\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x05\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 36\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02136754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x46572013\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC4\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x0B\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 37\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x12035674\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47561230\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x39\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x33\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 38\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x31204657\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x31\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 39\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 40\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x73\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 41\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x12035674\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47561230\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD4\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 42\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23014756\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC2\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC6\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 43\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x43\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x63\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 44\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x83\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x53\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 45\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75462031\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x4C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x93\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 46\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57462031\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x8C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA3\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 47\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026475\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x31\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC5\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 48\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x13026457\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x32\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 49\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65470123\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xBC\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x5C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 50\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56470123\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x7C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x6C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 51\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107465\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74651023\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3E\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x36\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 52\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x3A\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 53\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x12035674\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47561230\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x39\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x33\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 54\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x31204657\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560123\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x35\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 55\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 56\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57640213\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x73\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x9C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 57\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x12035674\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47561230\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD4\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 58\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23014756\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x47560132\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC2\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xC2\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 59\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23106574\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x43\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x43\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 60\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23015647\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x83\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x43\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 61\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45763120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x31027564\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x6C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 62\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54763120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x31205746\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x5C\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 63\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02136745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x64750213\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCB\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x3A\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 64\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02136754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x46572013\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCB\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x34\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 65\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x3210\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x3210\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x00\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x00\n        TX_POLARITY_FLIP_AUTO: 0\n...\n---\ndevice:\n  0:\n    PC_PORT_PHYS_MAP:\n      ?\n        PORT_ID: 1\n      :\n        PC_PHYS_PORT_ID: 1\n      ?\n        PORT_ID: 5\n      :\n        PC_PHYS_PORT_ID: 5\n      ?\n        PORT_ID: 8\n      :\n        PC_PHYS_PORT_ID: 9\n      ?\n        PORT_ID: 12\n      :\n        PC_PHYS_PORT_ID: 13\n      ?\n        PORT_ID: 18\n      :\n        PC_PHYS_PORT_ID: 17\n      ?\n        PORT_ID: 22\n      :\n        PC_PHYS_PORT_ID: 21\n      ?\n        PORT_ID: 26\n      :\n        PC_PHYS_PORT_ID: 25\n      ?\n        PORT_ID: 30\n      :\n        PC_PHYS_PORT_ID: 29\n      ?\n        PORT_ID: 36\n      :\n        PC_PHYS_PORT_ID: 33\n      ?\n        PORT_ID: 40\n      :\n        PC_PHYS_PORT_ID: 37\n      ?\n        PORT_ID: 44\n      :\n        PC_PHYS_PORT_ID: 41\n      ?\n        PORT_ID: 48\n      :\n        PC_PHYS_PORT_ID: 45\n      ?\n        PORT_ID: 54\n      :\n        PC_PHYS_PORT_ID: 49\n      ?\n        PORT_ID: 58\n      :\n        PC_PHYS_PORT_ID: 53\n      ?\n        PORT_ID: 62\n      :\n        PC_PHYS_PORT_ID: 57\n      ?\n        PORT_ID: 66\n      :\n        PC_PHYS_PORT_ID: 61\n      ?\n        PORT_ID: 72\n      :\n        PC_PHYS_PORT_ID: 65\n      ?\n        PORT_ID: 76\n      :\n        PC_PHYS_PORT_ID: 69\n      ?\n        PORT_ID: 80\n      :\n        PC_PHYS_PORT_ID: 73\n      ?\n        PORT_ID: 84\n      :\n        PC_PHYS_PORT_ID: 77\n      ?\n        PORT_ID: 90\n      :\n        PC_PHYS_PORT_ID: 81\n      ?\n        PORT_ID: 94\n      :\n        PC_PHYS_PORT_ID: 85\n      ?\n        PORT_ID: 98\n      :\n        PC_PHYS_PORT_ID: 89\n      ?\n        PORT_ID: 102\n      :\n        PC_PHYS_PORT_ID: 93\n      ?\n        PORT_ID: 108\n      :\n        PC_PHYS_PORT_ID: 97\n      ?\n        PORT_ID: 112\n      :\n        PC_PHYS_PORT_ID: 101\n      ?\n        PORT_ID: 116\n      :\n        PC_PHYS_PORT_ID: 105\n      ?\n        PORT_ID: 120\n      :\n        PC_PHYS_PORT_ID: 109\n      ?\n        PORT_ID: 126\n      :\n        PC_PHYS_PORT_ID: 113\n      ?\n        PORT_ID: 130\n      :\n        PC_PHYS_PORT_ID: 117\n      ?\n        PORT_ID: 134\n      :\n        PC_PHYS_PORT_ID: 121\n      ?\n        PORT_ID: 138\n      :\n        PC_PHYS_PORT_ID: 125\n      ?\n        PORT_ID: 144\n      :\n        PC_PHYS_PORT_ID: 129\n      ?\n        PORT_ID: 148\n      :\n        PC_PHYS_PORT_ID: 133\n      ?\n        PORT_ID: 152\n      :\n        PC_PHYS_PORT_ID: 137\n      ?\n        PORT_ID: 156\n      :\n        PC_PHYS_PORT_ID: 141\n      ?\n        PORT_ID: 162\n      :\n        PC_PHYS_PORT_ID: 145\n      ?\n        PORT_ID: 166\n      :\n        PC_PHYS_PORT_ID: 149\n      ?\n        PORT_ID: 170\n      :\n        PC_PHYS_PORT_ID: 153\n      ?\n        PORT_ID: 174\n      :\n        PC_PHYS_PORT_ID: 157\n      ?\n        PORT_ID: 180\n      :\n        PC_PHYS_PORT_ID: 161\n      ?\n        PORT_ID: 184\n      :\n        PC_PHYS_PORT_ID: 165\n      ?\n        PORT_ID: 188\n      :\n        PC_PHYS_PORT_ID: 169\n      ?\n        PORT_ID: 192\n      :\n        PC_PHYS_PORT_ID: 173\n      ?\n        PORT_ID: 198\n      :\n        PC_PHYS_PORT_ID: 177\n      ?\n        PORT_ID: 202\n      :\n        PC_PHYS_PORT_ID: 181\n      ?\n        PORT_ID: 206\n      :\n        PC_PHYS_PORT_ID: 185\n      ?\n        PORT_ID: 210\n      :\n        PC_PHYS_PORT_ID: 189\n      ?\n        PORT_ID: 216\n      :\n        PC_PHYS_PORT_ID: 193\n      ?\n        PORT_ID: 220\n      :\n        PC_PHYS_PORT_ID: 197\n      ?\n        PORT_ID: 224\n      :\n        PC_PHYS_PORT_ID: 201\n      ?\n        PORT_ID: 228\n      :\n        PC_PHYS_PORT_ID: 205\n      ?\n        PORT_ID: 234\n      :\n        PC_PHYS_PORT_ID: 209\n      ?\n        PORT_ID: 238\n      :\n        PC_PHYS_PORT_ID: 213\n      ?\n        PORT_ID: 242\n      :\n        PC_PHYS_PORT_ID: 217\n      ?\n        PORT_ID: 246\n      :\n        PC_PHYS_PORT_ID: 221\n      ?\n        PORT_ID: 252\n      :\n        PC_PHYS_PORT_ID: 225\n      ?\n        PORT_ID: 256\n      :\n        PC_PHYS_PORT_ID: 229\n      ?\n        PORT_ID: 260\n      :\n        PC_PHYS_PORT_ID: 233\n      ?\n        PORT_ID: 264\n      :\n        PC_PHYS_PORT_ID: 237\n      ?\n        PORT_ID: 270\n      :\n        PC_PHYS_PORT_ID: 241\n      ?\n        PORT_ID: 274\n      :\n        PC_PHYS_PORT_ID: 245\n      ?\n        PORT_ID: 278\n      :\n        PC_PHYS_PORT_ID: 249\n      ?\n        PORT_ID: 282\n      :\n        PC_PHYS_PORT_ID: 253\n      ?\n        PORT_ID: 288\n      :\n        PC_PHYS_PORT_ID: 257\n      ?\n        PORT_ID: 292\n      :\n        PC_PHYS_PORT_ID: 261\n      ?\n        PORT_ID: 296\n      :\n        PC_PHYS_PORT_ID: 265\n      ?\n        PORT_ID: 300\n      :\n        PC_PHYS_PORT_ID: 269\n      ?\n        PORT_ID: 306\n      :\n        PC_PHYS_PORT_ID: 273\n      ?\n        PORT_ID: 310\n      :\n        PC_PHYS_PORT_ID: 277\n      ?\n        PORT_ID: 314\n      :\n        PC_PHYS_PORT_ID: 281\n      ?\n        PORT_ID: 318\n      :\n        PC_PHYS_PORT_ID: 285\n      ?\n        PORT_ID: 324\n      :\n        PC_PHYS_PORT_ID: 289\n      ?\n        PORT_ID: 328\n      :\n        PC_PHYS_PORT_ID: 293\n      ?\n        PORT_ID: 332\n      :\n        PC_PHYS_PORT_ID: 297\n      ?\n        PORT_ID: 336\n      :\n        PC_PHYS_PORT_ID: 301\n      ?\n        PORT_ID: 342\n      :\n        PC_PHYS_PORT_ID: 305\n      ?\n        PORT_ID: 346\n      :\n        PC_PHYS_PORT_ID: 309\n      ?\n        PORT_ID: 350\n      :\n        PC_PHYS_PORT_ID: 313\n      ?\n        PORT_ID: 354\n      :\n        PC_PHYS_PORT_ID: 317\n      ?\n        PORT_ID: 360\n      :\n        PC_PHYS_PORT_ID: 321\n      ?\n        PORT_ID: 364\n      :\n        PC_PHYS_PORT_ID: 325\n      ?\n        PORT_ID: 368\n      :\n        PC_PHYS_PORT_ID: 329\n      ?\n        PORT_ID: 372\n      :\n        PC_PHYS_PORT_ID: 333\n      ?\n        PORT_ID: 378\n      :\n        PC_PHYS_PORT_ID: 337\n      ?\n        PORT_ID: 382\n      :\n        PC_PHYS_PORT_ID: 341\n      ?\n        PORT_ID: 386\n      :\n        PC_PHYS_PORT_ID: 345\n      ?\n        PORT_ID: 390\n      :\n        PC_PHYS_PORT_ID: 349\n      ?\n        PORT_ID: 396\n      :\n        PC_PHYS_PORT_ID: 353\n      ?\n        PORT_ID: 400\n      :\n        PC_PHYS_PORT_ID: 357\n      ?\n        PORT_ID: 404\n      :\n        PC_PHYS_PORT_ID: 361\n      ?\n        PORT_ID: 408\n      :\n        PC_PHYS_PORT_ID: 365\n      ?\n        PORT_ID: 414\n      :\n        PC_PHYS_PORT_ID: 369\n      ?\n        PORT_ID: 418\n      :\n        PC_PHYS_PORT_ID: 373\n      ?\n        PORT_ID: 422\n      :\n        PC_PHYS_PORT_ID: 377\n      ?\n        PORT_ID: 426\n      :\n        PC_PHYS_PORT_ID: 381\n      ?\n        PORT_ID: 432\n      :\n        PC_PHYS_PORT_ID: 385\n      ?\n        PORT_ID: 436\n      :\n        PC_PHYS_PORT_ID: 389\n      ?\n        PORT_ID: 440\n      :\n        PC_PHYS_PORT_ID: 393\n      ?\n        PORT_ID: 444\n      :\n        PC_PHYS_PORT_ID: 397\n      ?\n        PORT_ID: 450\n      :\n        PC_PHYS_PORT_ID: 401\n      ?\n        PORT_ID: 454\n      :\n        PC_PHYS_PORT_ID: 405\n      ?\n        PORT_ID: 458\n      :\n        PC_PHYS_PORT_ID: 409\n      ?\n        PORT_ID: 462\n      :\n        PC_PHYS_PORT_ID: 413\n      ?\n        PORT_ID: 468\n      :\n        PC_PHYS_PORT_ID: 417\n      ?\n        PORT_ID: 472\n      :\n        PC_PHYS_PORT_ID: 421\n      ?\n        PORT_ID: 476\n      :\n        PC_PHYS_PORT_ID: 425\n      ?\n        PORT_ID: 480\n      :\n        PC_PHYS_PORT_ID: 429\n      ?\n        PORT_ID: 486\n      :\n        PC_PHYS_PORT_ID: 433\n      ?\n        PORT_ID: 490\n      :\n        PC_PHYS_PORT_ID: 437\n      ?\n        PORT_ID: 494\n      :\n        PC_PHYS_PORT_ID: 441\n      ?\n        PORT_ID: 498\n      :\n        PC_PHYS_PORT_ID: 445\n      ?\n        PORT_ID: 504\n      :\n        PC_PHYS_PORT_ID: 449\n      ?\n        PORT_ID: 508\n      :\n        PC_PHYS_PORT_ID: 453\n      ?\n        PORT_ID: 512\n      :\n        PC_PHYS_PORT_ID: 457\n      ?\n        PORT_ID: 516\n      :\n        PC_PHYS_PORT_ID: 461\n      ?\n        PORT_ID: 522\n      :\n        PC_PHYS_PORT_ID: 465\n      ?\n        PORT_ID: 526\n      :\n        PC_PHYS_PORT_ID: 469\n      ?\n        PORT_ID: 530\n      :\n        PC_PHYS_PORT_ID: 473\n      ?\n        PORT_ID: 534\n      :\n        PC_PHYS_PORT_ID: 477\n      ?\n        PORT_ID: 540\n      :\n        PC_PHYS_PORT_ID: 481\n      ?\n        PORT_ID: 544\n      :\n        PC_PHYS_PORT_ID: 485\n      ?\n        PORT_ID: 548\n      :\n        PC_PHYS_PORT_ID: 489\n      ?\n        PORT_ID: 552\n      :\n        PC_PHYS_PORT_ID: 493\n      ?\n        PORT_ID: 558\n      :\n        PC_PHYS_PORT_ID: 497\n      ?\n        PORT_ID: 562\n      :\n        PC_PHYS_PORT_ID: 501\n      ?\n        PORT_ID: 566\n      :\n        PC_PHYS_PORT_ID: 505\n      ?\n        PORT_ID: 570\n      :\n        PC_PHYS_PORT_ID: 509\n      ?\n        PORT_ID: 0\n      :\n        PC_PHYS_PORT_ID: 0\n...\n---\ndevice:\n  0:\n    PC_PORT:\n      ?\n        PORT_ID: 0\n      :\n        ENABLE: 1\n        SPEED: 10000\n        NUM_LANES: 1\n      ?\n        PORT_ID: [[1, 1], [5, 5], [8, 8], [12, 12], [18, 18], [22, 22], [26, 26],\n        [30, 30], [36, 36], [40, 40], [44, 44], [48, 48], [54, 54], [58, 58], [62,\n        62], [66, 66], [72, 72], [76, 76], [80, 80], [84, 84], [90, 90], [94, 94],\n        [98, 98], [102, 102], [108, 108], [112, 112], [116, 116], [120, 120], [126,\n        126], [130, 130], [134, 134], [138, 138], [144, 144], [148, 148], [152, 152],\n        [156, 156], [162, 162], [166, 166], [170, 170], [174, 174], [180, 180], [184,\n        184], [188, 188], [192, 192], [198, 198], [202, 202], [206, 206], [210, 210],\n        [216, 216], [220, 220], [224, 224], [228, 228], [234, 234], [238, 238], [242,\n        242], [246, 246], [252, 252], [256, 256], [260, 260], [264, 264], [270, 270],\n        [274, 274], [278, 278], [282, 282], [288, 288], [292, 292], [296, 296], [300,\n        300], [306, 306], [310, 310], [314, 314], [318, 318], [324, 324], [328, 328],\n        [332, 332], [336, 336], [342, 342], [346, 346], [350, 350], [354, 354], [360,\n        360], [364, 364], [368, 368], [372, 372], [378, 378], [382, 382], [386, 386],\n        [390, 390], [396, 396], [400, 400], [404, 404], [408, 408], [414, 414], [418,\n        418], [422, 422], [426, 426], [432, 432], [436, 436], [440, 440], [444, 444],\n        [450, 450], [454, 454], [458, 458], [462, 462], [468, 468], [472, 472], [476,\n        476], [480, 480], [486, 486], [490, 490], [494, 494], [498, 498], [504, 504],\n        [508, 508], [512, 512], [516, 516], [522, 522], [526, 526], [530, 530], [534,\n        534], [540, 540], [544, 544], [548, 548], [552, 552], [558, 558], [562, 562],\n        [566, 566], [570, 570]]\n      :\n        ENABLE: 0\n        SPEED: 800000\n        NUM_LANES: 4\n        FEC_MODE: PC_FEC_RS544_2XN_IEEE\n        MAX_FRAME_SIZE: 9416\n...\n---\ndevice:\n  0:\n    PORT_CONFIG:\n      PORT_SYSTEM_PROFILE_OPERMODE_PIPEUNIQUE: 1\n...\n---\nbcm_device:\n  0:\n    global:\n      l3_alpm_template: 1\n      l3_alpm_hit_mode: 1\n      ipv6_lpm_128b_enable: 1\n      pktio_driver_type: 1\n      qos_map_multi_get_mode: 1\n      rx_cosq_mapping_management_mode: 0\n      l3_iif_reservation_skip: 0\n      pcie_host_intf_timeout_purge_enable: 0\n      macro_flow_hash_shuffle_random_seed: 34345645\n      bcm_linkscan_interval: 25000\n      sai_common_hash_crc: 0x1\n      sai_disable_srcmacqedstmac_ctrl: 0x1\n      sai_acl_qset_optimization: 0x1\n      sai_optimized_mmu: 0x1\n      sai_pkt_rx_custom_cfg: 1\n      sai_pkt_rx_pkt_size: 16512\n      sai_pkt_rx_cfg_ppc: 16\n      sai_async_fdb_nbr_enable: 0x1\n      sai_pfc_defaults_disable: 0x1\n      sai_ifp_enable_on_cpu_tx: 0x1\n      sai_vfp_smac_drop_filter_disable: 1\n      sai_macro_flow_based_hash: 1\n      sai_mmu_qgroups_default: 1\n      sai_dis_ctr_incr_on_port_ln_dn: 0\n      custom_feature_mesh_topology_sync_mode: 1\n      sai_ecmp_group_members_increment: 1\n      sai_field_group_auto_prioritize: 1\n      bcm_tunnel_term_compatible_mode: 1\n      sai_l2_cpu_fdb_event_suppress: 1\n      sai_port_phy_time_sync_en: 0\n      sai_stats_support_mask: 0x2\n      sai_disable_internal_port_serdes: 1\n      sai_eapol_trap_use_bcast_mac: 1\n      stat_custom_receive0_management_mode: 1\n      global_flexctr_ing_action_num_reserved: 20\n      global_flexctr_ing_pool_num_reserved: 8\n      global_flexctr_ing_op_profile_num_reserved: 20\n      global_flexctr_ing_group_num_reserved: 2\n      global_flexctr_egr_action_num_reserved: 8\n      global_flexctr_egr_pool_num_reserved: 5\n      global_flexctr_egr_op_profile_num_reserved: 10\n      global_flexctr_egr_group_num_reserved: 1\n      sai_uncached_port_stats: 0x1\n...\n---\ndevice:\n  0:\n    TM_THD_CONFIG:\n      THRESHOLD_MODE: LOSSY\n...\n---\ndevice:\n  0:\n    PORT:\n      ?\n        PORT_ID: [[1, 1], [5, 5], [8, 8], [12, 12], [18, 18], [22, 22], [26, 26],\n        [30, 30], [36, 36], [40, 40], [44, 44], [48, 48], [54, 54], [58, 58], [62,\n        62], [66, 66], [72, 72], [76, 76], [80, 80], [84, 84], [90, 90], [94, 94],\n        [98, 98], [102, 102], [108, 108], [112, 112], [116, 116], [120, 120], [126,\n        126], [130, 130], [134, 134], [138, 138], [144, 144], [148, 148], [152, 152],\n        [156, 156], [162, 162], [166, 166], [170, 170], [174, 174], [180, 180], [184,\n        184], [188, 188], [192, 192], [198, 198], [202, 202], [206, 206], [210, 210],\n        [216, 216], [220, 220], [224, 224], [228, 228], [234, 234], [238, 238], [242,\n        242], [246, 246], [252, 252], [256, 256], [260, 260], [264, 264], [270, 270],\n        [274, 274], [278, 278], [282, 282], [288, 288], [292, 292], [296, 296], [300,\n        300], [306, 306], [310, 310], [314, 314], [318, 318], [324, 324], [328, 328],\n        [332, 332], [336, 336], [342, 342], [346, 346], [350, 350], [354, 354], [360,\n        360], [364, 364], [368, 368], [372, 372], [378, 378], [382, 382], [386, 386],\n        [390, 390], [396, 396], [400, 400], [404, 404], [408, 408], [414, 414], [418,\n        418], [422, 422], [426, 426], [432, 432], [436, 436], [440, 440], [444, 444],\n        [450, 450], [454, 454], [458, 458], [462, 462], [468, 468], [472, 472], [476,\n        476], [480, 480], [486, 486], [490, 490], [494, 494], [498, 498], [504, 504],\n        [508, 508], [512, 512], [516, 516], [522, 522], [526, 526], [530, 530], [534,\n        534], [540, 540], [544, 544], [548, 548], [552, 552], [558, 558], [562, 562],\n        [566, 566], [570, 570]]\n      :\n        MTU: 9416\n        MTU_CHECK: 1\n...\n---\ndevice:\n  0:\n    DEVICE_CONFIG:\n      AUTOLOAD_BOARD_SETTINGS: 0\n...\n---\ndevice:\n  0:\n    FP_CONFIG:\n      FP_ING_OPERMODE: GLOBAL_PIPE_AWARE\n...\n---\ndevice:\n  0:\n    CTR_EFLEX_CONFIG:\n      CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n...\n"
         }
       }
     }
   },
-  "thriftApiToRateLimitInQps": {}
+  "thriftApiToRateLimitInQps": {
+    
+  }
 }


### PR DESCRIPTION
### **Description**
AgentCoppEapolTest/*EapolToHighPriQ failed with following error:

V0415 04:32:06.142405 240788 AgentCoppTests.cpp:387] Packet of dstMac=ff:ff:ff:ff:ff:ff. Ethertype=888e. Queue=9, before pkts:0, after pkts:0
/var/FBOSS/th6_0905/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp:393: Failure
Expected equality of these values:
1
afterOutPkts - beforeOutPkts
Which is: 0

### **Motivation**
fixup testcase AgentCoppEapolTest/*EapolToHighPriQ of sai_agent_hw_test
RootCause:
the Eapol packet constructed by Fboss was a broadcast packet, while ASIC TOMAHAWK6 won't punt the broadcast Eapol packet to the right queue without sai_eapol_trap_use_bcast_mac enabled
Fix:
1. Update fboss/oss/link_test_configs/vendor/icecube800bc.materialized_JSON to the latest sai test config file provided by Meta
2. Based on the upper file, add "sai_eapol_trap_use_bcast_mac :1" to platform->chip->asicConfig->common->yamlConfig part to fixup testcase AgentCoppEapolTest/*EapolToHighPriQ

### **Test Plan**
rerun sai_agent_hw_test with gtest_filter "AgentCoppEapolTest/0.EapolToHighPriQ"
./sai_agent_hw_test-sai_impl --gtest_filter=AgentCoppEapolTest/0.EapolToHighPriQ
[EapolToHighPriQ.txt](https://github.com/user-attachments/files/22288863/EapolToHighPriQ.txt)