### PR TITLE
Tahansb800bc: config: update sensors' threshold and calibration formulas

### DIFF
--- a/fboss/platform/configs/tahansb800bc/sensor_service.json
+++ b/fboss/platform/configs/tahansb800bc/sensor_service.json
@@ -460,6 +460,15 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "MCB_PU101_XP48R0V_STBY_PIN",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
           "name": "MCB_PU1066_XP48R0V_HOTSWAP_VIN",
           "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/in1_input",
           "type": 1,
@@ -4102,6 +4111,33 @@
           },
           "compute": "@/1000.0"
         }
+      ]
+    }
+  ],
+  "powerConfig": {
+    "perSlotPowerConfigs": [
+      {
+        "__comment__": "Hot-swap VRM chip ltc4287 monitors the main power consumption of the system",
+        "name": "HSC",
+        "powerSensorName": "MCB_PU1066_XP48R0V_HOTSWAP_PIN"
+      }
+    ],
+    "__comment__": "TPS16890 chip monitors the standby power consumption of the system",
+    "otherPowerSensorNames": [
+      "MCB_PU101_XP48R0V_STBY_PIN"
+    ],
+    "inputVoltageSensors": [
+      "MCB_PU1066_XP48R0V_HOTSWAP_VIN",
+      "MCB_PU101_XP48R0V_STBY_VIN"
+    ]
+  },
+  "temperatureConfigs": [
+    {
+      "name": "ASIC",
+      "temperatureSensorNames": [
+        "SMB_U29_LEFT_TMP432_1_TEMP2",
+        "SMB_U29_LEFT_TMP432_1_TEMP3",
+        "SMB_U30_RIGHT_TMP432_2_TEMP2"
       ]
     }
   ]


### PR DESCRIPTION
# Description

This PR is about updating some sensors' threshold and calibration formulas

# Motivation

Based on the latest hardware specifications , device datasheets and their validation, some sensors' thresholds and calibration formulas should be updated. The required changes include:


- Adding and Updating thresholds for several sensors 
- Adding  temperature sensors for SMB_TH6_SENSOR_TMP432_1 
- Revising the current and power calibration formulas for the LTC4287(/run/devmap/sensors/48V_HSC_MONITOR/curr1_input , /run/devmap/sensors/48V_HSC_MONITOR/power1_input ) and TPS25990(/run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input, /run/devmap/sensors/MCB_FAN1_SENSOR/curr1_input, /run/devmap/sensors/MCB_FAN2_SENSOR/curr1_input , /run/devmap/sensors/MCB_FAN3_SENSOR/curr1_input, /run/devmap/sensors/MCB_FAN4_SENSOR/curr1_input) devices.
- Updating the sensor node of TPS25990(changed in2_input to in3_input)
- Updating part of sensors name of SMB_ASIC_VOLTAGE_7(xdpe15284) for more accurate identification
- Adding the configuration for power and ASIC temperature

# Test Plan

1. Used jq command to pretty the format and the correctness of the format has been verified on this website https://jsonlint.com/ 
2. Compilation and config validation have passed
<img width="647" height="388" alt="image" src="https://github.com/user-attachments/assets/de5a07b4-35ee-46fa-8e29-61a160187f82" />

3. Services of platform_manager/sensor_service/data_corral_service/fan_service run normally on the tahansb device, pls refer the logs:
[platform_manager.log](https://github.com/user-attachments/files/22291834/platform_manager.log)
[sensor_service.log](https://github.com/user-attachments/files/22291838/sensor_service.log)
[data_corral_service.log](https://github.com/user-attachments/files/22291829/data_corral_service.log)
[fan_service.log](https://github.com/user-attachments/files/22291830/fan_service.log)

4. Hardware tests of platform_manager/sensor_service/data_corral_service/fan_service/weutil/fwutil passed, pls refer the logs:
[platform_manager_hw_test.log](https://github.com/user-attachments/files/22291871/platform_manager_hw_test.log)
[sensor_service_hw_test.log](https://github.com/user-attachments/files/22291872/sensor_service_hw_test.log)
[data_corral_service_hw_test.log](https://github.com/user-attachments/files/22291868/data_corral_service_hw_test.log)
[fan_service_hw_test.log](https://github.com/user-attachments/files/22291869/fan_service_hw_test.log)
[weutil_hw_test.log](https://github.com/user-attachments/files/22291873/weutil_hw_test.log)
[fw_util_hw_test.log](https://github.com/user-attachments/files/22291870/fw_util_hw_test.log)

The logs of commit 4f00fd2a59c34a387e956a66028d49b877588582 :
[PM Services & HW Tests.zip](https://github.com/user-attachments/files/23180447/PM.Services.HW.Tests.zip)

The logs of commit 6ffe6ffaa4c097298e3f2703c59158fd568fa237
[PM Services&HW Tests(come 421).zip](https://github.com/user-attachments/files/23496103/PM.Services.HW.Tests.come.421.zip)
[PM Services&Hw Tests(come 422).zip](https://github.com/user-attachments/files/23496485/PM.Services.Hw.Tests.come.422.zip)

The logs of commit e53e2744b76afdf21db75960cf502f5dad6345f9:
sensor_service worked as expected
<img width="772" height="94" alt="image" src="https://github.com/user-attachments/assets/1793cd47-8717-4b08-bca2-419ea97398ae" />

Pls refer the full logs:
[PM Services&HW Tests(come 421).zip](https://github.com/user-attachments/files/23673807/421.zip)
[PM Services&HW Tests(come 422).zip](https://github.com/user-attachments/files/23673907/422.zip)
