### PR TITLE
[Nexthop][fboss2-dev] Rewrite fboss2-dev CLI end-to-end tests in C++ with gtest

### DIFF
--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -524,6 +524,7 @@ add_library(fboss2_lib
   fboss/cli/fboss2/commands/show/transceiver/CmdShowTransceiver.cpp
   fboss/cli/fboss2/commands/start/pcap/CmdStartPcap.h
   fboss/cli/fboss2/commands/stop/pcap/CmdStopPcap.h
+  fboss/cli/fboss2/CliAppInit.h
   fboss/cli/fboss2/CmdSubcommands.cpp
   fboss/cli/fboss2/oss/CmdGlobalOptions.cpp
   fboss/cli/fboss2/oss/CmdList.cpp

--- a/cmake/CliFboss2Test.cmake
+++ b/cmake/CliFboss2Test.cmake
@@ -102,3 +102,33 @@ target_link_libraries(thrift_latency_test
   Folly::folly
   FBThrift::thriftcpp2
 )
+
+# cli_test - CLI E2E test binary
+#
+# CLI tests are platform/SAI independent - they test the CLI binary which
+# communicates with the agent via Thrift, without running the actual fboss2-dev
+# binary.
+add_executable(cli_test
+  fboss/cli/fboss2/oss/CmdListConfig.cpp
+  fboss/cli/fboss2/test/integration_test/CliTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigInterfaceDescriptionTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
+)
+
+target_link_libraries(cli_test
+  fboss2_lib
+  fboss2_config_lib
+  thrift_service_utils
+  CLI11::CLI11
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+  Folly::folly
+  Folly::folly_test_util
+  FBThrift::thriftcpp2
+  gflags
+  fmt::fmt
+)
+
+target_include_directories(cli_test PUBLIC
+  ${CMAKE_SOURCE_DIR}
+)

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -79,6 +79,7 @@ cpp_library(
         "CmdSubcommands.cpp",
     ],
     headers = [
+        "CliAppInit.h",
         "CmdArgsLists.h",
         "CmdSubcommands.h",
     ],

--- a/fboss/cli/fboss2/CliAppInit.h
+++ b/fboss/cli/fboss2/CliAppInit.h
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#pragma once
+
+#include <CLI/App.hpp>
+#include "fboss/cli/fboss2/CmdGlobalOptions.h"
+#include "fboss/cli/fboss2/CmdList.h"
+#include "fboss/cli/fboss2/CmdSubcommands.h"
+
+namespace facebook::fboss::utils {
+
+/**
+ * Initialize the CLI app with global options and command tree.
+ * This sets up the CLI infrastructure and should be called before parsing.
+ *
+ * This function is shared between the main CLI binary and CLI E2E tests
+ * to ensure consistent CLI initialization.
+ */
+inline void initApp(CLI::App& app) {
+  app.require_subcommand();
+
+  // Initialize global options (--fmt, --host, etc.)
+  CmdGlobalOptions::getInstance()->init(app);
+
+  // Initialize command tree with all available commands
+  CmdSubcommands::getInstance()->init(
+      app, kCommandTree(), kAdditionalCommandTree(), kSpecialCommands());
+}
+
+} // namespace facebook::fboss::utils

--- a/fboss/cli/fboss2/CmdHandler.cpp
+++ b/fboss/cli/fboss2/CmdHandler.cpp
@@ -11,17 +11,37 @@
 #include "fboss/cli/fboss2/CmdHandler.h"
 #include <thrift/lib/cpp2/visitation/for_each.h>
 #include "fboss/cli/fboss2/CmdGlobalOptions.h"
+#include "fboss/cli/fboss2/CmdList.h"
+#include "fboss/cli/fboss2/gen-cpp2/cli_types.h"
+#include "fboss/cli/fboss2/utils/AggregateOp.h"
+#include "fboss/cli/fboss2/utils/AggregateUtils.h"
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 #include "thrift/lib/cpp/util/EnumUtils.h"
 #include "thrift/lib/cpp2/protocol/Serializer.h"
 
+#include <fmt/format.h>
+#include <folly/Conv.h>
+#include <folly/Demangle.h>
+#include <folly/ScopeGuard.h>
+#include <folly/Traits.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/logging/xlog.h>
+#include <folly/stop_watch.h>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
+#include <exception>
 #include <future>
 #include <iostream>
+#include <map>
+#include <memory>
+#include <optional>
 #include <queue>
 #include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
 using ThriftField = apache::thrift::metadata::ThriftField;
 using ThriftType = apache::thrift::metadata::ThriftType;
@@ -159,20 +179,10 @@ void printAggregate(
 
 namespace facebook::fboss {
 
-static bool hasRun = false;
-
 template <typename CmdTypeT, typename CmdTypeTraits>
 void CmdHandler<CmdTypeT, CmdTypeTraits>::runHelper() {
-  // Parsing library invokes every chained command handler, but we only need
-  // the 'leaf' command handler to be invoked. Thus, after the first (leaf)
-  // command handler is invoked, simply return.
-  // TODO: explore if the parsing library provides a better way to implement
-  // this.
-  if (hasRun) {
-    return;
-  }
-
-  hasRun = true;
+  // Note: The callback wrapper in CmdSubcommands.cpp ensures that only the
+  // leaf command handler is invoked. It checks if get_subcommands() is empty.
   auto extraOptionsEC =
       CmdGlobalOptions::getInstance()->validateNonFilterOptions();
   if (extraOptionsEC != cli::CliOptionResult::EOK) {
@@ -294,11 +304,19 @@ void CmdHandler<CmdTypeT, CmdTypeTraits>::runHelper() {
     }
   }
 
-  // Collect errors and display at end of execution
+  // Collect errors and display at end of execution, then throw if any failures
+  std::string combinedErrors;
   while (!executionFailures.empty()) {
     auto [host, errStr] = executionFailures.front();
     executionFailures.pop();
     XLOG(ERR) << host << " - Error in command execution: " << errStr;
+    if (!combinedErrors.empty()) {
+      combinedErrors += "; ";
+    }
+    combinedErrors += fmt::format("{}: {}", host, errStr);
+  }
+  if (!combinedErrors.empty()) {
+    throw std::runtime_error(combinedErrors);
   }
 }
 
@@ -333,7 +351,9 @@ void CmdHandler<CmdTypeT, CmdTypeTraits>::run() {
     runHelper();
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;
-    exit(1);
+    // Rethrow so the caller can handle appropriately (e.g., tests can catch and
+    // check exit codes, CLI main() can exit with non-zero status)
+    throw;
   }
 }
 

--- a/fboss/cli/fboss2/Main.cpp
+++ b/fboss/cli/fboss2/Main.cpp
@@ -8,14 +8,13 @@
  *
  */
 
-#include <CLI/CLI.hpp>
-#include "fboss/cli/fboss2/CmdGlobalOptions.h"
-#include "fboss/cli/fboss2/CmdSubcommands.h"
+#include <CLI/App.hpp>
+#include "fboss/cli/fboss2/CliAppInit.h"
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 
 #include <folly/init/Init.h>
 #include <folly/logging/Init.h>
-#include <folly/logging/xlog.h>
+#include <exception>
 
 FOLLY_INIT_LOGGING_CONFIG("fboss=DBG0; default:async=true");
 
@@ -27,25 +26,15 @@ int cliMain(int argc, char* argv[]) {
 
   CLI::App app{"FBOSS CLI"};
 
-  app.require_subcommand();
-
-  /*
-   * initialize available global options for CLI
-   */
-  CmdGlobalOptions::getInstance()->init(app);
-
-  /*
-   * initialize/build CLI command token trees
-   *
-   * NOTE: kCommandTree/kAdditionalCommandTree/kSpecialCommands will be linked
-   * from elsewhere to make `CmdSubcommands` an independent lib.
-   */
-  CmdSubcommands::getInstance()->init(
-      app, kCommandTree(), kAdditionalCommandTree(), kSpecialCommands());
-
+  utils::initApp(app);
   utils::postAppInit(argc, argv, app);
 
-  CLI11_PARSE(app, argc, argv);
+  try {
+    CLI11_PARSE(app, argc, argv);
+  } catch (const std::exception& /* e */) {
+    // Errors are already printed to stderr by CmdHandler::run()
+    return 1;
+  }
 
   return 0;
 }

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -1,0 +1,40 @@
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
+
+oncall("fboss_agent_push")
+
+# CLI E2E test binary - End-to-end tests for CLI commands
+#
+# These tests run against a live FBOSS agent and execute actual CLI commands.
+# Unlike unit tests, they require the agent to be running with valid config.
+# They are equivalent to the Python tests in fboss/oss/cli_tests/.
+#
+# CLI tests are platform/SAI independent - they test the CLI binary which
+# communicates with the agent via Thrift, regardless of the underlying
+# hardware abstraction layer.
+#
+# Unlike the Python-based CLI tests, these C++ tests directly invoke the CLI
+# library code rather than spawning a subprocess.
+cpp_binary(
+    name = "cli_test",
+    srcs = [
+        "CliTest.cpp",
+        "ConfigInterfaceDescriptionTest.cpp",
+        "ConfigInterfaceMtuTest.cpp",
+    ],
+    deps = [
+        "fbsource//third-party/googletest:gtest",
+        "//fboss/cli/fboss2:cmd-global-options",
+        "//fboss/cli/fboss2:cmd-list-header",
+        "//fboss/cli/fboss2:cmd-subcommands",
+        "//folly:dynamic",
+        "//folly:format",
+        "//folly:subprocess",
+        "//folly/json:dynamic",
+        "//folly/logging:init",
+        "//folly/logging:logging",
+    ],
+    external_deps = [
+        "CLI11",
+        "gflags",
+    ],
+)

--- a/fboss/cli/fboss2/test/integration_test/CliTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/CliTest.cpp
@@ -1,0 +1,270 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/cli/fboss2/test/integration_test/CliTest.h"
+
+#include <CLI/App.hpp>
+#include <CLI/Error.hpp>
+#include <fmt/format.h>
+#include <folly/String.h>
+#include <folly/Subprocess.h>
+#include <folly/init/Init.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/logging/Init.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <cstdlib>
+#include <exception>
+#include <filesystem>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <streambuf>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "fboss/cli/fboss2/CliAppInit.h"
+
+namespace fs = std::filesystem;
+
+namespace facebook::fboss {
+
+void CliTest::SetUp() {
+  XLOG(INFO) << "CliTest::SetUp - starting CLI test";
+  // Discard any stale session from previous runs to ensure we start fresh
+  discardSession();
+}
+
+void CliTest::TearDown() {
+  XLOG(INFO) << "CliTest::TearDown - cleaning up CLI test";
+}
+
+void CliTest::discardSession() const {
+  // Delete the session files to ensure we start with a fresh session
+  // based on the current HEAD. ConfigSession::initializeSession() will
+  // reset internal state when it detects no session file exists.
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): HOME is read-only in practice
+  const char* home = std::getenv("HOME");
+  if (home == nullptr) {
+    XLOG(WARN) << "HOME environment variable not set, cannot discard session";
+    return;
+  }
+  fs::path sessionDir = fs::path(home) / ".fboss2";
+  fs::path sessionConfig = sessionDir / "agent.conf";
+  fs::path sessionMetadata = sessionDir / "cli_metadata.json";
+
+  std::error_code ec;
+  if (fs::exists(sessionConfig, ec)) {
+    XLOG(INFO) << "Discarding session config: " << sessionConfig.string();
+    fs::remove(sessionConfig, ec);
+    if (ec) {
+      XLOG(WARN) << "Failed to remove session config: " << ec.message();
+    }
+  }
+  if (fs::exists(sessionMetadata, ec)) {
+    XLOG(INFO) << "Discarding session metadata: " << sessionMetadata.string();
+    fs::remove(sessionMetadata, ec);
+    if (ec) {
+      XLOG(WARN) << "Failed to remove session metadata: " << ec.message();
+    }
+  }
+}
+
+CliTest::Result CliTest::executeCliCommand(
+    const std::vector<std::string>& args) const {
+  // Create a new CLI::App for this command
+  CLI::App app{"FBOSS CLI Test"};
+  utils::initApp(app);
+
+  // Build argv-style argument list
+  // Prepend program name and --fmt json
+  std::vector<std::string> fullArgs = {"cli_test", "--fmt", "json"};
+  fullArgs.insert(fullArgs.end(), args.begin(), args.end());
+
+  // Convert to argc/argv format
+  std::vector<char*> argv;
+  argv.reserve(fullArgs.size());
+  for (auto& arg : fullArgs) {
+    argv.push_back(arg.data());
+  }
+
+  // Redirect stdout and stderr to capture output
+  std::stringstream capturedStdout;
+  std::stringstream capturedStderr;
+  std::streambuf* oldStdout = std::cout.rdbuf(capturedStdout.rdbuf());
+  std::streambuf* oldStderr = std::cerr.rdbuf(capturedStderr.rdbuf());
+
+  int exitCode = 0;
+  try {
+    // Parse and execute the command
+    app.parse(static_cast<int>(argv.size()), argv.data());
+  } catch (const CLI::ParseError& e) {
+    exitCode = app.exit(e);
+  } catch (const std::exception& e) {
+    capturedStderr << "Error: " << e.what() << "\n";
+    exitCode = 1;
+  }
+
+  // Restore original stdout/stderr
+  std::cout.rdbuf(oldStdout);
+  std::cerr.rdbuf(oldStderr);
+
+  return Result{exitCode, capturedStdout.str(), capturedStderr.str()};
+}
+
+CliTest::Result CliTest::runCli(const std::vector<std::string>& args) const {
+  XLOG(INFO) << "Running CLI command: " << folly::join(" ", args);
+  return executeCliCommand(args);
+}
+
+folly::dynamic CliTest::runCliJson(const std::vector<std::string>& args) const {
+  auto result = runCli(args);
+  EXPECT_EQ(result.exitCode, 0) << "CLI command failed: " << result.stderr;
+
+  if (result.exitCode != 0 || result.stdout.empty()) {
+    return folly::dynamic::object();
+  }
+  return folly::parseJson(result.stdout);
+}
+
+CliTest::Result CliTest::runCmd(const std::vector<std::string>& args) const {
+  XLOG(INFO) << "Running command: " << folly::join(" ", args);
+
+  folly::Subprocess::Options options;
+  options.pipeStdout();
+  options.pipeStderr();
+
+  folly::Subprocess proc(args, options);
+  auto [stdout, stderr] = proc.communicate();
+  auto exitStatus = proc.wait().exitStatus();
+
+  return Result{exitStatus, stdout, stderr};
+}
+
+CliTest::Interface CliTest::parseInterfaceJson(
+    const folly::dynamic& data) const {
+  CliTest::Interface intf;
+  intf.name = data["name"].asString();
+  intf.status = data["status"].asString();
+  intf.speed = data["speed"].asString();
+  if (data.count("vlan") && !data["vlan"].isNull()) {
+    intf.vlan = data["vlan"].asInt();
+  }
+  intf.mtu = data["mtu"].asInt();
+
+  // Parse prefixes
+  if (data.count("prefixes")) {
+    for (const auto& prefix : data["prefixes"]) {
+      intf.addresses.push_back(
+          fmt::format(
+              "{}/{}",
+              prefix["ip"].asString(),
+              prefix["prefixLength"].asInt()));
+    }
+  }
+
+  intf.description = data.getDefault("description", "").asString();
+  return intf;
+}
+
+std::map<std::string, CliTest::Interface> CliTest::getAllInterfaces() const {
+  auto json = runCliJson({"show", "interface"});
+  std::map<std::string, CliTest::Interface> interfaces;
+
+  // JSON has a host key containing the interfaces
+  for (const auto& [host, hostData] : json.items()) {
+    if (!hostData.isObject() || !hostData.count("interfaces")) {
+      continue;
+    }
+    for (const auto& intfData : hostData["interfaces"]) {
+      auto intf = parseInterfaceJson(intfData);
+      interfaces[intf.name] = intf;
+    }
+  }
+
+  return interfaces;
+}
+
+CliTest::Interface CliTest::getInterfaceInfo(
+    const std::string& interfaceName) const {
+  auto json = runCliJson({"show", "interface", interfaceName});
+
+  XLOG(DBG2) << "getInterfaceInfo JSON: " << folly::toPrettyJson(json);
+
+  for (const auto& [host, hostData] : json.items()) {
+    XLOG(DBG2) << "  Host: " << host << ", isObject: " << hostData.isObject()
+               << ", hasInterfaces: " << hostData.count("interfaces");
+    if (!hostData.isObject() || !hostData.count("interfaces")) {
+      continue;
+    }
+    for (const auto& intfData : hostData["interfaces"]) {
+      XLOG(DBG2) << "    Interface: " << intfData["name"].asString();
+      if (intfData["name"].asString() == interfaceName) {
+        return parseInterfaceJson(intfData);
+      }
+    }
+  }
+
+  throw std::runtime_error(
+      fmt::format("Interface {} not found", interfaceName));
+}
+
+CliTest::Interface CliTest::findFirstEthInterface() const {
+  auto interfaces = getAllInterfaces();
+
+  for (const auto& [name, intf] : interfaces) {
+    if (name.rfind("eth", 0) == 0 && intf.vlan.has_value() && *intf.vlan > 1) {
+      return intf;
+    }
+  }
+
+  throw std::runtime_error(
+      "No suitable ethernet interface found with VLAN > 1");
+}
+
+void CliTest::commitConfig() const {
+  auto result = runCli({"config", "session", "commit"});
+  ASSERT_EQ(result.exitCode, 0) << "Failed to commit config: " << result.stderr;
+}
+
+int CliTest::getKernelInterfaceMtu(int vlanId) const {
+  auto kernelIntf = fmt::format("fboss{}", vlanId);
+  // Use full path to ip command since folly::Subprocess doesn't search PATH
+  auto result = runCmd({"/usr/sbin/ip", "-json", "link", "show", kernelIntf});
+
+  if (result.exitCode != 0) {
+    throw std::runtime_error(
+        fmt::format(
+            "Kernel interface {} not found ('ip link show' returned {})",
+            kernelIntf,
+            result.exitCode));
+  }
+
+  auto json = folly::parseJson(result.stdout);
+  if (json.empty()) {
+    throw std::runtime_error(
+        fmt::format("No data returned for kernel interface {}", kernelIntf));
+  }
+
+  return json[0]["mtu"].asInt();
+}
+
+} // namespace facebook::fboss
+
+#ifdef IS_OSS
+FOLLY_INIT_LOGGING_CONFIG("DBG2; default:async=true");
+#else
+FOLLY_INIT_LOGGING_CONFIG("fboss=DBG2; default:async=true");
+#endif
+
+int main(int argc, char* argv[]) {
+  // Initialize gtest first so it consumes --gtest_* flags before folly::init
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // Initialize folly singletons before using CLI components
+  folly::init(&argc, &argv, /* removeFlags = */ false);
+
+  return RUN_ALL_TESTS();
+}

--- a/fboss/cli/fboss2/test/integration_test/CliTest.h
+++ b/fboss/cli/fboss2/test/integration_test/CliTest.h
@@ -1,0 +1,133 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <folly/json/dynamic.h>
+#include <gtest/gtest.h>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook::fboss {
+
+/**
+ * CliTest is the base class for CLI end-to-end tests.
+ *
+ * Unlike the link tests, CLI tests don't need to be concerned with the SAI
+ * or what SAI we're using, since we're testing the CLI and the CLI is
+ * largely platform independent.
+ *
+ * The tests run against a live FBOSS agent and execute actual CLI commands
+ * by directly invoking the CLI library code (not spawning a subprocess).
+ */
+class CliTest : public ::testing::Test {
+ public:
+  /**
+   * Represents the result of a CLI command execution.
+   */
+  struct Result {
+    int exitCode;
+    std::string stdout;
+    std::string stderr;
+  };
+
+  /**
+   * Represents a network interface from the output of 'show interface'.
+   */
+  struct Interface {
+    std::string name;
+    std::string status;
+    std::string speed;
+    std::optional<int> vlan;
+    int mtu;
+    std::vector<std::string> addresses;
+    std::string description;
+  };
+
+  ~CliTest() override = default;
+
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+
+  /**
+   * Run a CLI command with the given arguments.
+   * The --fmt json flag is automatically prepended.
+   * @param args The command arguments (e.g., {"show", "interface"})
+   * @return Result with exit code, stdout, and stderr
+   */
+  Result runCli(const std::vector<std::string>& args) const;
+
+  /**
+   * Run a CLI command and parse the JSON output.
+   * Throws if the command fails or output is not valid JSON.
+   * @param args The command arguments
+   * @return Parsed JSON as folly::dynamic
+   */
+  folly::dynamic runCliJson(const std::vector<std::string>& args) const;
+
+  /**
+   * Run a shell command and return the result.
+   * @param args Command and arguments
+   * @return Result with exit code, stdout, and stderr
+   */
+  Result runCmd(const std::vector<std::string>& args) const;
+
+  /**
+   * Get information about a specific interface.
+   * @param interfaceName The interface name (e.g., "eth1/1/1")
+   * @return Interface object with the interface details
+   */
+  Interface getInterfaceInfo(const std::string& interfaceName) const;
+
+  /**
+   * Get all interfaces from the system.
+   * @return Map of interface name to Interface object
+   */
+  std::map<std::string, Interface> getAllInterfaces() const;
+
+  /**
+   * Find the first suitable ethernet interface for testing.
+   * Only returns ethernet interfaces (starting with 'eth') with a valid VLAN.
+   * @return Interface object
+   */
+  Interface findFirstEthInterface() const;
+
+  /**
+   * Commit the current configuration session.
+   */
+  void commitConfig() const;
+
+  /**
+   * Get the MTU of a kernel interface using 'ip -json link'.
+   * @param vlanId The VLAN ID (interface name will be fboss<vlanId>)
+   * @return MTU value, or -1 if interface not found
+   */
+  int getKernelInterfaceMtu(int vlanId) const;
+
+  /**
+   * Discard any pending config session by deleting session files.
+   * This ensures each test starts with a fresh session based on current HEAD.
+   */
+  void discardSession() const;
+
+ private:
+  Interface parseInterfaceJson(const folly::dynamic& data) const;
+
+  /**
+   * Execute a CLI command by parsing args and running the command.
+   * Captures stdout/stderr and returns the result.
+   */
+  Result executeCliCommand(const std::vector<std::string>& args) const;
+};
+
+/**
+ * Main function for CLI tests.
+ * Initializes gtest and runs all CLI tests.
+ */
+int cliTestMain(int argc, char** argv);
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/ConfigInterfaceDescriptionTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigInterfaceDescriptionTest.cpp
@@ -1,0 +1,85 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end test for 'fboss2-dev config interface <name> description <string>'
+ *
+ * This test:
+ * 1. Picks an interface from the running system
+ * 2. Gets the current description
+ * 3. Sets a new description
+ * 4. Verifies the description was set correctly via 'fboss2-dev show interface'
+ * 5. Restores the original description
+ *
+ * Requirements:
+ * - FBOSS agent must be running with a valid configuration
+ * - The test must be run as root (or with appropriate permissions)
+ */
+
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <string>
+#include "fboss/cli/fboss2/test/integration_test/CliTest.h"
+
+using namespace facebook::fboss;
+
+class ConfigInterfaceDescriptionTest : public CliTest {
+ protected:
+  void setInterfaceDescription(
+      const std::string& interfaceName,
+      const std::string& description) {
+    auto result = runCli(
+        {"config", "interface", interfaceName, "description", description});
+    ASSERT_EQ(result.exitCode, 0)
+        << "Failed to set description: " << result.stderr;
+    commitConfig();
+  }
+};
+
+TEST_F(ConfigInterfaceDescriptionTest, SetAndVerifyDescription) {
+  // Step 1: Find an interface to test with
+  XLOG(INFO) << "[Step 1] Finding an interface to test...";
+  Interface interface = findFirstEthInterface();
+  XLOG(INFO) << "  Using interface: " << interface.name << " (VLAN: "
+             << (interface.vlan.has_value() ? std::to_string(*interface.vlan)
+                                            : "none")
+             << ")";
+
+  // Step 2: Get the current description
+  XLOG(INFO) << "[Step 2] Getting current description...";
+  std::string originalDescription = interface.description;
+  XLOG(INFO) << "  Current description: '" << originalDescription << "'";
+
+  // Step 3: Set a new description
+  std::string testDescription = "CLI_E2E_TEST_DESCRIPTION";
+  if (originalDescription == testDescription) {
+    testDescription = "CLI_E2E_TEST_DESCRIPTION_ALT";
+  }
+  XLOG(INFO) << "[Step 3] Setting description to '" << testDescription
+             << "'...";
+  setInterfaceDescription(interface.name, testDescription);
+  XLOG(INFO) << "  Description set to '" << testDescription << "'";
+
+  // Step 4: Verify description via 'show interface'
+  XLOG(INFO) << "[Step 4] Verifying description via 'show interface'...";
+  Interface updatedInterface = getInterfaceInfo(interface.name);
+  EXPECT_EQ(updatedInterface.description, testDescription)
+      << "Expected description '" << testDescription << "', got '"
+      << updatedInterface.description << "'";
+  XLOG(INFO) << "  Verified: Description is '" << updatedInterface.description
+             << "'";
+
+  // Step 5: Restore original description
+  XLOG(INFO) << "[Step 5] Restoring original description ('"
+             << originalDescription << "')...";
+  setInterfaceDescription(interface.name, originalDescription);
+  XLOG(INFO) << "  Restored description to '" << originalDescription << "'";
+
+  // Verify restoration
+  Interface restoredInterface = getInterfaceInfo(interface.name);
+  if (restoredInterface.description != originalDescription) {
+    XLOG(WARN) << "  WARNING: Restoration may have failed. Current: '"
+               << restoredInterface.description << "'";
+  }
+
+  XLOG(INFO) << "TEST PASSED";
+}

--- a/fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
@@ -1,0 +1,83 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end test for the 'fboss2-dev config interface <name> mtu <N>' command.
+ *
+ * This test:
+ * 1. Picks an interface from the running system
+ * 2. Gets the current MTU value
+ * 3. Sets a new MTU value
+ * 4. Verifies the MTU was set correctly via 'fboss2-dev show interface'
+ * 5. Verifies the MTU on the kernel interface via 'ip link'
+ * 6. Restores the original MTU
+ *
+ * Requirements:
+ * - FBOSS agent must be running with a valid configuration
+ * - The test must be run as root (or with appropriate permissions)
+ */
+
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <string>
+#include "fboss/cli/fboss2/test/integration_test/CliTest.h"
+
+using namespace facebook::fboss;
+
+class ConfigInterfaceMtuTest : public CliTest {
+ protected:
+  void setInterfaceMtu(const std::string& interfaceName, int mtu) {
+    auto result = runCli(
+        {"config", "interface", interfaceName, "mtu", std::to_string(mtu)});
+    ASSERT_EQ(result.exitCode, 0) << "Failed to set MTU: " << result.stderr;
+    commitConfig();
+  }
+};
+
+TEST_F(ConfigInterfaceMtuTest, SetAndVerifyMtu) {
+  // Step 1: Find an interface to test with
+  XLOG(INFO) << "[Step 1] Finding an interface to test...";
+  Interface interface = findFirstEthInterface();
+  XLOG(INFO) << "  Using interface: " << interface.name << " (VLAN: "
+             << (interface.vlan.has_value() ? std::to_string(*interface.vlan)
+                                            : "none")
+             << ")";
+
+  // Step 2: Get the current MTU
+  XLOG(INFO) << "[Step 2] Getting current MTU...";
+  int originalMtu = interface.mtu;
+  XLOG(INFO) << "  Current MTU: " << originalMtu;
+
+  // Step 3: Set a new MTU (toggle between 1500 and 9000)
+  int newMtu = (originalMtu != 9000) ? 9000 : 1500;
+  XLOG(INFO) << "[Step 3] Setting MTU to " << newMtu << "...";
+  setInterfaceMtu(interface.name, newMtu);
+  XLOG(INFO) << "  MTU set to " << newMtu;
+
+  // Step 4: Verify MTU via 'show interface'
+  XLOG(INFO) << "[Step 4] Verifying MTU via 'show interface'...";
+  Interface updatedInterface = getInterfaceInfo(interface.name);
+  EXPECT_EQ(updatedInterface.mtu, newMtu)
+      << "Expected MTU " << newMtu << ", got " << updatedInterface.mtu;
+  XLOG(INFO) << "  Verified: MTU is " << updatedInterface.mtu;
+
+  // Step 5: Verify kernel interface MTU
+  XLOG(INFO) << "[Step 5] Verifying kernel interface MTU...";
+  ASSERT_TRUE(interface.vlan.has_value());
+  int kernelMtu = getKernelInterfaceMtu(*interface.vlan);
+  if (kernelMtu > 0) {
+    EXPECT_EQ(kernelMtu, newMtu)
+        << "Kernel MTU is " << kernelMtu << ", expected " << newMtu;
+    XLOG(INFO) << "  Verified: Kernel interface fboss" << *interface.vlan
+               << " has MTU " << kernelMtu;
+  } else {
+    XLOG(INFO) << "  Skipped: Kernel interface fboss" << *interface.vlan
+               << " not found";
+  }
+
+  // Step 6: Restore original MTU
+  XLOG(INFO) << "[Step 6] Restoring original MTU (" << originalMtu << ")...";
+  setInterfaceMtu(interface.name, originalMtu);
+  XLOG(INFO) << "  Restored MTU to " << originalMtu;
+
+  XLOG(INFO) << "TEST PASSED";
+}

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -249,13 +249,6 @@ FEATURE_LIST_PREFIX = "Feature List: "
 DEFAULT_TEST_RUN_TIMEOUT_IN_SECOND = 1200
 
 
-def _check_working_dir():
-    current_dir = os.getcwd()
-    if not current_dir.endswith("/opt/fboss"):
-        print("Error: Script must be run from /opt/fboss directory.")
-        sys.exit(1)
-
-
 def run_script(script_file: str):
     if not os.path.exists(script_file):
         raise Exception(f"Script file {script_file} does not exist")
@@ -288,6 +281,9 @@ def setup_fboss_env() -> None:
         os.environ["LD_LIBRARY_PATH"] = (
             f"{os.environ['FBOSS_LIB64']}:{os.environ['FBOSS_LIB']}"
         )
+
+    # Update TestRunner.ENV_VAR to pick up the modified environment
+    TestRunner.ENV_VAR = dict(os.environ)
 
 
 class TestRunner(abc.ABC):
@@ -802,6 +798,9 @@ class TestRunner(abc.ABC):
         self._write_results_to_csv(test_summaries)
 
     def _write_results_to_csv(self, output):
+        if not output:
+            print("No tests we were run.")
+            return
         output_csv = (
             f"hwtest_results_{datetime.now().strftime('%Y_%b_%d-%I_%M_%S_%p')}.csv"
         )
@@ -1551,122 +1550,68 @@ class PlatformServicesTestRunner(TestRunner):
         self._print_output_summary(output)
 
 
-class CliTestRunner:
+class CliTestRunner(TestRunner):
     """
     Runner for CLI end-to-end tests.
 
-    Unlike the gtest-based test runners, CLI tests are simple Python tests
-    that run CLI commands and verify output. They test the CLI tool itself
-    (fboss2-dev) on a running FBOSS instance.
+    CLI tests are C++ gtest-based tests that run CLI commands and verify output.
+    They test the CLI tool itself (fboss2-dev) on a running FBOSS instance.
+
+    CLI tests are platform/SAI independent - they test the CLI binary which
+    communicates with the agent via Thrift, regardless of the underlying
+    hardware abstraction layer.
     """
 
-    CLI_TEST_DIR = "./share/cli_tests"
+    def add_subcommand_arguments(self, sub_parser: ArgumentParser):
+        """Add CLI test-specific command line arguments"""
+        # Override defaults for CLI tests:
+        # - fruid_path: CLI tests don't use fruid files
+        # - coldboot_only: Some CLI tests use warmboot/coldboot but the test binary doesn't support the --setup-for-warmboot flag.
+        sub_parser.set_defaults(fruid_path=None, coldboot_only=True)
 
-    def run_test(self, args):  # noqa: PLR0912, PLR0915 - complex test orchestration; splitting would harm readability
-        """Run CLI end-to-end tests"""
-        print("Running CLI end-to-end tests...")
+    def _get_config_path(self):
+        return "/etc/coop/agent.conf"
 
-        # Find and run test scripts
-        test_dir = self.CLI_TEST_DIR
-        if not os.path.isdir(test_dir):
-            print(f"CLI test directory not found: {test_dir}")
-            print("No CLI tests to run.")
-            return
+    def _get_known_bad_tests_file(self):
+        return ""
 
-        # Get list of test scripts
-        test_scripts = []
-        for filename in sorted(os.listdir(test_dir)):
-            if filename.startswith("test_") and filename.endswith(".py"):
-                test_scripts.append(os.path.join(test_dir, filename))
+    def _get_unsupported_tests_file(self):
+        return ""
 
-        if not test_scripts:
-            print(f"No CLI test scripts found in {test_dir}")
-            return
+    def _get_test_binary_name(self):
+        return "cli_test"
 
-        # Apply filter if specified
-        if args.filter:
-            filtered_scripts = []
-            for script in test_scripts:
-                script_name = os.path.basename(script)
-                if args.filter in script_name:
-                    filtered_scripts.append(script)
-            test_scripts = filtered_scripts
-            if not test_scripts:
-                print(f"No tests match filter: {args.filter}")
-                return
+    def _get_sai_replayer_logging_flags(
+        self, sai_replayer_log_path: str | None
+    ) -> list[str]:
+        return []
 
-        # Run each test script
-        passed = 0
-        failed = 0
-        failed_tests = []
-        test_times = {}  # Track time for each test
-        total_start_time = time.time()
+    def _get_sai_logging_flags(self, sai_logging):
+        # CLI tests don't use SAI logging
+        return []
 
-        for test_script in test_scripts:
-            test_name = os.path.basename(test_script)
-            print(f"\n########## Running CLI test: {test_name}")
+    def _get_warmboot_check_file(self):
+        return ""
 
-            test_start_time = time.time()
-            try:
-                result = subprocess.run(
-                    ["python3", test_script],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=300,  # 5 minute timeout per test
-                )
-                test_elapsed = time.time() - test_start_time
-                test_times[test_name] = test_elapsed
+    def _get_test_run_args(self, conf_file):
+        # CLI tests don't need any additional args
+        return []
 
-                if result.returncode == 0:
-                    print(f"[  PASSED  ] {test_name} ({test_elapsed:.1f}s)")
-                    passed += 1
-                else:
-                    print(f"[  FAILED  ] {test_name} ({test_elapsed:.1f}s)")
-                    print(f"stdout: {result.stdout}")
-                    print(f"stderr: {result.stderr}")
-                    failed += 1
-                    failed_tests.append(test_name)
+    def _setup_coldboot_test(self, sai_replayer_log_path: str | None = None):
+        pass
 
-            except subprocess.TimeoutExpired as e:
-                test_elapsed = time.time() - test_start_time
-                test_times[test_name] = test_elapsed
-                print(f"[  TIMEOUT ] {test_name} ({test_elapsed:.1f}s)")
-                if e.stdout:
-                    print(f"stdout: {e.stdout}")
-                if e.stderr:
-                    print(f"stderr: {e.stderr}")
-                failed += 1
-                failed_tests.append(test_name)
-            except Exception as e:
-                test_elapsed = time.time() - test_start_time
-                test_times[test_name] = test_elapsed
-                print(f"[  ERROR   ] {test_name}: {e} ({test_elapsed:.1f}s)")
-                failed += 1
-                failed_tests.append(test_name)
+    def _setup_warmboot_test(self, sai_replayer_log_path: str | None = None):
+        pass
 
-        total_elapsed = time.time() - total_start_time
+    def _end_run(self):
+        pass
 
-        # Print summary
-        print("\n" + "=" * 60)
-        print("CLI Test Summary")
-        print("=" * 60)
-        print(f"  Passed: {passed}")
-        print(f"  Failed: {failed}")
-        print(f"  Total:  {passed + failed}")
-        print(f"  Time:   {total_elapsed:.1f}s")
-
-        if failed_tests:
-            print("\nFailed tests:")
-            for test in failed_tests:
-                print(f"  - {test} ({test_times.get(test, 0):.1f}s)")
-
-        if failed > 0:
-            sys.exit(1)
+    def _filter_tests(self, tests: list[str]) -> list[str]:
+        return tests
 
 
 if __name__ == "__main__":
-    _check_working_dir()
+    os.chdir("/opt/fboss")
     # Set env variables for FBOSS
     setup_fboss_env()
 
@@ -1908,6 +1853,7 @@ if __name__ == "__main__":
     )
     cli_test_runner = CliTestRunner()
     cli_test_parser.set_defaults(func=cli_test_runner.run_test)
