### PR TITLE
[Nexthop] Document build type options

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -47,6 +47,15 @@ class UsageError(Exception):
     pass
 
 
+# Shared argument definition for --build-type used by multiple commands
+BUILD_TYPE_ARG = {
+    "help": "Set the build type explicitly: Debug (unoptimized, debug symbols), RelWithDebInfo (optimized with debug symbols, default), MinSizeRel (size-optimized, no debug), or Release (optimized, no debug).",
+    "choices": ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
+    "action": "store",
+    "default": "RelWithDebInfo",
+}
+
+
 @cmd("validate-manifest", "parse a manifest and validate that it is correct")
 class ValidateManifest(SubCmd):
     def run(self, args):
@@ -881,13 +890,7 @@ class BuildCmd(ProjectCmdBase):
             action="store_true",
             default=False,
         )
-        parser.add_argument(
-            "--build-type",
-            help="Set the build type explicitly.  Cmake and cargo builders act on them. Only Debug and RelWithDebInfo widely supported.",
-            choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
-            action="store",
-            default=None,
-        )
+        parser.add_argument("--build-type", **BUILD_TYPE_ARG)
 
 
 @cmd("fixup-dyn-deps", "Adjusts dynamic dependencies for packaging purposes")
@@ -969,13 +972,7 @@ class TestCmd(ProjectCmdBase):
             default=None,
             help="Timeout in seconds for each individual test",
         )
-        parser.add_argument(
-            "--build-type",
-            help="Set the build type explicitly.  Cmake and cargo builders act on them. Only Debug and RelWithDebInfo widely supported.",
-            choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
-            action="store",
-            default=None,
-        )
+        parser.add_argument("--build-type", **BUILD_TYPE_ARG)
 
 
 @cmd(
@@ -1450,13 +1447,7 @@ jobs:
             action="store_true",
             default=False,
         )
