### PR TITLE
[showtech] Add Fanspinner Debug to Showtech

### DIFF
--- a/fboss/platform/configs/darwin/showtech.json
+++ b/fboss/platform/configs/darwin/showtech.json
@@ -71,5 +71,37 @@
       "statusSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_status",
       "inputOkSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_input_ok"
     }
+  ],
+  "fanspinners": [
+    {
+      "path": "/run/devmap/sensors/FS_FAN_SLG4F4527",
+      "isI2cDevice": true,
+      "sysfsAttributes": [
+        {
+          "name": "pwm",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/pwm"
+        },
+        {
+          "name": "fs_fan_rpm",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input"
+        },
+        {
+          "name": "idprom_wp",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/idprom_wp"
+        },
+        {
+          "name": "rackmon_idprom_wp",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/rm_idprom_wp"
+        },
+        {
+          "name": "led_green",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/led_green"
+        },
+        {
+          "name": "led_red",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/led_red"
+        }
+      ]
+    }
   ]
 }

--- a/fboss/platform/configs/darwin48v/showtech.json
+++ b/fboss/platform/configs/darwin48v/showtech.json
@@ -73,5 +73,37 @@
       "statusSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_status",
       "inputOkSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_input_ok"
     }
+  ],
+  "fanspinners": [
+    {
+      "path": "/run/devmap/sensors/FS_FAN_SLG4F4527",
+      "isI2cDevice": true,
+      "sysfsAttributes": [
+        {
+          "name": "pwm",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/pwm"
+        },
+        {
+          "name": "fs_fan_rpm",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/fan1_input"
+        },
+        {
+          "name": "idprom_wp",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/idprom_wp"
+        },
+        {
+          "name": "rackmon_idprom_wp",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/rm_idprom_wp"
+        },
+        {
+          "name": "led_green",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/led_green"
+        },
+        {
+          "name": "led_red",
+          "path": "/run/devmap/sensors/FS_FAN_SLG4F4527/led_red"
+        }
+      ]
+    }
   ]
 }

--- a/fboss/platform/configs/meru800bfa/showtech.json
+++ b/fboss/platform/configs/meru800bfa/showtech.json
@@ -9,5 +9,6 @@
     "/run/devmap/sensors/PSU4_PMBUS"
   ],
   "gpios": [],
-  "pems": []
+  "pems": [],
+  "fanspinners": []
 }

--- a/fboss/platform/configs/meru800bia/showtech.json
+++ b/fboss/platform/configs/meru800bia/showtech.json
@@ -61,5 +61,6 @@
       ]
     }
   ],
-  "pems": []
+  "pems": [],
+  "fanspinners": []
 }

--- a/fboss/platform/showtech/Main.cpp
+++ b/fboss/platform/showtech/Main.cpp
@@ -33,6 +33,7 @@ const std::unordered_map<std::string, std::function<void(Utils&)>>
         {"psu", [](Utils& util) { util.printPsuDetails(); }},
         {"pem", [](Utils& util) { util.printPemDetails(); }},
         {"fan", [](Utils& util) { util.printFanDetails(); }},
+        {"fanspinner", [](Utils& util) { util.printFanspinnerDetails(); }},
         {"gpio", [](Utils& util) { util.printGpioDetails(); }},
         {"i2c", [](Utils& util) { util.printI2cDetails(); }},
 };

--- a/fboss/platform/showtech/Utils.cpp
+++ b/fboss/platform/showtech/Utils.cpp
@@ -251,6 +251,22 @@ void Utils::printFanDetails() {
   }
 }
 
+void Utils::printFanspinnerDetails() {
+  std::cout << "##### Fanspinner Information #####" << std::endl;
+  if (config_.fanspinners()->empty()) {
+    std::cout << "No fanspinner found from configs\n" << std::endl;
+    return;
+  }
+  for (const auto& fs : *config_.fanspinners()) {
+    std::cout << fmt::format("#### Fanspinner Details {} ####", *fs.path())
+              << std::endl;
+    for (const auto& attr : *fs.sysfsAttributes()) {
+      printSysfsAttribute(*attr.name(), *attr.path());
+    }
+  }
+  std::cout << std::endl;
+}
+
 void Utils::runFbossCliCmd(const std::string& cmd) {
   if (!std::filesystem::exists("/etc/ramdisk")) {
     auto fullCmd = fmt::format("fboss2 show {}", cmd);

--- a/fboss/platform/showtech/Utils.h
+++ b/fboss/platform/showtech/Utils.h
@@ -25,6 +25,7 @@ class Utils {
   void printGpioDetails();
   void printPemDetails();
   void printFanDetails();
+  void printFanspinnerDetails();
 
  private:
   const showtech_config::ShowtechConfig& config_;

--- a/fboss/platform/showtech/showtech_config.thrift
+++ b/fboss/platform/showtech/showtech_config.thrift
@@ -6,6 +6,7 @@ struct ShowtechConfig {
   2: list<string> psus;
   3: list<Gpio> gpios;
   4: list<Pem> pems;
+  5: list<Device> fanspinners;
 }
 
 struct Gpio {
@@ -23,4 +24,15 @@ struct Pem {
   2: string presenceSysfsPath;
   3: string inputOkSysfsPath;
   4: string statusSysfsPath;
+}
+
+struct Device {
+  1: string path;
+  2: bool isI2cDevice;
+  3: optional list<SysfsAttribute> sysfsAttributes;
+}
+
+struct SysfsAttribute {
+  1: string name;
+  2: string path;
 }


### PR DESCRIPTION
## Background
Adding fanspinner debug section to oss showtech

## Changes
- Added Fanspinner configs to showtech configs for meru800bia, meru800bfa, darwin, and darwin48v
- Added `printFanspinnerDetails()` to print fanspinner debug info based on fanspinners specified in showtech configs

## Testing
`showtech --details fanspinner` output:

**darwin48v (same on darwin)**
```
[root@rkdo102 admin]# showtech --details fanspinner
I0918 20:42:28.738122  6236 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN48V
I0918 20:42:28.738231  6236 Main.cpp:97] Running showtech for platform: DARWIN48V
I0918 20:42:28.738249  6236 ConfigLib.cpp:27] The inferred platform is darwin48v
I0918 20:42:28.738294  6236 Main.cpp:63] Executing: fanspinner
##### Fanspinner Information #####
#### Fanspinner Details /run/devmap/sensors/FS_FAN_SLG4F4527 ####
pwm: 135
fs_fan_rpm: 12223
idprom_wp: 1
rackmon_idprom_wp: 1
led_green: 0
led_red: 1

```
**meru800bia (same on meru800bfa)**
```
[root@vpr424 admin]# showtech --details fanspinner
I0918 20:42:09.894987  6570 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0918 20:42:09.895038  6570 Main.cpp:97] Running showtech for platform: MERU800BIA
I0918 20:42:09.895049  6570 ConfigLib.cpp:27] The inferred platform is meru800bia
I0918 20:42:09.895073  6570 Main.cpp:63] Executing: fanspinner
##### Fanspinner Information #####
No fanspinner found from configs

```
