### PR TITLE
[Cisco][Q200] Admin Enable MPLS on RIFs if it is supported

### DIFF
--- a/fboss/agent/hw/sai/api/RouterInterfaceApi.h
+++ b/fboss/agent/hw/sai/api/RouterInterfaceApi.h
@@ -67,7 +67,12 @@ struct RouterInterfaceTraitsAttributes<
       typename Attributes::Type,
       typename Attributes::VlanId,
       std::optional<typename Attributes::SrcMac>,
-      std::optional<typename Attributes::Mtu>>;
+      std::optional<typename Attributes::Mtu>
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+      ,
+      std::optional<typename Attributes::AdminMplsState>
+#endif
+      >;
   using AdapterHostKey = std::
       tuple<typename Attributes::VirtualRouterId, typename Attributes::VlanId>;
 };
@@ -81,7 +86,12 @@ struct RouterInterfaceTraitsAttributes<
       typename Attributes::Type,
       typename Attributes::PortId,
       std::optional<typename Attributes::SrcMac>,
-      std::optional<typename Attributes::Mtu>>;
+      std::optional<typename Attributes::Mtu>
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+      ,
+      std::optional<typename Attributes::AdminMplsState>
+#endif
+      >;
   using AdapterHostKey = std::
       tuple<typename Attributes::VirtualRouterId, typename Attributes::PortId>;
 };
@@ -122,6 +132,13 @@ struct SaiRouterInterfaceTraitsT {
         SAI_ROUTER_INTERFACE_ATTR_MTU,
         sai_uint32_t,
         SaiIntDefault<sai_int32_t>>;
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+    using AdminMplsState = SaiAttribute<
+        EnumType,
+        SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE,
+        bool,
+        SaiBoolDefaultFalse>;
+#endif
   };
   using AdapterKey = RouterInterfaceSaiId;
   using AdapterHostKey = typename detail::
