### PR TITLE
Tahansb: config: setting PMBUS register value to fix the device page flip issue

### DIFF
--- a/fboss/platform/configs/tahansb/platform_manager.json
+++ b/fboss/platform/configs/tahansb/platform_manager.json
@@ -614,13 +614,29 @@
           "busName": "MCB_IOB_I2C_MASTER_5",
           "address": "0x60",
           "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PMBUS_1"
+          "pmUnitScopedName": "PMBUS_1",
+          "initRegSettings": [
+            {
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_5",
           "address": "0x61",
           "kernelDeviceName": "pmbus",
-          "pmUnitScopedName": "PMBUS_2"
+          "pmUnitScopedName": "PMBUS_2",
+          "initRegSettings": [
+            {
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_6",


### PR DESCRIPTION
# Description

This PR fixed the issue of two sensors of PMBus creating failure due to PMBus device page flip

# Motivation

FBOSS sensor_service test failed on EVT2B unit with new version power brick. 

<img width="1578" height="179" alt="image (7)" src="https://github.com/user-attachments/assets/46aaa3a9-ab5b-4277-9c87-fe6bf12ece86" />

The root cause of the issue is an unexpected change in the power brick's PMBus page register. After the initial system power-up , the PMBus driver is loaded successful, this register value switches from 0x00 to 0x01. Consequently, when the PMBus driver attempts to load, it fails because it expects to find the device on page 0x00.

The solution is set the page to 0 in platform_manager.json using "initRegSettings". The solution should apply on all the devices from EVT2B.

# Test Plan
1.Used jq command to pretty the format
2.Compilation and config validation have passed
3.Services of platform_manager/sensor_service/data_corral_service/fan_service run normally on the tahansb devices, pls refer the logs:
[platform_manager.log](https://github.com/user-attachments/files/22613257/platform_manager.log)
[sensor_service.log](https://github.com/user-attachments/files/22613258/sensor_service.log)
[data_corral_service.log](https://github.com/user-attachments/files/22613254/data_corral_service.log)
[fan_service.log](https://github.com/user-attachments/files/22613255/fan_service.log)


4.Hardware tests of platform_manager/sensor_service/data_corral_service/fan_service/weutil/fwutil passed, pls refer the logs:
[platform_manager_hw_test.log](https://github.com/user-attachments/files/22613268/platform_manager_hw_test.log)
[sensor_service_hw_test.log](https://github.com/user-attachments/files/22613269/sensor_service_hw_test.log)
[data_corral_service_hw_test.log](https://github.com/user-attachments/files/22613265/data_corral_service_hw_test.log)
[fan_service_hw_test.log](https://github.com/user-attachments/files/22613266/fan_service_hw_test.log)
[fw_util_hw_test.log](https://github.com/user-attachments/files/22613267/fw_util_hw_test.log)
[weutil_hw_test.log](https://github.com/user-attachments/files/22613270/weutil_hw_test.log)

