### PR TITLE
[showtech] Add Fan Debug to Showtech

### DIFF
--- a/cmake/PlatformShowtech.cmake
+++ b/cmake/PlatformShowtech.cmake
@@ -12,6 +12,7 @@ add_fbthrift_cpp_library(
 )
 
 add_executable(showtech
+  fboss/platform/showtech/FanHelper.cpp
   fboss/platform/showtech/I2cHelper.cpp
   fboss/platform/showtech/Main.cpp
   fboss/platform/showtech/PsuHelper.cpp
@@ -28,6 +29,8 @@ target_link_libraries(showtech
   common_file_utils
   i2c_ctrl
   gpiod_line
+  fan_service_config_types_cpp2
+  ${LIBGPIOD}
   ${RE2}
   CLI11::CLI11
 )

--- a/fboss/platform/showtech/BUCK
+++ b/fboss/platform/showtech/BUCK
@@ -18,6 +18,7 @@ thrift_library(
 cpp_binary(
     name = "showtech",
     srcs = [
+        "FanHelper.cpp",
         "I2cHelper.cpp",
         "Main.cpp",
         "PsuHelper.cpp",
@@ -30,6 +31,7 @@ cpp_binary(
         "//fboss/lib:gpiod_line",
         "//fboss/lib/i2c:i2c_ctrl",
         "//fboss/platform/config_lib:config_lib",
+        "//fboss/platform/fan_service/if:fan_service-cpp2-types",
         "//fboss/platform/helpers:init_cli",
         "//fboss/platform/helpers:platform_name_lib",
         "//fboss/platform/helpers:platform_utils",

--- a/fboss/platform/showtech/FanHelper.cpp
+++ b/fboss/platform/showtech/FanHelper.cpp
@@ -1,0 +1,49 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/platform/showtech/FanHelper.h"
+
+#include <fmt/core.h>
+#include <gpiod.h>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+
+#include "fboss/lib/CommonFileUtils.h"
+#include "fboss/lib/GpiodLine.h"
+#include "fboss/platform/fan_service/if/gen-cpp2/fan_service_config_types.h"
+
+namespace facebook::fboss::platform {
+
+bool readFanIsPresentOnDevice(const fan_service::Fan& fan) {
+  unsigned int readVal{0};
+  if (fan.presenceSysfsPath()) {
+    readVal = static_cast<unsigned>(readSysfsAsFloat(*fan.presenceSysfsPath()));
+    return readVal == *fan.fanPresentVal();
+  } else if (fan.presenceGpio()) {
+    struct gpiod_chip* chip =
+        gpiod_chip_open(fan.presenceGpio()->path()->c_str());
+    readVal = GpiodLine(chip, *fan.presenceGpio()->lineIndex(), "gpioline")
+                  .getValue();
+    return readVal == *fan.presenceGpio()->desiredValue();
+  } else {
+    throw std::runtime_error("No fan presence config provided");
+  }
+}
+
+int readFanRpm(const fan_service::Fan& fan) {
+  return readSysfsAsFloat(*fan.rpmSysfsPath());
+}
+
+int readFanPwmPercent(const fan_service::Fan& fan) {
+  int fanPwm = readSysfsAsFloat(*fan.pwmSysfsPath());
+  return 100 * fanPwm / *fan.pwmMax();
+}
+
+float readSysfsAsFloat(const std::string& path) {
+  std::ifstream juicejuice(path);
+  std::string buf = readSysfs(path);
+  return std::stof(buf);
+}
+
+} // namespace facebook::fboss::platform

--- a/fboss/platform/showtech/FanHelper.h
+++ b/fboss/platform/showtech/FanHelper.h
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+#include <tuple>
+
+#include "fboss/platform/fan_service/if/gen-cpp2/fan_service_config_types.h"
+
+namespace facebook::fboss::platform {
+
+bool readFanIsPresentOnDevice(const fan_service::Fan& fan);
+int readFanRpm(const fan_service::Fan& fan);
+int readFanPwmPercent(const fan_service::Fan& fan);
+float readSysfsAsFloat(const std::string& path);
+
+} // namespace facebook::fboss::platform

--- a/fboss/platform/showtech/Main.cpp
+++ b/fboss/platform/showtech/Main.cpp
@@ -10,6 +10,7 @@
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
 #include "fboss/platform/config_lib/ConfigLib.h"
+#include "fboss/platform/fan_service/if/gen-cpp2/fan_service_config_types.h"
 #include "fboss/platform/helpers/InitCli.h"
 #include "fboss/platform/helpers/PlatformNameLib.h"
 #include "fboss/platform/showtech/Utils.h"
@@ -31,8 +32,9 @@ const std::unordered_map<std::string, std::function<void(Utils&)>>
         {"port", [](Utils& util) { util.printPortDetails(); }},
         {"sensor", [](Utils& util) { util.printSensorDetails(); }},
         {"psu", [](Utils& util) { util.printPsuDetails(); }},
-        {"gpio", [](Utils& util) { util.printGpioDetails(); }},
         {"pem", [](Utils& util) { util.printPemDetails(); }},
+        {"fan", [](Utils& util) { util.printFanDetails(); }},
+        {"gpio", [](Utils& util) { util.printGpioDetails(); }},
         {"i2c", [](Utils& util) { util.printI2cDetails(); }},
 };
 
@@ -100,7 +102,12 @@ int main(int argc, char** argv) {
         apache::thrift::SimpleJSONSerializer::deserialize<ShowtechConfig>(
             showtechConfJson);
 
-    Utils showtechUtil(config);
+    std::string fanServiceConfJson =
+        ConfigLib().getFanServiceConfig(platformName);
+    auto fanServiceConfig = apache::thrift::SimpleJSONSerializer::deserialize<
+        fan_service::FanServiceConfig>(fanServiceConfJson);
+
+    Utils showtechUtil(config, fanServiceConfig);
     executeRequestedDetails(showtechUtil, detailsArg);
   } catch (const std::exception& e) {
     XLOG(ERR) << "Error during showtech execution: " << e.what();

--- a/fboss/platform/showtech/Utils.h
+++ b/fboss/platform/showtech/Utils.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "fboss/platform/fan_service/if/gen-cpp2/fan_service_config_types.h"
 #include "fboss/platform/helpers/PlatformUtils.h"
 #include "fboss/platform/showtech/I2cHelper.h"
 #include "fboss/platform/showtech/gen-cpp2/showtech_config_types.h"
@@ -10,7 +11,10 @@ namespace facebook::fboss::platform {
 
 class Utils {
  public:
-  Utils(const showtech_config::ShowtechConfig& config) : config_(config){};
+  Utils(
+      const showtech_config::ShowtechConfig& config,
+      const fan_service::FanServiceConfig& fanServiceConfig)
+      : config_(config), fanServiceConfig_(fanServiceConfig){};
   ~Utils() = default;
 
   void printHostDetails();
@@ -24,9 +28,11 @@ class Utils {
   void printPsuDetails();
   void printGpioDetails();
   void printPemDetails();
+  void printFanDetails();
 
  private:
   const showtech_config::ShowtechConfig& config_;
+  const fan_service::FanServiceConfig& fanServiceConfig_;
   PlatformUtils platformUtils_{};
   I2cHelper i2cHelper_{};
   void runFbossCliCmd(const std::string& cmd);

--- a/fboss/platform/showtech/showtech_config.thrift
+++ b/fboss/platform/showtech/showtech_config.thrift
@@ -16,7 +16,6 @@ struct Gpio {
 struct GpioLine {
   1: string name;
   2: i32 lineIndex;
-  3: list<Pem> pems;
 }
 
 struct Pem {


### PR DESCRIPTION
## Background
Adding fan debug section to oss showtech. Uses fan_service configs for fan details.

## Changes
- Added `printFanDetails()` to print fan debug info based on fans specified in fan_service configs 

## Testing

Note: Only tested on systems with sysfs fan presence, we don't have device with gpio fan presence

`showtech --details fan` output:

**darwin48v (same on darwin)**
```
[root@rkdo102 admin]# showtech --details fan
I0917 20:31:48.899522  6244 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN48V
I0917 20:31:48.899600  6244 Main.cpp:97] Running showtech for platform: DARWIN48V
I0917 20:31:48.899620  6244 ConfigLib.cpp:27] The inferred platform is darwin48v
I0917 20:31:48.899650  6244 ConfigLib.cpp:27] The inferred platform is darwin48v
I0917 20:31:48.899742  6244 Main.cpp:63] Executing: fan
##### Fan Information #####
fan_1 -> present=True, rpm=5319 (29%)
fan_2 -> present=True, rpm=5338 (29%)
fan_3 -> present=True, rpm=5328 (29%)
fan_4 -> present=True, rpm=5366 (29%)
fan_5 -> present=True, rpm=5338 (29%)
fan_6 -> present=True, rpm=4868 (29%)

Sleeping for 0.5s...

fan_1 -> present=True, rpm=5309 (29%)
fan_2 -> present=True, rpm=5328 (29%)
fan_3 -> present=True, rpm=5319 (29%)
fan_4 -> present=True, rpm=5366 (29%)
fan_5 -> present=True, rpm=5338 (29%)
fan_6 -> present=True, rpm=4855 (29%)

```
**meru800bfa**
```
[root@wlr202 admin]# showtech --details fan
I0917 20:26:28.040152  7286 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BFA
I0917 20:26:28.040203  7286 Main.cpp:97] Running showtech for platform: MERU800BFA
I0917 20:26:28.040215  7286 ConfigLib.cpp:27] The inferred platform is meru800bfa
I0917 20:26:28.040227  7286 ConfigLib.cpp:27] The inferred platform is meru800bfa
I0917 20:26:28.040322  7286 Main.cpp:63] Executing: fan
##### Fan Information #####
fan_1 -> present=True, rpm=6880 (50%)
fan_2 -> present=True, rpm=6864 (50%)
fan_3 -> present=True, rpm=6896 (50%)
fan_4 -> present=True, rpm=6880 (50%)
fan_5 -> present=True, rpm=6896 (50%)
fan_6 -> present=True, rpm=6864 (50%)
fan_7 -> present=True, rpm=6849 (50%)
fan_8 -> present=True, rpm=6864 (50%)
fan_9 -> present=True, rpm=6880 (50%)
fan_10 -> present=True, rpm=6880 (50%)
fan_11 -> present=True, rpm=6896 (50%)
fan_12 -> present=True, rpm=6880 (50%)

Sleeping for 0.5s...

fan_1 -> present=True, rpm=6880 (50%)
fan_2 -> present=True, rpm=6864 (50%)
fan_3 -> present=True, rpm=6880 (50%)
fan_4 -> present=True, rpm=6880 (50%)
fan_5 -> present=True, rpm=6880 (50%)
fan_6 -> present=True, rpm=6864 (50%)
fan_7 -> present=True, rpm=6864 (50%)
fan_8 -> present=True, rpm=6864 (50%)
fan_9 -> present=True, rpm=6896 (50%)
fan_10 -> present=True, rpm=6880 (50%)
fan_11 -> present=True, rpm=6912 (50%)
fan_12 -> present=True, rpm=6896 (50%)

```
**meru800bia**
```
[root@vpr424 admin]# showtech --details fan
I0917 20:26:13.911013  6550 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0917 20:26:13.911065  6550 Main.cpp:97] Running showtech for platform: MERU800BIA
I0917 20:26:13.911076  6550 ConfigLib.cpp:27] The inferred platform is meru800bia
I0917 20:26:13.911096  6550 ConfigLib.cpp:27] The inferred platform is meru800bia
I0917 20:26:13.911156  6550 Main.cpp:63] Executing: fan
##### Fan Information #####
fan_1 -> present=True, rpm=7194 (56%)
fan_2 -> present=True, rpm=7177 (56%)
fan_3 -> present=True, rpm=7177 (56%)
fan_4 -> present=True, rpm=7177 (56%)

Sleeping for 0.5s...

fan_1 -> present=True, rpm=7177 (56%)
fan_2 -> present=True, rpm=7177 (56%)
fan_3 -> present=True, rpm=7177 (56%)
fan_4 -> present=True, rpm=7177 (56%)

```
