### PR TITLE
[Nexthop] Use run_tests script to run benchmarks

### DIFF
--- a/cmake/BenchmarkConfFilesTest.cmake
+++ b/cmake/BenchmarkConfFilesTest.cmake
@@ -1,0 +1,21 @@
+# CMake configuration for benchmark configuration files validation test
+
+# Use system Python3 (/usr/bin/python3) which has pytest installed via pip
+# in the Docker image. CMake's find_package(Python3) finds Python 3.12 built
+# by getdeps.py, but pytest is only installed for the system Python 3.9.
+set(BENCHMARK_TEST_PYTHON "/usr/bin/python3")
+
+# Define the test
+add_test(
+  NAME benchmark_conf_files_test
+  COMMAND ${BENCHMARK_TEST_PYTHON} -m pytest
+    ${CMAKE_SOURCE_DIR}/fboss/oss/hw_benchmark_tests/test_benchmark_conf_files.py
+    -v
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/fboss/oss/hw_benchmark_tests
+)
+
+# Set test properties
+set_tests_properties(benchmark_conf_files_test PROPERTIES
+  LABELS "unit;config_validation"
+  TIMEOUT 30
+)

--- a/docs/docs/manuals/run_agent_benchmarks.md
+++ b/docs/docs/manuals/run_agent_benchmarks.md
@@ -93,8 +93,35 @@ to install benchmark binaries.
 
 ### Step 3: Run Benchmark Binaries
 
