### PR TITLE
[bsp_tests] Bind desiredDrivers when reloading kmods

### DIFF
--- a/fboss/platform/bsp_tests/utils/KmodUtils.cpp
+++ b/fboss/platform/bsp_tests/utils/KmodUtils.cpp
@@ -7,15 +7,93 @@
 #include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 #include <re2/re2.h>
+#include <chrono>
+#include <filesystem>
 #include <set>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include <folly/FileUtil.h>
+#include "fboss/platform/bsp_tests/BspTestEnvironment.h"
 #include "fboss/platform/helpers/PlatformUtils.h"
 #include "fboss/platform/platform_manager/PkgManager.h"
+#include "fboss/platform/platform_manager/Utils.h"
+
+namespace fs = std::filesystem;
 
 namespace facebook::fboss::platform::bsp_tests {
+
+void KmodUtils::bindDesiredDrivers(
+    const platform_manager::PlatformConfig& platformConfig) {
+  // Binds pci devices with a desiredDriver attribute to the driver
+  for (const auto& [pmUnitName, pmUnitConfig] :
+       *platformConfig.pmUnitConfigs()) {
+    for (const auto& pciConf : *pmUnitConfig.pciDeviceConfigs()) {
+      if (pciConf.desiredDriver()) {
+        for (const auto& dirEntry :
+             fs::directory_iterator("/sys/bus/pci/devices/")) {
+          std::string vendor, device, subSystemVendor, subSystemDevice;
+          auto deviceFilePath = dirEntry.path() / "device";
+          auto vendorFilePath = dirEntry.path() / "vendor";
+          auto subSystemVendorFilePath = dirEntry.path() / "subsystem_vendor";
+          auto subSystemDeviceFilePath = dirEntry.path() / "subsystem_device";
+          folly::readFile(vendorFilePath.c_str(), vendor);
+          folly::readFile(deviceFilePath.c_str(), device);
+          folly::readFile(subSystemVendorFilePath.c_str(), subSystemVendor);
+          folly::readFile(subSystemDeviceFilePath.c_str(), subSystemDevice);
+          if (folly::trimWhitespace(vendor).str() == *pciConf.vendorId() &&
+              folly::trimWhitespace(device).str() == *pciConf.deviceId() &&
+              folly::trimWhitespace(subSystemVendor).str() ==
+                  *pciConf.subSystemVendorId() &&
+              folly::trimWhitespace(subSystemDevice).str() ==
+                  *pciConf.subSystemDeviceId()) {
+            const auto& sysfsPath = dirEntry.path().string();
+            auto curDriver = fmt::format("{}/driver", sysfsPath);
+            if (fs::exists(curDriver)) {
+              break;
+            }
+
+            fs::path desiredDriverPath =
+                fs::path("/sys/bus/pci/drivers") / *pciConf.desiredDriver();
+            auto pciDevId = fmt::format(
+                "{} {} {} {}",
+                std::string(vendor, 2, 4),
+                std::string(device, 2, 4),
+                std::string(subSystemVendor, 2, 4),
+                std::string(subSystemDevice, 2, 4));
+
+            auto command = fmt::format(
+                "echo '{}' > /sys/bus/pci/drivers/{}/new_id",
+                pciDevId,
+                *pciConf.desiredDriver());
+            auto result = PlatformUtils().execCommand(command);
+            EXPECT_EQ(result.first, 0) << "Failed to bind a desiredDriver: "
+                                       << *pciConf.desiredDriver();
+
+            auto charDevPath = fmt::format(
+                "/dev/fbiob_{}.{}.{}.{}",
+                std::string(vendor, 2, 4),
+                std::string(device, 2, 4),
+                std::string(subSystemVendor, 2, 4),
+                std::string(subSystemDevice, 2, 4));
+            bool isReady = platform_manager::Utils().checkDeviceReadiness(
+                [&charDevPath]() { return fs::exists(charDevPath); },
+                fmt::format("Waiting for device {}", charDevPath),
+                std::chrono::seconds(10));
+
+            EXPECT_TRUE(isReady)
+                << "Timed out after 10 seconds waiting for device to appear at: "
+                << charDevPath;
+            EXPECT_EQ(result.first, 0) << "Failed to bind a desiredDriver: "
+                                       << *pciConf.desiredDriver();
+            break;
+          }
+        }
+      }
+    }
+  }
+}
 
 void KmodUtils::loadKmods(const BspKmodsFile& kmods) {
   // Load shared kmods first
@@ -23,6 +101,11 @@ void KmodUtils::loadKmods(const BspKmodsFile& kmods) {
     auto result = PlatformUtils().execCommand(fmt::format("modprobe {}", kmod));
     EXPECT_EQ(result.first, 0) << "Failed to load shared kmod: " << kmod;
   }
+
+  BspTestEnvironment* env = BspTestEnvironment::GetInstance();
+  const platform_manager::PlatformConfig& platformConfig =
+      env->getPlatformManagerConfig();
+  bindDesiredDrivers(platformConfig);
 
   // Then load BSP kmods
   for (const auto& kmod : *kmods.bspKmods()) {

--- a/fboss/platform/bsp_tests/utils/KmodUtils.h
+++ b/fboss/platform/bsp_tests/utils/KmodUtils.h
@@ -13,6 +13,8 @@ using platform_manager::BspKmodsFile;
 
 class KmodUtils {
  public:
+  static void bindDesiredDrivers(
+      const platform_manager::PlatformConfig& platformConfig);
   static void loadKmods(const BspKmodsFile& kmods);
   static void unloadKmods(const BspKmodsFile& kmods);
   static void fbspRemove(


### PR DESCRIPTION
# Summary

During bsp_tests, before each subtest, kmods are reloaded. This poses an issue for devices that need to use the [desiredDriver setting](https://github.com/facebook/fboss/blob/c9efa26116ebd19e46109c8ff5e964e43d1dbe64/fboss/platform/platform_manager/platform_manager_config.thrift#L423), as loading the scd driver will not actually bind the devices.

To fix this, I'm proposing a change similar to the way PciExplorer handles desiredDriver. In KmodUtils, the desiredDriver attribute is checked and the devices are bound during runtime.

# Test Plan

bsp_tests passes on darwin(48v), which use desiredDriver for scd devices.