@@ -186,6 +203,9 @@ SAI_ATTRIBUTE_NAME(VlanRouterInterface, VirtualRouterId)
 SAI_ATTRIBUTE_NAME(VlanRouterInterface, VlanId)
 SAI_ATTRIBUTE_NAME(PortRouterInterface, PortId)
 SAI_ATTRIBUTE_NAME(VlanRouterInterface, Mtu)
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+SAI_ATTRIBUTE_NAME(VlanRouterInterface, AdminMplsState)
+#endif
 
 class RouterInterfaceApi : public SaiApi<RouterInterfaceApi> {
  public:

--- a/fboss/agent/hw/sai/api/SaiApi.h
+++ b/fboss/agent/hw/sai/api/SaiApi.h
@@ -289,11 +289,15 @@ class SaiApi {
          * If default value is provided, allow fallback in case of certain
          * error conditions (primarily to support the case where adapter should,
          * but does not return a default value for unimplemented attributes).
+         * INVALID_PARAMETER is included so that adapters (e.g. fake_sai) that
+         * do not support get for an optional attribute can be skipped.
          * The error codes here are not very precise and may need to be revised
          * based on experience.
          */
-        static constexpr std::array<sai_status_t, 2> kFallbackToDefaultErrCode{
-            SAI_STATUS_NOT_IMPLEMENTED, SAI_STATUS_NOT_SUPPORTED};
+        static constexpr std::array<sai_status_t, 3> kFallbackToDefaultErrCode{
+            SAI_STATUS_NOT_IMPLEMENTED,
+            SAI_STATUS_NOT_SUPPORTED,
+            SAI_STATUS_INVALID_PARAMETER};
         auto status = e.getSaiStatus();
         auto fallbackToDefault =
             std::find(

--- a/fboss/agent/hw/sai/api/tests/AclApiTest.cpp
+++ b/fboss/agent/hw/sai/api/tests/AclApiTest.cpp
@@ -410,13 +410,22 @@ class AclApiTest : public ::testing::Test {
             true, // neighbor meta
             true, // ether type
             true, // outer vlan id
+#if !defined(TAJO_SDK) || defined(TAJO_SDK_GTE_24_8_3001)
             true, // bth opcode
+#endif
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
             true, // ipv6 next header
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
             kUserDefinedFieldGroup0(), // udf group 0
             kUserDefinedFieldGroup1(), // udf group 1
             kUserDefinedFieldGroup2(), // udf group 2
             kUserDefinedFieldGroup3(), // udf group 3
             kUserDefinedFieldGroup4(), // udf group 4
+#endif
         },
         kSwitchID());
   }
@@ -499,8 +508,14 @@ class AclApiTest : public ::testing::Test {
         aclFieldOuterVlanIdAttribute{AclEntryFieldU16(kOuterVlanId())};
     SaiAclEntryTraits::Attributes::FieldBthOpcode aclFieldBthOpcodeAttribute{
         AclEntryFieldU8(kBthOpcode())};
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
     SaiAclEntryTraits::Attributes::FieldIpv6NextHeader
         aclFieldIpv6NextHeaderAttribute{AclEntryFieldU8(kIpv6NextHeader())};
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
     SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin0
         aclUserDefinedGroup0{AclEntryFieldU8List{kUDFGroupData()}};
     SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin1
@@ -511,6 +526,7 @@ class AclApiTest : public ::testing::Test {
         aclUserDefinedGroup3{AclEntryFieldU8List{kUDFGroupData()}};
     SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin4
         aclUserDefinedGroup4{AclEntryFieldU8List{kUDFGroupData()}};
+#endif
     SaiAclEntryTraits::Attributes::ActionPacketAction aclActionPacketAction{
         AclEntryActionU32(kPacketAction())};
     SaiAclEntryTraits::Attributes::ActionCounter aclActionCounter{
@@ -526,8 +542,10 @@ class AclApiTest : public ::testing::Test {
         AclEntryActionSaiObjectIdList(kMirrorEgress())};
     SaiAclEntryTraits::Attributes::ActionMacsecFlow aclActionMacsecFlow{
         AclEntryActionSaiObjectIdT(kMacsecFlow())};
+#if !defined(TAJO_SDK)
     SaiAclEntryTraits::Attributes::ActionSetUserTrap aclActionSetUserTrap{
         AclEntryActionSaiObjectIdT(kSetUserTrap())};
+#endif
     SaiAclEntryTraits::Attributes::ActionSetArsObject aclActionSetArsObject{
         AclEntryActionSaiObjectIdT(kSetArsObject())};
     SaiAclEntryTraits::Attributes::ActionDisableArsForwarding
@@ -568,12 +586,19 @@ class AclApiTest : public ::testing::Test {
          aclFieldEtherTypeAttribute,
          aclFieldOuterVlanIdAttribute,
          aclFieldBthOpcodeAttribute,
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
          aclFieldIpv6NextHeaderAttribute,
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
          aclUserDefinedGroup0,
          aclUserDefinedGroup1,
          aclUserDefinedGroup2,
          aclUserDefinedGroup3,
          aclUserDefinedGroup4,
+#endif
          aclActionPacketAction,
          aclActionCounter,
          aclActionSetTC,
@@ -581,7 +606,9 @@ class AclApiTest : public ::testing::Test {
          aclActionMirrorIngress,
          aclActionMirrorEgress,
          aclActionMacsecFlow,
+#if !defined(TAJO_SDK)
          aclActionSetUserTrap,
+#endif
          aclActionSetArsObject,
          aclActionDisableArsForwarding,
          aclActionSetEcmpHashAlgorithm,
@@ -782,8 +809,14 @@ class AclApiTest : public ::testing::Test {
         aclEntryId, SaiAclEntryTraits::Attributes::FieldOuterVlanId());
     auto aclFieldBthOpcodeGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::FieldBthOpcode());
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
     auto aclFieldIpv6NextHeaderGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::FieldIpv6NextHeader());
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
     auto aclUdfGroupData0Got = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin0());
     auto aclUdfGroupData1Got = aclApi->getAttribute(
@@ -794,6 +827,7 @@ class AclApiTest : public ::testing::Test {
         aclEntryId, SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin3());
     auto aclUdfGroupData4Got = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin4());
+#endif
 
     auto aclActionPacketActionGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::ActionPacketAction());
@@ -809,8 +843,10 @@ class AclApiTest : public ::testing::Test {
         aclEntryId, SaiAclEntryTraits::Attributes::ActionMirrorEgress());
     auto aclActionMacsecFlowGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::ActionMacsecFlow());
+#if !defined(TAJO_SDK)
     auto aclActionSetUserTrapGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::ActionSetUserTrap());
