### PR TITLE
Jang/Tahan:config: fix FSC OSFP PID setpoint value

### DIFF
--- a/fboss/platform/configs/janga800bic/fan_service.json
+++ b/fboss/platform/configs/janga800bic/fan_service.json
@@ -24,7 +24,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -32,7 +32,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -40,7 +40,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -48,7 +48,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         }

--- a/fboss/platform/configs/tahan800bc/fan_service.json
+++ b/fboss/platform/configs/tahan800bc/fan_service.json
@@ -23,7 +23,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -31,7 +31,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -39,7 +39,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         },
@@ -47,7 +47,7 @@
           "kp": 2,
           "ki": 0.6,
           "kd": 0,
-          "setPoint": 76.0,
+          "setPoint": 65.0,
           "posHysteresis": 0.0,
           "negHysteresis": 2.0
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="491" height="141" alt="image" src="https://github.com/user-attachments/assets/28570658-c20e-45a3-aa7c-d43062ab9213" />


# Summary

The original setpoint value 76C is from Quanta. Quanta tested the Tcase temp and found 8-10C lower than OSFP reported temp, based on this, they set the OSFP PID set point value as 76C. However, the spec of OSFP is 70C based on OSFP reported temp, not related to Tcase temp. Which led to over temp reported in the Meta data center. So modify the FSC OSFP PID set point value to 65C.

# Test Plan

Janga test log:
[Janga_fix_FSC_PID_setpoint.txt](https://github.com/user-attachments/files/24877575/Janga_fix_FSC_PID_setpoint.txt)

Tahan test log:
[Tahan_fix_FSC_PID_setpoint.txt](https://github.com/user-attachments/files/24877580/Tahan_fix_FSC_PID_setpoint.txt)