-Run the relevant binaries that can be found in the `bin` directory on the
-switch:
+#### Option 1: Using the run_test.py Script (Recommended)
+
+The `run_test.py` script provides automated execution of benchmark suites with CSV output:
+
+```bash
+cd /opt/fboss
+source ./bin/setup_fboss_env
+
+# Run all benchmarks (T1 + T2 + additional)
+./bin/run_test.py benchmark
+
+# Run T1 benchmark suite
+./bin/run_test.py benchmark \
+--filter_file ./share/hw_benchmark_tests/t1_benchmarks.conf
+
+# Run T2 benchmark suite
+./bin/run_test.py benchmark \
+--filter_file ./share/hw_benchmark_tests/t2_benchmarks.conf
+
+# Run only additional benchmarks (not in T1 or T2)
+./bin/run_test.py benchmark \
+--filter_file ./share/hw_benchmark_tests/additional_benchmarks.conf
+```
+
+Results are written to a timestamped CSV file (e.g., `benchmark_results_20260119_143022.csv`) with detailed metrics.
+
+#### Option 2: Running Individual Binaries
+
+Run individual benchmark binaries directly from the `bin` directory:
 
 ```bash
 cd /opt/fboss

--- a/docs/docs/testing/test_categories.md
+++ b/docs/docs/testing/test_categories.md
@@ -213,11 +213,14 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 
 ### Agent Benchmark Tests
 
-- `sai_tx_slow_path_rate-sai_impl` binary
-- `sai_rx_slow_path_rate-sai_impl` binary
-- `sai_ecmp_shrink_speed-sai_impl` binary
-- `sai_rib_resolution_speed-sai_impl` binary
-- `sai_stats_collection_speed-sai_impl` binary
+`run_test.py`:
+```bash
+./bin/run_test.py benchmark \
+--filter_file ./share/hw_benchmark_tests/t1_benchmarks.conf
+```
+
+```bash file=../fboss/oss/hw_benchmark_tests/t1_benchmarks.conf
+```
 
 ### SAI Tests
 
@@ -259,19 +262,14 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 
 ### Agent Benchmark Tests
 
-- `sai_fsw_scale_route_add_speed-sai_impl` binary
-- `sai_hgrid_du_scale_route_add_speed-sai_impl` binary
-- `sai_th_alpm_scale_route_add_speed-sai_impl` binary
-- `sai_fsw_scale_route_del_speed-sai_impl` binary
-- `sai_ecmp_shrink_with_competing_route_updates_speed-sai_impl` binary
-- `sai_th_alpm_scale_route_del_speed-sai_impl` binary
-- `sai_hgrid_du_scale_route_del_speed-sai_impl` binary
-- `sai_init_and_exit_40Gx10G-sai_impl` binary
-- `sai_init_and_exit_100Gx10G-sai_impl` binary
-- `sai_init_and_exit_100Gx25G-sai_impl` binary
-- `sai_init_and_exit_100Gx50G-sai_impl` binary
-- `sai_init_and_exit_100Gx100G-sai_impl` binary
-- `sai_switch_reachability_change_speed-sai_impl` binary
+`run_test.py`:
+```bash
+./bin/run_test.py benchmark \
+--filter_file ./share/hw_benchmark_tests/t2_benchmarks.conf
+```
+
+```bash file=../fboss/oss/hw_benchmark_tests/t2_benchmarks.conf
+```
 
 ### SAI Tests
 

--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN dnf download libtool && \
     rpm -ivh --nodeps libtool-*.rpm && \
     rm -f libtool-*.rpm
 
-RUN python3 -m pip install boto3 botocore gitpython meson jinja2
+RUN python3 -m pip install boto3 botocore gitpython meson jinja2 pytest
 
 COPY .pre-commit-config.yaml /tmp/.pre-commit-config.yaml
 COPY ./fboss/oss/docker/setup_clang.sh /tmp/setup_clang.sh

--- a/fboss/oss/hw_benchmark_tests/additional_benchmarks.conf
+++ b/fboss/oss/hw_benchmark_tests/additional_benchmarks.conf
@@ -1,0 +1,25 @@
+# Additional Agent Benchmark Test Suite
+# These are benchmarks that are not included in the T1 or T2 test suites.
+# This allows users to run only these additional tests if they've already
+# verified T1 and T2 benchmarks.
+
+# Route scale benchmarks
+sai_anticipated_scale_route_add_speed-sai_impl
+sai_anticipated_scale_route_del_speed-sai_impl
+sai_hgrid_uu_scale_route_add_speed-sai_impl
+sai_hgrid_uu_scale_route_del_speed-sai_impl
+
+# Performance benchmarks
+sai_rib_sync_fib_speed-sai_impl
+sai_ucmp_scale_benchmark-sai_impl
+
+# Init and exit benchmarks
+sai_init_and_exit_400Gx400G-sai_impl
+
+# VOQ benchmarks (BRCM DNX only)
+sai_init_and_exit_fabric-sai_impl
+sai_init_and_exit_voq-sai_impl
+sai_voq_remote_entity_programming-sai_impl
+sai_voq_scale_route_add_speed-sai_impl
+sai_voq_scale_route_del_speed-sai_impl
+sai_voq_sys_port_programming-sai_impl

--- a/fboss/oss/hw_benchmark_tests/t1_benchmarks.conf
+++ b/fboss/oss/hw_benchmark_tests/t1_benchmarks.conf
@@ -1,0 +1,7 @@
+# T1 Agent Benchmark Test Suite
+
+sai_tx_slow_path_rate-sai_impl
+sai_rx_slow_path_rate-sai_impl
+sai_ecmp_shrink_speed-sai_impl
+sai_rib_resolution_speed-sai_impl
+sai_stats_collection_speed-sai_impl

--- a/fboss/oss/hw_benchmark_tests/t2_benchmarks.conf
+++ b/fboss/oss/hw_benchmark_tests/t2_benchmarks.conf
@@ -1,0 +1,15 @@
+# T2 Agent Benchmark Test Suite
+
+sai_fsw_scale_route_add_speed-sai_impl
+sai_hgrid_du_scale_route_add_speed-sai_impl
+sai_th_alpm_scale_route_add_speed-sai_impl
+sai_fsw_scale_route_del_speed-sai_impl
+sai_ecmp_shrink_with_competing_route_updates_speed-sai_impl
+sai_th_alpm_scale_route_del_speed-sai_impl
+sai_hgrid_du_scale_route_del_speed-sai_impl
+sai_init_and_exit_40Gx10G-sai_impl
+sai_init_and_exit_100Gx10G-sai_impl
+sai_init_and_exit_100Gx25G-sai_impl
+sai_init_and_exit_100Gx50G-sai_impl
+sai_init_and_exit_100Gx100G-sai_impl
+sai_switch_reachability_change_speed-sai_impl

--- a/fboss/oss/hw_benchmark_tests/test_benchmark_conf_files.py
+++ b/fboss/oss/hw_benchmark_tests/test_benchmark_conf_files.py
@@ -8,8 +8,17 @@ do not have overlaps.
 
 import itertools
 import pathlib
+import sys
 
 import pytest
+
+# Add run_scripts to the path so run_test and its sibling modules (e.g.
+# fboss_agent_utils) can be imported directly
+sys.path.insert(
+    0,
+    str(pathlib.Path(__file__).resolve().parent.parent / "scripts" / "run_scripts"),
+)
+from run_test import _load_from_file
 
 # Configuration files to check for overlaps
 CONF_FILES = [
@@ -17,18 +26,6 @@ CONF_FILES = [
     "t2_benchmarks.conf",
     "additional_benchmarks.conf",
 ]
-
-
-def load_benchmarks_from_file(filepath):
-    """Load benchmark names from a configuration file, ignoring comments and empty lines."""
-    benchmarks = []
-    with open(filepath) as f:
-        for line in f:
-            stripped_line = line.strip()
-            # Skip empty lines and comments
-            if stripped_line and not stripped_line.startswith("#"):
-                benchmarks.append(stripped_line)
-    return set(benchmarks)
 
 
 def get_conf_file_path(filename):
@@ -57,8 +54,8 @@ def test_no_overlap(file1, file2):
     conf_file1 = get_conf_file_path(file1)
     conf_file2 = get_conf_file_path(file2)
 
-    benchmarks1 = load_benchmarks_from_file(conf_file1)
-    benchmarks2 = load_benchmarks_from_file(conf_file2)
+    benchmarks1 = set(_load_from_file(conf_file1))
+    benchmarks2 = set(_load_from_file(conf_file2))
 
     # Find overlaps
     overlaps = benchmarks1 & benchmarks2
@@ -76,11 +73,22 @@ def test_all_files_exist():
         assert conf_file.exists(), f"Required configuration file not found: {filename}"
 
 
+def test_no_duplicates_within_files():
+    """Test that no benchmark configuration file contains duplicate entries."""
+    for filename in CONF_FILES:
+        conf_file = get_conf_file_path(filename)
+        benchmarks = _load_from_file(conf_file)
+        assert len(set(benchmarks)) == len(benchmarks), (
+            f"Found duplicates in {filename}: "
+            f"{[b for b in benchmarks if benchmarks.count(b) > 1]}"
+        )
+
+
 def test_no_empty_files():
     """Test that all benchmark configuration files contain at least one benchmark."""
     for filename in CONF_FILES:
         conf_file = get_conf_file_path(filename)
-        benchmarks = load_benchmarks_from_file(conf_file)
+        benchmarks = _load_from_file(conf_file)
         assert benchmarks, (
             f"Configuration file is empty or contains only comments: {filename}"
         )

--- a/fboss/oss/hw_benchmark_tests/test_benchmark_conf_files.py
+++ b/fboss/oss/hw_benchmark_tests/test_benchmark_conf_files.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""
+Validates that T1, T2, and additional benchmark configuration files
+do not have overlaps.
+"""
+
+import itertools
+import pathlib
+
+import pytest
+
+# Configuration files to check for overlaps
+CONF_FILES = [
+    "t1_benchmarks.conf",
+    "t2_benchmarks.conf",
+    "additional_benchmarks.conf",
+]
+
+
+def load_benchmarks_from_file(filepath):
+    """Load benchmark names from a configuration file, ignoring comments and empty lines."""
+    benchmarks = []
+    with open(filepath) as f:
+        for line in f:
+            stripped_line = line.strip()
+            # Skip empty lines and comments
+            if stripped_line and not stripped_line.startswith("#"):
+                benchmarks.append(stripped_line)
+    return set(benchmarks)
+
+
+def get_conf_file_path(filename):
+    """Get the path to a benchmark configuration file."""
+    # Try to find the file relative to this test file
+    test_dir = pathlib.Path(__file__).parent
+    conf_file = test_dir / filename
+
+    if conf_file.exists():
+        return conf_file
+
+    # Fallback: try relative to current working directory
+    conf_file = pathlib.Path(filename)
+    if conf_file.exists():
+        return conf_file
+
+    raise FileNotFoundError(f"Configuration file not found: {filename}")
+
+
+@pytest.mark.parametrize(
+    "file1,file2",
+    list(itertools.combinations(CONF_FILES, 2)),
+)
+def test_no_overlap(file1, file2):
+    """Test that benchmark files don't have overlaps."""
+    conf_file1 = get_conf_file_path(file1)
+    conf_file2 = get_conf_file_path(file2)
+
+    benchmarks1 = load_benchmarks_from_file(conf_file1)
+    benchmarks2 = load_benchmarks_from_file(conf_file2)
+
+    # Find overlaps
+    overlaps = benchmarks1 & benchmarks2
+
+    assert not overlaps, (
+        f"Found overlaps between {file1} and {file2}: {overlaps}\n"
+        f"Each benchmark should only appear in one configuration file."
+    )
+
+
+def test_all_files_exist():
+    """Test that all required benchmark configuration files exist."""
+    for filename in CONF_FILES:
+        conf_file = get_conf_file_path(filename)
+        assert conf_file.exists(), f"Required configuration file not found: {filename}"
+
+
+def test_no_empty_files():
+    """Test that all benchmark configuration files contain at least one benchmark."""
+    for filename in CONF_FILES:
+        conf_file = get_conf_file_path(filename)
+        benchmarks = load_benchmarks_from_file(conf_file)
+        assert benchmarks, (
+            f"Configuration file is empty or contains only comments: {filename}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fboss/oss/scripts/package-fboss.py
+++ b/fboss/oss/scripts/package-fboss.py
@@ -147,6 +147,9 @@ class PackageFboss:
         hw_sanity_test_configs_path = os.path.join(
             self.git_path, "fboss/oss/hw_sanity_tests"
         )
+        hw_benchmark_tests_path = os.path.join(
+            self.git_path, "fboss/oss/hw_benchmark_tests"
+        )
         print(f"Copying {hw_test_configs_path} to {tmp_dir_name}")
         shutil.copytree(
             "fboss/oss/hw_test_configs",
@@ -166,6 +169,11 @@ class PackageFboss:
         shutil.copytree(
             "fboss/oss/hw_sanity_tests",
             os.path.join(tmp_dir_name, PackageFboss.DATA, "hw_sanity_tests"),
+        )
+        print(f"Copying {hw_benchmark_tests_path} to {tmp_dir_name}")
+        shutil.copytree(
+            "fboss/oss/hw_benchmark_tests",
+            os.path.join(tmp_dir_name, PackageFboss.DATA, "hw_benchmark_tests"),
         )
 
     def _copy_production_features(self, tmp_dir_name):

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -197,6 +197,7 @@ SUB_CMD_LINK = "link"
 SUB_CMD_SAI_AGENT = "sai_agent"
 SUB_CMD_PLATFORM = "platform"
 SUB_CMD_FBOSS2_INTEGRATION = "fboss2_integration"
+SUB_CMD_BENCHMARK = "benchmark"
 SUB_ARG_AGENT_RUN_MODE = "--agent-run-mode"
 SUB_ARG_AGENT_RUN_MODE_MONO = "mono"
 SUB_ARG_AGENT_RUN_MODE_MULTI = "multi_switch"
@@ -247,6 +248,37 @@ GTEST_NAME_PREFIX = "[ RUN      ] "
 FEATURE_LIST_PREFIX = "Feature List: "
 
 DEFAULT_TEST_RUN_TIMEOUT_IN_SECOND = 1200
+
+
+def _load_from_file(file_path, profile=None):
+    """Load list from a configuration file, skipping comment lines.
+
+    Args:
+        file_path: Path to the configuration file
+        profile: Optional tag to filter the input file
+
+    Returns:
+        List of strings in the file
+    """
+    file_lines = []
+    if os.path.exists(file_path):
+        with open(file_path) as file:
+            file_lines = []
+            for line in file:
+                stripped_line = line.strip()
+                if not stripped_line or stripped_line.startswith("#"):
+                    continue
+                parts = stripped_line.split()
+                pattern = parts[0]
+                tags = parts[1:] if len(parts) > 1 else []
+                if profile:
+                    if profile not in tags:
+                        continue
+                # no --profile: include untagged lines and t-tagged lines
+                elif tags and "t" not in tags:
+                    continue
+                file_lines.append(pattern)
+    return file_lines
 
 
 def run_script(script_file: str):
@@ -513,23 +545,8 @@ class TestRunner(abc.ABC):
         test_names = []
         if args.filter or args.filter_file:
             if args.filter_file:
-                with open(args.filter_file) as file:
-                    gtest_regexes = []
-                    for line in file:
-                        stripped_line = line.strip()
-                        if not stripped_line or stripped_line.startswith("#"):
-                            continue
-                        parts = stripped_line.split()
-                        pattern = parts[0]
-                        tags = parts[1:] if len(parts) > 1 else []
-                        if args.profile:
-                            if args.profile not in tags:
-                                continue
-                        # no --profile: include untagged lines and t-tagged lines
-                        elif tags and "t" not in tags:
-                            continue
-                        gtest_regexes.append(pattern)
-                    test_names = self._list_tests_to_run(":".join(gtest_regexes), False)
+                gtest_regexes = _load_from_file(args.filter_file, args.profile)
+                test_names = self._list_tests_to_run(":".join(gtest_regexes), False)
             elif args.filter:
                 test_names = self._list_tests_to_run(args.filter, False)
         else:
@@ -1610,6 +1627,301 @@ class Fboss2IntegrationTestRunner(TestRunner):
         return tests
 
 
+class BenchmarkTestRunner:
+    """
+    Runner for benchmark test binaries.
+
+    Unlike gtest-based test runners, benchmark tests are standalone performance
+    measurement binaries that output metrics like throughput, latency, and speed.
+    """
+
+    # Benchmark test suite configuration file paths
+    BENCHMARK_CONFIG_DIR = "./share/hw_benchmark_tests"
+    T1_BENCHMARKS_CONF = os.path.join(BENCHMARK_CONFIG_DIR, "t1_benchmarks.conf")
+    T2_BENCHMARKS_CONF = os.path.join(BENCHMARK_CONFIG_DIR, "t2_benchmarks.conf")
+    ADDITIONAL_BENCHMARKS_CONF = os.path.join(
+        BENCHMARK_CONFIG_DIR, "additional_benchmarks.conf"
+    )
+    BENCHMARK_BIN_DIR = "/opt/fboss/bin"
+
+    def add_subcommand_arguments(self, sub_parser: ArgumentParser):
+        """Add benchmark-specific command line arguments"""
+        sub_parser.add_argument(
+            OPT_ARG_FILTER_FILE,
+            type=str,
+            help=("File containing list of benchmark binaries to run (one per line)."),
+            default=None,
+        )
+        sub_parser.add_argument(
+            OPT_ARG_PLATFORM_MAPPING_OVERRIDE_PATH,
+            nargs="?",
+            type=str,
+            help="A file path to a platform mapping JSON file to be used.",
+            default=None,
+        )
+
+    def _parse_benchmark_output(self, binary_name, stdout):
+        """Parse benchmark output to extract metrics.
+
+        Returns a dict with:
+        - benchmark_binary_name: str
+        - benchmark_test_name: str
+        - test_status: str (OK, FAILED, or TIMEOUT)
+        - relative_time_per_iter: str (includes time unit)
+        - iters_per_sec: str (includes possible numeric suffix)
+        - cpu_time_usec: str
+        - max_rss: str
+        """
+        result = {
+            "benchmark_binary_name": binary_name,
+            "benchmark_test_name": "",
+            "test_status": "FAILED",
+            "relative_time_per_iter": "",
+            "iters_per_sec": "",
+            "cpu_time_usec": "",
+            "max_rss": "",
+        }
+
+        # Look for the benchmark name line (e.g., "RibResolutionBenchmark                                       1.46s   684.78m")
+        # Pattern: benchmark name followed by time and rate
+        benchmark_line_pattern = (
+            r"^([A-Za-z0-9_]+)\s+(\d+\.?\d*[a-z]?s)\s+(\d+\.?\d*[a-z]?)$"
+        )
+
+        # Look for JSON output with cpu_time_usec and max_rss (multiline pattern)
+        json_pattern = r'\{[^}]*"cpu_time_usec":\s*(\d+)[^}]*"max_rss":\s*(\d+)[^}]*\}'
+
+        found_benchmark_line = False
+        found_json = False
+
+        # Parse multiline benchmark result line
+        match = re.search(benchmark_line_pattern, stdout, re.MULTILINE)
+        if match:
+            result["benchmark_test_name"] = match.group(1)
+            result["relative_time_per_iter"] = match.group(2)
+            result["iters_per_sec"] = match.group(3)
+            found_benchmark_line = True
+
+        # Parse JSON output (can be multiline)
+        match = re.search(json_pattern, stdout, re.DOTALL)
+        if match:
+            result["cpu_time_usec"] = match.group(1)
+            result["max_rss"] = match.group(2)
+            found_json = True
+
+        # Only mark as OK if we found both the benchmark line and JSON
+        if found_benchmark_line and found_json:
+            result["test_status"] = "OK"
+
+        return result
+
+    def _run_benchmark_binary(self, binary_name, args):
+        """Run a single benchmark binary and return parsed results"""
+        print(f"########## Running benchmark binary: {binary_name}", flush=True)
+
+        # Build command to run the benchmark
+        run_cmd = [binary_name]
+
+        # Add config and other args if provided
+        if args.config:
+            run_cmd.extend(["--config", args.config, "--mgmt-if", args.mgmt_if])
+        if args.platform_mapping_override_path is not None:
+            run_cmd.extend(
+                [
+                    "--platform_mapping_override_path",
+                    args.platform_mapping_override_path,
+                ]
+            )
+        if args.fruid_path is not None:
+            run_cmd.extend(["--fruid_filepath=" + args.fruid_path])
+
+        # Add logging flags
+        run_cmd.extend(["--enable_sai_log", args.sai_logging])
+        run_cmd.extend(["--logging", args.fboss_logging])
+
+        print(f"Running command: {' '.join(run_cmd)}", flush=True)
+
+        try:
+            # Run the benchmark binary
+            result = subprocess.run(
+                run_cmd,
+                check=False,
+                timeout=args.test_run_timeout,
+                capture_output=True,
+                text=True,
+            )
+
+            print(f"########## Benchmark output for {binary_name}:")
+            print(result.stdout)
+            if result.stderr:
+                print(f"########## Benchmark stderr for {binary_name}:")
+                print(result.stderr)
+
+            if result.returncode != 0:
+                print(
+                    f"########## Benchmark {binary_name} failed with return code {result.returncode}"
+                )
+                # Parse output even on failure to get partial results
+            else:
+                print(f"########## Benchmark {binary_name} completed")
+            return self._parse_benchmark_output(binary_name, result.stdout)
+
+        except subprocess.TimeoutExpired:
+            print(
+                f"########## Benchmark {binary_name} timed out after {args.test_run_timeout} seconds"
+            )
+            # Return timed out result with no metrics
+            return {
+                "benchmark_binary_name": binary_name,
+                "benchmark_test_name": "",
+                "test_status": "TIMEOUT",
+                "relative_time_per_iter": "",
+                "iters_per_sec": "",
+                "cpu_time_usec": "",
+                "max_rss": "",
+            }
+        except Exception as e:
+            print(f"########## Error running benchmark {binary_name}: {e!s}")
+            # Return failed result with no metrics
+            return {
+                "benchmark_binary_name": binary_name,
+                "benchmark_test_name": "",
+                "test_status": "FAILED",
+                "relative_time_per_iter": "",
+                "iters_per_sec": "",
+                "cpu_time_usec": "",
+                "max_rss": "",
+            }
+
+    def _get_benchmarks_to_run(self, filter_file=None):
+        """Get list of benchmarks to run based on filter_file or default config.
+
+        Args:
+            filter_file: Optional path to file containing list of benchmarks.
+                        If None, loads from T1, T2, and additional benchmark configs
+
+        Returns:
+            List of benchmark names to run, or None if no benchmarks found
+        """
+        benchmarks_to_run = set()
+
+        if filter_file:
+            # User specified a custom filter file
+            if not os.path.exists(filter_file):
+                print(f"Error: Benchmark configuration file not found: {filter_file}")
+                return None
+            benchmarks_to_run = _load_from_file(filter_file)
+        else:
+            # Default: concatenate T1, T2, and additional benchmarks
+            for conf_file in [
+                self.T1_BENCHMARKS_CONF,
+                self.T2_BENCHMARKS_CONF,
+                self.ADDITIONAL_BENCHMARKS_CONF,
+            ]:
+                if os.path.exists(conf_file):
+                    benchmarks_from_file = _load_from_file(conf_file)
+                    benchmarks_to_run.update(benchmarks_from_file)
+                else:
+                    print(f"  Warning: Configuration file not found: {conf_file}")
+
+        if not benchmarks_to_run:
+            print("Error: No benchmarks found in configuration files")
+            return None
+
+        return list(benchmarks_to_run)
+
+    def run_test(self, args):  # noqa: PLR0912 - complex benchmark orchestration; splitting would harm readability
+        """Run benchmark test binaries"""
+        benchmarks_to_run = self._get_benchmarks_to_run(args.filter_file)
+
+        if benchmarks_to_run is None:
+            return
+
+        # If --list_tests is specified, just list the benchmarks and exit
+        if args.list_tests:
+            for benchmark in benchmarks_to_run:
+                print(benchmark)
+            return
+
+        print(f"Total benchmarks to run: {len(benchmarks_to_run)}")
+
+        # Filter out binaries that don't exist
+        existing_benchmarks = []
+        missing_benchmarks = []
+        for benchmark in benchmarks_to_run:
+            # Construct full path to binary
+            binary_path = os.path.join(self.BENCHMARK_BIN_DIR, benchmark)
+            if os.path.exists(binary_path) and os.path.isfile(binary_path):
+                existing_benchmarks.append(binary_path)
+            else:
+                missing_benchmarks.append(benchmark)
+
+        if missing_benchmarks:
+            print(
+                f"\nWarning: {len(missing_benchmarks)} benchmark binaries not found in {self.BENCHMARK_BIN_DIR}:"
+            )
+            for benchmark in missing_benchmarks:
+                print(f"  - {benchmark}")
+
+        if not existing_benchmarks:
+            print(f"\nError: No benchmark binaries found in {self.BENCHMARK_BIN_DIR}.")
+            print(
+                f"Make sure you have built the benchmarks with BENCHMARK_INSTALL=1 and copied them to {self.BENCHMARK_BIN_DIR} directory."
+            )
+            return
+
+        print(f"\nFound {len(existing_benchmarks)} benchmark binaries to run")
+
+        # Run each benchmark and collect detailed results
+        results = []
+        for benchmark_path in existing_benchmarks:
+            benchmark_result = self._run_benchmark_binary(benchmark_path, args)
+            results.append(benchmark_result)
+
+        # Write results to CSV file
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        csv_filename = f"benchmark_results_{timestamp}.csv"
+
+        with open(csv_filename, "w", newline="") as csvfile:
+            fieldnames = [
+                "benchmark_binary_name",
+                "benchmark_test_name",
+                "test_status",
+                "relative_time_per_iter",
+                "iters_per_sec",
+                "cpu_time_usec",
+                "max_rss",
+            ]
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+
+            writer.writeheader()
+            for result in results:
+                writer.writerow(result)
+
+        print(f"\n########## Benchmark results written to: {csv_filename}")
+
+        # Print summary
+        print("\n" + "=" * 80)
+        print("BENCHMARK RESULTS SUMMARY")
+        print("=" * 80)
+        for result in results:
+            print(f"{result['benchmark_binary_name']}: {result['test_status']}")
+        print("=" * 80)
+
+        # Count results
+        ok = sum(1 for r in results if r["test_status"] == "OK")
+        failed = sum(1 for r in results if r["test_status"] == "FAILED")
+        timed_out = sum(1 for r in results if r["test_status"] == "TIMEOUT")
+        print(f"\nTotal: {len(results)} benchmarks")
+        print(f"OK: {ok}")
+        print(f"Failed: {failed}")
+        print(f"Timed Out: {timed_out}")
+
+        # Exit with error if any benchmarks failed or timed out
+        if failed > 0 or timed_out > 0:
+            sys.exit(1)
+
+
 if __name__ == "__main__":
     os.chdir("/opt/fboss")
     # Set env variables for FBOSS
@@ -1858,6 +2170,14 @@ if __name__ == "__main__":
     fboss2_integration_test_runner.add_subcommand_arguments(
         fboss2_integration_test_parser
     )
+
+    # Add subparser for Benchmark tests
+    benchmark_test_parser = subparsers.add_parser(
+        SUB_CMD_BENCHMARK, help="run benchmark tests"
+    )
+    benchmark_test_runner = BenchmarkTestRunner()
+    benchmark_test_parser.set_defaults(func=benchmark_test_runner.run_test)
+    benchmark_test_runner.add_subcommand_arguments(benchmark_test_parser)
 
     # Parse the args
     args = ap.parse_known_args()

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -1805,7 +1805,7 @@ class BenchmarkTestRunner:
         Returns:
             List of benchmark names to run, or None if no benchmarks found
         """
-        benchmarks_to_run = set()
+        benchmarks_to_run = []
 
         if filter_file:
             # User specified a custom filter file
@@ -1822,7 +1822,7 @@ class BenchmarkTestRunner:
             ]:
                 if os.path.exists(conf_file):
                     benchmarks_from_file = _load_from_file(conf_file)
-                    benchmarks_to_run.update(benchmarks_from_file)
+                    benchmarks_to_run.extend(benchmarks_from_file)
                 else:
                     print(f"  Warning: Configuration file not found: {conf_file}")
 
@@ -1830,7 +1830,7 @@ class BenchmarkTestRunner:
             print("Error: No benchmarks found in configuration files")
             return None
 
-        return list(benchmarks_to_run)
+        return benchmarks_to_run
 
     def run_test(self, args):  # noqa: PLR0912 - complex benchmark orchestration; splitting would harm readability
         """Run benchmark test binaries"""

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -1688,8 +1688,9 @@ class BenchmarkTestRunner:
             r"^([A-Za-z0-9_]+)\s+(\d+\.?\d*[a-z]?s)\s+(\d+\.?\d*[a-z]?)$"
         )
 
-        # Look for JSON output with cpu_time_usec and max_rss (multiline pattern)
-        json_pattern = r'\{[^}]*"cpu_time_usec":\s*(\d+)[^}]*"max_rss":\s*(\d+)[^}]*\}'
+        # Look for cpu_time_usec and max_rss in JSON output (separate patterns so order doesn't matter)
+        cpu_time_pattern = r'"cpu_time_usec":\s*(\d+)'
+        max_rss_pattern = r'"max_rss":\s*(\d+)'
 
         found_benchmark_line = False
         found_json = False
@@ -1702,11 +1703,12 @@ class BenchmarkTestRunner:
             result["iters_per_sec"] = match.group(3)
             found_benchmark_line = True
 
-        # Parse JSON output (can be multiline)
-        match = re.search(json_pattern, stdout, re.DOTALL)
-        if match:
-            result["cpu_time_usec"] = match.group(1)
-            result["max_rss"] = match.group(2)
+        # Parse JSON output for cpu_time_usec and max_rss independently
+        cpu_match = re.search(cpu_time_pattern, stdout)
+        rss_match = re.search(max_rss_pattern, stdout)
+        if cpu_match and rss_match:
+            result["cpu_time_usec"] = cpu_match.group(1)
+            result["max_rss"] = rss_match.group(1)
             found_json = True
 
         # Only mark as OK if we found both the benchmark line and JSON

--- a/fboss/oss/scripts/run_scripts/test_run_test.py
+++ b/fboss/oss/scripts/run_scripts/test_run_test.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+# Copyright Meta Platforms, Inc. and affiliates.
+
+"""
+Unit tests for run_test.py using pytest framework.
+
+Provides comprehensive coverage of the BenchmarkTestRunner class,
+including benchmark loading, parsing, execution, and error handling.
+"""
+
+import os
+import subprocess
+import tempfile
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from run_test import BenchmarkTestRunner
+
+# Fixtures
+
+
+@pytest.fixture
+def runner():
+    """Create a BenchmarkTestRunner instance for testing"""
+    return BenchmarkTestRunner()
+
+
+@pytest.fixture
+def mock_args():
+    """Create a mock args object with common attributes"""
+    args = Mock()
+    args.filter_file = None
+    args.list_tests = False
+    args.config = None
+    args.mgmt_if = "eth0"
+    args.platform_mapping_override_path = None
+    args.fruid_path = None
+    args.sai_logging = "WARN"
+    args.fboss_logging = "WARN"
+    args.test_run_timeout = 300
+    return args
+
+
+@pytest.fixture
+def temp_benchmark_file():
+    """Create a temporary benchmark configuration file"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        f.write("# Comment line\n")
+        f.write("benchmark1\n")
+        f.write("\n")
+        f.write("benchmark2\n")
+        f.write("# Another comment\n")
+        f.write("benchmark3\n")
+        temp_file = f.name
+
+    yield temp_file
+
+    # Cleanup
+    if os.path.exists(temp_file):
+        os.unlink(temp_file)
+
+
+# Tests for _get_benchmarks_to_run
+
+
+def test_get_benchmarks_with_filter_file(runner, temp_benchmark_file):
+    """Test loading benchmarks from a custom filter file"""
+    benchmarks = runner._get_benchmarks_to_run(temp_benchmark_file)
+    assert benchmarks == ["benchmark1", "benchmark2", "benchmark3"]
+
+
+def test_get_benchmarks_with_nonexistent_file(runner, capsys):
+    """Test handling of nonexistent filter file"""
+    benchmarks = runner._get_benchmarks_to_run("/nonexistent/file.conf")
+    assert benchmarks is None
+
+    captured = capsys.readouterr()
+    assert "Error: Benchmark configuration file not found" in captured.out
+
+
+def test_get_benchmarks_with_empty_file(runner, capsys):
+    """Test handling of empty benchmark file"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        temp_file = f.name
+
+    try:
+        benchmarks = runner._get_benchmarks_to_run(temp_file)
+        assert benchmarks is None
+
+        captured = capsys.readouterr()
+        assert "Error: No benchmarks found" in captured.out
+    finally:
+        os.unlink(temp_file)
+
+
+@patch("os.path.exists")
+@patch("run_test._load_from_file")
+def test_get_benchmarks_default_configs(mock_load, mock_exists, runner):
+    """Test loading benchmarks from default T1, T2, and additional configs"""
+    # Mock that all config files exist
+    mock_exists.return_value = True
+
+    # Mock different benchmarks from each file
+    mock_load.side_effect = [
+        ["t1_bench1", "t1_bench2"],
+        ["t2_bench1", "t2_bench2"],
+        ["additional_bench1"],
+    ]
+
+    benchmarks = runner._get_benchmarks_to_run(None)
+
+    # Should return all benchmarks combined (as a list from a set, order may vary)
+    assert set(benchmarks) == {
+        "t1_bench1",
+        "t1_bench2",
+        "t2_bench1",
+        "t2_bench2",
+        "additional_bench1",
+    }
+    assert len(benchmarks) == 5
+
+
+@patch("os.path.exists")
+@patch("run_test._load_from_file")
+def test_get_benchmarks_missing_default_configs(mock_load, mock_exists, runner, capsys):
+    """Test handling when some default config files are missing"""
+    # Mock that only T1 config exists
+    mock_exists.side_effect = [True, False, False]
+    mock_load.return_value = ["t1_bench1", "t1_bench2"]
+
+    benchmarks = runner._get_benchmarks_to_run(None)
+
+    assert set(benchmarks) == {"t1_bench1", "t1_bench2"}
+
+    captured = capsys.readouterr()
+    assert "Warning: Configuration file not found" in captured.out
+
+
+@patch("os.path.exists")
+def test_get_benchmarks_all_default_configs_missing(mock_exists, runner, capsys):
+    """Test handling when all default config files are missing"""
+    mock_exists.return_value = False
+
+    benchmarks = runner._get_benchmarks_to_run(None)
+
+    assert benchmarks is None
+    captured = capsys.readouterr()
+    assert "Error: No benchmarks found" in captured.out
+
+
+# Tests for _parse_benchmark_output
+
+
+def test_parse_benchmark_output_success(runner):
+    """Test parsing successful benchmark output with all metrics"""
+    stdout = """
+RibResolutionBenchmark                                       1.46s   684.78m
+{"cpu_time_usec": 1460000, "max_rss": 123456}
+"""
+
+    result = runner._parse_benchmark_output("test_binary", stdout)
+
+    assert result["benchmark_binary_name"] == "test_binary"
+    assert result["benchmark_test_name"] == "RibResolutionBenchmark"
+    assert result["test_status"] == "OK"
+    assert result["relative_time_per_iter"] == "1.46s"
+    assert result["iters_per_sec"] == "684.78m"
+    assert result["cpu_time_usec"] == "1460000"
+    assert result["max_rss"] == "123456"
+
+
+def test_parse_benchmark_output_missing_json(runner):
+    """Test parsing benchmark output with missing JSON metrics"""
+    stdout = """
+RibResolutionBenchmark                                       1.46s   684.78m
+"""
+
+    result = runner._parse_benchmark_output("test_binary", stdout)
+
+    assert result["benchmark_binary_name"] == "test_binary"
+    assert result["benchmark_test_name"] == "RibResolutionBenchmark"
+    assert result["test_status"] == "FAILED"  # Missing JSON means FAILED
+    assert result["relative_time_per_iter"] == "1.46s"
+    assert result["iters_per_sec"] == "684.78m"
+    assert result["cpu_time_usec"] == ""
+    assert result["max_rss"] == ""
+
+
+def test_parse_benchmark_output_missing_benchmark_line(runner):
+    """Test parsing benchmark output with missing benchmark line"""
+    stdout = """
+{"cpu_time_usec": 1460000, "max_rss": 123456}
+"""
+
+    result = runner._parse_benchmark_output("test_binary", stdout)
+
+    assert result["benchmark_binary_name"] == "test_binary"
+    assert result["benchmark_test_name"] == ""
+    assert result["test_status"] == "FAILED"  # Missing benchmark line means FAILED
+    assert result["relative_time_per_iter"] == ""
+    assert result["iters_per_sec"] == ""
+    assert result["cpu_time_usec"] == "1460000"
+    assert result["max_rss"] == "123456"
+
+
+def test_parse_benchmark_output_empty(runner):
+    """Test parsing empty benchmark output"""
+    result = runner._parse_benchmark_output("test_binary", "")
+
+    assert result["benchmark_binary_name"] == "test_binary"
+    assert result["benchmark_test_name"] == ""
+    assert result["test_status"] == "FAILED"
+    assert result["relative_time_per_iter"] == ""
+    assert result["iters_per_sec"] == ""
+    assert result["cpu_time_usec"] == ""
+    assert result["max_rss"] == ""
+
+
+def test_parse_benchmark_output_with_units(runner):
+    """Test parsing benchmark output with different time units"""
+    stdout = """
+FastBenchmark                                                123ms   8.13
+{"cpu_time_usec": 123000, "max_rss": 98765}
+"""
+
+    result = runner._parse_benchmark_output("test_binary", stdout)
+
+    assert result["test_status"] == "OK"
+    assert result["benchmark_test_name"] == "FastBenchmark"
+    assert result["relative_time_per_iter"] == "123ms"
+    assert result["iters_per_sec"] == "8.13"
+
+
+# Tests for _run_benchmark_binary
+
+
+@patch("subprocess.run")
+def test_run_benchmark_binary_success(mock_run, runner, mock_args):
+    """Test successful benchmark binary execution"""
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_result.stdout = """
+TestBenchmark                                                2.5s    400m
+{"cpu_time_usec": 2500000, "max_rss": 200000}
+"""
+    mock_result.stderr = ""
+    mock_run.return_value = mock_result
+
+    result = runner._run_benchmark_binary("/opt/fboss/bin/test_bench", mock_args)
+
+    assert result["test_status"] == "OK"
+    assert result["benchmark_test_name"] == "TestBenchmark"
+    mock_run.assert_called_once()
+
+
+@patch("subprocess.run")
+def test_run_benchmark_binary_timeout(mock_run, runner, mock_args):
+    """Test benchmark binary timeout handling"""
+    mock_run.side_effect = subprocess.TimeoutExpired("cmd", 300)
+
+    result = runner._run_benchmark_binary("/opt/fboss/bin/test_bench", mock_args)
+
+    assert result["test_status"] == "TIMEOUT"
+    assert result["benchmark_binary_name"] == "/opt/fboss/bin/test_bench"
+    assert result["benchmark_test_name"] == ""
+
+
+@patch("subprocess.run")
+def test_run_benchmark_binary_failure(mock_run, runner, mock_args):
+    """Test benchmark binary execution failure"""
+    mock_result = Mock()
+    mock_result.returncode = 1
+    mock_result.stdout = "Some error output"
+    mock_result.stderr = "Error message"
+    mock_run.return_value = mock_result
+
+    result = runner._run_benchmark_binary("/opt/fboss/bin/test_bench", mock_args)
+
+    assert result["test_status"] == "FAILED"
+    mock_run.assert_called_once()
+
+
+@patch("subprocess.run")
+def test_run_benchmark_binary_exception(mock_run, runner, mock_args):
+    """Test benchmark binary execution with exception"""
+    mock_run.side_effect = Exception("Unexpected error")
+
+    result = runner._run_benchmark_binary("/opt/fboss/bin/test_bench", mock_args)
+
+    assert result["test_status"] == "FAILED"
+    assert result["benchmark_binary_name"] == "/opt/fboss/bin/test_bench"
+
+
+@patch("subprocess.run")
+def test_run_benchmark_binary_with_config(mock_run, runner, mock_args):
+    """Test benchmark binary execution with config arguments"""
+    mock_args.config = "/path/to/config.conf"
+    mock_args.mgmt_if = "eth1"
+
+    mock_result = Mock()
+    mock_result.returncode = 0
+    mock_result.stdout = """
+TestBenchmark                                                1.0s    1000m
+{"cpu_time_usec": 1000000, "max_rss": 100000}
+"""
+    mock_result.stderr = ""
+    mock_run.return_value = mock_result
+
+    runner._run_benchmark_binary("/opt/fboss/bin/test_bench", mock_args)
+
+    # Verify config arguments were passed
+    call_args = mock_run.call_args[0][0]
+    assert "--config" in call_args
+    assert "/path/to/config.conf" in call_args
+    assert "--mgmt-if" in call_args
+    assert "eth1" in call_args
+
+
+# Tests for run_test method
+
+
+def test_run_test_with_nonexistent_filter_file(runner, mock_args, capsys):
+    """Test run_test with nonexistent filter file"""
+    mock_args.filter_file = "/nonexistent/file.conf"
+
+    runner.run_test(mock_args)
+
+    captured = capsys.readouterr()
+    assert "Error: Benchmark configuration file not found" in captured.out
+
+
+def test_run_test_list_tests_mode(runner, mock_args, temp_benchmark_file, capsys):
+    """Test run_test in list_tests mode"""
+    mock_args.filter_file = temp_benchmark_file
+    mock_args.list_tests = True
+
+    runner.run_test(mock_args)
+
+    captured = capsys.readouterr()
+    assert "benchmark1" in captured.out
+    assert "benchmark2" in captured.out
+    assert "benchmark3" in captured.out
+
+
+@patch("os.path.exists")
+@patch("os.path.isfile")
+@patch.object(BenchmarkTestRunner, "_run_benchmark_binary")
+@patch("builtins.open", create=True)
+def test_run_test_execution(
+    mock_open,
+    mock_run_binary,
+    mock_isfile,
+    mock_exists,
+    runner,
+    mock_args,
+    temp_benchmark_file,
+):
+    """Test run_test executes benchmarks and writes CSV"""
+    mock_args.filter_file = temp_benchmark_file
+
+    # Mock that all benchmark binaries exist
+    mock_exists.return_value = True
+    mock_isfile.return_value = True
+
+    # Mock benchmark execution results
+    mock_run_binary.side_effect = [
+        {
+            "benchmark_binary_name": "/opt/fboss/bin/benchmark1",
+            "benchmark_test_name": "Bench1",
+            "test_status": "OK",
+            "relative_time_per_iter": "1.0s",
+            "iters_per_sec": "1000m",
+            "cpu_time_usec": "1000000",
+            "max_rss": "100000",
+        },
+        {
+            "benchmark_binary_name": "/opt/fboss/bin/benchmark2",
+            "benchmark_test_name": "Bench2",
+            "test_status": "OK",
+            "relative_time_per_iter": "2.0s",
+            "iters_per_sec": "500m",
+            "cpu_time_usec": "2000000",
+            "max_rss": "200000",
+        },
+        {
+            "benchmark_binary_name": "/opt/fboss/bin/benchmark3",
+            "benchmark_test_name": "Bench3",
+            "test_status": "OK",
+            "relative_time_per_iter": "3.0s",
+            "iters_per_sec": "333m",
+            "cpu_time_usec": "3000000",
+            "max_rss": "300000",
+        },
+    ]
+
+    # Mock CSV file writing
+    mock_file = MagicMock()
+    mock_open.return_value.__enter__.return_value = mock_file
+
+    runner.run_test(mock_args)
+
+    # Verify all benchmarks were executed
+    assert mock_run_binary.call_count == 3
+
+    # Verify CSV file was opened for writing
+    mock_open.assert_called_once()
+    assert ".csv" in str(mock_open.call_args)
+
+
+@patch("os.path.exists")
+@patch("os.path.isfile")
+def test_run_test_no_existing_binaries(
+    mock_isfile, mock_exists, runner, mock_args, temp_benchmark_file, capsys
+):
+    """Test run_test when no benchmark binaries exist"""
+    mock_args.filter_file = temp_benchmark_file
+
+    # Mock that benchmark binaries don't exist
+    mock_exists.return_value = False
+    mock_isfile.return_value = False
+
+    runner.run_test(mock_args)
+
+    captured = capsys.readouterr()
+    assert "Error: No benchmark binaries found" in captured.out
+
+
+@patch("os.path.exists")
+@patch("os.path.isfile")
+def test_run_test_some_missing_binaries(
+    mock_isfile, mock_exists, runner, mock_args, temp_benchmark_file, capsys
+):
+    """Test run_test when some benchmark binaries are missing"""
+    mock_args.filter_file = temp_benchmark_file
+
+    # Mock that only benchmark1 exists
+    def exists_side_effect(path):
+        return "benchmark1" in path
+
+    def isfile_side_effect(path):
+        return "benchmark1" in path
+
+    mock_exists.side_effect = exists_side_effect
+    mock_isfile.side_effect = isfile_side_effect
+
+    # Mock benchmark execution
+    with (
+        patch.object(BenchmarkTestRunner, "_run_benchmark_binary") as mock_run,
+        patch("builtins.open", create=True),
+    ):
+        mock_run.return_value = {
+            "benchmark_binary_name": "/opt/fboss/bin/benchmark1",
+            "benchmark_test_name": "Bench1",
+            "test_status": "OK",
+            "relative_time_per_iter": "1.0s",
+            "iters_per_sec": "1000m",
+            "cpu_time_usec": "1000000",
+            "max_rss": "100000",
+        }
+
+        runner.run_test(mock_args)
+
+    captured = capsys.readouterr()
+    assert "Warning:" in captured.out
+    assert "benchmark binaries not found" in captured.out
+
+
+# Integration tests
+
+
+@patch("os.path.exists")
+@patch("run_test._load_from_file")
+def test_integration_default_configs_to_list_tests(
+    mock_load, mock_exists, runner, mock_args, capsys
+):
+    """Integration test: load from default configs and list tests"""
+    # Mock default config files exist
+    mock_exists.return_value = True
+    mock_load.side_effect = [["t1_bench"], ["t2_bench"], ["additional_bench"]]
+
+    mock_args.list_tests = True
+
+    runner.run_test(mock_args)
+
+    captured = capsys.readouterr()
+    assert "t1_bench" in captured.out
+    assert "t2_bench" in captured.out
+    assert "additional_bench" in captured.out

--- a/fboss/oss/scripts/run_scripts/test_run_test.py
+++ b/fboss/oss/scripts/run_scripts/test_run_test.py
@@ -14,7 +14,7 @@ import tempfile
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from run_test import BenchmarkTestRunner
+from run_test import BenchmarkTestRunner, _load_from_file
 
 # Fixtures
 
@@ -342,6 +342,7 @@ def test_run_test_list_tests_mode(runner, mock_args, temp_benchmark_file, capsys
     assert "benchmark3" in captured.out
 
 
+@patch("run_test._load_from_file")
 @patch("os.path.exists")
 @patch("os.path.isfile")
 @patch.object(BenchmarkTestRunner, "_run_benchmark_binary")
@@ -351,6 +352,7 @@ def test_run_test_execution(
     mock_run_binary,
     mock_isfile,
     mock_exists,
+    mock_load,
     runner,
     mock_args,
     temp_benchmark_file,
@@ -361,6 +363,7 @@ def test_run_test_execution(
     # Mock that all benchmark binaries exist
     mock_exists.return_value = True
     mock_isfile.return_value = True
+    mock_load.return_value = ["benchmark1", "benchmark2", "benchmark3"]
 
     # Mock benchmark execution results
     mock_run_binary.side_effect = [
@@ -407,16 +410,19 @@ def test_run_test_execution(
     assert ".csv" in str(mock_open.call_args)
 
 
+@patch("run_test._load_from_file")
 @patch("os.path.exists")
 @patch("os.path.isfile")
 def test_run_test_no_existing_binaries(
-    mock_isfile, mock_exists, runner, mock_args, temp_benchmark_file, capsys
+    mock_isfile, mock_exists, mock_load, runner, mock_args, temp_benchmark_file, capsys
 ):
     """Test run_test when no benchmark binaries exist"""
     mock_args.filter_file = temp_benchmark_file
 
-    # Mock that benchmark binaries don't exist
-    mock_exists.return_value = False
+    # Mock loading benchmarks from filter file
+    mock_load.return_value = ["benchmark1", "benchmark2", "benchmark3"]
+    # Mock that the filter file exists but benchmark binaries don't
+    mock_exists.side_effect = lambda path: path == temp_benchmark_file
     mock_isfile.return_value = False
 
     runner.run_test(mock_args)
@@ -425,17 +431,20 @@ def test_run_test_no_existing_binaries(
     assert "Error: No benchmark binaries found" in captured.out
 
 
+@patch("run_test._load_from_file")
 @patch("os.path.exists")
 @patch("os.path.isfile")
 def test_run_test_some_missing_binaries(
-    mock_isfile, mock_exists, runner, mock_args, temp_benchmark_file, capsys
+    mock_isfile, mock_exists, mock_load, runner, mock_args, temp_benchmark_file, capsys
 ):
     """Test run_test when some benchmark binaries are missing"""
     mock_args.filter_file = temp_benchmark_file
 
-    # Mock that only benchmark1 exists
+    mock_load.return_value = ["benchmark1", "benchmark2", "benchmark3"]
+
+    # Mock that filter file exists and only benchmark1 binary exists
     def exists_side_effect(path):
-        return "benchmark1" in path
+        return path == temp_benchmark_file or "benchmark1" in path
 
     def isfile_side_effect(path):
         return "benchmark1" in path
@@ -486,3 +495,85 @@ def test_integration_default_configs_to_list_tests(
     assert "t1_bench" in captured.out
     assert "t2_bench" in captured.out
     assert "additional_bench" in captured.out
+
+
+# Tests for _load_from_file
+
+
+def test_load_from_file_basic():
+    """Test loading entries from a file with comments and blank lines"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        f.write("# Comment line\n")
+        f.write("entry1\n")
+        f.write("\n")
+        f.write("entry2\n")
+        f.write("# Another comment\n")
+        f.write("entry3\n")
+        temp_file = f.name
+    try:
+        result = _load_from_file(temp_file)
+        assert result == ["entry1", "entry2", "entry3"]
+    finally:
+        os.unlink(temp_file)
+
+
+def test_load_from_file_nonexistent():
+    """Test loading from a nonexistent file returns empty list"""
+    result = _load_from_file("/nonexistent/path.conf")
+    assert result == []
+
+
+def test_load_from_file_empty():
+    """Test loading from an empty file returns empty list"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        temp_file = f.name
+    try:
+        result = _load_from_file(temp_file)
+        assert result == []
+    finally:
+        os.unlink(temp_file)
+
+
+def test_load_from_file_with_profile():
+    """Test loading with profile filters to matching tagged lines"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        f.write("entry_untagged\n")
+        f.write("entry_tagged_p1 p1\n")
+        f.write("entry_tagged_p2 p2\n")
+        f.write("entry_tagged_t t\n")
+        temp_file = f.name
+    try:
+        result = _load_from_file(temp_file, profile="p1")
+        assert result == ["entry_tagged_p1"]
+    finally:
+        os.unlink(temp_file)
+
+
+def test_load_from_file_no_profile_includes_untagged_and_t():
+    """Test that without profile, untagged and t-tagged lines are included"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        f.write("entry_untagged\n")
+        f.write("entry_tagged_p1 p1\n")
+        f.write("entry_tagged_t t\n")
+        temp_file = f.name
+    try:
+        result = _load_from_file(temp_file)
+        assert result == ["entry_untagged", "entry_tagged_t"]
+    finally:
+        os.unlink(temp_file)
+
+
+def test_load_from_file_comments_and_whitespace():
+    """Test that comments and whitespace-only lines are skipped"""
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
+        f.write("# full comment\n")
+        f.write("   \n")
+        f.write("\n")
+        f.write("  # indented comment\n")
+        f.write("entry1\n")
+        temp_file = f.name
+    try:
+        result = _load_from_file(temp_file)
+        assert result == ["entry1"]
+    finally:
+        os.unlink(temp_file)


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Adds support for running FBOSS benchmark test binaries as test suites using the existing `run_test.py` script. Benchmark tests measure performance metrics like throughput, latency, and speed of various FBOSS operations. Users can now easily run benchmark suites with automated CSV output containing detailed metrics for analysis.

Changes are the latest [two commits](https://github.com/facebook/fboss/pull/895/changes/0f7bfb2134ee97f863befe35de93376f6194e057..ac29fd767a01c7b1153fefeb424e652830ef055b) since it's based off of https://github.com/facebook/fboss/pull/989 to adjust for the recent introduction of ruff in the pre-commit.

## Key Features

### Benchmark Suite Management
- Created benchmark suite configuration files in `fboss/oss/hw_benchmark_tests/`:
  - `t1_benchmarks.conf` - T1 agent benchmark suite (9 benchmarks)
  - `t2_benchmarks.conf` - T2 agent benchmark suite (13 benchmarks)
  - `additional_benchmarks.conf` - Remaining benchmarks (15 benchmarks)
- Configuration files packaged to `./share/hw_benchmark_tests/` following existing test config patterns

### Performance Metrics Collection
- Parses benchmark output to extract:
  - Benchmark test name
  - Relative time per iteration
  - Iterations per second
  - CPU time (microseconds)
  - Maximum RSS memory usage
- Generates timestamped CSV files with results for tracking and analysis
- Three status values: **OK** (success), **FAILED** (incomplete output), **TIMEOUT** (exceeded 1200s limit)

### Command-Line Interface
- Added "benchmark" subcommand to `run_test.py`
- Supports custom filter files via `--filter_file` argument
- Filters out unavailable binaries automatically (e.g., DNX vs. XGS chips)
- Provides helpful messages when no benchmark binaries are found

## Implementation Details

### BenchmarkTestRunner Architecture
Implemented as a standalone class (does not extend `TestRunner`) with:
- **Class-level constants:** `BENCHMARK_CONFIG_DIR`, `T1_BENCHMARKS_CONF`, `T2_BENCHMARKS_CONF`, `ALL_BENCHMARKS_CONF`
- **Public methods:**
  - `add_subcommand_arguments()` - Register command-line arguments
  - `run_test(args)` - Main entry point for running benchmarks
- **Private methods:**
  - `_parse_benchmark_output()` - Extract metrics from benchmark output
  - `_run_benchmark_binary()` - Execute a single benchmark binary

**Design rationale:** Unlike other test runners that extend the abstract `TestRunner` base class, `BenchmarkTestRunner` is standalone because:
- Benchmark tests are standalone binaries, not gtest-based tests
- No warmboot/coldboot variants needed
- Standard test filtering mechanisms not applicable
- Simpler, more maintainable implementation

### Packaging Updates
- Updated `package-fboss.py` to copy benchmark configuration files to `share/hw_benchmark_tests/`
- Benchmark binaries packaged to `bin/` directory

### Documentation Updates
- Added **Option 1: Using the run_test.py Script (Recommended)** section with examples for running all benchmarks, T1 suite, T2 suite, and additional benchmarks
- Kept existing manual execution as **Option 2: Running Individual Binaries**
- Updated **T1 Tests → Agent Benchmark Tests** and **T2 Tests → Agent Benchmark Tests** sections to use `run_test.py` commands
- Added note about CSV output with timestamped filenames

## Testing

### Unit Test Coverage
Added comprehensive unit tests using pytest (25 test cases total):

**test_run_test.py** - BenchmarkTestRunner coverage:
- Loading from custom filter files
- Handling nonexistent/empty files
- Loading from default T1, T2, and additional configs
- Handling missing default configs
- Successful parsing with all metrics
- Missing JSON metrics and benchmark lines
- Empty output and different time units
- Successful execution, timeout handling, execution failures
- Exception handling
- Execution with config arguments
- List tests mode
- Full execution with CSV writing
- No existing binaries and some missing binaries
- End-to-end workflow from default configs to list tests

**test_benchmark_conf_files.py** - Configuration validation:
- Ensures no overlaps between benchmark suite lists

**Test features:**
- All tests use mocking to avoid side effects
- Tests verify both success and error cases
- Temporary files properly cleaned up
- Pythonic code style with list comprehensions

**Integration:** Tests integrated into CMake and run with ctest

### Manual Verification
Verified benchmark subcommand, configuration files, and execution on device with T1 suite showing proper handling of successful benchmarks, failures, and timeouts with correct CSV output.

### Visual Inspection of Documentation
Verified documentation formatting is correct by serving Docusaurus locally:
<img width="777" height="586" alt="image"
src="https://github.com/user-attachments/assets/09e6230b-10db-4f80-9e2b-395886e906eb"
/>

<img width="1912" height="1270" alt="image"
src="https://github.com/user-attachments/assets/bac98ba6-8654-42e8-9585-71dc3e4f2633"
/>

