### PR TITLE
[showtech] Add GPIO Debug to Showtech

### DIFF
--- a/cmake/PlatformShowtech.cmake
+++ b/cmake/PlatformShowtech.cmake
@@ -26,6 +26,8 @@ target_link_libraries(showtech
   platform_config_lib
   platform_name_lib
   i2c_ctrl
+  gpiod_line
+  ${LIBGPIOD}
   ${RE2}
   CLI11::CLI11
 )

--- a/fboss/platform/configs/darwin/showtech.json
+++ b/fboss/platform/configs/darwin/showtech.json
@@ -1,4 +1,67 @@
 {
   "i2cBusIgnore": [],
-  "psus": []
+  "psus": [],
+  "gpios": [
+    {
+      "path": "/run/devmap/gpiochips/RACKMON_PLS",
+      "lines": [
+        {
+          "name": "RJ1_BKP_RED",
+          "lineIndex": 0
+        },
+        {
+          "name": "RJ2_BKP_RED",
+          "lineIndex": 1
+        },
+        {
+          "name": "RJ3_BKP_RED",
+          "lineIndex": 2
+        },
+        {
+          "name": "GPIO_FTDI_RST",
+          "lineIndex": 3
+        },
+        {
+          "name": "RJ1_PWR_OK",
+          "lineIndex": 4
+        },
+        {
+          "name": "RJ2_PWR_OK",
+          "lineIndex": 5
+        },
+        {
+          "name": "RJ3_PWR_OK",
+          "lineIndex": 6
+        },
+        {
+          "name": "BMC_MOD_ID0",
+          "lineIndex": 9
+        },
+        {
+          "name": "BMC_MOD_ID1",
+          "lineIndex": 10
+        },
+        {
+          "name": "BMC_MOD_ID2",
+          "lineIndex": 11
+        },
+        {
+          "name": "BMC_ALIVE",
+          "lineIndex": 12
+        },
+        {
+          "name": "BMC_PGOOD_CONN",
+          "lineIndex": 13
+        },
+        {
+          "name": "IOEXP_BMC_RESET",
+          "lineIndex": 14
+        },
+        {
+          "name": "BMC_PRSNT_L",
+          "lineIndex": 15
+        }
+      ]
+    }
+  ]
 }

--- a/fboss/platform/configs/darwin48v/showtech.json
+++ b/fboss/platform/configs/darwin48v/showtech.json
@@ -2,5 +2,68 @@
   "i2cBusIgnore": [],
   "psus": [
     "/run/devmap/sensors/PSU_PMBUS"
+  ],
+  "gpios": [
+    {
+      "path": "/run/devmap/gpiochips/RACKMON_PLS",
+      "lines": [
+        {
+          "name": "RJ1_BKP_RED",
+          "lineIndex": 0
+        },
+        {
+          "name": "RJ2_BKP_RED",
+          "lineIndex": 1
+        },
+        {
+          "name": "RJ3_BKP_RED",
+          "lineIndex": 2
+        },
+        {
+          "name": "GPIO_FTDI_RST",
+          "lineIndex": 3
+        },
+        {
+          "name": "RJ1_PWR_OK",
+          "lineIndex": 4
+        },
+        {
+          "name": "RJ2_PWR_OK",
+          "lineIndex": 5
+        },
+        {
+          "name": "RJ3_PWR_OK",
+          "lineIndex": 6
+        },
+        {
+          "name": "BMC_MOD_ID0",
+          "lineIndex": 9
+        },
+        {
+          "name": "BMC_MOD_ID1",
+          "lineIndex": 10
+        },
+        {
+          "name": "BMC_MOD_ID2",
+          "lineIndex": 11
+        },
+        {
+          "name": "BMC_ALIVE",
+          "lineIndex": 12
+        },
+        {
+          "name": "BMC_PGOOD_CONN",
+          "lineIndex": 13
+        },
+        {
+          "name": "IOEXP_BMC_RESET",
+          "lineIndex": 14
+        },
+        {
+          "name": "BMC_PRSNT_L",
+          "lineIndex": 15
+        }
+      ]
+    }
   ]
 }

--- a/fboss/platform/configs/meru800bfa/showtech.json
+++ b/fboss/platform/configs/meru800bfa/showtech.json
@@ -7,5 +7,6 @@
     "/run/devmap/sensors/PSU2_PMBUS",
     "/run/devmap/sensors/PSU3_PMBUS",
     "/run/devmap/sensors/PSU4_PMBUS"
-  ]
+  ],
+  "gpios": []
 }

