### PR TITLE
[Nexthop] Refactor MacAddressCheck to support configurable network interfaces

### DIFF
--- a/fboss/platform/platform_checks/checks/MacAddressCheck.cpp
+++ b/fboss/platform/platform_checks/checks/MacAddressCheck.cpp
@@ -26,9 +26,9 @@ namespace facebook::fboss::platform::platform_checks {
 
 CheckResult MacAddressCheck::run() {
   try {
-    auto eth0Mac = getMacAddress("eth0");
-    if (eth0Mac == folly::MacAddress::ZERO) {
-      return makeError("eth0 interface has zero MAC address");
+    auto ifaceMac = getMacAddress(interfaceName_);
+    if (ifaceMac == folly::MacAddress::ZERO) {
+      return makeError(interfaceName_ + " interface has zero MAC address");
     }
 
     auto eepromMacList = getEepromMacAddressList();
@@ -37,10 +37,9 @@ CheckResult MacAddressCheck::run() {
     }
 
     for (const auto& [eepromName, eepromMac] : eepromMacList) {
-      if (eth0Mac != eepromMac) {
-        std::string errorMsg =
-            "MAC address mismatch: eth0=" + eth0Mac.toString() + " " +
-            eepromName + "=" + eepromMac.toString();
+      if (ifaceMac != eepromMac) {
+        std::string errorMsg = "MAC address mismatch: " + interfaceName_ + "=" +
+            ifaceMac.toString() + " " + eepromName + "=" + eepromMac.toString();
         std::string remediationMsg = "RMA device to correct MAC address";
         return makeProblem(
             errorMsg, RemediationType::RMA_REQUIRED, remediationMsg);

--- a/fboss/platform/platform_checks/checks/MacAddressCheck.h
+++ b/fboss/platform/platform_checks/checks/MacAddressCheck.h
@@ -2,15 +2,23 @@
 
 #include <folly/MacAddress.h>
 
+#include <string>
+#include <unordered_map>
+#include <utility>
+
 #include "fboss/platform/platform_checks/PlatformCheck.h"
 
 namespace facebook::fboss::platform::platform_checks {
 
 /**
- * Validates that the eth0 MAC address matches the EEPROM MAC address.
+ * Validates that the management interface MAC address matches the EEPROM MAC
+ * address.
  */
 class MacAddressCheck : public PlatformCheck {
  public:
+  explicit MacAddressCheck(std::string interfaceName = "eth0")
+      : interfaceName_(std::move(interfaceName)) {}
+
   CheckResult run() override;
 
   CheckType getType() const override {
@@ -22,13 +30,16 @@ class MacAddressCheck : public PlatformCheck {
   }
 
   std::string getDescription() const override {
-    return "Validates that eth0 MAC address matches EEPROM MAC address";
+    return "Validates that management interface MAC address matches EEPROM MAC address";
   }
 
  protected:
   virtual folly::MacAddress getMacAddress(const std::string& interface);
   virtual std::unordered_map<std::string, folly::MacAddress>
   getEepromMacAddressList();
+
+ private:
+  std::string interfaceName_;
 };
 
 } // namespace facebook::fboss::platform::platform_checks

--- a/fboss/platform/platform_hw_test/PlatformHwTest.cpp
+++ b/fboss/platform/platform_hw_test/PlatformHwTest.cpp
@@ -10,6 +10,8 @@
 
 #include <gtest/gtest.h>
 
+#include <gflags/gflags.h>
+
 #include "fboss/platform/helpers/Init.h"
 #include "fboss/platform/helpers/PlatformFsUtils.h"
 #ifndef IS_OSS
@@ -18,6 +20,11 @@
 #include "fboss/platform/platform_checks/checks/MacAddressCheck.h"
 #include "fboss/platform/platform_checks/checks/PciDeviceCheck.h"
 #include "fboss/platform/platform_manager/ConfigUtils.h"
+
+DEFINE_string(
+    mgmt_interface,
+    "eth0",
+    "Management interface name for MAC address validation");
 
 namespace facebook::fboss::platform {
 
@@ -32,7 +39,7 @@ class PlatformHwTest : public ::testing::Test {
 };
 
 TEST_F(PlatformHwTest, CorrectMacX86) {
-  platform_checks::MacAddressCheck macCheck;
+  platform_checks::MacAddressCheck macCheck(FLAGS_mgmt_interface);
   auto result = macCheck.run();
 
   if (result.status() != platform_checks::CheckStatus::OK) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Remove hardcoded `eth0` from `MacAddressCheck` and add configurable interface support.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The `MacAddressCheck` class had a hardcoded `eth0` interface when validating that a network interface's MAC address matches the base MAC address stored in EEPROM. This hardcoded limitation prevented the class from being reusable for platforms with different management interface names.

In this PR:
- Refactored `MacAddressCheck` to remove the hardcoded `eth0 `and make the interface name configurable
- Enhanced `platform_hw_test` to leverage the improved `MacAddressCheck` by adding a `-mgmt_interface` command-line flag
- Maintained backward compatibility by defaulting to `eth0` when no interface is specified



# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

Ran the test `platform_hw_test` on a Nexthop platform with `-mgmt_interface=eth1` and it passed without any errors.
```
./bin/platform_hw_test -config_file=... -mgmt_interface=eth1
```
and it also passed on FBOSS supported HW platform with default options as expected.
```
./bin/platform_hw_test
```

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
