### PR TITLE
[Nexthop] Refactor TestRunner test filtering logic

### DIFF
--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -330,6 +330,11 @@ class TestRunner(abc.ABC):
         re.VERBOSE,
     )
 
+    def __init__(self):
+        # Test lists will be initialized in run_test() when args are available
+        self._known_bad_test_regexes = None
+        self._unsupported_test_regexes = None
+
     @abc.abstractmethod
     def _get_config_path(self):
         pass
@@ -418,52 +423,95 @@ class TestRunner(abc.ABC):
             run_test_result = (line[:idx] + test_prefix + line[idx:]).encode("utf-8")
         return run_test_result
 
-    def _get_known_bad_test_regexes(self):
-        if not args.skip_known_bad_tests:
+    def _get_test_regexes_from_file(
+        self,
+        file_path: str,
+        test_dict_key: str,
+        keys_to_try: list[str],
+    ) -> list[str]:
+        """
+        Helper function to extract test regexes from a JSON file.
+
+        Tries multiple key variants provided in keys_to_try list.
+        Collects regexes from all matching keys.
+
+        Args:
+            file_path: Path to the JSON file containing test configurations
+            test_dict_key: Key in the JSON to access the test dictionary (e.g., "known_bad_tests", "unsupported_tests")
+            keys_to_try: List of keys to try in the test dictionary
+
+        Returns:
+            List of test name regexes from all matching keys
+        """
+        if not os.path.exists(file_path):
+            print(f"Warning: Test file {file_path} does not exist")
             return []
 
-        known_bad_tests_file = self._get_known_bad_tests_file()
-        if not os.path.exists(known_bad_tests_file):
-            return []
+        with open(file_path) as f:
+            test_json = json.load(f)
+            test_dict = test_json[test_dict_key]
 
-        with open(known_bad_tests_file) as f:
-            known_bad_test_json = json.load(f)
-            known_bad_tests = known_bad_test_json["known_bad_tests"]
-            key = args.skip_known_bad_tests
-            if key not in known_bad_tests and args.agent_run_mode:
-                key = key + "/" + args.agent_run_mode
-            known_bad_test_structs = known_bad_tests[key]
-            known_bad_tests = []
-            for test_struct in known_bad_test_structs:
-                known_bad_test = test_struct["test_name_regex"]
-                known_bad_tests.append(known_bad_test)
-        return known_bad_tests
+            # Collect regexes from all matching keys
+            test_regexes = set()
+            for key in keys_to_try:
+                if key in test_dict:
+                    for test_struct in test_dict[key]:
+                        test_regexes.add(test_struct["test_name_regex"])
 
-    def _get_unsupported_test_regexes(self):
+            if not test_regexes:
+                print(
+                    f"Warning: Could not find tests for key '{keys_to_try[0]}'. "
+                    f"Available keys: {list(test_dict.keys())}"
+                )
+
+            return list(test_regexes)
+
+    def _initialize_test_lists(self, args):
+        """
+        Initialize known bad and unsupported test lists.
+        This should be called once at the start of run_test() when args are available.
+        """
         if not args.skip_known_bad_tests:
             print(
                 "The --skip-known-bad-tests option is not set, therefore unsupported tests will be run."
             )
-            return []
+            self._known_bad_test_regexes = []
+            self._unsupported_test_regexes = []
+            return
 
+        # Build list of keys to try - always try exactly two keys:
+        # 1. The key as provided
+        # 2. Either the key with run mode suffix stripped (if it ends with one)
+        #    or the key with run mode suffix appended (if it doesn't)
+        base_key = args.skip_known_bad_tests
+        keys_to_try = [base_key]
+
+        # Only try run mode suffix if the subcommand has agent_run_mode
+        if hasattr(args, "agent_run_mode"):
+            run_mode_suffix = f"/{args.agent_run_mode}"
+            if base_key.endswith(run_mode_suffix):
+                # Key already has the run mode suffix, try the stripped version
+                stripped_key = base_key[: -len(run_mode_suffix)]
+                keys_to_try.append(stripped_key)
+            else:
+                # Key doesn't have the run mode suffix, try adding it
+                keys_to_try.append(f"{base_key}{run_mode_suffix}")
+
+        # Load known bad tests
+        known_bad_tests_file = self._get_known_bad_tests_file()
+        self._known_bad_test_regexes = self._get_test_regexes_from_file(
+            file_path=known_bad_tests_file,
+            test_dict_key="known_bad_tests",
+            keys_to_try=keys_to_try,
+        )
+
+        # Load unsupported tests
         unsupported_tests_file = self._get_unsupported_tests_file()
