### PR TITLE
Migrate to bp4a_isl68137 Driver for ISL68226 Devices in meru800bia

### DIFF
--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -242,13 +242,13 @@
         {
           "busName": "SMB_I2C_MASTER0@0",
           "address": "0x54",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_J3"
         },
         {
           "busName": "SMB_I2C_MASTER0@0",
           "address": "0x55",
-          "kernelDeviceName": "isl68226",
+          "kernelDeviceName": "bp4a_isl68226",
           "pmUnitScopedName": "SMB_ISL68226_OPTICS"
         },
         {


### PR DESCRIPTION
### Summary
The `bp4a_isl68137` driver is a superset of the legacy driver, maintaining all existing functionalities additionally exposing sysfs entries for firmware version and manufacturer model. This PR binds `ISL68226` devices to the `bp4a_isl68137` driver instead of `isl68137` driver to easily interpret these information.
### Testing
Verified that there are no errors in driver binding and all the sysfs entries are created as expected.