### PR TITLE
[Nexthop][fboss2-dev] Stub out DNS lookups in `fboss2 show host` unit tests

### DIFF
--- a/fboss/cli/fboss2/commands/show/host/CmdShowHost.cpp
+++ b/fboss/cli/fboss2/commands/show/host/CmdShowHost.cpp
@@ -13,13 +13,12 @@
 
 #include "fboss/cli/fboss2/utils/Table.h"
 
-#include <boost/algorithm/string.hpp>
-
 namespace facebook::fboss {
 
 CmdShowHost::RetType CmdShowHost::queryClient(
     const HostInfo& hostInfo,
-    const ObjectArgType& queriedPorts) {
+    const ObjectArgType& queriedPorts,
+    const DnsResolver& resolver) {
   std::vector<int32_t> ports;
   std::vector<NdpEntryThrift> ndpEntries;
   std::map<int32_t, PortInfoThrift> portInfoEntries;
@@ -30,14 +29,15 @@ CmdShowHost::RetType CmdShowHost::queryClient(
   agentClient->sync_getAllPortInfo(portInfoEntries);
   agentClient->sync_getPortStatus(portStatusEntries, ports);
   return createModel(
-      ndpEntries, portInfoEntries, portStatusEntries, queriedPorts);
+      ndpEntries, portInfoEntries, portStatusEntries, queriedPorts, resolver);
 }
 
 CmdShowHost::RetType CmdShowHost::createModel(
     const std::vector<NdpEntryThrift>& ndpEntries,
     const std::map<int32_t, PortInfoThrift>& portInfoEntries,
     const std::map<int32_t, PortStatus>& portStatusEntries,
-    const ObjectArgType& queriedPorts) {
+    const ObjectArgType& queriedPorts,
+    const DnsResolver& resolver) {
   RetType model;
   for (const auto& ndpEntry : ndpEntries) {
     cli::ShowHostModelEntry hostDetails;
@@ -57,7 +57,7 @@ CmdShowHost::RetType CmdShowHost::createModel(
       hostDetails.queueID() = "Olympic";
     }
     std::string ndpEntryHostName =
-        utils::removeFbDomains(NetworkUtil::getHostByAddr(ndpEntryAddr));
+        utils::removeFbDomains(resolver(ndpEntryAddr));
     if (ndpEntryHostName.empty()) {
       hostDetails.hostName() = ndpEntryAddr;
     } else {
@@ -67,7 +67,7 @@ CmdShowHost::RetType CmdShowHost::createModel(
     if (ndpEntryPortInfoEntry != portInfoEntries.end()) {
       const auto& ndpEntryPortInfo = ndpEntryPortInfoEntry->second;
       auto ndpEntryPortName = ndpEntryPortInfo.name().value();
-      if (queriedSet.size() > 0 && queriedSet.count(ndpEntryPortName) == 0) {
+      if (!queriedSet.empty() && queriedSet.count(ndpEntryPortName) == 0) {
         continue;
       }
       hostDetails.portName() = ndpEntryPortName;

--- a/fboss/cli/fboss2/commands/show/host/CmdShowHost.h
+++ b/fboss/cli/fboss2/commands/show/host/CmdShowHost.h
@@ -18,10 +18,22 @@
 #include "fboss/cli/fboss2/utils/CmdUtils.h"
 #include "fboss/cli/fboss2/utils/Table.h"
 
+#include <boost/algorithm/string.hpp>
+#include <functional>
+
 namespace facebook::fboss {
 
 using facebook::network::NetworkUtil;
 using utils::Table;
+
+// Type alias for DNS resolver function: takes IP address string, returns
+// hostname
+using DnsResolver = std::function<std::string(const std::string&)>;
+
+// Default DNS resolver using the real NetworkUtil
+inline std::string defaultDnsResolver(const std::string& ipAddr) {
+  return NetworkUtil::getHostByAddr(ipAddr);
+}
 
 struct CmdShowHostTraits : public ReadCommandTraits {
   static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
@@ -37,12 +49,14 @@ class CmdShowHost : public CmdHandler<CmdShowHost, CmdShowHostTraits> {
 
   RetType queryClient(
       const HostInfo& hostInfo,
-      const ObjectArgType& queriedPorts);
+      const ObjectArgType& queriedPorts,
+      const DnsResolver& resolver = defaultDnsResolver);
   RetType createModel(
       const std::vector<NdpEntryThrift>& ndpEntries,
       const std::map<int32_t, PortInfoThrift>& portInfoEntries,
       const std::map<int32_t, PortStatus>& portStatusEntries,
-      const ObjectArgType& queriedPorts);
+      const ObjectArgType& queriedPorts,
+      const DnsResolver& resolver = defaultDnsResolver);
   void printOutput(const RetType& model, std::ostream& out = std::cout);
 };
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The DNS lookups were causing the test to be flaky and also were inherently brittle as the hostnames used could cease to exist or change over time.

# Test Plan

Improved unit tests.