+#endif
     auto aclActionSetArsObjectGot = aclApi->getAttribute(
         aclEntryId, SaiAclEntryTraits::Attributes::ActionSetArsObject());
     auto aclActionDisableArsForwardingGot = aclApi->getAttribute(
@@ -851,12 +887,19 @@ class AclApiTest : public ::testing::Test {
     EXPECT_EQ(aclFieldEtherTypeGot.getDataAndMask(), etherType);
     EXPECT_EQ(aclFieldOuterVlanIdGot.getDataAndMask(), outerVlanId);
     EXPECT_EQ(aclFieldBthOpcodeGot.getDataAndMask(), bthOpcode);
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
     EXPECT_EQ(aclFieldIpv6NextHeaderGot.getDataAndMask(), ipv6NextHeader);
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
     EXPECT_EQ(aclUdfGroupData0Got.getDataAndMask(), udfGroupData0);
     EXPECT_EQ(aclUdfGroupData1Got.getDataAndMask(), udfGroupData1);
     EXPECT_EQ(aclUdfGroupData2Got.getDataAndMask(), udfGroupData2);
     EXPECT_EQ(aclUdfGroupData3Got.getDataAndMask(), udfGroupData3);
     EXPECT_EQ(aclUdfGroupData4Got.getDataAndMask(), udfGroupData4);
+#endif
 
     EXPECT_EQ(aclActionPacketActionGot.getData(), packetAction);
     EXPECT_EQ(aclActionCounterGot.getData(), counter);
@@ -865,7 +908,9 @@ class AclApiTest : public ::testing::Test {
     EXPECT_EQ(aclActionMirrorIngress.getData(), mirrorIngress);
     EXPECT_EQ(aclActionMirrorEgress.getData(), mirrorEgress);
     EXPECT_EQ(aclActionMacsecFlowGot.getData(), macsecFlow);
+#if !defined(TAJO_SDK)
     EXPECT_EQ(aclActionSetUserTrapGot.getData(), setUserTrap);
+#endif
     EXPECT_EQ(aclActionSetArsObjectGot.getData(), setArsObject);
     EXPECT_EQ(aclActionDisableArsForwardingGot.getData(), disableArsForwarding);
     EXPECT_EQ(aclActionSetEcmpHashAlgorithmGot.getData(), setEcmpHashAlgorithm);
@@ -1016,6 +1061,10 @@ TEST_F(AclApiTest, getAclTableAttribute) {
       aclTableId, SaiAclTableTraits::Attributes::FieldRouteDstUserMeta());
   auto aclTableFieldNeighborDstUserMetaGot = aclApi->getAttribute(
       aclTableId, SaiAclTableTraits::Attributes::FieldNeighborDstUserMeta());
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
   auto aclTableUserDefinedFieldGroup0 = aclApi->getAttribute(
       aclTableId, SaiAclTableTraits::Attributes::UserDefinedFieldGroupMin0());
   auto aclTableUserDefinedFieldGroup1 = aclApi->getAttribute(
@@ -1026,6 +1075,7 @@ TEST_F(AclApiTest, getAclTableAttribute) {
       aclTableId, SaiAclTableTraits::Attributes::UserDefinedFieldGroupMin3());
   auto aclTableUserDefinedFieldGroup4 = aclApi->getAttribute(
       aclTableId, SaiAclTableTraits::Attributes::UserDefinedFieldGroupMin4());
+#endif
 
   EXPECT_EQ(aclTableStageGot, SAI_ACL_STAGE_INGRESS);
   EXPECT_EQ(aclTableBindPointTypeListGot.size(), 1);
@@ -1057,11 +1107,16 @@ TEST_F(AclApiTest, getAclTableAttribute) {
   EXPECT_EQ(aclTableFieldFdbDstUserMetaGot, true);
   EXPECT_EQ(aclTableFieldRouteDstUserMetaGot, true);
   EXPECT_EQ(aclTableFieldNeighborDstUserMetaGot, true);
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
   EXPECT_EQ(aclTableUserDefinedFieldGroup0, kUserDefinedFieldGroup0());
   EXPECT_EQ(aclTableUserDefinedFieldGroup1, kUserDefinedFieldGroup1());
   EXPECT_EQ(aclTableUserDefinedFieldGroup2, kUserDefinedFieldGroup2());
   EXPECT_EQ(aclTableUserDefinedFieldGroup3, kUserDefinedFieldGroup3());
   EXPECT_EQ(aclTableUserDefinedFieldGroup4, kUserDefinedFieldGroup4());
+#endif
 }
 
 TEST_F(AclApiTest, getAclEntryAttribute) {
@@ -1292,8 +1347,14 @@ TEST_F(AclApiTest, setAclEntryAttribute) {
       AclEntryFieldU16(kOuterVlanId())};
   SaiAclEntryTraits::Attributes::FieldBthOpcode aclFieldBthOpcode{
       AclEntryFieldU8(kBthOpcode())};
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
   SaiAclEntryTraits::Attributes::FieldIpv6NextHeader aclFieldIpv6NextHeader{
       AclEntryFieldU8(kIpv6NextHeader())};
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
   SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin0 aclUserDefinedGroup0{
       AclEntryFieldU8List{kUDFGroupData()}};
   SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin1 aclUserDefinedGroup1{
@@ -1304,6 +1365,7 @@ TEST_F(AclApiTest, setAclEntryAttribute) {
       AclEntryFieldU8List{kUDFGroupData()}};
   SaiAclEntryTraits::Attributes::UserDefinedFieldGroupMin4 aclUserDefinedGroup4{
       AclEntryFieldU8List{kUDFGroupData()}};
+#endif
 
   SaiAclEntryTraits::Attributes::ActionPacketAction aclActionPacketAction2{
       AclEntryActionU32(kPacketAction2())};
@@ -1319,8 +1381,10 @@ TEST_F(AclApiTest, setAclEntryAttribute) {
       AclEntryActionSaiObjectIdList(kMirrorEgress2())};
   SaiAclEntryTraits::Attributes::ActionMacsecFlow aclActionMacsecFlow2{
       AclEntryActionSaiObjectIdT(kMacsecFlow2())};
+#if !defined(TAJO_SDK)
   SaiAclEntryTraits::Attributes::ActionSetUserTrap aclActionSetUserTrap{
       AclEntryActionSaiObjectIdT(kSetUserTrap())};
+#endif
   SaiAclEntryTraits::Attributes::ActionSetArsObject aclActionSetArsObject{
       AclEntryActionSaiObjectIdT(kSetArsObject())};
   SaiAclEntryTraits::Attributes::ActionDisableArsForwarding
@@ -1358,12 +1422,19 @@ TEST_F(AclApiTest, setAclEntryAttribute) {
   aclApi->setAttribute(aclEntryId, aclFieldEtherType);
   aclApi->setAttribute(aclEntryId, aclFieldOuterVlanId);
   aclApi->setAttribute(aclEntryId, aclFieldBthOpcode);
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
   aclApi->setAttribute(aclEntryId, aclFieldIpv6NextHeader);
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
   aclApi->setAttribute(aclEntryId, aclUserDefinedGroup0);
   aclApi->setAttribute(aclEntryId, aclUserDefinedGroup1);
   aclApi->setAttribute(aclEntryId, aclUserDefinedGroup2);
   aclApi->setAttribute(aclEntryId, aclUserDefinedGroup3);
   aclApi->setAttribute(aclEntryId, aclUserDefinedGroup4);
+#endif
   aclApi->setAttribute(aclEntryId, aclActionPacketAction2);
   aclApi->setAttribute(aclEntryId, aclActionCounter2);
   aclApi->setAttribute(aclEntryId, aclActionSetTC2);
@@ -1371,7 +1442,9 @@ TEST_F(AclApiTest, setAclEntryAttribute) {
   aclApi->setAttribute(aclEntryId, aclActionMirrorIngress2);
   aclApi->setAttribute(aclEntryId, aclActionMirrorEgress2);
   aclApi->setAttribute(aclEntryId, aclActionMacsecFlow2);
+#if !defined(TAJO_SDK)
   aclApi->setAttribute(aclEntryId, aclActionSetUserTrap);
+#endif
   aclApi->setAttribute(aclEntryId, aclActionSetArsObject);
   aclApi->setAttribute(aclEntryId, aclActionDisableArsForwarding);
   aclApi->setAttribute(aclEntryId, aclActionSetEcmpHashAlgorithm);

--- a/fboss/agent/hw/sai/api/tests/RouterInterfaceApiTest.cpp
+++ b/fboss/agent/hw/sai/api/tests/RouterInterfaceApiTest.cpp
@@ -36,6 +36,7 @@ class RouterInterfaceApiTest : public ::testing::Test {
          typeAttribute,
          vlanIdAttribute,
          std::nullopt,
+         std::nullopt,
          std::nullopt},
         0);
     EXPECT_EQ(rifId, fs->routeInterfaceManager.get(rifId).id);
@@ -67,6 +68,7 @@ class RouterInterfaceApiTest : public ::testing::Test {
         {virtualRouterIdAttribute,
          typeAttribute,
          portIdAttribute,
+         std::nullopt,
          std::nullopt,
          std::nullopt},
         0);

--- a/fboss/agent/hw/sai/fake/FakeSaiRouterInterface.cpp
+++ b/fboss/agent/hw/sai/fake/FakeSaiRouterInterface.cpp
@@ -48,6 +48,9 @@ sai_status_t create_router_interface_fn(
       case SAI_ROUTER_INTERFACE_ATTR_MTU:
         mtu = attr_list[i].value.u32;
         break;
+      case SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE:
+        // Ignore in fake implementation - just accept the attribute
+        break;
       default:
         return SAI_STATUS_INVALID_PARAMETER;
     }
@@ -99,6 +102,9 @@ sai_status_t set_router_interface_attribute_fn(
     case SAI_ROUTER_INTERFACE_ATTR_MTU:
       ri.mtu = attr->value.u32;
       break;
+    case SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE:
+      // Ignore in fake implementation - just accept the attribute
+      break;
     default:
       return SAI_STATUS_INVALID_PARAMETER;
   }
@@ -136,6 +142,10 @@ sai_status_t get_router_interface_attribute_fn(
         break;
       case SAI_ROUTER_INTERFACE_ATTR_MTU:
         attr[i].value.u32 = ri.mtu;
+        break;
+      case SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE:
+        // Return default value (false) in fake implementation
+        attr[i].value.booldata = false;
         break;
       default:
         return SAI_STATUS_INVALID_PARAMETER;

--- a/fboss/agent/hw/sai/store/tests/AclTableGroupStoreTest.cpp
+++ b/fboss/agent/hw/sai/store/tests/AclTableGroupStoreTest.cpp
@@ -68,13 +68,22 @@ class AclTableGroupStoreTest : public SaiStoreTest {
             true, // neighbor meta
             true, // ether type
             true, // outer vlan id
+#if !defined(TAJO_SDK) || defined(TAJO_SDK_GTE_24_8_3001)
             true, // bth opcode
+#endif
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
             true, // ipv6 next header
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
             0, // udf group 0
             1, // udf group 1
             2, // udf group 2
             3, // udf group 3
             4, // udf group 4
+#endif
         },
         0);
   }

--- a/fboss/agent/hw/sai/store/tests/AclTableStoreTest.cpp
+++ b/fboss/agent/hw/sai/store/tests/AclTableStoreTest.cpp
@@ -261,13 +261,22 @@ class AclTableStoreTest : public SaiStoreTest {
             true, // neighbor meta
             true, // ethertype
             true, // outer vlan id
+#if !defined(TAJO_SDK) || defined(TAJO_SDK_GTE_24_8_3001)
             true, // bth opcode
+#endif
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
             true, // ipv6 next header
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
             kUdfGroupId(), // udf group 0
             kUdfGroupId() + 1, // udf group 1
             kUdfGroupId() + 2, // udf group 2
             kUdfGroupId() + 3, // udf group 3
             kUdfGroupId() + 4, // udf group 4
+#endif
         },
         0);
   }
@@ -304,12 +313,19 @@ class AclTableStoreTest : public SaiStoreTest {
             AclEntryFieldU16(this->kEtherType()),
             AclEntryFieldU16(this->kOuterVlanId()),
             AclEntryFieldU8(this->kBthOpcode()),
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
             AclEntryFieldU8(this->kIpv6NextHeader()),
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
             AclEntryFieldU8List(this->kUdfGroupData()),
             AclEntryFieldU8List(this->kUdfGroupData()),
             AclEntryFieldU8List(this->kUdfGroupData()),
             AclEntryFieldU8List(this->kUdfGroupData()),
             AclEntryFieldU8List(this->kUdfGroupData()),
+#endif
             AclEntryActionU32(this->kPacketAction()),
             AclEntryActionSaiObjectIdT(this->kCounter()),
             AclEntryActionU8(this->kSetTC()),
@@ -317,7 +333,9 @@ class AclTableStoreTest : public SaiStoreTest {
             AclEntryActionSaiObjectIdList(this->kMirrorIngress()),
             AclEntryActionSaiObjectIdList(this->kMirrorEgress()),
             AclEntryActionSaiObjectIdT(this->kMacsecFlow()),
+#if !defined(TAJO_SDK)
             AclEntryActionSaiObjectIdT(this->kSetUserTrap()),
+#endif
             AclEntryActionSaiObjectIdT(this->kSetArsObject()),
             AclEntryActionBool(this->kDisableArsForwarding()),
             AclEntryActionU32(this->kHashAlgorithm()),
@@ -448,13 +466,22 @@ TEST_P(AclTableStoreParamTest, aclTableCtorCreate) {
       true, // neighbor meta
       true, // ethertype
       true, // outer vlan id
+#if !defined(TAJO_SDK) || defined(TAJO_SDK_GTE_24_8_3001)
       true, // bth opcode
+#endif
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
       true, // ipv6 next header
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
       kUdfGroupId(), // udf group 0
       kUdfGroupId() + 1, // udf group 1
       kUdfGroupId() + 2, // udf group 2
       kUdfGroupId() + 3, // udf group 3
       kUdfGroupId() + 4, // udf group 4
+#endif
   };
 
   SaiAclTableTraits::AdapterHostKey k{
@@ -498,12 +525,19 @@ TEST_P(AclTableStoreParamTest, AclEntryCreateCtor) {
       this->kEtherType(),
       this->kOuterVlanId(),
       this->kBthOpcode(),
+#if !defined(TAJO_SDK) && !defined(BRCM_SAI_SDK_XGS)
       this->kIpv6NextHeader(),
+#endif
+#if (                                                                  \
+    (SAI_API_VERSION >= SAI_VERSION(1, 14, 0) ||                       \
+     (defined(BRCM_SAI_SDK_GTE_11_0) && defined(BRCM_SAI_SDK_XGS))) && \
+    !defined(TAJO_SDK))
       this->kUdfGroupData(),
       this->kUdfGroupData(),
       this->kUdfGroupData(),
       this->kUdfGroupData(),
       this->kUdfGroupData(),
+#endif
       this->kPacketAction(),
       this->kCounter(),
       this->kSetTC(),
@@ -511,7 +545,9 @@ TEST_P(AclTableStoreParamTest, AclEntryCreateCtor) {
       this->kMirrorIngress(),
       this->kMirrorEgress(),
       this->kMacsecFlow(),
+#if !defined(TAJO_SDK)
       this->kSetUserTrap(),
+#endif
       this->kSetArsObject(),
       this->kDisableArsForwarding(),
       this->kHashAlgorithm(),

--- a/fboss/agent/hw/sai/store/tests/RouterInterfaceStoreTest.cpp
+++ b/fboss/agent/hw/sai/store/tests/RouterInterfaceStoreTest.cpp
@@ -23,23 +23,63 @@ class RouterInterfaceStoreTest : public SaiStoreTest {
       sai_object_id_t vlanId,
       const folly::MacAddress& mac,
       sai_uint32_t mtu) {
+    SaiVlanRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiVlanRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_VLAN);
+    SaiVlanRouterInterfaceTraits::Attributes::VlanId vlanIdAttribute(vlanId);
+    SaiVlanRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(mac);
+    SaiVlanRouterInterfaceTraits::Attributes::Mtu mtuAttribute(mtu);
     return saiApiTable->routerInterfaceApi()
         .create<SaiVlanRouterInterfaceTraits>(
-            {0, SAI_ROUTER_INTERFACE_TYPE_VLAN, vlanId, mac, mtu}, 0);
+            {
+                virtualRouterIdAttribute,
+                typeAttribute,
+                vlanIdAttribute,
+                srcMacAttribute,
+                mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+                ,
+                std::nullopt // AdminMplsState
+#endif
+            },
+            0);
   }
   RouterInterfaceSaiId createPortRouterInterface(
       sai_object_id_t portId,
       const folly::MacAddress& mac,
       sai_uint32_t mtu) {
+    SaiPortRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiPortRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_PORT);
+    SaiPortRouterInterfaceTraits::Attributes::PortId portIdAttribute(portId);
+    SaiPortRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(mac);
+    SaiPortRouterInterfaceTraits::Attributes::Mtu mtuAttribute(mtu);
     return saiApiTable->routerInterfaceApi()
         .create<SaiPortRouterInterfaceTraits>(
-            {0, SAI_ROUTER_INTERFACE_TYPE_PORT, portId, mac, mtu}, 0);
+            {
+                virtualRouterIdAttribute,
+                typeAttribute,
+                portIdAttribute,
+                srcMacAttribute,
+                mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+                ,
+                std::nullopt // AdminMplsState
+#endif
+            },
+            0);
   }
 
   RouterInterfaceSaiId createMplsRouterInterface() {
+    SaiMplsRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiMplsRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_MPLS_ROUTER);
     return saiApiTable->routerInterfaceApi()
         .create<SaiMplsRouterInterfaceTraits>(
-            {0, SAI_ROUTER_INTERFACE_TYPE_MPLS_ROUTER}, 0);
+            {virtualRouterIdAttribute, typeAttribute}, 0);
   }
 };
 
@@ -122,8 +162,24 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceCreateCtor) {
   folly::MacAddress srcMac{"41:41:41:41:41:41"};
   {
     SaiVlanRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiVlanRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiVlanRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_VLAN);
+    SaiVlanRouterInterfaceTraits::Attributes::VlanId vlanIdAttribute(41);
+    SaiVlanRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiVlanRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiVlanRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_VLAN, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        vlanIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
 
     auto obj = createObj<SaiVlanRouterInterfaceTraits>(k, c, 0);
     EXPECT_EQ(GET_ATTR(VlanRouterInterface, VlanId, obj.attributes()), 41);
@@ -133,8 +189,24 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceCreateCtor) {
   }
   {
     SaiPortRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiPortRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiPortRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_PORT);
