### PR TITLE
[MERU800BIA]: remove unused presentLedColor & absentLedColor attributes

### DIFF
--- a/fboss/platform/configs/meru800bia/led_manager.json
+++ b/fboss/platform/configs/meru800bia/led_manager.json
@@ -1,21 +1,15 @@
 {
   "systemLedConfig": {
-    "presentLedColor": 1,
     "presentLedSysfsPath": "/sys/class/leds/sys_led:green:status/brightness",
-    "absentLedColor": 2,
     "absentLedSysfsPath": "/sys/class/leds/sys_led:red:status/brightness"
   },
   "fruTypeLedConfigs": {
     "FAN": {
-      "presentLedColor": 1,
       "presentLedSysfsPath": "/sys/class/leds/fan_led:green:status/brightness",
-      "absentLedColor": 2,
       "absentLedSysfsPath": "/sys/class/leds/fan_led:red:status/brightness"
     },
     "PSU": {
-      "presentLedColor": 1,
       "presentLedSysfsPath": "/sys/class/leds/psu_led:green:status/brightness",
-      "absentLedColor": 2,
       "absentLedSysfsPath": "/sys/class/leds/psu_led:red:status/brightness"
     }
   },


### PR DESCRIPTION
# Description

Remove unused led_manager attributes (presentLedColor & absentLedColor), following in suit of this commit https://github.com/facebook/fboss/commit/ac8a3e5599e44eaf27e9d0410687638046be5631

# Testing
data_corral_service_hw_test passes
```
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from DataCorralServiceHwTest
[ RUN      ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck
I0925 20:55:08.038075  6523 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:08.038132  6523 ConfigLib.cpp:27] The inferred platform is meru800bia
I0925 20:55:08.038178  6523 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0925 20:55:08.038183  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0925 20:55:08.039352  6523 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0925 20:55:08.039357  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0925 20:55:08.040442  6523 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0925 20:55:08.040446  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0925 20:55:08.041466  6523 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0925 20:55:08.041471  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0925 20:55:08.042441  6523 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0925 20:55:08.042445  6523 FruPresenceExplorer.cpp:34] Detecting presence of PSU1 (via sysfs)
I0925 20:55:08.042461  6523 FruPresenceExplorer.cpp:49] Detected that PSU1 is present
I0925 20:55:08.042466  6523 FruPresenceExplorer.cpp:34] Detecting presence of PSU2 (via sysfs)
I0925 20:55:08.042477  6523 FruPresenceExplorer.cpp:49] Detected that PSU2 is present
I0925 20:55:08.042486  6523 LedManager.cpp:45] Programming PSU LED with true
I0925 20:55:08.042518  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0925 20:55:08.042535  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0925 20:55:08.042539  6523 LedManager.cpp:55] Programmed PSU LED with presence true
I0925 20:55:08.042543  6523 LedManager.cpp:45] Programming FAN LED with true
I0925 20:55:08.042560  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0925 20:55:08.042575  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0925 20:55:08.042579  6523 LedManager.cpp:55] Programmed FAN LED with presence true
I0925 20:55:08.042585  6523 LedManager.cpp:25] Programming system LED with true
I0925 20:55:08.042600  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0925 20:55:08.042617  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0925 20:55:08.042621  6523 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLedProgrammingSysfsCheck (4 ms)
[ RUN      ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck
I0925 20:55:08.042671  6523 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:08.042676  6523 ConfigLib.cpp:27] The inferred platform is meru800bia
I0925 20:55:08.042700  6523 FruPresenceExplorer.cpp:26] Detecting presence of FRUs
I0925 20:55:08.042704  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN1 (via sysfs)
I0925 20:55:08.043442  6523 FruPresenceExplorer.cpp:49] Detected that FAN1 is present
I0925 20:55:08.043447  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN2 (via sysfs)
I0925 20:55:08.044443  6523 FruPresenceExplorer.cpp:49] Detected that FAN2 is present
I0925 20:55:08.044448  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN3 (via sysfs)
I0925 20:55:08.045453  6523 FruPresenceExplorer.cpp:49] Detected that FAN3 is present
I0925 20:55:08.045458  6523 FruPresenceExplorer.cpp:34] Detecting presence of FAN4 (via sysfs)
I0925 20:55:08.046442  6523 FruPresenceExplorer.cpp:49] Detected that FAN4 is present
I0925 20:55:08.046447  6523 FruPresenceExplorer.cpp:34] Detecting presence of PSU1 (via sysfs)
I0925 20:55:08.046459  6523 FruPresenceExplorer.cpp:49] Detected that PSU1 is present
I0925 20:55:08.046464  6523 FruPresenceExplorer.cpp:34] Detecting presence of PSU2 (via sysfs)
I0925 20:55:08.046477  6523 FruPresenceExplorer.cpp:49] Detected that PSU2 is present
I0925 20:55:08.046482  6523 LedManager.cpp:45] Programming PSU LED with true
I0925 20:55:08.046497  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/psu_led:green:status/brightness
I0925 20:55:08.046511  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/psu_led:red:status/brightness
I0925 20:55:08.046518  6523 LedManager.cpp:55] Programmed PSU LED with presence true
I0925 20:55:08.046523  6523 LedManager.cpp:45] Programming FAN LED with true
I0925 20:55:08.046536  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/fan_led:green:status/brightness
I0925 20:55:08.046549  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/fan_led:red:status/brightness
I0925 20:55:08.046553  6523 LedManager.cpp:55] Programmed FAN LED with presence true
I0925 20:55:08.046558  6523 LedManager.cpp:25] Programming system LED with true
I0925 20:55:08.046574  6523 LedManager.cpp:80] Wrote 1 to file /sys/class/leds/sys_led:green:status/brightness
I0925 20:55:08.046587  6523 LedManager.cpp:80] Wrote 0 to file /sys/class/leds/sys_led:red:status/brightness
I0925 20:55:08.046592  6523 LedManager.cpp:34] Programmed system LED with true
[       OK ] DataCorralServiceHwTest.FruLEDProgrammingODSCheck (3 ms)
[ RUN      ] DataCorralServiceHwTest.getCachedFruid
I0925 20:55:08.046613  6523 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:08.046619  6523 ConfigLib.cpp:27] The inferred platform is meru800bia
I0925 20:55:08.047462  6530 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:55:08.047692  6530 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:55:08.050090  6533 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:08.050107  6533 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:08.050113  6533 ConfigLib.cpp:27] The inferred platform is meru800bia
[       OK ] DataCorralServiceHwTest.getCachedFruid (13512 ms)
[ RUN      ] DataCorralServiceHwTest.getUncachedFruid
I0925 20:55:21.558715  6523 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:21.558732  6523 ConfigLib.cpp:27] The inferred platform is meru800bia
I0925 20:55:21.559018  6551 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:55:21.559203  6551 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:55:21.560074  6554 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:21.560091  6554 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:21.560097  6554 ConfigLib.cpp:27] The inferred platform is meru800bia
[       OK ] DataCorralServiceHwTest.getUncachedFruid (14039 ms)
[ RUN      ] DataCorralServiceHwTest.testThrift
I0925 20:55:35.597896  6523 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:35.597914  6523 ConfigLib.cpp:27] The inferred platform is meru800bia
I0925 20:55:35.598207  6556 ThriftServer.cpp:980] Using resource pools on address/port [::1]:0: thrift flag: true, enable gflag: false, disable gflag: false, runtime actions: 
I0925 20:55:35.598394  6556 ThriftServer.cpp:1537] Resource pools configured: 2
I0925 20:55:35.599285  6559 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:35.599304  6559 PlatformNameLib.cpp:79] Platform name read from cache: MERU800BIA
I0925 20:55:35.599313  6559 ConfigLib.cpp:27] The inferred platform is meru800bia
[       OK ] DataCorralServiceHwTest.testThrift (12708 ms)
[----------] 5 tests from DataCorralServiceHwTest (40268 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (40268 ms total)
[  PASSED  ] 5 tests.
```