### PR TITLE
[Celestica][Ladakh800bcls] Fix PAI concurrency crash by passing in sync callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ if ($ENV{SAI_BRCM_PAI_IMPL})
   # epdm headers
   include_directories("${SAI_BRCM_PAI_IMPL_INC_DIR}/epdm")
 
+  add_definitions (-DSAI_BRCM_PAI_IMPL)
   # SDK artifacts directory which hosts libpai.a, EPDM SW artifact, PHY Driver
   # SW artifact
   set(SAI_BRCM_PAI_IMPL_LIB_DIR "/var/FBOSS/pai_impl/lib")

--- a/fboss/agent/hw/sai/api/SwitchApi.h
+++ b/fboss/agent/hw/sai/api/SwitchApi.h
@@ -873,7 +873,26 @@ struct SaiSwitchTraits {
         SAI_SWITCH_ATTR_SWITCHING_MODE,
         sai_int32_t,
         SaiIntDefault<sai_int32_t>>;
+
+#if defined(SAI_BRCM_PAI_IMPL)
+    struct AttributeSyncLockWrapper {
+      std::optional<sai_attr_id_t> operator()();
+    };
+    using SyncLock = SaiExtensionAttribute<
+        sai_pointer_t,
+        AttributeSyncLockWrapper,
+        SaiPointerDefault>;
+
+    struct AttributeSyncUnlockWrapper {
+      std::optional<sai_attr_id_t> operator()();
+    };
+    using SyncUnlock = SaiExtensionAttribute<
+        sai_pointer_t,
+        AttributeSyncUnlockWrapper,
+        SaiPointerDefault>;
+#endif
   };
+
   using AdapterKey = SwitchSaiId;
   using AdapterHostKey = std::monostate;
   using CreateAttributes = std::tuple<
@@ -976,7 +995,14 @@ struct SaiSwitchTraits {
 #endif
       std::optional<Attributes::PfcMonitorEnable>,
       std::optional<Attributes::CablePropagationDelayMeasurement>,
-      std::optional<Attributes::SwitchingMode>>;
+      std::optional<Attributes::SwitchingMode>
+
+#if defined(SAI_BRCM_PAI_IMPL)
+      ,
+      std::optional<Attributes::SyncLock>,
+      std::optional<Attributes::SyncUnlock>
+#endif
+      >;
 
   // Avoid using SAI_SWITCH_STAT_PACKET_INTEGRITY_DROP as that counts
   // both DramPacketError and EgressRcvPacketError. As we now have a
@@ -1176,6 +1202,10 @@ SAI_ATTRIBUTE_NAME(Switch, ModuleIdFabricPortList)
 SAI_ATTRIBUTE_NAME(Switch, LocalSystemPortIdRangeList)
 #endif
 
+#if defined(SAI_BRCM_PAI_IMPL)
+SAI_ATTRIBUTE_NAME(Switch, SyncLock)
+SAI_ATTRIBUTE_NAME(Switch, SyncUnlock)
+#endif
 template <>
 struct SaiObjectHasStats<SaiSwitchTraits> : public std::true_type {};
 

--- a/fboss/agent/hw/sai/api/oss/SwitchApi.cpp
+++ b/fboss/agent/hw/sai/api/oss/SwitchApi.cpp
@@ -400,4 +400,17 @@ const std::vector<sai_stat_id_t>& SaiSwitchTraits::deviceWatermarkBytes() {
   return stats;
 }
 
+#if defined(SAI_BRCM_PAI_IMPL)
+#include <brcm_pai_extensions.h>
+
+std::optional<sai_attr_id_t>
+SaiSwitchTraits::Attributes::AttributeSyncLockWrapper::operator()() {
+  return BRCM_PAI_SWITCH_ATTR_SYNC_LOCK;
+}
+
+std::optional<sai_attr_id_t>
+SaiSwitchTraits::Attributes::AttributeSyncUnlockWrapper::operator()() {
+  return BRCM_PAI_SWITCH_ATTR_SYNC_UNLOCK;
+}
+#endif
 } // namespace facebook::fboss

--- a/fboss/agent/platforms/sai/SaiPlatform.cpp
+++ b/fboss/agent/platforms/sai/SaiPlatform.cpp
@@ -1091,6 +1091,10 @@ SaiSwitchTraits::CreateAttributes SaiPlatform::getSwitchAttributes(
       std::nullopt, // enable PFC monitoring for the switch
       measureCableLengths, // enable cable propagation delay measurement
       std::nullopt, // switching mode (store-and-forward / cut-through)
+#if defined(SAI_BRCM_PAI_IMPL)
+      std::nullopt, // SyncLock
+      std::nullopt, // SyncUnlock
+#endif
   };
 }
 

--- a/fboss/lib/phy/SaiPhyRetimer.cpp
+++ b/fboss/lib/phy/SaiPhyRetimer.cpp
@@ -21,6 +21,11 @@
 
 #include <fmt/format.h>
 
