### PR TITLE
icecube:config: setting TMP432 register value for HW OTP function

### DIFF
--- a/fboss/platform/configs/icecube/platform_manager.json
+++ b/fboss/platform/configs/icecube/platform_manager.json
@@ -2949,7 +2949,45 @@
           "busName": "SMB_MUX@1",
           "address": "0x4c",
           "kernelDeviceName": "tmp432",
-          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1"
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1",
+          "initRegSettings": [
+            {
+              "regOffset": 13,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 21,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_MUX@2",
@@ -2973,7 +3011,33 @@
           "busName": "SMB_MUX@3",
           "address": "0x4c",
           "kernelDeviceName": "tmp432",
-          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2"
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2",
+          "initRegSettings": [
+            {
+              "regOffset": 13,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_MUX@4",


### PR DESCRIPTION
### Description
According to the hardware team's test result, the 0x27 & 0x28 register values ​​need to be set to 0x05 to calibrate the TMP432 temperature values.
According to HW OTP(over temperature protection) requirements, the TMP432 remote temperature high threshold should be set to 105°C after the OS boots.
<img width="557" height="176" alt="image" src="https://github.com/user-attachments/assets/047735a1-3a56-44bc-a073-c9d759ae7fc5" />

### Motivation
Set 0x27 & 0x28 register values ​ to be set to 0x05.
Set tmp432 remote temperature high threshold values to 105.

### Test Plan
Step 1: Check the original TMP432 sensor value and register value.
Step 2: Run platform_manager, **Note: if the tmp432 driver ever been loaded before, then the "--reload-kmods" is required when running platform_manager for the first time.**
Step3: Check the TMP432 sensor value and register value again.
Attach test log: 
[TMP432_setting_log.txt](https://github.com/user-attachments/files/22460855/TMP432_setting_log.txt)
Sensor log after setting:
<img width="423" height="269" alt="image" src="https://github.com/user-attachments/assets/48519cca-2b82-4f3f-aa57-690d5e32f54c" />
