### PR TITLE
Align fw_util spi_layout for BIOS verify and read commands with upgrade command

### DIFF
--- a/fboss/platform/configs/darwin/fw_util.json
+++ b/fboss/platform/configs/darwin/fw_util.json
@@ -24,6 +24,7 @@
       "verify": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "A00000:FFFFFF normal\n400000:9EFFFF fallback",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",
@@ -41,6 +42,7 @@
       "read": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "A00000:FFFFFF normal\n400000:9EFFFF fallback",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",

--- a/fboss/platform/configs/darwin48v/fw_util.json
+++ b/fboss/platform/configs/darwin48v/fw_util.json
@@ -42,6 +42,7 @@
       "verify": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "A00000:FFFFFF normal\n400000:9EFFFF fallback",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",
@@ -59,6 +60,7 @@
       "read": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "A00000:FFFFFF normal\n400000:9EFFFF fallback",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",

--- a/fboss/platform/configs/meru800bfa/fw_util.json
+++ b/fboss/platform/configs/meru800bfa/fw_util.json
@@ -18,6 +18,7 @@
       "verify": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "3000000:3FFFFFF image",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",
@@ -29,6 +30,7 @@
       "read": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "3000000:3FFFFFF image",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",

--- a/fboss/platform/configs/meru800bia/fw_util.json
+++ b/fboss/platform/configs/meru800bia/fw_util.json
@@ -18,6 +18,7 @@
       "verify": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "3000000:3FFFFFF image",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",
@@ -29,6 +30,7 @@
       "read": {
         "commandType": "flashrom",
         "flashromArgs": {
+          "spi_layout": "3000000:3FFFFFF image",
           "programmer_type": "internal",
           "flashromExtraArgs": [
             "-i",


### PR DESCRIPTION
### Summary
This PR addresses a bug where the `spi_layout` was missing from the BIOS `verify` and `read` command configurations in the fw_util config files. This caused the layout for these commands to not match the one used by the upgrade command. This issue was introduced during a refactoring a few months ago, when the `preUpgradeCmd` was removed.

### Testing
Verified BIOS read and verify commands on darwin, darwin48v, meru800bfa and meru800bia systems.