-        if not os.path.exists(unsupported_tests_file):
-            unsupported_tests_file_abs_path = os.path.abspath(unsupported_tests_file)
-            print(
-                f"The unsupported tests file {unsupported_tests_file_abs_path} does not exist, therefore all tests will be considered supported"
-            )
-            return []
-
-        with open(unsupported_tests_file) as f:
-            unsupported_test_json = json.load(f)
-            unsupported_test_structs = unsupported_test_json["unsupported_tests"][
-                args.skip_known_bad_tests
-            ]
-            unsupported_tests = []
-            for test_struct in unsupported_test_structs:
-                unsupported_test = test_struct["test_name_regex"]
-                unsupported_tests.append(unsupported_test)
-        return unsupported_tests
+        self._unsupported_test_regexes = self._get_test_regexes_from_file(
+            file_path=unsupported_tests_file,
+            test_dict_key="unsupported_tests",
+            keys_to_try=keys_to_try,
+        )
 
     def _parse_list_test_output(self, output):
         ret = []
@@ -498,7 +546,7 @@ class TestRunner(abc.ABC):
             test_summary.append(line)
         return test_summary
 
-    def _list_tests_to_run(self, test_filter, should_print=True):
+    def _list_tests_to_run(self, test_filter):
         output = subprocess.check_output(
             [
                 self._get_test_binary_name(),
@@ -506,24 +554,28 @@ class TestRunner(abc.ABC):
                 f"--gtest_filter={test_filter}",
             ]
         )
-        # Print all the matching tests
-        if should_print:
-            print(output.decode("utf-8"))
         return self._parse_list_test_output(output)
 
+    def _test_matches_any_regex(self, test, regex_list):
+        """
+        Check if a test name matches any regex in the provided list.
+
+        Args:
+            test: Test name to check
+            regex_list: List of regex patterns to match against
+
+        Returns:
+            True if test matches any regex in the list, False otherwise
+        """
+        return any(re.match(regex_pattern, test) for regex_pattern in regex_list)
+
     def _is_known_bad_test(self, test):
-        known_bad_test_regexes = self._get_known_bad_test_regexes()
-        for known_bad_test_regex in known_bad_test_regexes:
-            if re.match(known_bad_test_regex, test):
-                return True
-        return False
+        """Check if a test is in the known bad tests list."""
+        return self._test_matches_any_regex(test, self._known_bad_test_regexes)
 
     def _is_unsupported_test(self, test):
-        unsupported_test_regexes = self._get_unsupported_test_regexes()
-        for unsupported_test_regex in unsupported_test_regexes:
-            if re.match(unsupported_test_regex, test):
-                return True
-        return False
+        """Check if a test is in the unsupported tests list."""
+        return self._test_matches_any_regex(test, self._unsupported_test_regexes)
 
     def _get_tests_to_run(self):
         # Filter syntax is -
@@ -546,11 +598,11 @@ class TestRunner(abc.ABC):
         if args.filter or args.filter_file:
             if args.filter_file:
                 gtest_regexes = _load_from_file(args.filter_file, args.profile)
-                test_names = self._list_tests_to_run(":".join(gtest_regexes), False)
+                test_names = self._list_tests_to_run(":".join(gtest_regexes))
             elif args.filter:
-                test_names = self._list_tests_to_run(args.filter, False)
+                test_names = self._list_tests_to_run(args.filter)
         else:
-            test_names = self._list_tests_to_run("*", False)
+            test_names = self._list_tests_to_run("*")
         test_filter = ""
         known_bad_test_regexes = self._get_known_bad_test_regexes()
         unsupported_test_regexes = self._get_unsupported_test_regexes()
@@ -562,8 +614,7 @@ class TestRunner(abc.ABC):
             test_filter += f"{test_name}:"
         if not test_filter:
             return []
-        should_print = not getattr(args, "list_tests_for_features", None)
-        return self._list_tests_to_run(test_filter, should_print)
+        return self._list_tests_to_run(test_filter)
 
     def _restart_bcmsim(self, asic):
         try:
@@ -846,16 +897,17 @@ class TestRunner(abc.ABC):
         print(f"\nTest output stored at: {output_csv}")
 
     def run_test(self, args):
+        # Initialize test lists once at the start
+        self._initialize_test_lists(args)
+
         tests_to_run = self._get_tests_to_run()
         tests_to_run = self._filter_tests(tests_to_run)
 
