### PR TITLE
Add bsp_tests.json for WEDGE800CACT platform

### DIFF
--- a/fboss/platform/configs/wedge800cact/bsp_tests.json
+++ b/fboss/platform/configs/wedge800cact/bsp_tests.json
@@ -1,0 +1,9 @@
+{
+  "testData": {
+    "MCB.MCB_FAN_CPLD": {
+      "watchdogTestData": {
+        "numWatchdogs": 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="882" height="235" alt="image" src="https://github.com/user-attachments/assets/897c06e5-958b-4bdc-875b-88a6192f1e45" />

## Summary:
This commit adds the `bsp_tests.json` file for the WEDGE800CACT
platform after running the full BSP validation suite. The tests were executed
with the `--enable_stress_tests=true` flag to ensure platform stability under
stress conditions.

A total of 28 tests were executed:
- 25 tests passed successfully
- 3 tests were skipped (GPIO tests not applicable)

This file serves as the baseline reference for BSP regression tracking and
can be used to validate subsequent platform updates.

## Test Plan:
1. Run the bsp_tests command to verify BSP behavior.
2. Verify test summary output:
   Total tests: 28
	Passed: 25
	Skipped: 3

   Skipped tests include:
	- GpioTest.*

Test Log:
[w800c_20260108_bsp_tests_passed.txt](https://github.com/user-attachments/files/24490303/w800c_20260108_bsp_tests_passed.txt)