### PR TITLE
[Nexthop] Simplify run_test.py arguments

### DIFF
--- a/docs/docs/testing/test_categories.md
+++ b/docs/docs/testing/test_categories.md
@@ -46,7 +46,7 @@ When running tests with `run_test.py`, you may need to specify the following var
 - **$CONFIG**: Path to the hardware test configuration file for your platform
 - **$QSFP_CONFIG**: Path to the QSFP test configuration file for your platform
 - **$ASIC**: ASIC identifier for production features filtering. Available ASICs can be found in `./share/production_features/asic_production_features.materialized_JSON` under the `asicToFeatureNames` key.
-- **$KEY**: Test configuration key for skipping known bad or unsupported tests. The key format is: `vendor/coldboot-sai/warmboot-sai/asic` (e.g., `brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk`). Available keys can be found in:
+- **$KEY**: Test configuration key for skipping known bad or unsupported tests, used with `--skip-known-bad-tests`. The key format is: `vendor/coldboot-sai/warmboot-sai/asic` (e.g., `brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk`). Each test runner uses default known-bad and unsupported test files for the lookup, but these can be overridden with `--known-bad-tests-file` and `--unsupported-tests-file` if needed. Available keys can be found in:
   - For SAI Agent tests: `./share/sai_hw_unsupported_tests/sai_hw_unsupported_tests.materialized_JSON`
   - For SAI tests: `./share/sai_hw_unsupported_tests/sai_hw_unsupported_tests.materialized_JSON`
   - For QSFP tests: `./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON`

--- a/docs/docs/testing/test_categories.md
+++ b/docs/docs/testing/test_categories.md
@@ -39,6 +39,21 @@ T0/T1/T2, a filter file, or a gtest filter so that the binary runs all tests.
 Even though we recommend following this process to make testing more organized,
 feel free to run all tests and work through them however you please.
 
+:::note Test Configuration Variables
+
+When running tests with `run_test.py`, you may need to specify the following variables:
+
+- **$CONFIG**: Path to the hardware test configuration file for your platform
+- **$QSFP_CONFIG**: Path to the QSFP test configuration file for your platform
+- **$ASIC**: ASIC identifier for production features filtering. Available ASICs can be found in `./share/production_features/asic_production_features.materialized_JSON` under the `asicToFeatureNames` key.
+- **$KEY**: Test configuration key for skipping known bad or unsupported tests. The key format is: `vendor/coldboot-sai/warmboot-sai/asic` (e.g., `brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk`). Available keys can be found in:
+  - For SAI Agent tests: `./share/sai_hw_unsupported_tests/sai_hw_unsupported_tests.materialized_JSON`
+  - For SAI tests: `./share/sai_hw_unsupported_tests/sai_hw_unsupported_tests.materialized_JSON`
+  - For QSFP tests: `./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON`
+  - For Link tests: `./share/link_known_bad_tests/agent_ensemble_link_known_bad_tests.materialized_JSON`
+
+:::
+
 ## T0 Tests
 
 ### Platform Services
@@ -63,12 +78,8 @@ feel free to run all tests and work through them however you please.
 ./bin/run_test.py sai_agent \
 --filter_file=./share/hw_sanity_tests/t0_agent_hw_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_agent_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--enable-production-features $ASIC \
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_agent_hw_tests.conf
@@ -81,12 +92,7 @@ feel free to run all tests and work through them however you please.
 ./bin/run_test.py sai \
 --filter_file=./share/hw_sanity_tests/t0_sai_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_sai_tests.conf
@@ -99,9 +105,7 @@ feel free to run all tests and work through them however you please.
 ./bin/run_test.py qsfp \
 --filter_file=./share/hw_sanity_tests/t0_qsfp_hw_tests.conf \
 --qsfp-config ./share/qsfp_test_configs/$CONFIG \
---known-bad-tests-file ./share/qsfp_known_bad_tests/fboss_qsfp_known_bad_tests.materialized_JSON \
---unsupported-tests-file ./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_qsfp_hw_tests.conf
@@ -115,9 +119,7 @@ feel free to run all tests and work through them however you please.
 ./bin/run_test.py qsfp \
 --filter_file=./share/hw_sanity_tests/t0_qsfp_hw_tests_without_transceivers.conf \
 --qsfp-config ./share/qsfp_test_configs/$CONFIG \
---known-bad-tests-file ./share/qsfp_known_bad_tests/fboss_qsfp_known_bad_tests.materialized_JSON \
---unsupported-tests-file ./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_qsfp_hw_tests_without_transceivers.conf
@@ -133,7 +135,7 @@ feel free to run all tests and work through them however you please.
 --config ./share/link_test_configs/$CONFIG \
 --qsfp-config /opt/fboss/share/qsfp_test_configs/$QSFP_CONFIG \
 --known-bad-tests-file ./share/link_known_bad_tests/agent_ensemble_link_known_bad_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_ensemble_link_tests.conf
@@ -150,7 +152,7 @@ feel free to run all tests and work through them however you please.
 --config ./share/link_test_configs/$CONFIG \
 --qsfp-config /opt/fboss/share/qsfp_test_configs/$QSFP_CONFIG \
 --known-bad-tests-file ./share/link_known_bad_tests/agent_ensemble_link_known_bad_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t0_ensemble_link_tests_without_transceivers.conf