--- a/fboss/platform/configs/meru800bia/showtech.json
+++ b/fboss/platform/configs/meru800bia/showtech.json
@@ -5,5 +5,60 @@
   "psus": [
     "/run/devmap/sensors/PSU1_PMBUS",
     "/run/devmap/sensors/PSU2_PMBUS"
+  ],
+  "gpios": [
+    {
+      "path": "/run/devmap/gpiochips/SMB_PCA",
+      "lines": [
+        {
+          "name": "SCD_DONE",
+          "lineIndex": 0
+        },
+        {
+          "name": "OVER_TEMP_L",
+          "lineIndex": 1
+        },
+        {
+          "name": "SYS_PGOOD",
+          "lineIndex": 2
+        },
+        {
+          "name": "P1V2_CP_PGOOD",
+          "lineIndex": 3
+        },
+        {
+          "name": "SCD_CRC_ERR",
+          "lineIndex": 4
+        },
+        {
+          "name": "P1V0_CP_PGOOD",
+          "lineIndex": 5
+        },
+        {
+          "name": "P1V8_CP_PGOOD",
+          "lineIndex": 6
+        },
+        {
+          "name": "P3V3_CP_PGOOD",
+          "lineIndex": 7
+        },
+        {
+          "name": "SCD_PRGM_L",
+          "lineIndex": 8
+        },
+        {
+          "name": "SCD_HOLD_L",
+          "lineIndex": 9
+        },
+        {
+          "name": "CPU_QSPI_SEL",
+          "lineIndex": 12
+        },
+        {
+          "name": "SCD_RESET_L",
+          "lineIndex": 14
+        }
+      ]
+    }
   ]
 }

--- a/fboss/platform/showtech/BUCK
+++ b/fboss/platform/showtech/BUCK
@@ -34,9 +34,11 @@ cpp_binary(
         "//folly:string",
         "//folly/logging:logging",
         "//thrift/lib/cpp2/protocol:protocol",
+        "//fboss/lib:gpiod_line",
     ],
     external_deps = [
         "CLI11",
         "re2",
+        ("libgpiod", None, "gpiod"),
     ],
 )

--- a/fboss/platform/showtech/Main.cpp
+++ b/fboss/platform/showtech/Main.cpp
@@ -31,6 +31,7 @@ const std::unordered_map<std::string, std::function<void(Utils&)>>
         {"port", [](Utils& util) { util.printPortDetails(); }},
         {"sensor", [](Utils& util) { util.printSensorDetails(); }},
         {"psu", [](Utils& util) { util.printPsuDetails(); }},
+        {"gpio", [](Utils& util) { util.printGpioDetails(); }},
         {"i2c", [](Utils& util) { util.printI2cDetails(); }},
 };
 

--- a/fboss/platform/showtech/Utils.h
+++ b/fboss/platform/showtech/Utils.h
@@ -22,6 +22,7 @@ class Utils {
   void printSensorDetails();
   void printI2cDetails();
   void printPsuDetails();
+  void printGpioDetails();
   void runFbossCliCmd(const std::string& cmd);
 
  private:

--- a/fboss/platform/showtech/showtech_config.thrift
+++ b/fboss/platform/showtech/showtech_config.thrift
@@ -4,4 +4,15 @@ namespace cpp2 facebook.fboss.platform.showtech_config
 struct ShowtechConfig {
   1: set<string> i2cBusIgnore;
   2: list<string> psus;
+  3: list<Gpio> gpios;
+}
+
+struct Gpio {
+  1: string path;
+  2: list<GpioLine> lines;
+}
+
+struct GpioLine {
+  1: string name;
+  2: i32 lineIndex;
 }


### PR DESCRIPTION
## Background
Adding gpio debug section to showtech

## Changes
- Added gpiochip configs to showtech configs for meru800bia, meru800bfa, darwin, and darwin48v
- Added `printGpioDetails()` to print gpio debug information for gpiochips specified in showtech configs

## Testing
gpio showtech output on meru800bfa
```
##### GPIO Information #####
No GPIO chip found from configs
```
gpio showtech output on meru800bia
```
##### GPIO Information #####
#### GPIO Chip Details /run/devmap/gpiochips/SMB_PCA ####
line   0:   SCD_DONE        -> 1
line   1:   OVER_TEMP_L     -> 1
line   2:   SYS_PGOOD       -> 1
line   3:   P1V2_CP_PGOOD   -> 1
line   4:   SCD_CRC_ERR     -> 0
line   5:   P1V0_CP_PGOOD   -> 1
line   6:   P1V8_CP_PGOOD   -> 1
line   7:   P3V3_CP_PGOOD   -> 1
line   8:   SCD_PRGM_L      -> 1
line   9:   SCD_HOLD_L      -> 1
line  12:   CPU_QSPI_SEL    -> 0
line  14:   SCD_RESET_L     -> 1
```
gpio showtech output on darwin48v(same on darwin)
```
##### GPIO Information #####
#### GPIO Chip Details /run/devmap/gpiochips/RACKMON_PLS ####
line   0:   RJ1_BKP_RED     -> 1
line   1:   RJ2_BKP_RED     -> 1
line   2:   RJ3_BKP_RED     -> 1
line   3:   GPIO_FTDI_RST   -> 1
line   4:   RJ1_PWR_OK      -> 1
line   5:   RJ2_PWR_OK      -> 1
line   6:   RJ3_PWR_OK      -> 1
line   9:   BMC_MOD_ID0     -> 0
line  10:   BMC_MOD_ID1     -> 0
line  11:   BMC_MOD_ID2     -> 0
line  12:   BMC_ALIVE       -> 1
line  13:   BMC_PGOOD_CONN  -> 1
line  14:   IOEXP_BMC_RESET -> 0
line  15:   BMC_PRSNT_L     -> 0
```