-        parser.add_argument(
-            "--build-type",
-            help="Set the build type explicitly.  Cmake and cargo builders act on them. Only Debug and RelWithDebInfo widely supported.",
-            choices=["Debug", "Release", "RelWithDebInfo", "MinSizeRel"],
-            action="store",
-            default=None,
-        )
+        parser.add_argument("--build-type", **BUILD_TYPE_ARG)
         parser.add_argument(
             "--no-build-cache",
             action="store_false",

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -113,10 +113,6 @@ class BuildOptions(object):
         self.lfs_path = lfs_path
         self.shared_libs = shared_libs
         self.free_up_disk = free_up_disk
-
-        if build_type is None:
-            build_type = "RelWithDebInfo"
-
         self.build_type = build_type
 
         lib_path = None

--- a/docs/docs/build/Building_FBOSS_on_containers.md
+++ b/docs/docs/build/Building_FBOSS_on_containers.md
@@ -114,7 +114,7 @@ we highly recommend to do it in the following order:
 
 ### Build Type Options
 
-The `getdeps.py` script supports different build types via the `--build-type` flag. This controls optimization levels and debug information:
+The `run-getdeps.py` script supports different build types via the `--build-type` flag. This controls optimization levels and debug information:
 
 | Build Type | Description | Use Case |
 |------------|-------------|----------|

--- a/docs/docs/build/Building_FBOSS_on_containers.md
+++ b/docs/docs/build/Building_FBOSS_on_containers.md
@@ -112,6 +112,19 @@ we highly recommend to do it in the following order:
 ```bash file=./static/code_snips/build_qsfp_targets_with_brcm_pai.sh
 ```
 
+### Build Type Options
+
+The `getdeps.py` script supports different build types via the `--build-type` flag. This controls optimization levels and debug information:
+
+| Build Type | Description | Use Case |
+|------------|-------------|----------|
+| **Debug** | No optimization, full debug symbols | Development and debugging |
+| **RelWithDebInfo** | Optimized with debug symbols | **Default** - Balances performance with debuggability |
+| **MinSizeRel** | Optimized for size, no debug symbols | Production deployments and resource-constrained environments |
+| **Release** | Full optimization, no debug symbols | Maximum performance (may have compatibility issues) |
+
+**Note**: If `--build-type` is not specified, the build defaults to `RelWithDebInfo`, which balances performance with the ability to debug issues.
+
 ### Limit the Build to a Specific Target
 
 You can limit the build to a specific target by using the `--cmake-target` flag.

--- a/docs/docs/platform/Building_Platform_Services.md
+++ b/docs/docs/platform/Building_Platform_Services.md
@@ -17,7 +17,8 @@ you can just build the platform services by running
 
 ```
 time ./fboss/oss/scripts/run-getdeps.py build --allow-system-packages \
---extra-cmake-defines='{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20"}' \
+--build-type MinSizeRel \
+--extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20"}' \
 --scratch-path /var/FBOSS/tmp_bld_dir --cmake-target fboss_platform_services fboss
 ```
 

--- a/docs/static/code_snips/build_forwarding_stack.sh
+++ b/docs/static/code_snips/build_forwarding_stack.sh
@@ -12,6 +12,7 @@ time ./fboss/oss/scripts/run-getdeps.py \
   --npu-experiments-path /opt/sdk/experimental \
   build \
   --allow-system-packages \
+  --build-type MinSizeRel \
   --extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
   --scratch-path /var/FBOSS/tmp_bld_dir \
   fboss

--- a/docs/static/code_snips/build_forwarding_stack.sh
+++ b/docs/static/code_snips/build_forwarding_stack.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 # Navigate to the right directory
-cd /var/FBOSS/fboss
+cd /var/FBOSS/fboss || exit
 
 # Set environment variables appropriate for your build
 export SAI_BRCM_IMPL=1
@@ -11,6 +12,6 @@ time ./fboss/oss/scripts/run-getdeps.py \
   --npu-experiments-path /opt/sdk/experimental \
   build \
   --allow-system-packages \
-  --extra-cmake-defines='{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
+  --extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
   --scratch-path /var/FBOSS/tmp_bld_dir \
   fboss

--- a/docs/static/code_snips/build_qsfp_targets_with_brcm_pai.sh
+++ b/docs/static/code_snips/build_qsfp_targets_with_brcm_pai.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 # Navigate to the right directory
-cd /var/FBOSS/fboss
+cd /var/FBOSS/fboss || exit
 
 # Prepare BRCM_PAI SDK artifacts directory for linking
 mkdir -p /var/FBOSS/pai_impl
@@ -28,7 +29,8 @@ export SAI_BRCM_PAI_IMPL=1
 time ./fboss/oss/scripts/run-getdeps.py \
   build \
   --allow-system-packages \
-  --extra-cmake-defines='{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
+  --build-type MinSizeRel \
+  --extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
   --scratch-path /var/FBOSS/tmp_bld_dir \
   --cmake-target qsfp_targets \
   fboss

--- a/docs/static/code_snips/build_with_cmake_target.sh
+++ b/docs/static/code_snips/build_with_cmake_target.sh
@@ -1,11 +1,13 @@
+#!/bin/bash
 # Navigate to the right directory
-cd /var/FBOSS/fboss
+cd /var/FBOSS/fboss || exit
 
 # Build using a cmake target
 time ./fboss/oss/scripts/run-getdeps.py \
   build \
   --allow-system-packages \
-  --extra-cmake-defines='{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
+  --build-type MinSizeRel \
+  --extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
   --scratch-path /var/FBOSS/tmp_bld_dir \
   --cmake-target $TARGET \
   fboss

--- a/docs/static/code_snips/build_with_src_dir.sh
+++ b/docs/static/code_snips/build_with_src_dir.sh
@@ -1,11 +1,13 @@
+#!/bin/bash
 # Navigate to the right directory
-cd /var/FBOSS/fboss
+cd /var/FBOSS/fboss || exit
 
 # Build using a cmake target
 time ./fboss/oss/scripts/run-getdeps.py \
   build \
   --allow-system-packages \
-  --extra-cmake-defines='{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
+  --build-type MinSizeRel \
+  --extra-cmake-defines='{"CMAKE_CXX_STANDARD": "20", "RANGE_V3_TESTS": "OFF", "RANGE_V3_PERF": "OFF"}' \
   --scratch-path /var/FBOSS/tmp_bld_dir \
   --src-dir . \
   fboss


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Document the `--build-type` option for the run-getdeps.py build script and refactor the argument definition to eliminate code duplication.

- **docs/docs/build/Building_FBOSS_on_containers.md**: Added comprehensive documentation about build types (Debug, Release, RelWithDebInfo, MinSizeRel) with a table explaining each option
- **docs/docs/platform/Building_Platform_Services.md**: Updated build commands to use `--build-type` flag
- **docs/static/code_snips/*.sh**: Updated all build script examples to use `--build-type` instead of passing `CMAKE_BUILD_TYPE` in `--extra-cmake-defines`

- Updated the `--build-type` help text in run-getdeps.py to include:
  - Concise descriptions of each build type
  - Indication that RelWithDebInfo is the default
  - Removed the outdated "widely supported" comment

- Created a shared `BUILD_TYPE_ARG` kwargs dictionary to define the `--build-type` argument once
- Replaced three duplicate argument definitions in BuildCmd, TestCmd, and GenerateGithubActionsCmd classes
- Reduced code duplication and improved maintainability

- Users now understand what each build type does
- Cleaner syntax: `--build-type MinSizeRel` vs JSON in `--extra-cmake-defines`
- Single source of truth for the argument definition
- Easier to maintain and update in the future

Verified that help output works correctly for all three commands:
- `build --help`
- `test --help`
- `generate-github-actions --help`

# Test Plan

Visually inspected a local serve of the documentation
<img width="973" height="551" alt="image" src="https://github.com/user-attachments/assets/7636e9c3-992b-4e08-8f64-f76ad4bfe45a" />

<img width="973" height="488" alt="image" src="https://github.com/user-attachments/assets/1d8e0255-3931-49ff-a57e-aee8686e53ac" />