@@ -169,12 +171,8 @@ feel free to run all tests and work through them however you please.
 ./bin/run_test.py sai_agent \
 --filter_file=./share/hw_sanity_tests/t1_agent_hw_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_agent_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--enable-production-features $ASIC \
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t1_agent_hw_tests.conf
@@ -190,9 +188,7 @@ T1 QSFP HW tests scope is controlled by the known-bad and unsupported test files
 ```bash
 ./bin/run_test.py qsfp \
 --qsfp-config ./share/qsfp_test_configs/$CONFIG \
---known-bad-tests-file ./share/qsfp_known_bad_tests/fboss_qsfp_known_bad_tests.materialized_JSON \
---unsupported-tests-file ./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ### Link Tests
@@ -208,7 +204,7 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 --config ./share/link_test_configs/$CONFIG \
 --qsfp-config /opt/fboss/share/qsfp_test_configs/$QSFP_CONFIG \
 --known-bad-tests-file ./share/link_known_bad_tests/agent_ensemble_link_known_bad_tests.materialized_JSON \
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ### Agent Benchmark Tests
@@ -229,12 +225,7 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 ./bin/run_test.py sai \
 --filter_file=./share/hw_sanity_tests/t1_sai_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t1_sai_tests.conf
@@ -249,12 +240,8 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 ./bin/run_test.py sai_agent \
 --filter_file=./share/hw_sanity_tests/t2_agent_hw_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_agent_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--enable-production-features $ASIC \
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t2_agent_hw_tests.conf
@@ -278,12 +265,7 @@ T1 Link tests scope is controlled by the known-bad and unsupported test files, s
 ./bin/run_test.py sai \
 --filter_file=./share/hw_sanity_tests/t2_sai_tests.conf \
 --config ./share/hw_test_configs/$CONFIG \
---enable-production-features \
---production-features ./share/production_features/asic_production_features.materialized_JSON \
---known-bad-tests-file ./share/hw_known_bad_tests/sai_known_bad_tests.materialized_JSON \
---unsupported-tests-file $UNSUPPORTED_TESTS \
---asic $ASIC \ # $ASIC can be found in asic_production_features.materialized_JSON
---skip-known-bad-tests $KEY # $KEY can be found in known bad test file
+--skip-known-bad-tests $KEY
 ```
 
 ```bash file=../fboss/oss/hw_sanity_tests/t2_sai_tests.conf

--- a/fboss/oss/scripts/run_scripts/fsdb_service_utils.py
+++ b/fboss/oss/scripts/run_scripts/fsdb_service_utils.py
@@ -4,7 +4,6 @@ import os
 import subprocess
 import typing as t
 
-
 _DEFAULT_OSS_FSDB_SERVICE_PATH = "/opt/fboss/bin/fsdb"
 # TODO: Add file.
 _DEFAULT_OSS_FSDB_SERVICE_CONFIG_PATH = "/opt/fboss/share/link_test_configs/fsdb.conf"
@@ -47,19 +46,17 @@ WantedBy=multi-user.target
 
 
 def _cleanup_fsdb_service_rsyslog_conf() -> None:
-    subprocess.run(f"rm {_FSDB_SERVICE_RSYSLOG_CONF_PATH}", shell=True)
-    subprocess.run("systemctl restart rsyslog", shell=True)
+    subprocess.run(f"rm {_FSDB_SERVICE_RSYSLOG_CONF_PATH}", check=False, shell=True)
+    subprocess.run("systemctl restart rsyslog", check=False, shell=True)
 
 
 def _setup_fsdb_service(
-    fsdb_service_bin_path: t.Optional[str] = None,
     fsdb_service_config_path: t.Optional[str] = None,
 ) -> None:
     print(f"Setting up {_FSDB_SERVICE_OSS}")
 
     # Prepare fsdb_service binary and config file
-    if not fsdb_service_bin_path:
-        fsdb_service_bin_path = _DEFAULT_OSS_FSDB_SERVICE_PATH
+    fsdb_service_bin_path = _DEFAULT_OSS_FSDB_SERVICE_PATH
     if not os.path.exists(fsdb_service_bin_path):
         raise Exception(f"fsdb_service binary: {fsdb_service_bin_path} does not exist")
 
@@ -94,15 +91,16 @@ def _setup_fsdb_service(
     with open(_FSDB_SERVICE_RSYSLOG_CONF_PATH, "w") as f:
         f.write(_FSDB_SERVICE_RSYSLOG_CONF_CONTENT)
         f.flush()
-    subprocess.run("systemctl restart rsyslog; sleep 5", shell=True)
-
-    return
+    subprocess.run("systemctl restart rsyslog; sleep 5", check=False, shell=True)
 
 
 def _setup_fsdb_service_coldboot() -> None:
-    subprocess.run(f"mkdir -p {_DEFAULT_FSDB_SERVICE_VOLATILE_DIR}", shell=True)
+    subprocess.run(
+        f"mkdir -p {_DEFAULT_FSDB_SERVICE_VOLATILE_DIR}", check=False, shell=True
+    )
     subprocess.run(
         f"touch {_DEFAULT_FSDB_SERVICE_VOLATILE_DIR}/{_FSDB_SERVICE_COLD_BOOT_FILE}",
+        check=False,
         shell=True,
     )
 
@@ -115,19 +113,20 @@ def _start_fsdb_service(is_warm_boot: bool = False) -> None:
     if not is_warm_boot:
         _setup_fsdb_service_coldboot()
 
-    subprocess.run(f"systemctl enable {_FSDB_SERVICE_UNIT_FILE_PATH}", shell=True)
-    subprocess.run("systemctl daemon-reload", shell=True)
-    subprocess.run(f"systemctl start {_FSDB_SERVICE_OSS}; sleep 10", shell=True)
-
-    return
+    subprocess.run(
+        f"systemctl enable {_FSDB_SERVICE_UNIT_FILE_PATH}", check=False, shell=True
+    )
+    subprocess.run("systemctl daemon-reload", check=False, shell=True)
+    subprocess.run(
+        f"systemctl start {_FSDB_SERVICE_OSS}; sleep 10", check=False, shell=True
+    )
 
 
 def setup_and_start_fsdb_service(
-    fsdb_service_bin_path: t.Optional[str] = None,
     fsdb_service_config_path: t.Optional[str] = None,
     is_warm_boot: bool = False,
 ) -> None:
-    _setup_fsdb_service(fsdb_service_bin_path, fsdb_service_config_path)
+    _setup_fsdb_service(fsdb_service_config_path)
     _start_fsdb_service(is_warm_boot)
 
 
@@ -138,15 +137,17 @@ def cleanup_fsdb_service() -> None:
     """
     print(f"Cleaning up {_FSDB_SERVICE_OSS}")
 
-    subprocess.run(f"systemctl stop {_FSDB_SERVICE_PROD}", shell=True)
-    subprocess.run(f"systemctl stop {_FSDB_SERVICE_FOR_TESTING}", shell=True)
-    subprocess.run(f"systemctl stop {_FSDB_SERVICE_OSS}", shell=True)
-    subprocess.run(f"systemctl disable {_FSDB_SERVICE_OSS}", shell=True)
-    subprocess.run("systemctl daemon-reload", shell=True)
+    subprocess.run(f"systemctl stop {_FSDB_SERVICE_PROD}", check=False, shell=True)
+    subprocess.run(
+        f"systemctl stop {_FSDB_SERVICE_FOR_TESTING}", check=False, shell=True
+    )
+    subprocess.run(f"systemctl stop {_FSDB_SERVICE_OSS}", check=False, shell=True)
+    subprocess.run(f"systemctl disable {_FSDB_SERVICE_OSS}", check=False, shell=True)
+    subprocess.run("systemctl daemon-reload", check=False, shell=True)
 
     # Just wanna be safe, also use pkill in case systemctl stop gets stuck
-    subprocess.run(f"pkill -f {_FSDB_SERVICE_PROD}", shell=True)
-    subprocess.run(f"pkill -f {_FSDB_SERVICE_FOR_TESTING}", shell=True)
-    subprocess.run(f"pkill -f {_FSDB_SERVICE_OSS}", shell=True)
+    subprocess.run(f"pkill -f {_FSDB_SERVICE_PROD}", check=False, shell=True)
+    subprocess.run(f"pkill -f {_FSDB_SERVICE_FOR_TESTING}", check=False, shell=True)
+    subprocess.run(f"pkill -f {_FSDB_SERVICE_OSS}", check=False, shell=True)
 
     _cleanup_fsdb_service_rsyslog_conf()

--- a/fboss/oss/scripts/run_scripts/qsfp_service_utils.py
+++ b/fboss/oss/scripts/run_scripts/qsfp_service_utils.py
@@ -6,7 +6,6 @@ import os
 import subprocess
 import typing as t
 
-
 _DEFAULT_OSS_QSFP_SERVICE_PATH = "/opt/fboss/bin/qsfp_service"
 _DEFAULT_OSS_LOG_DIR = "/opt/fboss/logs/"
 _PLATFORM_MAPPING_OVERRIDE_PATH_ARG = "--platform_mapping_override_path"
@@ -49,12 +48,11 @@ if $programname == "{_QSFP_SERVICE_OSS}" then {_DEFAULT_OSS_LOG_DIR}/{_QSFP_SERV
 
 
 def _cleanup_qsfp_service_rsyslog_conf() -> None:
-    subprocess.run(f"rm {_QSFP_SERVICE_RSYSLOG_CONF_PATH}", shell=True)
-    subprocess.run("systemctl restart rsyslog", shell=True)
+    subprocess.run(f"rm {_QSFP_SERVICE_RSYSLOG_CONF_PATH}", check=False, shell=True)
+    subprocess.run("systemctl restart rsyslog", check=False, shell=True)
 
 
 def _setup_qsfp_service(
-    qsfp_service_bin_path: t.Optional[str] = None,
     qsfp_service_config_path: t.Optional[str] = None,
     platform_mapping_override_path: t.Optional[str] = None,
     bsp_platform_mapping_override_path: t.Optional[str] = None,
@@ -63,8 +61,7 @@ def _setup_qsfp_service(
     print(f"Setting up {_QSFP_SERVICE_OSS}")
 
     # Prepare qsfp_service binary and config file
-    if not qsfp_service_bin_path:
-        qsfp_service_bin_path = _DEFAULT_OSS_QSFP_SERVICE_PATH
+    qsfp_service_bin_path = _DEFAULT_OSS_QSFP_SERVICE_PATH
     if not os.path.exists(qsfp_service_bin_path):
         raise Exception(f"qsfp_service binary: {qsfp_service_bin_path} does not exist")
     print(f"qsfp_service binary path: {qsfp_service_bin_path}")
@@ -114,13 +111,16 @@ def _setup_qsfp_service(
     with open(_QSFP_SERVICE_RSYSLOG_CONF_PATH, "w") as f:
         f.write(_QSFP_SERVICE_RSYSLOG_CONF_CONTENT)
         f.flush()
-    subprocess.run("systemctl restart rsyslog; sleep 5", shell=True)
+    subprocess.run("systemctl restart rsyslog; sleep 5", check=False, shell=True)
 
 
 def _setup_qsfp_service_coldboot() -> None:
-    subprocess.run(f"mkdir -p {_DEFAULT_QSFP_SERVICE_VOLATIRE_DIR}", shell=True)
+    subprocess.run(
+        f"mkdir -p {_DEFAULT_QSFP_SERVICE_VOLATIRE_DIR}", check=False, shell=True
+    )
     subprocess.run(
         f"touch {_DEFAULT_QSFP_SERVICE_VOLATIRE_DIR}/{_QSFP_SERVICE_COLD_BOOT_FILE}",
+        check=False,
         shell=True,
     )
 
@@ -133,13 +133,16 @@ def _start_qsfp_service(is_warm_boot: bool = False) -> None:
     if not is_warm_boot:
         _setup_qsfp_service_coldboot()
 
-    subprocess.run(f"systemctl enable {_QSFP_SERVICE_UNIT_FILE_PATH}", shell=True)
-    subprocess.run("systemctl daemon-reload", shell=True)
-    subprocess.run(f"systemctl start {_QSFP_SERVICE_OSS}; sleep 10", shell=True)
+    subprocess.run(
+        f"systemctl enable {_QSFP_SERVICE_UNIT_FILE_PATH}", check=False, shell=True
+    )
+    subprocess.run("systemctl daemon-reload", check=False, shell=True)
+    subprocess.run(
+        f"systemctl start {_QSFP_SERVICE_OSS}; sleep 10", check=False, shell=True
+    )
 
 
 def setup_and_start_qsfp_service(
-    qsfp_service_bin_path: t.Optional[str] = None,
     qsfp_service_config_path: t.Optional[str] = None,
     platform_mapping_override_path: t.Optional[str] = None,
     bsp_platform_mapping_override_path: t.Optional[str] = None,
@@ -148,7 +151,6 @@ def setup_and_start_qsfp_service(
 ) -> None:
     # First setup qsfp_service unit file for systemd and rsyslog config for logging
     _setup_qsfp_service(
-        qsfp_service_bin_path,
         qsfp_service_config_path,
         platform_mapping_override_path,
         bsp_platform_mapping_override_path,
@@ -166,14 +168,16 @@ def cleanup_qsfp_service() -> None:
     """
     print(f"Cleaning up {_QSFP_SERVICE_OSS}")
 
-    subprocess.run(f"systemctl stop {_QSFP_SERVICE_PROD}", shell=True)
-    subprocess.run(f"systemctl stop {_QSFP_SERVICE_FOR_TESTING}", shell=True)
-    subprocess.run(f"systemctl stop {_QSFP_SERVICE_OSS}", shell=True)
-    subprocess.run(f"systemctl disable {_QSFP_SERVICE_OSS}", shell=True)
-    subprocess.run("systemctl daemon-reload", shell=True)
+    subprocess.run(f"systemctl stop {_QSFP_SERVICE_PROD}", check=False, shell=True)
+    subprocess.run(
+        f"systemctl stop {_QSFP_SERVICE_FOR_TESTING}", check=False, shell=True
+    )
+    subprocess.run(f"systemctl stop {_QSFP_SERVICE_OSS}", check=False, shell=True)
+    subprocess.run(f"systemctl disable {_QSFP_SERVICE_OSS}", check=False, shell=True)
+    subprocess.run("systemctl daemon-reload", check=False, shell=True)
     # Just wanna be safe, also use pkill in case systemctl stop gets stuck
-    subprocess.run(f"pkill -f {_QSFP_SERVICE_PROD}", shell=True)
-    subprocess.run(f"pkill -f {_QSFP_SERVICE_FOR_TESTING}", shell=True)
-    subprocess.run(f"pkill -f {_QSFP_SERVICE_OSS}", shell=True)
+    subprocess.run(f"pkill -f {_QSFP_SERVICE_PROD}", check=False, shell=True)
+    subprocess.run(f"pkill -f {_QSFP_SERVICE_FOR_TESTING}", check=False, shell=True)
+    subprocess.run(f"pkill -f {_QSFP_SERVICE_OSS}", check=False, shell=True)
 
     _cleanup_qsfp_service_rsyslog_conf()

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -669,9 +669,8 @@ class TestRunner(abc.ABC):
         if args.coldboot_only is False:
             warmboot = True
 
-        test_binary_name = self._get_test_binary_name()
-        if test_binary_name != "qsfp_hw_test" and not os.path.exists(conf_file):
-            print("########## Conf file not found: " + conf_file)
+        if conf_file and not os.path.exists(conf_file):
+            print(f"########## Required configuration file not found: {conf_file}")
             return []
 
         test_outputs = []

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -28,8 +28,10 @@ from qsfp_service_utils import cleanup_qsfp_service, setup_and_start_qsfp_servic
 # This script runs hardware tests for FBOSS. It supports multiple test types:
 # - sai_agent: SAI agent hardware tests
 # - sai: SAI hardware tests
+# - bcm: BCM hardware tests
 # - qsfp: QSFP hardware tests
 # - link: Link tests
+# - platform: Platform service hardware tests
 # - benchmark: Benchmark tests
 # - cli: CLI tests
 #
@@ -53,6 +55,9 @@ from qsfp_service_utils import cleanup_qsfp_service, setup_and_start_qsfp_servic
 # Run specific tests using filter:
 #   ./run_test.py sai --config $CONFIG --filter=HwVlanTest.VlanApplyConfig
 #   ./run_test.py sai --config $CONFIG --filter=*Route*V6*
+#
+# Run tests with multiple filters and negative filter:
+#   ./run_test.py sai --config $CONFIG --filter=*Vlan*:*Port*:-*Mac*:*Intf*
 #
 # Run tests from a filter file:
 #   ./run_test.py sai_agent --config $CONFIG --filter_file=./share/hw_sanity_tests/t0_agent_hw_tests.conf
@@ -96,8 +101,6 @@ OPT_ARG_PLATFORM_MAPPING_OVERRIDE_PATH = "--platform_mapping_override_path"
 OPT_ARG_BSP_PLATFORM_MAPPING_OVERRIDE_PATH = "--bsp_platform_mapping_override_path"
 OPT_ARG_SAI_REPLAYER_LOGGING = "--sai_replayer_logging"
 OPT_ARG_SKIP_KNOWN_BAD_TESTS = "--skip-known-bad-tests"
-OPT_ARG_OSS = "--oss"
-OPT_ARG_NO_OSS = "--no-oss"
 OPT_ARG_MGT_IF = "--mgmt-if"
 OPT_ARG_FRUID_PATH = "--fruid-path"
 OPT_ARG_SIMULATOR = "--simulator"
@@ -113,7 +116,6 @@ OPT_ARG_SETUP_WB = "--setup-for-warmboot"
 OPT_ARG_TEST_RUN_TIMEOUT = "--test-run-timeout"
 OPT_ARG_DISABLE_FSDB = "--disable-fsdb"
 OPT_ARG_FSDB_CONFIG_FILE = "--fsdb-config"
-OPT_ARG_FSDB_BIN_PATH = "--fsdb-bin-path"
 SUB_CMD_BCM = "bcm"
 SUB_CMD_SAI = "sai"
 SUB_CMD_QSFP = "qsfp"
@@ -1077,7 +1079,6 @@ class LinkTestRunner(TestRunner):
         # Start FSDB service if not disabled
         if not args.disable_fsdb:
             setup_and_start_fsdb_service(
-                fsdb_service_bin_path=args.fsdb_bin_path,
                 fsdb_service_config_path=args.fsdb_config,
                 is_warm_boot=False,
             )
@@ -1103,7 +1104,6 @@ class LinkTestRunner(TestRunner):
         # Start FSDB service if not disabled
         if not args.disable_fsdb:
             setup_and_start_fsdb_service(
-                fsdb_service_bin_path=args.fsdb_bin_path,
                 fsdb_service_config_path=args.fsdb_config,
                 is_warm_boot=True,
             )
@@ -1941,20 +1941,6 @@ if __name__ == "__main__":
     )
 
     ap.add_argument(
-        OPT_ARG_OSS,
-        action="store_true",
-        help="OSS build",
-    )
-
-    ap.add_argument(
-        OPT_ARG_NO_OSS,
-        action="store_false",
-        dest="oss",
-        help="No OSS build",
-    )
-    ap.set_defaults(oss=True)
-
-    ap.add_argument(
         OPT_ARG_FRUID_PATH,
         type=str,
         default="/var/facebook/fboss/fruid.json",
@@ -2026,14 +2012,6 @@ if __name__ == "__main__":
         ),
         default=None,
     )
-    ap.add_argument(
-        OPT_ARG_FSDB_BIN_PATH,
-        nargs="?",
-        type=str,
-        help="FBOSS FSDB binary path(absolute path).",
-        default=None,
-    )
-
     # Add subparsers for different test types
     subparsers = ap.add_subparsers()
 
@@ -2099,9 +2077,7 @@ if __name__ == "__main__":
     args = ap.parse_known_args()
     args = ap.parse_args(args[1], args[0])
 
-    if args.oss and (
-        ("FBOSS_BIN" not in os.environ) or ("FBOSS_LIB" not in os.environ)
-    ):
+    if ("FBOSS_BIN" not in os.environ) or ("FBOSS_LIB" not in os.environ):
         print("FBOSS environment not set. Run `source /opt/fboss/bin/setup_fboss_env'")
         sys.exit(0)
 

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -23,141 +23,67 @@ from fboss_agent_utils import (
 from fsdb_service_utils import cleanup_fsdb_service, setup_and_start_fsdb_service
 from qsfp_service_utils import cleanup_qsfp_service, setup_and_start_qsfp_service
 
-# Helper to run HwTests
+# FBOSS Hardware Test Runner
 #
-# RUNNING HW TESTS:
-# -----------------
+# This script runs hardware tests for FBOSS. It supports multiple test types:
+# - sai_agent: SAI agent hardware tests
+# - sai: SAI hardware tests
+# - qsfp: QSFP hardware tests
+# - link: Link tests
+# - benchmark: Benchmark tests
+# - cli: CLI tests
 #
-# Running Sanity Tests:
+# USAGE EXAMPLES:
 #
-# 1. Run Jericho2 Sanity Tests
-#    ./run_test.py sai --config meru400biu.agent.materialized_JSON --coldboot_only --filter_file=/root/jericho2_sanity_tests
+# Run all SAI agent tests:
+#   ./run_test.py sai_agent --config $CONFIG
 #
-# 2. Run Ramon Sanity Tests
-#    ./run_test.py sai --config meru400bfu.agent.materialized_JSON --coldboot_only --filter_file=/root/ramon_sanity_tests
+# Run all SAI tests:
+#   ./run_test.py sai --config $CONFIG
 #
-# Running HW Test Regression:
+# Run all QSFP tests:
+#   ./run_test.py qsfp --qsfp-config $QSFP_CONFIG
 #
-#  1. Run entire BCM SAI XGS Regression for a specific ASIC type and SDK
+# Run all link tests:
+#   ./run_test.py link --config $CONFIG --qsfp-config $QSFP_CONFIG
 #
-#   ./run_test.py sai --config $confFile --skip-known-bad-tests $test-config
-#      Example to run HW Tests on Fuji Tomahawk4 Platform with bcm-sai SDK 8.2 and skips all known bad tests
-#     ./run_test.py sai --config fuji.agent.materialized_JSON --skip-known-bad-tests "brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk4"
+# Run only coldboot tests:
+#   ./run_test.py sai --config $CONFIG --coldboot_only
 #
-#  2. Run entire SAI DNX regression for Jericho2 and SDK:
-#   ./run_test.py sai --config $confFile --coldboot_only --skip-known-bad-tests $test-config
-#      Example to run HW Tests on Meru Jericho2 Platform and runs only the known good test listed for Jericho2 asic.
-#     ./run_test.py sai --config meru400biu.agent.materialized_JSON --skip-known-bad-tests "brcm/9.0_ea_dnx_odp/9.0_ea_dnx_odp/jericho2"
+# Run specific tests using filter:
+#   ./run_test.py sai --config $CONFIG --filter=HwVlanTest.VlanApplyConfig
+#   ./run_test.py sai --config $CONFIG --filter=*Route*V6*
 #
-# Sample invocation for HW Tests:
-#
-#  1. Running all HW SAI TESTS:
-#      ./run_test.py sai --config $confFile
-#      desc: Runs ALL Hw SAI tests: coldboot and warmboot
-#
-#  2. Running all HW QSFP TESTS:
-#     ./run_test.py qsfp --qsfp-config $qsfpConfFile
-#     desc: Runs ALL Hw QSFP tests: coldboot and warmboot
-#
-#  3. Running all HW Link TESTS:
-#     ./run_test.py link --config $linkConfFile --qsfp-config $qsfpConfFile
-#     desc: Runs ALL Hw Link tests: coldboot and warmboot
-#
-#  4. Running only coldboot tests:
-#      ./run_test.py sai --config $confFile --coldboot_only
-#      desc: Runs all HW tests only on coldboot mode
-#
-#  5. Running specific tests through regex:
-#      ./run_test.py sai --config $confFile --filter=*Route*V6*
-#      desc: Runs only the HW test matching the regex *Route*V6*
-#
-#      e./run_test.py sai --config $confFile --filter=*Vlan*:*Port*
-#      desc: Run tests matching "Vlan" and "Port" filters
-#
-#  6. Running specific tests through regex and excluding certain tests:
-#      ./run_test.py sai --config $confFile --filter=*Vlan*:*Port*:-*Mac*:*Intf*
-#      desc: Run tests matching "Vlan" and "Port" filters, but excluding "Mac" and "Intf" tests in that list
-#
-#  7. Running a targeted test:
-#      ./run_test.py sai --config $confFile --filter=HwVlanTest.VlanApplyConfig
-#      desc: Runs a single test by providing the entire test name as a filter
-#
-#  8. Enable SAI Replayer Logging:
-#      ./run_test.py sai --config $confFile --filter=HwVlanTest.VlanApplyConfig --sai_replayer_logging /tmp/XYZ #
-#      desc: Enables SAI Replayer Logging for the specified test case
-#
-#      ./run_test.py sai --config $confFile --sai_replayer_logging /root/all_replayer_logs
-#      desc: Enables SAI replayer Logging for all test cases
-#
-#  9. Running a single test in coldboot mode:
-#      ./run_test.py sai --config $confFile --filter=HwVlanTest.VlanApplyConfig --coldboot_only
-#      desc: Runs a single test and performs only coldboot
-#
-#  10. Example of control plane tests:
-#      ./run_test.py sai --config $confFile --filter=HwAclQualifierTest*
-#      desc: Sample HW test by programming the hardware and validating the functionality
-#
-#  11. Example of data plane tests:
-#      ./run_test.py sai --config $confFile --filter=HwOlympicQosSchedulerTest*
-#      desc: Sample HW test by programming the hardware, creating a dataplane loop and validating functionality
-#
-#  12. List all tests in the test binary:
-#      ./run_test.py sai --config $confFile --list_tests
-#      desc: Print all the tests but do not run any test
-#
-#  13. List tests matching given regex:
-#      ./run_test.py sai --config $confFile --filter=<filter_regex> --list_tests
-#      desc: Print the matching tests but do not run any test
-#
-#  14. Skip running Known Bad Tests:
-#      ./run_test.py sai --config $confFile --skip-known-bad-tests $test-config
-#      desc: Run tests but skip running known bad tests for a specific platform
-#
-#  15. Use Custom Management Interface:
-#      ./run_test.py sai --config $confFile --filter=HwVlanTest.VlanApplyConfig --mgmt-if eth0
-#      desc: Instead of eth0, provide a custom mgmt-if
-#
-#  16. Running non-OSS Binary using run_test helper:
-#      ./run_test.py sai --config fuji.agent.materialized_JSON --filter HwVlanTest.VlanApplyConfig --sai_replayer_logging /root/skhare/sai_replayer_logs --no-oss --sai-bin /root/skhare/sai_test-brcm-8.2.0.0_odp --mgmt-if eth0
-#      desc: Runs tests but does not use OSS binary for testing
-#
-#  17. Enable more FBOSS Logging:
-#      ./run_test.py sai --config $confFile --filter=HwVlanTest.VlanApplyConfig --fboss_logging DBG5
-#      desc: Enable more FBOSS logging
-#
-#
-# TERMS & DEFINITIONS:
-# ---------------------
+# Run tests from a filter file:
+#   ./run_test.py sai_agent --config $CONFIG --filter_file=./share/hw_sanity_tests/t0_agent_hw_tests.conf
 #
 # Skip known bad tests:
-# We maintain a list of known bad tests per SDK per platform to skip running them
-# when running the entite suite of HW tests.
+#   ./run_test.py sai --config $CONFIG --skip-known-bad-tests $KEY
+#   Example: --skip-known-bad-tests "brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk4"
 #
-# For SAI HW tests, there is a consolidated JSON file under fboss.git/oss/hw_known_bad_tests/sai_known_bad_tests.materialized_JSON.
-# This file is indexed based on $test-config format - vendor/coldboot-sdk-version-from/warmboot-sdk-version-to/asic.
-# The known bad list can be provided to run_test.py as an argument --skip-known-bad-tests $testConfig
-# which can be used to skip running known bad tests for specific platforms.
-# eg: To skip running bad tests on tomahawk asic on SDK 7.2, the test-config to be used is
-# "brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk"
+# Filter by production features (sai_agent only):
+#   ./run_test.py sai_agent --config $CONFIG --enable-production-features $ASIC
 #
-# Similarly, for QSFP HW tests, there is a consolidated JSON file under fboss.git/oss/qsfp_known_bad_tests/fboss_qsfp_known_bad_tests.materialized_JSON.
-# This file is also indexed based on $test-config format - platform/coldboot-phy-sdk-version-from/warmboot-phy-sdk-version-to.
-# The known bad list can be provided to run_test.py as an argument --skip-known-bad-tests $testConfig
-# which can be used to skip running known bad tests for specific platforms.
-# eg: To skip running bad tests on meru400bfu on phy sdk version credo-0.7.2, the test-config to be used is
-# "meru400bfu/physdk-credo-0.7.2/credo-0.7.2"
+# List tests without running:
+#   ./run_test.py sai --config $CONFIG --list_tests
 #
-# Similarly, for link HW tests, there is a consolidated JSON file under fboss.git/oss/link_known_bad_tests/fboss_link_known_bad_tests.materialized_JSON.
-# This file is also indexed based on $test-config format - platform/{bcm,sai}/coldboot-asic-sdk-version-from/warmboot-asic-sdk-version-to.
-# The known bad list can be provided to run_test.py as an argument --skip-known-bad-tests $testConfig
-# which can be used to skip running known bad tests for specific platforms.
-# eg: To skip running bad tests on SAI-configured meru400bfu on asic sdk version 10.0_ea_dnx_odp, the test-config to be used is
-# "meru400bfu/sai/asicsdk-10.0_ea_dnx_odp/10.0_ea_dnx_odp"
+# Enable SAI replayer logging:
+#   ./run_test.py sai --config $CONFIG --sai_replayer_logging /tmp/logs
 #
-# (TODO):
-# SDK Logging:
-# Coldboot & Warmboot:
-# Regex
+# Enable FBOSS logging:
+#   ./run_test.py sai --config $CONFIG --fboss_logging DBG5
+#
+# KNOWN BAD TESTS AND UNSUPPORTED TESTS:
+#
+# Known bad tests and unsupported tests are maintained in JSON files indexed by test configuration key.
+# Key format: vendor/coldboot-sai/warmboot-sai/asic (e.g., "brcm/8.2.0.0_odp/8.2.0.0_odp/tomahawk4")
+#
+# File locations:
+# - SAI/SAI Agent: ./share/hw_known_bad_tests/sai_*_known_bad_tests.materialized_JSON
+#                  ./share/sai_hw_unsupported_tests/sai_hw_unsupported_tests.materialized_JSON
+# - QSFP: ./share/qsfp_known_bad_tests/fboss_qsfp_known_bad_tests.materialized_JSON
+#         ./share/qsfp_unsupported_tests/fboss_qsfp_unsupported_tests.materialized_JSON
+# - Link: ./share/link_known_bad_tests/agent_ensemble_link_known_bad_tests.materialized_JSON
 
 OPT_ARG_COLDBOOT = "--coldboot_only"
 OPT_ARG_FILTER = "--filter"
@@ -173,7 +99,6 @@ OPT_ARG_SKIP_KNOWN_BAD_TESTS = "--skip-known-bad-tests"
 OPT_ARG_OSS = "--oss"
 OPT_ARG_NO_OSS = "--no-oss"
 OPT_ARG_MGT_IF = "--mgmt-if"
-OPT_ARG_SAI_BIN = "--sai-bin"
 OPT_ARG_FRUID_PATH = "--fruid-path"
 OPT_ARG_SIMULATOR = "--simulator"
 OPT_ARG_SAI_LOGGING = "--sai_logging"
@@ -181,7 +106,6 @@ OPT_ARG_FBOSS_LOGGING = "--fboss_logging"
 OPT_ARG_PRODUCTION_FEATURES = "--production-features"
 OPT_ARG_ENABLE_PRODUCTION_FEATURES = "--enable-production-features"
 OPT_ARG_LIST_TESTS_FOR_FEATURE = "--list-tests-for-features"
-OPT_ARG_ASIC = "--asic"
 OPT_KNOWN_BAD_TESTS_FILE = "--known-bad-tests-file"
 OPT_UNSUPPORTED_TESTS_FILE = "--unsupported-tests-file"
 OPT_ARG_SETUP_CB = "--setup-for-coldboot"
@@ -203,7 +127,6 @@ SUB_ARG_AGENT_RUN_MODE_MONO = "mono"
 SUB_ARG_AGENT_RUN_MODE_MULTI = "multi_switch"
 SUB_ARG_AGENT_RUN_MODE_LEGACY = "legacy"
 SUB_ARG_NUM_NPUS = "--num-npus"
-SUB_ARG_HW_AGENT_BIN_PATH = "--hw-agent-bin-path"
 SUB_ARG_TEST_TYPE = "--type"
 SUB_ARG_PLATFORM_HW_TEST = "platform_hw_test"
 SUB_ARG_DATA_CORRAL_HW_TEST = "data_corral_service_hw_test"
@@ -212,7 +135,6 @@ SUB_ARG_FW_UTIL_HW_TEST = "fw_util_hw_test"
 SUB_ARG_SENSOR_HW_TEST = "sensor_service_hw_test"
 SUB_ARG_WEUTIL_HW_TEST = "weutil_hw_test"
 SUB_ARG_PLATFORM_MANAGER_HW_TEST = "platform_manager_hw_test"
-
 
 SAI_HW_KNOWN_BAD_TESTS = (
     "./share/hw_known_bad_tests/sai_known_bad_tests.materialized_JSON"
@@ -885,7 +807,7 @@ class BcmTestRunner(TestRunner):
         return ""
 
     def _get_test_binary_name(self):
-        return "bcm_test"
+        return "/opt/fboss/bin/bcm_test"
 
     def _get_sai_replayer_logging_flags(
         self, sai_replayer_log_path: str | None
@@ -941,7 +863,7 @@ class SaiTestRunner(TestRunner):
         return args.unsupported_tests_file
 
     def _get_test_binary_name(self):
-        return args.sai_bin if args.sai_bin else "sai_test-sai_impl"
+        return "/opt/fboss/bin/sai_test-sai_impl"
 
     def _get_sai_replayer_logging_flags(
         self, sai_replayer_log_path: str | None
@@ -991,10 +913,6 @@ class SaiTestRunner(TestRunner):
 class QsfpTestRunner(TestRunner):
     def add_subcommand_arguments(self, sub_parser: ArgumentParser):
         sub_parser.add_argument(
-            OPT_ARG_PRODUCTION_FEATURES, type=str, help="", default=None
-        )
-
-        sub_parser.add_argument(
             OPT_ARG_PLATFORM_MAPPING_OVERRIDE_PATH,
             nargs="?",
             type=str,
@@ -1022,7 +940,7 @@ class QsfpTestRunner(TestRunner):
         return QSFP_UNSUPPORTED_TESTS
 
     def _get_test_binary_name(self):
-        return "qsfp_hw_test"
+        return "/opt/fboss/bin/qsfp_hw_test"
 
     def _get_sai_replayer_logging_flags(
         self, sai_replayer_log_path: str | None
@@ -1104,13 +1022,6 @@ class LinkTestRunner(TestRunner):
             type=int,
             help="Specify number of npus to run in multi switch mode. Default is 1.",
         )
-        sub_parser.add_argument(
-            SUB_ARG_HW_AGENT_BIN_PATH,
-            nargs="?",
-            type=str,
-            help="FBOSS HW Agent binary path(absolute path).",
-            default=None,
-        )
 
     def _get_config_path(self):
         return ""
@@ -1124,14 +1035,12 @@ class LinkTestRunner(TestRunner):
         return ""
 
     def _get_test_binary_name(self):
-        if args.sai_bin:
-            return args.sai_bin
         if args.agent_run_mode == SUB_ARG_AGENT_RUN_MODE_MONO:
-            return "sai_mono_link_test-sai_impl"
+            return "/opt/fboss/bin/sai_mono_link_test-sai_impl"
         if args.agent_run_mode == SUB_ARG_AGENT_RUN_MODE_MULTI:
-            return "sai_multi_link_test-sai_impl"
+            return "/opt/fboss/bin/sai_multi_link_test-sai_impl"
         # Deprecate legacy mode when we finish testing mono mode on all platforms
-        return "sai_link_test-sai_impl"
+        return "/opt/fboss/bin/sai_link_test-sai_impl"
 
     def _get_sai_replayer_logging_flags(
         self, sai_replayer_log_path: str | None
@@ -1184,7 +1093,6 @@ class LinkTestRunner(TestRunner):
             setup_and_start_hw_agent_service(
                 switch_indexes=list(range(args.num_npus)),
                 fboss_agent_config_path=args.config,
-                hw_agent_service_bin_path=args.hw_agent_bin_path,
                 platform_mapping_override_path=args.platform_mapping_override_path,
                 sai_replayer_log_path=sai_replayer_log_path,
                 is_fsdb_disabled=args.disable_fsdb,
@@ -1210,7 +1118,6 @@ class LinkTestRunner(TestRunner):
             setup_and_start_hw_agent_service(
                 switch_indexes=list(range(args.num_npus)),
                 fboss_agent_config_path=args.config,
-                hw_agent_service_bin_path=args.hw_agent_bin_path,
                 platform_mapping_override_path=args.platform_mapping_override_path,
                 sai_replayer_log_path=sai_replayer_log_path,
                 is_fsdb_disabled=args.disable_fsdb,
@@ -1238,14 +1145,9 @@ class SaiAgentTestRunner(TestRunner):
         )
         sub_parser.add_argument(
             OPT_ARG_ENABLE_PRODUCTION_FEATURES,
-            action="store_true",
-            help="enable/disable filtering by production feature",
-            default=False,
-        )
-        sub_parser.add_argument(
-            OPT_ARG_ASIC,
             type=str,
-            help="Specify asic to filter production feature",
+            metavar="ASIC",
+            help="Enable filtering by production features for the specified ASIC",
             default=None,
         )
         sub_parser.add_argument(
@@ -1279,13 +1181,6 @@ class SaiAgentTestRunner(TestRunner):
             type=int,
             help="Specify number of npus to run in multi switch mode. Default is 1.",
         )
-        sub_parser.add_argument(
-            SUB_ARG_HW_AGENT_BIN_PATH,
-            nargs="?",
-            type=str,
-            help="FBOSS HW Agent binary path(absolute path).",
-            default=None,
-        )
 
     def _get_config_path(self):
         # TOOO Not available in OSS
@@ -1302,12 +1197,10 @@ class SaiAgentTestRunner(TestRunner):
         return args.unsupported_tests_file
 
     def _get_test_binary_name(self):
-        if args.sai_bin:
-            return args.sai_bin
         if args.agent_run_mode == SUB_ARG_AGENT_RUN_MODE_MULTI:
-            return "multi_switch_agent_hw_test"
+            return "/opt/fboss/bin/multi_switch_agent_hw_test"
         # Default is mono mode
-        return "sai_agent_hw_test-sai_impl"
+        return "/opt/fboss/bin/sai_agent_hw_test-sai_impl"
 
     def _get_sai_replayer_logging_flags(
         self, sai_replayer_log_path: str | None
@@ -1365,7 +1258,6 @@ class SaiAgentTestRunner(TestRunner):
             setup_and_start_hw_agent_service(
                 switch_indexes=list(range(args.num_npus)),
                 fboss_agent_config_path=args.config,
-                hw_agent_service_bin_path=args.hw_agent_bin_path,
                 platform_mapping_override_path=args.platform_mapping_override_path,
                 sai_replayer_log_path=sai_replayer_log_path,
                 is_warm_boot=False,
@@ -1378,7 +1270,6 @@ class SaiAgentTestRunner(TestRunner):
             setup_and_start_hw_agent_service(
                 switch_indexes=list(range(args.num_npus)),
                 fboss_agent_config_path=args.config,
-                hw_agent_service_bin_path=args.hw_agent_bin_path,
                 platform_mapping_override_path=args.platform_mapping_override_path,
                 sai_replayer_log_path=sai_replayer_log_path,
                 is_warm_boot=True,
@@ -1418,10 +1309,18 @@ class SaiAgentTestRunner(TestRunner):
 
         if not args.enable_production_features:
             return tests
-        asic = str(args.asic)
+
+        asic = str(args.enable_production_features)
         with open(args.production_features) as f:
             asic_production_features = json.load(f)
-        producition_features = set(asic_production_features["asicToFeatureNames"][asic])
+        asic_to_feature_names = asic_production_features["asicToFeatureNames"]
+
+        # Check if the specified asic exists in the production features file
+        if asic not in asic_to_feature_names:
+            print(f"Error: ASIC '{asic}' not found in production features file.")
+            sys.exit(1)
+
+        production_features = set(asic_to_feature_names.get(asic, []))
         tests_to_run = []
         for test in tests:
             cmd = [
@@ -1445,7 +1344,7 @@ class SaiAgentTestRunner(TestRunner):
                 if "HW_SWITCH" in test_features:
                     tests_to_run += (test,)
                     break
-                if test_features.issubset(producition_features):
+                if test_features.issubset(production_features):
                     tests_to_run += (test,)
                     break
         return tests_to_run
@@ -1552,6 +1451,9 @@ class PlatformServicesTestRunner(TestRunner):
         if args.type is not None:
             super().run_test(args)
             return
+
+        # Initialize test lists once at the start
+        self._initialize_test_lists(args)
 
         output = []
         start_time = datetime.now()
@@ -2037,7 +1939,6 @@ if __name__ == "__main__":
         default="eth0",
         help=("Management interface (default = eth0)"),
     )
-    ap.add_argument(OPT_ARG_SAI_BIN, type=str, help=("SAI Test binary name"))
 
     ap.add_argument(
         OPT_ARG_OSS,


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

Simplify the command-line interface for run_test.py by
removing redundant options and consolidating related functionality.

## Changes

### Removed Options
- Remove --sai-bin and --hw-agent-bin-path option (install WIP binaries in the absolute path instead)
- Remove --asic option (consolidated into --enable-production-features)

### Updated Options
- Consolidate --enable-production-features to take ASIC as argument
instead of being a boolean flag
- Update all test binaries to use absolute paths (/opt/fboss/bin/*)

### Bug Fixes
- Fix typo: producition_features -> production_features

### Documentation
- Update documentation with simplified command examples
- Add test configuration variables documentation
- Simplify T0/T1/T2 test examples in documentation

## Testing

### Integration Test Results

**Device:** fboss101
**Build ID:** 23679
**Test Suite:** 11 targeted integration tests
**Results:** ✅ **11/11 PASSED (100%)**

<details>
<summary>Click to expand full test results</summary>

```
=========================================
Starting Integration Tests for PR https://github.com/facebook/fboss/pull/408
DUT: fboss101
Results Directory: /tmp/pr408_integration_results_20260203_155518
=========================================

========================================
Test 1: Verify --enable-production-features takes ASIC argument
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py sai_agent --help 2>&1 | grep -A3 "enable-production-features"'
========================================
✓ PASSED

Output:
                             [--enable-production-features ASIC]
                             [--platform_mapping_override_path [PLATFORM_MAPPING_OVERRIDE_PATH]]
                             [--agent-run-mode [{mono,multi_switch}]]
                             [--num-npus {1,2}]
--
  --enable-production-features ASIC
                        Enable filtering by production features for the
                        specified ASIC
  --platform_mapping_override_path [PLATFORM_MAPPING_OVERRIDE_PATH]

========================================
Test 2: Test --enable-production-features with valid ASIC (tomahawk5)
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 30 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --enable-production-features tomahawk5 2>&1 | tail -10'
========================================
✓ PASSED

Output:
  VerifyPortRateTraffic/1  # GetParam() = 100000
  VerifyPortRateTraffic/2  # GetParam() = 200000
  VerifyPortRateTraffic/3  # GetParam() = 400000
test/AgentHwPtpTcProvisionTests.
  VerifyPtpTcDelayRequest/TWENTYFIVEG  # GetParam() = 25000
  VerifyPtpTcDelayRequest/FIFTYG  # GetParam() = 50000
  VerifyPtpTcDelayRequest/HUNDREDG  # GetParam() = 100000
  VerifyPtpTcDelayRequest/TWOHUNDREDG  # GetParam() = 200000
  VerifyPtpTcDelayRequest/FOURHUNDREDG  # GetParam() = 400000

========================================
Test 3: Test --enable-production-features with invalid ASIC shows error
Command: ssh fboss101 -c 'cd /opt/fboss && timeout 10 ./bin/run_test.py sai_agent --list_tests --config ./share/hw_test_configs/meru400biu.agent.materialized_JSON --enable-production-features invalid_asic_xyz 2>&1 || true' | grep "Error: ASIC"
========================================
✓ PASSED

Output:
Error: ASIC 'invalid_asic_xyz' not found in production features file.

========================================
Test 4: Verify --asic option is removed
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py sai_agent --help 2>&1' | grep -c "\-\-asic"
========================================
✓ PASSED

Output:
0

========================================
Test 5: Verify --sai-bin option is removed from global options
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py --help 2>&1' | grep -c "\-\-sai-bin"
========================================
✓ PASSED

Output:
0

========================================
Test 6: Verify --hw-agent-bin-path option is removed
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py sai_agent --help 2>&1' | grep -c "\-\-hw-agent-bin-path"
========================================
✓ PASSED

Output:
0

========================================
Test 7: Verify run_test.py references absolute paths for test binaries
Command: ssh fboss101 -c 'sudo cat /opt/fboss/bin/run_test.py | grep -c "/opt/fboss/bin/sai_test-sai_impl"'
========================================
✓ PASSED

Output:
1

========================================
Test 8: Verify typo fix: production_features (not producition_features)
Command: ssh fboss101 -c 'sudo cat /opt/fboss/bin/run_test.py' | grep -c "producition_features"
========================================
✓ PASSED

Output:
0

========================================
Test 9: Verify run_test.py has valid Python syntax
Command: ssh fboss101 -c 'sudo cp /opt/fboss/bin/run_test.py /tmp/run_test_syntax_check.py && python3 -m py_compile /tmp/run_test_syntax_check.py && echo "Syntax check passed" && sudo rm -f /tmp/run_test_syntax_check.py*'
========================================
✓ PASSED

Output:
Syntax check passed

========================================
Test 10: Verify run_test.py can be imported as module
Command: ssh fboss101 -c 'cd /opt/fboss/bin && python3 -c "import sys; sys.path.insert(0, \".\"); import run_test" && echo "Import successful"'
========================================
✓ PASSED

Output:
Import successful

========================================
Test 11: Verify --production-features option removed from qsfp subcommand
Command: ssh fboss101 -c 'cd /opt/fboss && ./bin/run_test.py qsfp --help 2>&1' | grep -c "\-\-production-features"
========================================
✓ PASSED

Output:
0

=========================================
Test Summary
=========================================
Total Tests: 11
Passed: 11
Failed: 0
=========================================
Results saved to: /tmp/pr408_integration_results_20260203_155518

All tests passed!
```

</details>