+    SaiPortRouterInterfaceTraits::Attributes::PortId portIdAttribute(41);
+    SaiPortRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiPortRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiPortRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_PORT, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        portIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
 
     auto obj = createObj<SaiPortRouterInterfaceTraits>(k, c, 0);
     EXPECT_EQ(GET_ATTR(PortRouterInterface, PortId, obj.attributes()), 41);
@@ -161,8 +233,24 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceSetSrcMac) {
   folly::MacAddress srcMac{"41:41:41:41:41:41"};
   {
     SaiVlanRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiVlanRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiVlanRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_VLAN);
+    SaiVlanRouterInterfaceTraits::Attributes::VlanId vlanIdAttribute(41);
+    SaiVlanRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiVlanRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiVlanRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_VLAN, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        vlanIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
 
     auto obj = createObj<SaiVlanRouterInterfaceTraits>(k, c, 0);
     EXPECT_EQ(GET_ATTR(VlanRouterInterface, VlanId, obj.attributes()), 41);
@@ -171,8 +259,19 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceSetSrcMac) {
     EXPECT_EQ(GET_OPT_ATTR(VlanRouterInterface, Mtu, obj.attributes()), 9000);
 
     folly::MacAddress srcMac2{"42:42:42:42:42:42"};
+    SaiVlanRouterInterfaceTraits::Attributes::SrcMac srcMac2Attribute(srcMac2);
+    SaiVlanRouterInterfaceTraits::Attributes::Mtu mtu2Attribute(1514);
     SaiVlanRouterInterfaceTraits::CreateAttributes newAttrs{
-        0, SAI_ROUTER_INTERFACE_TYPE_VLAN, 41, srcMac2, 1514};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        vlanIdAttribute,
+        srcMac2Attribute,
+        mtu2Attribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
     obj.setAttributes(newAttrs);
     EXPECT_EQ(GET_ATTR(VlanRouterInterface, VlanId, obj.attributes()), 41);
     EXPECT_EQ(
@@ -181,8 +280,24 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceSetSrcMac) {
   }
   {
     SaiPortRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiPortRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiPortRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_PORT);
+    SaiPortRouterInterfaceTraits::Attributes::PortId portIdAttribute(41);
+    SaiPortRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiPortRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiPortRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_PORT, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        portIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
 
     auto obj = createObj<SaiPortRouterInterfaceTraits>(k, c, 0);
     EXPECT_EQ(GET_ATTR(PortRouterInterface, PortId, obj.attributes()), 41);
@@ -191,8 +306,19 @@ TEST_F(RouterInterfaceStoreTest, routerInterfaceSetSrcMac) {
     EXPECT_EQ(GET_OPT_ATTR(PortRouterInterface, Mtu, obj.attributes()), 9000);
 
     folly::MacAddress srcMac2{"42:42:42:42:42:42"};
+    SaiPortRouterInterfaceTraits::Attributes::SrcMac srcMac2Attribute(srcMac2);
+    SaiPortRouterInterfaceTraits::Attributes::Mtu mtu2Attribute(1514);
     SaiPortRouterInterfaceTraits::CreateAttributes newAttrs{
-        0, SAI_ROUTER_INTERFACE_TYPE_PORT, 41, srcMac2, 1514};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        portIdAttribute,
+        srcMac2Attribute,
+        mtu2Attribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
     obj.setAttributes(newAttrs);
     EXPECT_EQ(GET_ATTR(PortRouterInterface, PortId, obj.attributes()), 41);
     EXPECT_EQ(
@@ -223,8 +349,24 @@ TEST_F(RouterInterfaceStoreTest, routerFormatTest) {
   folly::MacAddress srcMac{"41:41:41:41:41:41"};
   {
     SaiVlanRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiVlanRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiVlanRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_VLAN);
+    SaiVlanRouterInterfaceTraits::Attributes::VlanId vlanIdAttribute(41);
+    SaiVlanRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiVlanRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiVlanRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_VLAN, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        vlanIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
     auto obj = createObj<SaiVlanRouterInterfaceTraits>(k, c, 0);
     auto expected =
         "RouterInterfaceSaiId(0): "
@@ -234,8 +376,24 @@ TEST_F(RouterInterfaceStoreTest, routerFormatTest) {
   }
   {
     SaiPortRouterInterfaceTraits::AdapterHostKey k{0, 41};
+    SaiPortRouterInterfaceTraits::Attributes::VirtualRouterId
+        virtualRouterIdAttribute(0);
+    SaiPortRouterInterfaceTraits::Attributes::Type typeAttribute(
+        SAI_ROUTER_INTERFACE_TYPE_PORT);
+    SaiPortRouterInterfaceTraits::Attributes::PortId portIdAttribute(41);
+    SaiPortRouterInterfaceTraits::Attributes::SrcMac srcMacAttribute(srcMac);
+    SaiPortRouterInterfaceTraits::Attributes::Mtu mtuAttribute(9000);
     SaiPortRouterInterfaceTraits::CreateAttributes c{
-        0, SAI_ROUTER_INTERFACE_TYPE_PORT, 41, srcMac, 9000};
+        virtualRouterIdAttribute,
+        typeAttribute,
+        portIdAttribute,
+        srcMacAttribute,
+        mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+        ,
+        std::nullopt // AdminMplsState
+#endif
+    };
     auto obj = createObj<SaiPortRouterInterfaceTraits>(k, c, 0);
     auto expected =
         "RouterInterfaceSaiId(1): "

--- a/fboss/agent/hw/sai/switch/SaiRouterInterfaceManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiRouterInterfaceManager.cpp
@@ -111,13 +111,28 @@ RouterInterfaceSaiId SaiRouterInterfaceManager::addOrUpdateVlanRouterInterface(
         static_cast<uint32_t>(swInterface->getMtu()));
   }
 
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+  // Enable MPLS admin state if supported
+  std::optional<SaiVlanRouterInterfaceTraits::Attributes::AdminMplsState>
+      adminMplsStateAttribute = std::nullopt;
+  if (platform_->getAsic()->isSupported(HwAsic::Feature::MPLS)) {
+    adminMplsStateAttribute =
+        SaiVlanRouterInterfaceTraits::Attributes::AdminMplsState(true);
+  }
+#endif
+
   // create the router interface
   SaiVlanRouterInterfaceTraits::CreateAttributes attributes{
       virtualRouterIdAttribute,
       typeAttribute,
       vlanIdAttribute,
       srcMacAttribute,
-      mtuAttribute};
+      mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+      ,
+      adminMplsStateAttribute
+#endif
+  };
   SaiVlanRouterInterfaceTraits::AdapterHostKey k{
       virtualRouterIdAttribute,
       vlanIdAttribute,
@@ -178,13 +193,29 @@ RouterInterfaceSaiId SaiRouterInterfaceManager::addOrUpdatePortRouterInterface(
       swInterface->getType() == cfg::InterfaceType::SYSTEM_PORT
       ? getSystemPortId(swInterface)
       : getPortId(swInterface);
+
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+  // Enable MPLS admin state if supported
+  std::optional<SaiPortRouterInterfaceTraits::Attributes::AdminMplsState>
+      adminMplsStateAttribute = std::nullopt;
+  if (platform_->getAsic()->isSupported(HwAsic::Feature::MPLS)) {
+    adminMplsStateAttribute =
+        SaiPortRouterInterfaceTraits::Attributes::AdminMplsState(true);
+  }
+#endif
+
   // create the router interface
   SaiPortRouterInterfaceTraits::CreateAttributes attributes{
       virtualRouterIdAttribute,
       typeAttribute,
       portIdAttribute,
       srcMacAttribute,
-      mtuAttribute};
+      mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+      ,
+      adminMplsStateAttribute
+#endif
+  };
   SaiPortRouterInterfaceTraits::AdapterHostKey k{
       virtualRouterIdAttribute,
       portIdAttribute,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
MPLS can be enabled on router interface using the SAI attribute SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE. As per the SAI spec, the default for SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE is false and needs to be enabled by the NOS. This is a fix to enable SAI_ROUTER_INTERFACE_ATTR_ADMIN_MPLS_STATE on L3 AC ports and SVIs.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Executed all the MPLS FBOSS test cases and verified they are passing. 
HwMPLSTest/0.ExpiringTTL
HwMPLSTest/0.Php
HwMPLSTest/0.Pop
HwMPLSTest/0.Swap
HwMPLSTest/1.ExpiringTTL
HwMPLSTest/1.Php
HwMPLSTest/1.Pop
HwMPLSTest/1.Swap
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksV4MplsPhpFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksV4MplsSwapFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksV6MplsPhpFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksV6MplsSwapFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksV4MplsSwapFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksV6MplsPhpFrontPanelTraffic
AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksV6MplsSwapFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksV4MplsPhpFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksV4MplsSwapFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksV6MplsSwapFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksV4MplsPhpFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksV4MplsSwapFrontPanelTraffic
HwTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksV6MplsPhpFrontPanelTraffic

Fake test verification:
Store_test
[       OK ] RouterInterfaceStoreTest.loadRouterInterfaces (0 ms)
[----------] 1 test from RouterInterfaceStoreTest (0 ms total)

api_test --gtest_filter='RouterInterfaceApiTest.*'
[==========] Running 13 tests from 1 test suite.
[==========] 13 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 13 tests.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