+    cli_test_runner.add_subcommand_arguments(cli_test_parser)
 
     # Parse the args
     args = ap.parse_known_args()


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

This change enables running multiple CLI commands within a single process, which is required for C++ end-to-end tests. The first two end-to-end tests that were originally written in Python, along with helper functions, have been rewritten in C++, and can now run as a self-contained gtest binary, without depending on the fboss2-dev binary.

Some fixes were necessary to make this work, so the CLI could be re-used as a library instead of being invoked as a subprocess:

1. Remove the `hasRun` static variable from `CmdHandler`
   - Previously, a static `hasRun` flag prevented commands from executing more than once per process
   - Now we wrap callbacks in `CmdSubcommands` to check `get_subcommands().empty()` to detect leaf commands, eliminating the need for static state

2. Throw exceptions instead of calling `exit(1)` in `CmdHandler`
   - `CmdHandler::run()` now rethrows exceptions instead of calling `exit(1)`
   - This allows tests to catch errors and verify exit codes
   - `Main.cpp` catches exceptions and returns exit code 1

3. Factor out `CLI::App` initialization into `CliAppInit.h`
   - Header-only `initApp()` function shared between `Main.cpp` and tests
   - Eliminates code duplication for CLI setup
   - This couldn't be packaged into a library of its own without going into circular dependency hell, hence why it's a header-only helper

