### PR TITLE
[MERU800BIA]: Increased fan_service ttable granularity & enable boost mode

### DIFF
--- a/fboss/platform/configs/meru800bia/fan_service.json
+++ b/fboss/platform/configs/meru800bia/fan_service.json
@@ -1,8 +1,8 @@
 {
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
-  "pwmBoostOnNoQsfpAfterInSec": 0,
-  "pwmBoostValue": 60,
+  "pwmBoostOnNoQsfpAfterInSec": 31,
+  "pwmBoostValue": 73,
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,
@@ -17,6 +17,11 @@
       "tempToPwmMaps": {
         "OPTIC_TYPE_800_GENERIC": {
           "5": 43,
+          "64": 45,
+          "65": 47,
+          "66": 49,
+          "67": 51,
+          "68": 53,
           "69": 56,
           "70": 73,
           "71": 100


### PR DESCRIPTION
# Description

Increased granularity to the temperature tables by adding more points to help reduce temperature oscillations.

- More points were added to the lower half of the optics table to prevent large pwm changes across small temperature changes
- Enable boost mode on the system and increase the boost value to line up with the highest ttable entry before 100% pwm

# Testing

## Testing Boos Mode

**Normal operation (qsfp_service is running)**
Observe:

The system zone sensors & optics resolving to 43%
```
 ... 18:20:36.616407  6884 ControlLogic.cpp:602] Processing Sensors ...
 ... 18:20:36.616414  6884 ControlLogic.cpp:260] SMB_BOARD_FRONT_TEMP: Sensor read value is 27.5
 ... 18:20:36.616420  6884 ControlLogic.cpp:243] SMB_BOARD_FRONT_TEMP: Calculated PWM is 30
 ... 18:20:36.616423  6884 ControlLogic.cpp:606] Processing Optics ...
 ... 18:20:36.616429  6884 ControlLogic.cpp:319] OPTIC_TYPE_400_GENERIC: Optic sensor read value is 36.339844. PWM is 0
 ... 18:20:36.616433  6884 ControlLogic.cpp:319] OPTIC_TYPE_400_GENERIC: Optic sensor read value is 36.23828. PWM is 0
 ... 18:20:36.616437  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 65.04297. PWM is 43
 ... 18:20:36.616440  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 67.69141. PWM is 43
 ... 18:20:36.616444  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 66.08203. PWM is 43
 ... 18:20:36.616448  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 64.71875. PWM is 43
 ... 18:20:36.616451  6884 ControlLogic.cpp:368] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 43
 ... 18:20:36.616457  6884 ControlLogic.cpp:503] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 43.
 ... 18:20:36.617371  6884 ControlLogic.cpp:439] fan_1: Programmed with PWM 43 (raw value 110)
 ... 18:20:36.618283  6884 ControlLogic.cpp:439] fan_2: Programmed with PWM 43 (raw value 110)
 ... 18:20:36.619191  6884 ControlLogic.cpp:439] fan_3: Programmed with PWM 43 (raw value 110)
 ... 18:20:36.620099  6884 ControlLogic.cpp:439] fan_4: Programmed with PWM 43 (raw value 110)
```


**Boost mode (qsfp_service NOT running)**
Observe:

All the fans running at 73%
```
... 18:30:59.794403  6884 ControlLogic.cpp:602] Processing Sensors ...
... 18:30:59.794409  6884 ControlLogic.cpp:260] SMB_BOARD_FRONT_TEMP: Sensor read value is 28
... 18:30:59.794415  6884 ControlLogic.cpp:243] SMB_BOARD_FRONT_TEMP: Calculated PWM is 30
... 18:30:59.794418  6884 ControlLogic.cpp:606] Processing Optics ...
... 18:30:59.794423  6884 ControlLogic.cpp:319] OPTIC_TYPE_400_GENERIC: Optic sensor read value is 35.898438. PWM is 0
... 18:30:59.794426  6884 ControlLogic.cpp:319] OPTIC_TYPE_400_GENERIC: Optic sensor read value is 35.92578. PWM is 0
... 18:30:59.794430  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 64.61719. PWM is 43
... 18:30:59.794433  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 67.26953. PWM is 43
... 18:30:59.794436  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 65.640625. PWM is 43
... 18:30:59.794439  6884 ControlLogic.cpp:319] OPTIC_TYPE_800_GENERIC: Optic sensor read value is 64.47656. PWM is 43
... 18:30:59.794443  6884 ControlLogic.cpp:368] Optics: Aggregation Type: OPTIC_AGGREGATION_TYPE_MAX. Aggregate PWM is 43
... 18:30:59.794448  6884 ControlLogic.cpp:628] Boost mode enabled for optics update missing for 398s
... 18:30:59.794452  6884 ControlLogic.cpp:503] zone1: Components: SMB_BOARD_FRONT_TEMP,osfp_group_1. Aggregation Type: ZONE_TYPE_MAX. Aggregate PWM is 73.
... 18:30:59.795362  6884 ControlLogic.cpp:439] fan_1: Programmed with PWM 73 (raw value 186)
... 18:30:59.796270  6884 ControlLogic.cpp:439] fan_2: Programmed with PWM 73 (raw value 186)
... 18:30:59.797176  6884 ControlLogic.cpp:439] fan_3: Programmed with PWM 73 (raw value 186)
... 18:30:59.798093  6884 ControlLogic.cpp:439] fan_4: Programmed with PWM 73 (raw value 186)
```

## Testing Added Granularity

The peak-to-peak temperature measurements observed to be relatively lower with the added granularity to the table as show in the tables below.

### BEFORE
<img width="803" height="656" alt="Screenshot 2025-09-25 at 7 45 54 PM" src="https://github.com/user-attachments/assets/cf9faacb-2769-4b3a-aa2e-3dae2fc9596b" />

### AFTER
<img width="816" height="638" alt="Screenshot 2025-09-25 at 7 46 53 PM" src="https://github.com/user-attachments/assets/ff56f69a-ce6a-4a21-a1ec-be6ea23631d3" />



