### PR TITLE
optimize the docker file to speed up the docker build

### DIFF
--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -2,16 +2,6 @@ FROM quay.io/centos/centos:stream9
 
 RUN dnf install git sudo lsof -y
 
-# Use /var/FBOSS as the set location to clone the git repository and store the outputs of the build.
-WORKDIR /var/FBOSS/
-
-RUN mkdir -p /var/FBOSS/fboss
-COPY . fboss
-WORKDIR fboss
-
-RUN rm -rf build/deps/github_hashes/
-RUN tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
-
 RUN dnf install -y 'dnf-command(config-manager)'
 RUN dnf config-manager --set-enabled crb
 RUN dnf install -y epel-release epel-next-release
@@ -23,7 +13,6 @@ RUN sudo dnf install -y autoconf automake binutils binutils-devel bzip2 \
     libzstd libzstd-devel lz4-devel ncurses-devel ninja-build openssl \
     openssl-devel openssl-libs python3 python3-devel re2 re2-devel \
     snappy-devel xxhash-devel xz-devel zlib-devel zlib-static -y --allowerasing
-RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive fboss
 RUN dnf install bison flex -y
 RUN dnf group install "Development Tools" -y
 RUN python3 -m pip install gitpython
@@ -32,8 +21,6 @@ RUN python3 -m pip install jinja2
 RUN dnf install gperf libcap-devel libmount-devel -y
 RUN dnf install gcc-toolset-12 gcc-toolset-12-libasan-devel gcc-toolset-12-libubsan-devel -y
 RUN echo "source /opt/rh/gcc-toolset-12/enable" >> ~/.bashrc
-
-RUN rm -rf /var/FBOSS/fboss/*
 
 # The following libraries are needed for building SDK
 RUN dnf install -y doxygen aspell libyaml-devel vim-common libnsl libnsl2-devel
@@ -44,4 +31,18 @@ RUN dnf install -y perl-diagnostics perl-sort perl-English perl-Clone perl-Data-
 RUN dnf install -y libxml2-devel expat-devel wget
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip install pyyaml filelock
+
+# Use /var/FBOSS as the set location to clone the git repository and store the outputs of the build.
+WORKDIR /var/FBOSS/
+
+RUN mkdir -p /var/FBOSS/fboss
+COPY . fboss
+WORKDIR fboss
+
+RUN rm -rf build/deps/github_hashes/
+RUN tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
+
+RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive fboss
+
+RUN rm -rf /var/FBOSS/fboss/*
 # ============================================================

--- a/fboss/oss/docker/Dockerfile.debian
+++ b/fboss/oss/docker/Dockerfile.debian
@@ -1,12 +1,7 @@
 FROM debian:bookworm
 RUN apt update && apt upgrade -y
 RUN apt install git sudo lsof -y
-WORKDIR /var/FBOSS/
-RUN mkdir -p /var/FBOSS/fboss
-COPY . fboss
-WORKDIR fboss
-RUN rm -rf build/deps/github_hashes/
-RUN tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
+
 RUN apt install python3-pip -y
 RUN python3 -m pip config set global.break-system-packages true
 RUN apt install -y wget autoconf automake binutils binutils-dev bzip2 \
@@ -16,11 +11,6 @@ RUN apt install -y wget autoconf automake binutils binutils-dev bzip2 \
     libusb-1.0-0-dev zstd libzstd-dev liblz4-dev libncurses-dev ninja-build \
     libssl-dev python3-all-dev libre2-dev libsnappy-dev xxhash libxxhash-dev \
     liblzma-dev zlib1g-dev
-RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive fboss
-WORKDIR /var/FBOSS/
-RUN wget http://ftp.us.debian.org/debian/pool/main/f/fast-float/libfast-float-dev_8.0.0-0.1_amd64.deb
-RUN dpkg -i libfast-float-dev_8.0.0-0.1_amd64.deb
-WORKDIR fboss
 RUN apt install -y bison flex
 RUN apt install -y openssl
 RUN apt install -y python3-git
@@ -33,5 +23,20 @@ RUN apt install -y doxygen graphviz aspell bc libyaml-dev libyaml-libyaml-perl l
     libdata-compare-perl liblist-moreutils-perl libnamespace-autoclean-perl libyaml-perl libjson-xs-perl xxd
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN pip install pyyaml filelock
+
+WORKDIR /var/FBOSS/
+RUN wget http://ftp.us.debian.org/debian/pool/main/f/fast-float/libfast-float-dev_8.0.0-0.1_amd64.deb
+RUN dpkg -i libfast-float-dev_8.0.0-0.1_amd64.deb
+
+RUN mkdir -p /var/FBOSS/fboss
+COPY . fboss
+WORKDIR fboss
+
+RUN rm -rf build/deps/github_hashes/
+RUN tar xvzf fboss/oss/stable_commits/latest_stable_hashes.tar.gz
+
+RUN ./build/fbcode_builder/getdeps.py install-system-deps --recursive fboss
+
+RUN rm -rf /var/FBOSS/fboss/*
 # ============================================================
 RUN python3 -m pip config set global.break-system-packages false


### PR DESCRIPTION
**Description:**
This PR optimizes the Dockerfile to speed up the Docker build process.

**Motivation:**
The FBOSS source files change frequently. Placing FBOSS-related actions at the beginning of the Dockerfile invalidates the cache for all subsequent layers upon any change to these files.

By moving these steps to the end of the Dockerfile, we can better leverage Docker's layer caching. This ensures that preceding, less frequently changed layers remain cached, which significantly speeds up subsequent builds.

**Test Plan:**
1. Build the Docker image.
2. Re-run the build and verify that layers preceding the FBOSS-related steps are loaded from the cache, resulting in a faster build time.
[centos_build.log](https://github.com/user-attachments/files/22532293/centos_build.log)
[debian_build.log](https://github.com/user-attachments/files/22532294/debian_build.log)