4. Reset state in `ConfigSession::initializeSession()`
   - Clear `ConfigSession` attributes when creating a new session (when session file doesn't exist)
   - Allows re-using the same `ConfigSession` singleton after `commit()`

5. Update state in `ConfigSession::commit()`
   - Set `base_` to the new commit SHA after successful commit
   - Set `configLoaded_ = false` to force config reload on next access
   - Allows re-using the same `ConfigSession` singleton after `commit()`

6. Automatically initialize session in `ConfigSession::loadConfig()`
   - If session file doesn't exist (e.g., after commit deleted it), call `initializeSession()` to create a fresh session

These changes allow the ConfigSession singleton to be properly reused across multiple CLI command invocations within the same process.

Note: this change is part of a series, the previous one is #881, the next one is #896.

# Test Plan

Added new end-to-end tests in C++ that replace `test_config_interface_mtu.py` and `test_config_interface_description.py` (the Python scripts will be removed in a future PR soon).

Sample output (simplified, without timestamps and other noise):

```
[==========] Running 2 tests from 2 test suites.
[----------] 1 test from ConfigInterfaceDescriptionTest
[ RUN      ] ConfigInterfaceDescriptionTest.SetAndVerifyDescription
[Step 1] Finding an interface to test...
  Using interface: eth1/1/1 (VLAN: 2001)
[Step 2] Getting current description...
  Current description: 'CLI_E2E_TEST_DESCRIPTION_ALT'
[Step 3] Setting description to 'CLI_E2E_TEST_DESCRIPTION'...
  Description set to 'CLI_E2E_TEST_DESCRIPTION'
[Step 4] Verifying description via 'show interface'...
  Verified: Description is 'CLI_E2E_TEST_DESCRIPTION'
[Step 5] Restoring original description ('CLI_E2E_TEST_DESCRIPTION_ALT')...
  Restored description to 'CLI_E2E_TEST_DESCRIPTION_ALT'
TEST PASSED
[       OK ] ConfigInterfaceDescriptionTest.SetAndVerifyDescription (412 ms)

[----------] 1 test from ConfigInterfaceMtuTest
[ RUN      ] ConfigInterfaceMtuTest.SetAndVerifyMtu
[Step 1] Finding an interface to test...
  Using interface: eth1/1/1 (VLAN: 2001)
[Step 2] Getting current MTU...
  Current MTU: 9000
[Step 3] Setting MTU to 1500...
  MTU set to 1500
[Step 4] Verifying MTU via 'show interface'...
  Verified: MTU is 1500
[Step 5] Verifying kernel interface MTU...
  Verified: Kernel interface fboss2001 has MTU 1500
[Step 6] Restoring original MTU (9000)...
  Restored MTU to 9000
TEST PASSED
[       OK ] ConfigInterfaceMtuTest.SetAndVerifyMtu (384 ms)

[==========] 2 tests from 2 test suites ran. (797 ms total)
[  PASSED  ] 2 tests.
```