### PR TITLE
configs: Optimize the PM config of MP3&Minerva to fix the issue of occasional I2C failures

### DIFF
--- a/fboss/platform/configs/janga800bic/platform_manager.json
+++ b/fboss/platform/configs/janga800bic/platform_manager.json
@@ -49,7 +49,8 @@
     }
   },
   "i2cAdaptersFromCpu": [
-    "SMBus I801 adapter at 5000"
+    "SMBus I801 adapter at 5000",
+    "SMBus iSMT adapter at 20fffa7b000"
   ],
   "versionedPmUnitConfigs": {
     "NETLAKE": [
@@ -2773,6 +2774,7 @@
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
+    "fboss_iob_i2c",
     "ledtrig_timer"
   ]
 }

--- a/fboss/platform/configs/montblanc/platform_manager.json
+++ b/fboss/platform/configs/montblanc/platform_manager.json
@@ -3891,6 +3891,7 @@
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
+    "fboss_iob_i2c",
     "ledtrig_timer"
   ]
 }

--- a/fboss/platform/configs/tahan800bc/platform_manager.json
+++ b/fboss/platform/configs/tahan800bc/platform_manager.json
@@ -49,7 +49,8 @@
     }
   },
   "i2cAdaptersFromCpu": [
-    "SMBus I801 adapter at 5000"
+    "SMBus I801 adapter at 5000",
+    "SMBus iSMT adapter at 20fffa7b000"
   ],
   "versionedPmUnitConfigs": {
     "NETLAKE": [
@@ -2122,6 +2123,7 @@
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
+    "fboss_iob_i2c",
     "ledtrig_timer"
   ]
 }


### PR DESCRIPTION
**Description**
Fixed an issue that caused delays when creating the IOB_I2C_MASTER bus.
More details: https://fb.workplace.com/groups/264616536023347/permalink/787002797118049/

**Motivation**
The device requires time during registration to attach and initialize its driver.However, a check for the presence of the device node may occur before the driver is fully ready,resulting in a failed readiness check.

Reference the commit: https://github.com/facebook/fboss/commit/41ca446398434e47b1eddbb5a8ca9435a4a16f03

**Test Plan**
The platform_manager service started successfully; then check the logs：
Montblanc:
[Montblanc-platform_manager_log_20250925.txt](https://github.com/user-attachments/files/22536370/Montblanc-platform_manager_log_20250925.txt)

Janga:
[Janga-platform_manager_log_20250925.txt](https://github.com/user-attachments/files/22536371/Janga-platform_manager_log_20250925.txt)

Tahab:
[Tahan-platform_manager_log_20250925.txt](https://github.com/user-attachments/files/22536372/Tahan-platform_manager_log_20250925.txt)


After updated the configs, we ran tests on one DUT without encountering any errors:
DUT was tested over 1382 cycles.