+DEFINE_bool(
+    enable_xphy_global_lock,
+    false,
+    "Enable/disable global lock for all XPHY chips");
+
 namespace facebook::fboss::phy {
 
 namespace {
@@ -34,6 +39,44 @@ FecMode getFecMode(sai_port_fec_mode_t fec, cfg::PortSpeed /* speed */) {
       static_cast<int>(fec),
       ". Only SAI_PORT_FEC_MODE_NONE is supported for now");
 }
+
+#if defined(SAI_BRCM_PAI_IMPL)
+// Global mutex for fallback, controlled by environment variable
+std::mutex gPaiGlobalMutex;
+
+sai_status_t pai_lock_callback(uint64_t platform_context) {
+  if (FLAGS_enable_xphy_global_lock) {
+    gPaiGlobalMutex.lock();
+    XLOG(DBG5) << "PAI Sync Lock acquired (GLOBAL)";
+  } else {
+    if (platform_context == 0) {
+      XLOG(ERR) << "PAI lock callback invoked with a null context.";
+      return SAI_STATUS_FAILURE;
+    }
+    auto* retimer = reinterpret_cast<SaiPhyRetimer*>(platform_context);
+    retimer->getPaiMutex().lock();
+    XLOG(DBG5) << "PAI Sync Lock acquired for xphy:" << retimer->getPhyAddr();
+  }
+  return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t pai_unlock_callback(uint64_t platform_context) {
+  if (FLAGS_enable_xphy_global_lock) {
+    gPaiGlobalMutex.unlock();
+    XLOG(DBG5) << "PAI Sync Lock released (GLOBAL)";
+  } else {
+    if (platform_context == 0) {
+      // This might happen on a failed lock, so don't log an error
+      return SAI_STATUS_SUCCESS;
+    }
+    auto* retimer = reinterpret_cast<SaiPhyRetimer*>(platform_context);
+    retimer->getPaiMutex().unlock();
+    XLOG(DBG5) << "PAI Sync Lock released for xphy:" << retimer->getPhyAddr();
+  }
+  return SAI_STATUS_SUCCESS;
+}
+#endif
+
 /*
  * This is a static function for reading a Phy register. This function will be
  * passed to the SAI layer. The SAI driver will use this function to read a
@@ -322,6 +365,10 @@ SaiSwitchTraits::CreateAttributes SaiPhyRetimer::getSwitchAttributes() {
       std::nullopt, // enable PFC monitoring for the switch
       std::nullopt, // enable cable propagation delay measurement
       std::nullopt, // switching mode
+#if defined(SAI_BRCM_PAI_IMPL)
+      (sai_pointer_t)pai_lock_callback, // user sync_lock for pai
+      (sai_pointer_t)pai_unlock_callback, // user sync_unlock for pai
+#endif
   };
 }
 

--- a/fboss/lib/phy/SaiPhyRetimer.h
+++ b/fboss/lib/phy/SaiPhyRetimer.h
@@ -26,6 +26,8 @@
 #include <folly/Conv.h>
 #include <memory>
 
+#include <mutex>
+
 namespace facebook::fboss {
 class SaiPlatform;
 class StateObserver;
@@ -171,6 +173,10 @@ class SaiPhyRetimer : public ExternalPhy, public HwSwitchCallback {
   void* getRegisterWriteFuncPtr();
   SaiSwitchTraits::CreateAttributes getSwitchAttributes();
 
+  std::mutex& getPaiMutex() {
+    return paiMutex_;
+  }
+
  protected:
   void dumpImpl() const;
 
@@ -186,6 +192,7 @@ class SaiPhyRetimer : public ExternalPhy, public HwSwitchCallback {
   SaiPlatform* platform_;
   BspPhyIO* xphyIO_;
   std::optional<SwitchSaiId> switchId_;
+  std::mutex paiMutex_;
 };
 
 } // namespace facebook::fboss::phy


### PR DESCRIPTION
**Pre-submission checklist**
- [✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [✓ ] `pre-commit run`
clang-format.............................................................Passed
black................................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped

# Summary
The Broadcom PAI implementation is not thread-safe, which can lead to crashes when multiple threads attempt to initialize PHYs concurrently.

# Motivation
This change fixes the race condition by providing the PAI layer with a thread-safe locking mechanism from the agent. Two new SAI extension attributes, SyncLock and SyncUnlock, are introduced to pass pointers to lock and unlock functions. These functions wrap a global mutex, allowing the PAI layer to serialize access to its critical sections and prevent crashes.

The change is enabled only when SAI_BRCM_PAI_IMPL is defined, ensuring no impact on other SAI implementations.

Currently, both a global lock and per-XPHY locks have been implemented. The per-XPHY lock is enabled by default to ensure high concurrency. The global lock can be enabled by configuring enable_xphy_global_lock.

# Test Plan
In addition to the initial testing, we have run qsfp_hw_test 100 consecutive times with a 100% pass rate. It is currently being used across multiple project testbeds, and no issues have been found.

## build
targets fboss_hw_agent-sai_impl, multi_switch_agent_hw_test, sai_agent_hw_test-sai_impl, qsfp_hw_test, qsfp_service build passed. This ensures the definition SAI_BRCM_PAI_IMPL isolates SAI and PAI, preventing them from affecting each other.
**note**: need brcm_pai_extensions.h in PAI, saved in /var/FBOSS/pai_impl/include/sai/experimental/brcm_pai_extensions.h

## run scripts as below
```
ulimit -n 65535
for ((i=0; i<10; i++) do
for filter in EmptyHwTest.CheckInit; do
  TS=$(date +%Y%m%d_%H%M%S)
  rm /dev/shm/fboss/qsfp_service/can_warm_boot
  LD_LIBRARY_PATH=/opt/fboss/lib/ /root/gangtao/img/qsfp_hw_test --port-manager-mode --qsfp-config /root/gangtao/cfg/qsfpfull2.conf --gtest_filter=${filter} --enable_sai_log DEBUG --sai_log /root/gangtao/log/sai_replayer_${TS}.log --enable_replayer=true --phy_config_file=/root/gangtao/cfg/retimer.conf --logging=DBG5  2>&1 | tee /root/gangtao/log/qsfp_hwtest_${filter}_${TS}.log
  echo log is /root/gangtao/log/qsfp_hwtest_${filter}_${TS}.log
done
done
```
## result
```
-rw-r--r-- 1 root root           0 Jan 31 16:24 '=========2roundtest============'
-rw-r--r-- 1 root root     1172137 Jan 31 16:45  sai_replayer_20260131_163715.log
-rw-r--r-- 1 root root  2431063669 Jan 31 16:45  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_163715.log
-rw-r--r-- 1 root root     1172137 Jan 31 16:54  sai_replayer_20260131_164551.log
-rw-r--r-- 1 root root  2441761681 Jan 31 16:54  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_164551.log
-rw-r--r-- 1 root root     1172136 Jan 31 17:03  sai_replayer_20260131_165429.log
-rw-r--r-- 1 root root  2449867093 Jan 31 17:03  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_165429.log
-rw-r--r-- 1 root root     1172133 Jan 31 17:11  sai_replayer_20260131_170306.log
-rw-r--r-- 1 root root  2536055347 Jan 31 17:11  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_170306.log
-rw-r--r-- 1 root root     1172137 Jan 31 17:20  sai_replayer_20260131_171144.log
-rw-r--r-- 1 root root  2469150715 Jan 31 17:20  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_171144.log
-rw-r--r-- 1 root root     1172137 Jan 31 17:28  sai_replayer_20260131_172021.log
-rw-r--r-- 1 root root  2502823460 Jan 31 17:28  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_172021.log
-rw-r--r-- 1 root root     1172137 Jan 31 17:37  sai_replayer_20260131_172859.log
-rw-r--r-- 1 root root  2462251124 Jan 31 17:37  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_172859.log
-rw-r--r-- 1 root root     1172135 Jan 31 17:46  sai_replayer_20260131_173735.log
-rw-r--r-- 1 root root  2409597262 Jan 31 17:46  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_173735.log
-rw-r--r-- 1 root root     1172137 Jan 31 17:54  sai_replayer_20260131_174610.log
-rw-r--r-- 1 root root  2484741728 Jan 31 17:54  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_174610.log
-rw-r--r-- 1 root root     1172136 Jan 31 18:03  sai_replayer_20260131_175447.log
-rw-r--r-- 1 root root  2451277658 Jan 31 18:03  qsfp_hwtest_EmptyHwTest.CheckInit_20260131_175447.log
[root@localhost log]# ls -lrt ../log/ | sed -n '/2roundtest/,$p' | grep qsfp | awk '{print $9}' | xargs -n 1 grep '\[       OK \] EmptyHwTest.CheckInit'
[       OK ] EmptyHwTest.CheckInit (515956 ms)
[       OK ] EmptyHwTest.CheckInit (517313 ms)
[       OK ] EmptyHwTest.CheckInit (517547 ms)
[       OK ] EmptyHwTest.CheckInit (517416 ms)
[       OK ] EmptyHwTest.CheckInit (517482 ms)
[       OK ] EmptyHwTest.CheckInit (517300 ms)
[       OK ] EmptyHwTest.CheckInit (515789 ms)
[       OK ] EmptyHwTest.CheckInit (515057 ms)
[       OK ] EmptyHwTest.CheckInit (517277 ms)
[       OK ] EmptyHwTest.CheckInit (515753 ms)
[root@localhost log]# ls -lrt ../log/ | sed -n '/2roundtest/,$p' | grep qsfp | awk '{print $9}' | xargs -n 1 grep '\[       OK \] EmptyHwTest.CheckInit' | wc -l
10

```