### PR TITLE
[DARWIN]: remove unused presentLedColor & absentLedColor attributes

### DIFF
--- a/fboss/platform/configs/darwin/led_manager.json
+++ b/fboss/platform/configs/darwin/led_manager.json
@@ -1,21 +1,15 @@
 {
   "systemLedConfig": {
-    "presentLedColor": 1,
     "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:green:status/brightness",
-    "absentLedColor": 2,
     "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/system:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
-      "presentLedColor": 1,
       "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:green:status/brightness",
-      "absentLedColor": 2,
       "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/fan:red:status/brightness"
     },
     "PEM": {
-      "presentLedColor": 1,
       "presentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:green:status/brightness",
-      "absentLedColor": 2,
       "absentLedSysfsPath": "/run/devmap/fpgas/SCD_FPGA/scd-leds.0/leds/pem:red:status/brightness"
     }
   },


### PR DESCRIPTION
# Description

Remove unused led_manager attributes (presentLedColor & absentLedColor), following in suit of this commit https://github.com/facebook/fboss/commit/ac8a3e5599e44eaf27e9d0410687638046be5631

# Testing
data_corral_service_hw_test passes
```
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from DataCorralServiceHwTest
[ RUN      ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck
I0925 20:54:23.905576  6352 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:23.905668  6352 ConfigLib.cpp:27] The inferred platform is darwin
I0925 20:54:23.905760  6352 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0925 20:54:23.905770  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0925 20:54:23.906559  6352 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0925 20:54:23.906569  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0925 20:54:23.907551  6352 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0925 20:54:23.907560  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0925 20:54:23.908550  6352 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0925 20:54:23.908559  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0925 20:54:23.909553  6352 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0925 20:54:23.909563  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN5 (via sysfs)
I0925 20:54:23.910549  6352 FruPresenceExplorer.cpp:49] Detected that FAN5 is present
I0925 20:54:23.910558  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN6 (via sysfs)
I0925 20:54:23.910587  6352 FruPresenceExplorer.cpp:49] Detected that FAN6 is present
I0925 20:54:23.910596  6352 FruPresenceExplorer.cpp:34] Detecting presence of PEM1 (via sysfs)
I0925 20:54:23.910618  6352 FruPresenceExplorer.cpp:49] Detected that PEM1 is present
I0925 20:54:23.910638  6352 LedManager.cpp:45] Programming PEM LED with true
I0925 20:54:23.910689  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0925 20:54:23.910722  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0925 20:54:23.910732  6352 LedManager.cpp:55] Programmed PEM LED with presence true
I0925 20:54:23.910742  6352 LedManager.cpp:45] Programming FAN LED with true
I0925 20:54:23.910771  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0925 20:54:23.910801  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0925 20:54:23.910810  6352 LedManager.cpp:55] Programmed FAN LED with presence true
I0925 20:54:23.910822  6352 LedManager.cpp:25] Programming system LED with true
I0925 20:54:23.910851  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0925 20:54:23.910880  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0925 20:54:23.910890  6352 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck (5 ms)
[ RUN      ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck
I0925 20:54:23.910993  6352 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:23.911004  6352 ConfigLib.cpp:27] The inferred platform is darwin
I0925 20:54:23.911071  6352 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0925 20:54:23.911080  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0925 20:54:23.912251  6352 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0925 20:54:23.912261  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0925 20:54:23.913427  6352 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0925 20:54:23.913437  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0925 20:54:23.914549  6352 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0925 20:54:23.914559  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0925 20:54:23.915552  6352 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0925 20:54:23.915562  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN5 (via sysfs)
I0925 20:54:23.916564  6352 FruPresenceExplorer.cpp:49] Detected that FAN5 is present
I0925 20:54:23.916578  6352 FruPresenceExplorer.cpp:34] Detecting presence of FAN6 (via sysfs)
I0925 20:54:23.916606  6352 FruPresenceExplorer.cpp:49] Detected that FAN6 is present
I0925 20:54:23.916615  6352 FruPresenceExplorer.cpp:34] Detecting presence of PEM1 (via sysfs)
I0925 20:54:23.916638  6352 FruPresenceExplorer.cpp:49] Detected that PEM1 is present
I0925 20:54:23.916649  6352 LedManager.cpp:45] Programming PEM LED with true
I0925 20:54:23.916684  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0925 20:54:23.916715  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0925 20:54:23.916725  6352 LedManager.cpp:55] Programmed PEM LED with presence true
I0925 20:54:23.916735  6352 LedManager.cpp:45] Programming FAN LED with true
I0925 20:54:23.916763  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0925 20:54:23.916795  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0925 20:54:23.916805  6352 LedManager.cpp:55] Programmed FAN LED with presence true
I0925 20:54:23.916815  6352 LedManager.cpp:25] Programming system LED with true
I0925 20:54:23.916847  6352 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0925 20:54:23.916874  6352 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0925 20:54:23.916886  6352 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck (5 ms)
[ RUN      ] DataCorralServiceHwTest.getCachedFruid
I0925 20:54:23.916935  6352 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:23.916947  6352 ConfigLib.cpp:27] The inferred platform is darwin
I0925 20:54:23.933788  6359 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:54:23.934157  6359 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:54:24.091912  6362 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:24.091941  6362 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:24.091950  6362 ConfigLib.cpp:27] The inferred platform is darwin
[       OK ] DataCorralServiceHwTest.getCachedFruid (7287 ms)
[ RUN      ] DataCorralServiceHwTest.getUncachedFruid
I0925 20:54:31.204896  6352 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:31.204919  6352 ConfigLib.cpp:27] The inferred platform is darwin
I0925 20:54:31.217625  6379 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:54:31.217955  6379 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:54:31.281569  6382 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:31.281604  6382 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:31.281615  6382 ConfigLib.cpp:27] The inferred platform is darwin
[       OK ] DataCorralServiceHwTest.getUncachedFruid (5109 ms)
[ RUN      ] DataCorralServiceHwTest.testThrift
I0925 20:54:36.314896  6352 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:36.314919  6352 ConfigLib.cpp:27] The inferred platform is darwin
I0925 20:54:36.319604  6391 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:54:36.332576  6391 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:54:36.373464  6394 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:36.373503  6394 PlatformNameLib.cpp:79] Platform name read from cache: DARWIN
I0925 20:54:36.373515  6394 ConfigLib.cpp:27] The inferred platform is darwin
[       OK ] DataCorralServiceHwTest.testThrift (5693 ms)
[----------] 5 tests from DataCorralServiceHwTest (18103 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (18103 ms total)
[  PASSED  ] 5 tests.
```