### PR TITLE
[Nexthop] Add missing `common_cpp2` dependency to `thriftpath_test_cpp2`

### DIFF
--- a/cmake/fsdb/FsdbTests.cmake
+++ b/cmake/fsdb/FsdbTests.cmake
@@ -9,6 +9,8 @@ add_fbthrift_cpp_library(
   OPTIONS
     json
     reflection
+  DEPENDS
+    common_cpp2
 )
 
 add_library(fsdb_test_server


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Bring the cmake build in line with the BUCK build. In `thriftpath_test.thrift` we [include](https://github.com/facebook/fboss/blob/83adf9deb5f37c98ca8f8f42bb9fb54183bfa696/fboss/fsdb/tests/thriftpath_test.thrift#L9) `fboss/agent/if/common.thrift`, and `fboss/fsdb/tests/BUCK` correctly [declares](https://github.com/facebook/fboss/blob/83adf9deb5f37c98ca8f8f42bb9fb54183bfa696/fboss/fsdb/tests/BUCK#L18) this dependency as `//fboss/agent/if:common`. The cmake build was missing the corresponding `DEPENDS` on `common_cpp2`, causing intermittent build failures when `common_types.h` was not yet generated:

```
In file included from /var/FBOSS/tmp_bld_dir/build/fboss/fboss/fsdb/tests/gen-cpp2/thriftpath_test_constants.cpp:8:
In file included from /var/FBOSS/tmp_bld_dir/build/fboss/fboss/fsdb/tests/gen-cpp2/thriftpath_test_constants.h:11:
/var/FBOSS/tmp_bld_dir/build/fboss/fboss/fsdb/tests/gen-cpp2/thriftpath_test_types.h:11:10: fatal error: 'fboss/agent/if/gen-cpp2/common_types.h' file not found
```


# Test Plan

This resolves occasional build errors in high concurrency builds (Nexthop uses `-j 310` typically).