### PR TITLE
fan_config: minipack3ba: update fan service config with incremental PID logic

### DIFF
--- a/fboss/platform/configs/minipack3ba/fan_service.json
+++ b/fboss/platform/configs/minipack3ba/fan_service.json
@@ -2,10 +2,11 @@
   "pwmBoostOnNumDeadFan": 2,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 50,
+  "pwmBoostValue": 60,
   "pwmTransitionValue": 45,
   "pwmLowerThreshold": 25,
   "pwmUpperThreshold": 70,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD/th5_pwr_en",
   "watchdog": {
     "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
@@ -21,39 +22,39 @@
         "accessType": "ACCESS_TYPE_QSFP"
       },
       "portList": [],
-      "aggregationType": "OPTIC_AGGREGATION_TYPE_PID",
+      "aggregationType": "OPTIC_AGGREGATION_TYPE_INCREMENTAL_PID",
       "pidSettings": {
         "OPTIC_TYPE_800_GENERIC": {
-          "kp": -4,
-          "ki": -0.06,
+          "kp": 2,
+          "ki": 0.6,
           "kd": 0,
-          "setPoint": 67.0,
-          "posHysteresis": 0.0,
-          "negHysteresis": 3.0
+          "setPoint": 65.0,
+          "posHysteresis": 2.0,
+          "negHysteresis": 0.0
         },
         "OPTIC_TYPE_400_GENERIC": {
-          "kp": -4,
-          "ki": -0.06,
+          "kp": 2,
+          "ki": 0.6,
           "kd": 0,
-          "setPoint": 67.0,
-          "posHysteresis": 0.0,
-          "negHysteresis": 3.0
+          "setPoint": 65.0,
+          "posHysteresis": 2.0,
+          "negHysteresis": 0.0
         },
         "OPTIC_TYPE_200_GENERIC": {
-          "kp": -4,
-          "ki": -0.06,
+          "kp": 2,
+          "ki": 0.6,
           "kd": 0,
-          "setPoint": 67.0,
-          "posHysteresis": 0.0,
-          "negHysteresis": 3.0
+          "setPoint": 65.0,
+          "posHysteresis": 2.0,
+          "negHysteresis": 0.0
         },
         "OPTIC_TYPE_100_GENERIC": {
-          "kp": -4,
-          "ki": -0.06,
+          "kp": 2,
+          "ki": 0.6,
           "kd": 0,
-          "setPoint": 67.0,
-          "posHysteresis": 0.0,
-          "negHysteresis": 3.0
+          "setPoint": 65.0,
+          "posHysteresis": 2.0,
+          "negHysteresis": 0.0
         }
       }
     }
