### PR TITLE
[Nexthop] Update FBOSS-OSS Kernel to include missed commits

### DIFF
--- a/fboss-image/kernel/scripts/build_kernel.sh
+++ b/fboss-image/kernel/scripts/build_kernel.sh
@@ -27,18 +27,6 @@ CONTAINER_SPECS_DIR="$KERNEL_ROOT/specs"
 CONTAINER_CONFIGS_DIR="$KERNEL_ROOT/configs"
 CONTAINER_SCRIPTS_DIR="$KERNEL_ROOT/scripts"
 
-# Source common configuration for sccache distributed build and caching
-# The component builder mounts fboss/oss/scripts at /fboss/oss/scripts
-# shellcheck source=fboss/oss/scripts/nhfboss-common.sh
-source "/fboss/oss/scripts/nhfboss-common.sh"
-# Set CC to use sccache for kernel compilation
-export CC="sccache gcc"
-echo "Using sccache for kernel build with $COMPILE_JOBS compile jobs"
-
-# Debug: verify sccache config before build
-sccache --stop-server 2>/dev/null || true
-sccache --start-server
-
 # Install kernel build dependencies
 bash "$CONTAINER_SCRIPTS_DIR/setup_kernel_build_deps.sh"
 
@@ -72,7 +60,6 @@ rpmbuild -ba "$CONTAINER_SPECS_DIR/kernel.spec" \
   exit 1
 }
 echo "$(date) Kernel build completed successfully"
-sccache -s
 
 # Copy RPMs to output directory
 cp -r RPMS/* "$OUT_DIR"/ 2>/dev/null


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This commit updates the FBOSS-OSS Kernel files to remove Nexthop-specific references that were inadvertently included in the initial merge:
 - Remove sccache distributed build references from build_kernel.sh
 - Remove nhfboss-common.sh sourcing
 - Update kernel.spec copyright header to Meta/Facebook format
 - Fix import ordering in Python scripts to match upstream style
 - Simplify kernel build process to use standard gcc without sccache wrapper


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
