### PR TITLE
Icetea: config: setting TMP432 register value for HW OTP function

### DIFF
--- a/fboss/platform/configs/icetea/platform_manager.json
+++ b/fboss/platform/configs/icetea/platform_manager.json
@@ -1845,7 +1845,45 @@
           "busName": "SMB_MUX@1",
           "address": "0x4c",
           "kernelDeviceName": "tmp432",
-          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1"
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1",
+          "initRegSettings": [
+            {
+              "regOffset": 13,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 21,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_MUX@2",
@@ -1869,7 +1907,33 @@
           "busName": "SMB_MUX@3",
           "address": "0x4c",
           "kernelDeviceName": "tmp432",
-          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2"
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2",
+          "initRegSettings": [
+            {
+              "regOffset": 13,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_MUX@4",


### PR DESCRIPTION
# Description

Update platform_manager.json file:
1. To set the TMP432 register address 0x27 & 0x28 values ​to be set to 0x05.
2. To set the TMP432 remote temperature high threshold values to 105.

# Motivation

1. According to the hardware team's test result, the 0x27 & 0x28 register values ​​need to be set to 0x05 to calibrate the TMP432 temperature values.
3. According to HW OTP(over temperature protection) requirements, the TMP432 remote temperature high threshold should be set to 105°C after the OS boots.
<img width="1114" height="352" alt="image" src="https://github.com/user-attachments/assets/27e22213-d40d-4baf-a3c3-faf1e695e09f" />

# Test Plan

Step 1:  Check the original TMP432 sensor value and register value.
Step 2:  Run platform_manager. Note: if the tmp432 driver has ever been loaded before, then the "--reload-kmods" is required when running platform_manager for the first time.
Step 3:  Check the TMP432 sensor value and register value again.
<img width="853" height="561" alt="image" src="https://github.com/user-attachments/assets/4a42e5af-35f0-462f-93f6-f283ccb01acd" />
Please refer to the detailed logs: [TMP432_setting_log.txt](https://github.com/user-attachments/files/22590843/TMP432_setting_log.txt)