@@ -64,14 +65,14 @@
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
-      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
       "pidSetting": {
-        "kp": -4,
-        "ki": -0.06,
+        "kp": 2,
+        "ki": 0.6,
         "kd": 0,
-        "setPoint": 97.0,
-        "posHysteresis": 0.0,
-        "negHysteresis": 8.0
+        "setPoint": 94.0,
+        "posHysteresis": 3.0,
+        "negHysteresis": 3.0
       }
     },
     {
@@ -110,17 +111,27 @@
       "access": {
         "accessType": "ACCESS_TYPE_THRIFT"
       },
-      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_PID",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
       "pidSetting": {
-        "kp": -8,
-        "ki": -0.06,
+        "kp": 2,
+        "ki": 0.6,
         "kd": 0,
-        "setPoint": 97.0,
-        "posHysteresis": 0.0,
-        "negHysteresis": 3.0
+        "setPoint": 95.0,
+        "posHysteresis": 2.0,
+        "negHysteresis": 0.0
       }
     }
   ],
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 1,
+    "conditions": [
+      {
+        "sensorName": "SMB_TH5_TEMP",
+        "overtempThreshold": 110.0,
+        "slidingWindowSize": 1
+      }
+    ]
+  },
   "fans": [
     {
       "fanName": "FAN_1_F",
@@ -128,7 +139,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
       "goodLedSysfsPath": "/sys/class/leds/fan1:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan1:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan1:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -141,7 +152,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
       "goodLedSysfsPath": "/sys/class/leds/fan1:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan1:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan1:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -154,7 +165,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
       "goodLedSysfsPath": "/sys/class/leds/fan2:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan2:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan2:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -167,7 +178,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
       "goodLedSysfsPath": "/sys/class/leds/fan2:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan2:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan2:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -180,7 +191,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
       "goodLedSysfsPath": "/sys/class/leds/fan3:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan3:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan3:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -193,7 +204,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
       "goodLedSysfsPath": "/sys/class/leds/fan3:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan3:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan3:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -206,7 +217,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
       "goodLedSysfsPath": "/sys/class/leds/fan4:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan4:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan4:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -219,7 +230,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
       "goodLedSysfsPath": "/sys/class/leds/fan4:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan4:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan4:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -232,7 +243,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm5",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_present",
       "goodLedSysfsPath": "/sys/class/leds/fan5:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan5:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan5:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -245,7 +256,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm5",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_present",
       "goodLedSysfsPath": "/sys/class/leds/fan5:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan5:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan5:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -258,7 +269,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm6",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_present",
       "goodLedSysfsPath": "/sys/class/leds/fan6:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan6:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan6:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -271,7 +282,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm6",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_present",
       "goodLedSysfsPath": "/sys/class/leds/fan6:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan6:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan6:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -284,7 +295,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm7",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_present",
       "goodLedSysfsPath": "/sys/class/leds/fan7:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan7:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan7:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -297,7 +308,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm7",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_present",
       "goodLedSysfsPath": "/sys/class/leds/fan7:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan7:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan7:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -310,7 +321,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm8",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_present",
       "goodLedSysfsPath": "/sys/class/leds/fan8:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan8:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan8:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,
@@ -323,7 +334,7 @@
       "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm8",
       "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_present",
       "goodLedSysfsPath": "/sys/class/leds/fan8:blue:status",
-      "badLedSysfsPath": "/sys/class/leds/fan8:amber:status",
+      "failLedSysfsPath": "/sys/class/leds/fan8:amber:status",
       "pwmMin": 0,
       "pwmMax": 40,
       "fanPresentVal": 1,

--- a/fboss/platform/configs/minipack3ba/platform_manager.json
+++ b/fboss/platform/configs/minipack3ba/platform_manager.json
@@ -1873,7 +1873,7 @@
         },
         {
           "busName": "INCOMING@3",
-          "address": "0x3e",
+          "address": "0x33",
           "kernelDeviceName": "mp3_smbcpld",
           "pmUnitScopedName": "SMB_CPLD"
         },


### PR DESCRIPTION
**Description:**
Incremental PID logic has been verified by thermal team. Update the fan service config data according to thermal's tuning result.

**Changes:**
1.	Applied OPTIC_AGGREGATION_TYPE_INCREMENTAL_PID for optics temperature management.
2.	Applied SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID for CPU_UNCORE_TEMP.
3.	Applied SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID for SMB_TH5_TEMP.
4.	Updated platform_manager.json: changed SMB CPLD address from 0x3e to 0x33 to enable TH5 power control.
5.	Added shutdownCondition with associated shutdownCmd for TH5.

**Test Plan:**
1.	Build and deploy the latest versions of fboss components including fan_service, sensor_service, and platform_manager to ensure the updated configuration is in effect.
2.	Run platform_manager and confirm that the SMB CPLD address has been updated from 0x3e to 0x33 for TH5 power control.
3.	Start sensor_service, qsfp_service, and fan_service to ensure proper initialization and inter-service communication with the new configuration.
4.	Confirm with the thermal team that the new incremental PID logic adjusts fan speed dynamically based on temperature changes (optics, CPU, inlet, ASIC).
5.	Trigger the shutdown condition and verify that the shutdownCmd for TH5 is executed correctly.

**Test Log:**
[1_mp3ba_platform_manager_smb_change_to_0x33.txt](https://github.com/user-attachments/files/22898822/1_mp3ba_platform_manager_smb_change_to_0x33.txt)
[2_mp3ba_thermal_team_fan_service_35C.txt](https://github.com/user-attachments/files/22898837/2_mp3ba_thermal_team_fan_service_35C.txt)
[3_mp3ba_thermal_team_fan_service_35C.xlsx](https://github.com/user-attachments/files/22898841/3_mp3ba_thermal_team_fan_service_35C.xlsx)
[4_mp3ba_thermal_team_fan_service_35C_fan3_one_rotor_failed.txt](https://github.com/user-attachments/files/22898842/4_mp3ba_thermal_team_fan_service_35C_fan3_one_rotor_failed.txt)
[5_mp3ba_thermal_team_fan_service_35C_fan3_one_rotor_failed.xlsx](https://github.com/user-attachments/files/22898845/5_mp3ba_thermal_team_fan_service_35C_fan3_one_rotor_failed.xlsx)
[6_mp3ba_th5_pwr_en_test_log.txt](https://github.com/user-attachments/files/22898851/6_mp3ba_th5_pwr_en_test_log.txt)
