### PR TITLE
[MERU800BFA]: Change voltage readings to mili in sensor_service

### DIFF
--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -226,14 +226,13 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R0_CORE_VOUT_0V75",
+          "name": "SMB_VRM_R3R0_CORE_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.008,
-            "lowerCriticalVal": 0.504
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1008.0,
+            "lowerCriticalVal": 504.0
+          }
         },
         {
           "name": "SMB_VRM_R3R0_CORE_TEMP",
@@ -256,34 +255,31 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R0_ANLG0_VOUT_0V9",
+          "name": "SMB_VRM_R3R0_ANLG0_VOUT_0V9_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.72
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 720.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R0_ANLG0_VOUT_0V75",
+          "name": "SMB_VRM_R3R0_ANLG0_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 900.0,
+            "lowerCriticalVal": 600.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R0_ANLG0_VOUT_1V2",
+          "name": "SMB_VRM_R3R0_ANLG0_VOUT_1V2_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.44,
-            "lowerCriticalVal": 0.96
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1440.0,
+            "lowerCriticalVal": 960.0
+          }
         },
         {
           "name": "SMB_VRM_R3R0_ANLG0_TEMP_0V9",
@@ -326,24 +322,22 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R0_ANLG1_VOUT_0V9",
+          "name": "SMB_VRM_R3R0_ANLG1_VOUT_0V9_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.72
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 720.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R0_ANLG1_VOUT_0V75",
+          "name": "SMB_VRM_R3R0_ANLG1_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 900.0,
+            "lowerCriticalVal": 600.0
+          }
         },
         {
           "name": "SMB_VRM_R3R0_ANLG1_VOUT_1V8",
@@ -396,14 +390,13 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R1_CORE_VOUT_0V75",
+          "name": "SMB_VRM_R3R1_CORE_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.008,
-            "lowerCriticalVal": 0.504
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1008.0,
+            "lowerCriticalVal": 504.0
+          }
         },
         {
           "name": "SMB_VRM_R3R1_CORE_TEMP",
@@ -426,34 +419,31 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R1_ANLG0_VOUT_0V9",
+          "name": "SMB_VRM_R3R1_ANLG0_VOUT_0V9_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.72
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 720.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R1_ANLG0_VOUT_0V75",
+          "name": "SMB_VRM_R3R1_ANLG0_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 900.0,
+            "lowerCriticalVal": 600.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R1_ANLG0_VOUT_1V2",
+          "name": "SMB_VRM_R3R1_ANLG0_VOUT_1V2_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0/in5_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.44,
-            "lowerCriticalVal": 0.96
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1440.0,
+            "lowerCriticalVal": 960.0
+          }
         },
         {
           "name": "SMB_VRM_R3R1_ANLG0_TEMP_0V9",
@@ -496,24 +486,22 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_VRM_R3R1_ANLG1_VOUT_0V9",
+          "name": "SMB_VRM_R3R1_ANLG1_VOUT_0V9_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.08,
-            "lowerCriticalVal": 0.72
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1080.0,
+            "lowerCriticalVal": 720.0
+          }
         },
         {
-          "name": "SMB_VRM_R3R1_ANLG1_VOUT_0V75",
+          "name": "SMB_VRM_R3R1_ANLG1_VOUT_0V75_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9,
-            "lowerCriticalVal": 0.6
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 900.0,
+            "lowerCriticalVal": 600.0
+          }
         },
         {
           "name": "SMB_VRM_R3R1_ANLG1_VOUT_1V8",
@@ -570,7 +558,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OSFP_TL/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
+            "upperCriticalVal": 3.7,
             "lowerCriticalVal": 2.64
           },
           "compute": "1.2*@/1000.0"
@@ -600,7 +588,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OSFP_TR/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
+            "upperCriticalVal": 3.7,
             "lowerCriticalVal": 2.64
           },
           "compute": "1.2*@/1000.0"
@@ -630,7 +618,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OSFP_BL/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
+            "upperCriticalVal": 3.7,
             "lowerCriticalVal": 2.64
           },
           "compute": "1.2*@/1000.0"
@@ -660,7 +648,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_ISL68226_OSFP_BR/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 3.96,
+            "upperCriticalVal": 3.7,
             "lowerCriticalVal": 2.64
           },
           "compute": "1.2*@/1000.0"
@@ -706,14 +694,13 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_DPM_1V2_DKR",
+          "name": "SMB_DPM_1V2_DKR_MILLIVOLT",
           "sysfsPath": "/run/devmap/sensors/SMB_UCD90320/in4_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 1.44,
-            "lowerCriticalVal": 0.96
-          },
-          "compute": "@/1000.0"
+            "upperCriticalVal": 1440.0,
+            "lowerCriticalVal": 960.0
+          }
         },
         {
           "name": "SMB_DPM_3V3",


### PR DESCRIPTION
# Description

Decimal points are rounded down in ODS, which limit debugging certain sensors where the decimals hold significance. This has been an issue when debugging vrm issues were certain voltages hold a value betwen 0-1V. 

The proposed solution is to display voltages with thresholds that can fall below 1V as millivolts with "_MILLIVOLT" in the sensor name.

# Testing
All sensor readings are within thresholds.