### PR TITLE
[Cisco][G202x] Fix PFC watchdog test

### DIFF
--- a/fboss/agent/hw/test/HwVerifyPfcConfigInHwTest.cpp
+++ b/fboss/agent/hw/test/HwVerifyPfcConfigInHwTest.cpp
@@ -395,8 +395,10 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
 
     // All PFC WD configuration combinations to test
     std::vector<PfcWdTestConfigs> configTest;
-    if (getAsic()->getAsicVendor() == HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-      // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+    if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+      // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR intervals
       configTest.push_back(
           {200,
            400,
@@ -453,8 +455,10 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
 
     // PFC watchdog deadlock config on multiple ports
     auto portId2 = this->portIdsForTest()[1];
-    if (getAsic()->getAsicVendor() == HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-      // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+    if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+      // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR intervals
       setupPfcWdAndValidateProgramming(
           {200,
            500,
@@ -490,8 +494,11 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
       // In SAI implementation, PFC and PFC WD are separate attributes
       // and are independently configured, so unconfiguring PFC will not
       // unconfigure PFC WD.
-      if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB) {
-        // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+      if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+          getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+          getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+        // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR
+        // intervals
         setupPfcWdAndValidateProgramming(
             {200,
              400,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
black................................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
 

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Incorrect interval configured results in failure for HwVerifyPfcConfigInHwTest.PfcWatchdogProgrammingSequence on G202x/yuba 
The accepted range is minimum 25ms and in multiples of 25ms.
# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Verified manually that HwVerifyPfcConfigInHwTest.PfcWatchdogProgrammingSequence is passing with the fix now. 
[       OK ] HwVerifyPfcConfigInHwTest.PfcWatchdogProgrammingSequence (15075 ms)
[==========] 1 test from 1 test suite ran. (15075 ms total)
[  PASSED  ] 1 test.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