-        if getattr(args, "list_tests_for_features", None):
-            for test in tests_to_run:
-                print(test)
-            return
-
         # Check if tests need to be run or only listed
-        if args.list_tests is False:
+        if (
+            args.list_tests is False
+            and getattr(args, "list_tests_for_features", None) is None
+        ):
             start_time = datetime.now()
             original_conf_file = (
                 args.config if (args.config is not None) else self._get_config_path()
@@ -869,6 +921,10 @@ class TestRunner(abc.ABC):
                 flush=True,
             )
             self._print_output_summary(output)
+        else:
+            # Print the filtered tests
+            for test in tests_to_run:
+                print(test)
 
 
 class BcmTestRunner(TestRunner):
@@ -1553,6 +1609,9 @@ class PlatformServicesTestRunner(TestRunner):
             super().run_test(args)
             return
 
+        # Initialize test lists once at the start
+        self._initialize_test_lists(args)
+
         output = []
         start_time = datetime.now()
 
@@ -1570,6 +1629,10 @@ class PlatformServicesTestRunner(TestRunner):
                 )
                 conf_file = self._backup_and_modify_config(original_conf_file)
                 output.extend(self._run_tests(tests_to_run, conf_file, args))
+            else:
+                for test in tests_to_run:
+                    print(test)
+                return
 
         end_time = datetime.now()
         delta_time = end_time - start_time
@@ -2014,7 +2077,9 @@ if __name__ == "__main__":
         OPT_ARG_SKIP_KNOWN_BAD_TESTS,
         type=str,
         help=(
-            "test config to specify which known bad tests to skip e.g. "
+            "test config key to specify which known bad tests to skip. "
+            "The key format is: vendor/coldboot-sai/warmboot-sai/asic. "
+            "Example: "
             + OPT_ARG_SKIP_KNOWN_BAD_TESTS
             + "=brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk"
         ),

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -604,11 +604,9 @@ class TestRunner(abc.ABC):
         else:
             test_names = self._list_tests_to_run("*")
         test_filter = ""
-        known_bad_test_regexes = self._get_known_bad_test_regexes()
-        unsupported_test_regexes = self._get_unsupported_test_regexes()
         for test_name in test_names:
-            if any(re.match(r, test_name) for r in known_bad_test_regexes) or any(
-                re.match(r, test_name) for r in unsupported_test_regexes
+            if self._is_known_bad_test(test_name) or self._is_unsupported_test(
+                test_name
             ):
                 continue
             test_filter += f"{test_name}:"


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

This PR refactors the test filtering logic in the TestRunner class to
improve maintainability and fix several bugs.

## Changes

- Extract test regex loading into a helper method to reduce code
duplication
- Refactor known bad and unsupported tests file extraction into a shared
helper function (the original functions were extremely similar)
- Fix bug where "skipping unsupported tests" message was printed too
many times
- Fix bug with using --enable_production_features with --list_tests
- Add eager loading of test lists at start of test execution
- Add helper method for cleaner test matching
- Simplify test filtering methods to use the new helpers
- Improve help text for command-line options
- Print filtered tests when --list_tests is used

## Testing

### Integration Test Results

**Device:** fboss101
**Build ID:** 23679
**Test Suite:** 11 targeted integration tests
**Results:** ✅ **11/11 PASSED (100%)**

<details>
<summary>Click to expand full test results</summary>

```
=========================================
Starting Integration Tests for PR https://github.com/facebook/fboss/pull/407
DUT: fboss101
Results Directory: /tmp/pr407_integration_results_20260203_153529
=========================================

========================================
Test 1: Verify --list_tests prints filtered tests
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --filter "*Port*" 2>&1 | head -20'
========================================
✓ PASSED

Output:
Setting fboss environment variables
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp
AgentCoppTest/1.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/1.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp
AgentCoppPortMtuTest/0.PortMTUErrorToLowPriQ
AgentCoppPortMtuTest/1.PortMTUErrorToLowPriQ
AgentPacketSendTest.LldpToFrontPanelOutOfPort
AgentPacketSendTest.LldpToFrontPanelOutOfPortWithBufClone
AgentPacketSendTest.PortTxEnableTest
AgentPacketSendReceiveTest.LldpPacketReceiveSrcPort
AgentPacketSendReceiveLagTest.LacpPacketReceiveSrcPort
AgentSwitchedPacketSendTest.ArpRequestToFrontPanelPortSwitched
AgentL4PortBlackHolingTest.v6UDP
AgentL4PortBlackHolingTest.v4UDP
AgentMacLearningTest.VerifyHwLearningForPort
AgentMacLearningTest.VerifyHwAgingForPort

========================================
Test 2: Verify test filtering doesn't print during execution
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON 2>&1 | wc -l' | grep -E '^[0-9]+$'
========================================
✓ PASSED

Output:
714

========================================
Test 3: Test --skip-known-bad-tests with valid base key (brcm/13.0_ea_odp/13.0_ea_odp/tomahawk5)
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --skip-known-bad-tests brcm/13.0_ea_odp/13.0_ea_odp/tomahawk5 2>&1 | head -15'
========================================
✓ PASSED

Output:
Setting fboss environment variables
Agent2QueueToOlympicQoSTest.verifyDscpToQueueMapping
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/0.Ipv6LinkLocalMcastToMidPriQ
AgentCoppTest/0.Ipv6LinkLocalMcastTxFromCpu
AgentCoppTest/0.Ipv6LinkLocalUcastToMidPriQ
AgentCoppTest/0.SlowProtocolsMacToHighPriQ
AgentCoppTest/0.DstIpNetworkControlDscpToHighPriQ
AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp
AgentCoppTest/0.Ipv6LinkLocalMcastNetworkControlDscpToHighPriQ
AgentCoppTest/0.ArpRequestAndReplyToHighPriQ
AgentCoppTest/0.NdpSolicitationToHighPriQ
AgentCoppTest/0.NdpSolicitNeighbor
AgentCoppTest/0.NdpAdvertisementToHighPriQ

========================================
Test 4: Test --skip-known-bad-tests with base key + mono mode (brcm/13.0_ea_odp/13.0_ea_odp/tomahawk5/mono)
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --skip-known-bad-tests brcm/13.0_ea_odp/13.0_ea_odp/tomahawk5/mono --agent-run-mode mono 2>&1 | head -15'
========================================
✓ PASSED

Output:
Setting fboss environment variables
Agent2QueueToOlympicQoSTest.verifyDscpToQueueMapping
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/0.Ipv6LinkLocalMcastToMidPriQ
AgentCoppTest/0.Ipv6LinkLocalMcastTxFromCpu
AgentCoppTest/0.Ipv6LinkLocalUcastToMidPriQ
AgentCoppTest/0.SlowProtocolsMacToHighPriQ
AgentCoppTest/0.DstIpNetworkControlDscpToHighPriQ
AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp
AgentCoppTest/0.Ipv6LinkLocalMcastNetworkControlDscpToHighPriQ
AgentCoppTest/0.ArpRequestAndReplyToHighPriQ
AgentCoppTest/0.NdpSolicitationToHighPriQ
AgentCoppTest/0.NdpSolicitNeighbor
AgentCoppTest/0.NdpAdvertisementToHighPriQ

========================================
Test 5: Test --skip-known-bad-tests with unsupported key shows warning
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --skip-known-bad-tests brcm/99.0_invalid/99.0_invalid/invalid_asic 2>&1 | head -5'
========================================
✓ PASSED

Output:
Setting fboss environment variables
Warning: Could not find tests for key 'brcm/99.0_invalid/99.0_invalid/invalid_asic'. Available keys: [...]
Agent2QueueToOlympicQoSTest.verifyDscpToQueueMapping
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ

========================================
Test 6: Verify unsupported tests message prints only once
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON 2>&1 | grep -c "unsupported tests will be run"' | grep '^1$'
========================================
✓ PASSED

Output:
1

========================================
Test 7: Test filter with multiple patterns
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --filter "*Port*:*Vlan*" 2>&1 | head -20'
========================================
✓ PASSED

Output:
Setting fboss environment variables
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp
AgentCoppTest/1.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/1.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp
AgentCoppPortMtuTest/0.PortMTUErrorToLowPriQ
AgentCoppPortMtuTest/1.PortMTUErrorToLowPriQ
AgentPacketSendTest.LldpToFrontPanelOutOfPort
AgentPacketSendTest.LldpToFrontPanelOutOfPortWithBufClone
AgentPacketSendTest.PortTxEnableTest
AgentPacketSendReceiveTest.LldpPacketReceiveSrcPort
AgentPacketSendReceiveLagTest.LacpPacketReceiveSrcPort
AgentSwitchedPacketSendTest.ArpRequestToFrontPanelPortSwitched
AgentL4PortBlackHolingTest.v6UDP
AgentL4PortBlackHolingTest.v4UDP
AgentMacLearningTest.VerifyHwLearningForPort
AgentMacLearningTest.VerifyHwAgingForPort

========================================
Test 8: Test filter with exclusion pattern
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --filter "*Port*:-*Mac*" 2>&1 | head -20'
========================================
✓ PASSED

Output:
Setting fboss environment variables
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp
AgentCoppTest/1.LocalDstIpBgpPortToHighPriQ
AgentCoppTest/1.LocalDstIpNonBgpPortToMidPriQ
AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp
AgentCoppPortMtuTest/0.PortMTUErrorToLowPriQ
AgentCoppPortMtuTest/1.PortMTUErrorToLowPriQ
AgentPacketSendTest.LldpToFrontPanelOutOfPort
AgentPacketSendTest.LldpToFrontPanelOutOfPortWithBufClone
AgentPacketSendTest.PortTxEnableTest
AgentPacketSendReceiveTest.LldpPacketReceiveSrcPort
AgentPacketSendReceiveLagTest.LacpPacketReceiveSrcPort
AgentSwitchedPacketSendTest.ArpRequestToFrontPanelPortSwitched
AgentL4PortBlackHolingTest.v6UDP
AgentL4PortBlackHolingTest.v4UDP
AgentIngressPortSpanMirroringTest/IPv4.SpanPortMirror
AgentIngressPortSpanMirroringTest/IPv4.UpdateSpanPortMirror

========================================
Test 9: Verify improved help text for --skip-known-bad-tests (contains key format description)
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py --help 2>&1 | grep -A5 "skip-known-bad-tests" | grep -q "key format" && echo "Help text contains key format description"'
========================================
✓ PASSED

Output:
Help text contains key format description

========================================
Test 10: Verify run_test.py has valid Python syntax
Command: ssh fboss101 -c 'sudo cp /opt/fboss/bin/run_test.py /tmp/run_test_syntax_check.py && python3 -m py_compile /tmp/run_test_syntax_check.py && echo "Syntax check passed" && sudo rm -f /tmp/run_test_syntax_check.py*'
========================================
✓ PASSED

Output:
Syntax check passed

========================================
Test 11: Verify run_test.py can be imported as module
Command: ssh fboss101 -c 'cd /opt/fboss/bin && python3 -c "import sys; sys.path.insert(0, \".\"); import run_test"'
========================================
✓ PASSED

Output:

=========================================
Test Summary
=========================================
Total Tests: 11
Passed: 11
Failed: 0
=========================================
Results saved to: /tmp/pr407_integration_results_20260203_153529

All tests passed!
```

</details>

### Unit Tests for `--list_tests` and `--list-tests-for-features`

**4 unit tests** verifying the `--list_tests` and `--list-tests-for-features` flags,
their combination, and normal test execution. Tests use mocked subprocess calls to
verify the filtering logic locally without requiring a device.

**Results:** 4/4 PASSED (100%)

<details>
<summary>Click to expand full test results</summary>

```
========================================
Test 1: Verify --list_tests prints tests without running them
Command: ./run_test.py sai_agent --list_tests --config $confFile
========================================
✓ PASSED

Output:
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentAclTest/0.AclEntry
AgentCoppTest/0.BgpPort

========================================
Test 2: Verify --list-tests-for-features filters tests by feature tags
Command: ./run_test.py sai_agent --list-tests-for-features=DLB,ACL_COUNTER,SINGLE_ACL_TABLE --config $confFile
========================================
✓ PASSED

Output:
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentDlbTest/0.DlbEntry
AgentAclTest/0.AclEntry

========================================
Test 3: Verify --list_tests combined with --list-tests-for-features filters then lists
Command: ./run_test.py sai_agent --list_tests --list-tests-for-features=DLB --config $confFile
========================================
✓ PASSED

Output:
The --skip-known-bad-tests option is not set, therefore unsupported tests will be run.
AgentDlbTest/0.DlbEntry

========================================
Test 4: Verify without --list_tests or --list-tests-for-features, tests are executed
Command: ./run_test.py sai_agent --config $confFile
========================================
✓ PASSED

Output:
_run_tests() was called with ['AgentAclTest/0.AclEntry'] — tests would be executed on device

=========================================
Test Summary
=========================================
Total Tests: 4
Passed: 4
Failed: 0
=========================================
```

</details>
