### PR TITLE
[Darwin] add spidev to platform manager requiredKmodsToLoad

### DIFF
--- a/fboss/platform/configs/darwin/platform_manager.json
+++ b/fboss/platform/configs/darwin/platform_manager.json
@@ -464,6 +464,7 @@
   "bspKmodsRpmName": "arista_bsp_kmods",
   "bspKmodsRpmVersion": "0.7.9-1",
   "requiredKmodsToLoad": [
+    "spidev",
     "i2c_i801",
     "scd"
   ]

--- a/fboss/platform/configs/darwin48v/platform_manager.json
+++ b/fboss/platform/configs/darwin48v/platform_manager.json
@@ -455,6 +455,7 @@
   "bspKmodsRpmName": "arista_bsp_kmods",
   "bspKmodsRpmVersion": "0.7.17-1",
   "requiredKmodsToLoad": [
+    "spidev",
     "i2c_i801",
     "scd",
     "scd_spi",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

## Issue

On Darwin, we have seen instances where platform_manager reports a failure to set up the SPI interface on the SMB FPGA. The root cause is the following sequence:

To load the SPI device, platform_manager first creates the PCIe subdevice, then sets the spidev driver override, and finally binds the device to the spidev driver. We are seeing this fail as follows:
```
I1113 14:51:22.091393  6433 PciExplorer.cpp:370] Creating device SCD_SPI_MASTER in /sys/bus/pci/devices/0000:07:00.0 using /dev/fbiob_3475.0001.3475.0002. Args - deviceNam
e: spi_master instanceId: 2007, csrOffset: 0x7900, iobufOffset: 0x0                                                                                                        
I1113 14:51:22.091793  6433 PciExplorer.cpp:456] Successfully created device SCD_SPI_MASTER at /sys/bus/pci/devices/0000:07:00.0/scd.spi_master.2007 using /dev/fbiob_3475.
0001.3475.0002. Args - deviceName: spi_master instanceId: 2007, csrOffset: 0x7900, iobufOffset: 0x0            
V1113 14:51:22.091907  6433 PlatformFsUtils.cpp:115] Writing "spidev" to sysfs file: /sys/bus/spi/devices/spi2007.0/driver_override
V1113 14:51:22.091929  6433 PlatformFsUtils.cpp:115] Writing "spi2007.0" to sysfs file: /sys/bus/spi/drivers/spidev/bind
E1113 14:51:22.091952  6433 PlatformFsUtils.cpp:129] Received error code 2 from writing to path /sys/bus/spi/drivers/spidev/bind: No such file or directory
E1113 14:51:22.098603  6433 PlatformExplorer.cpp:922] Failed to explore PCISubDevice SCD_SPI_MASTER_DEVICE1 at /. Details: Failed binding SpiDevice spi2007.0 to /sys/bus/s
pi/drivers/spidev/bind for SpiDevice SCD_SPI_MASTER_DEVICE1
```

If we monitor sysfs during the platform_manager initialization, we can see the following state:
```
Nov 13 14:51:22.090141469
total 0
drwxr-xr-x  3 root root    0 Nov 13 14:51 .
drwxr-xr-x 12 root root    0 Nov 13 14:48 ..
lrwxrwxrwx  1 root root    0 Nov 13 14:51 driver -> ../../../../../bus/auxiliary/drivers/scd_spi
drwxr-xr-x  3 root root    0 Nov 13 14:51 spi_master
lrwxrwxrwx  1 root root    0 Nov 13 14:51 subsystem -> ../../../../../bus/auxiliary
-rw-r--r--  1 root root 4096 Nov 13 14:51 uevent
-rw-r--r-- 1 root root 4096 Nov 13 14:51 /sys/bus/spi/devices/spi2007.0/driver_override
spidev
ls: cannot access '/sys/bus/spi/drivers/spidev/bind': No such file or directory
```
This shows that there can be a state wherein platform_manager has loaded the PCIe subdevice, but the spidev driver itself still is not loaded.

## Solution

To fix this issue, include the spidev driver in the `requiredKmodsToLoad` in the platform_manager.json config file for Darwin and Darwin48v so that we can guarantee that the spidev driver is already loaded before platform exploration.

# Test Plan

Validated by stress-testing restarting the platform_manager service and verifying that SCD_SPI_MASTER and SCD_SPI_MASTER_DEVICE1 are always created successfully:
```
I0126 14:01:47.422804  5848 PciExplorer.cpp:249] Defining SpiDevice SCD_SPI_MASTER_DEVICE1 under SpiController SCD_SPI_MASTER. Args - modalias: spidev, chip_select: 0, max_speed_hz: 25000000
I0126 14:01:47.422810  5848 PciExplorer.cpp:347] Creating device SCD_SPI_MASTER in /sys/bus/pci/devices/0000:07:00.0 using /dev/fbiob_3475.0001.3475.0002. Args - deviceName: spi_master instanceId: 2007, csrOffset: 0x7900, iobufOffset: 0x0
I0126 14:01:47.423152  5848 PciExplorer.cpp:433] Successfully created device SCD_SPI_MASTER at /sys/bus/pci/devices/0000:07:00.0/scd.spi_master.2007 using /dev/fbiob_3475.0001.3475.0002. Args - deviceName: spi_master instanceId: 2007, csrOffset: 0x7900, iobufOffset: 0x0
I0126 14:01:47.423321  5848 PciExplorer.cpp:593] Completed initializing SpiDevice spi2007.0 as /dev/spidev2007.0 for SpiDevice SCD_SPI_MASTER_DEVICE1
I0126 14:01:47.423340  5848 DataStore.cpp:100] Updating CharDevPath for /[SCD_SPI_MASTER_DEVICE1] to /dev/spidev2007.0
```
