### PR TITLE
[Celestica][Ladakh800bcls] route packets to correct switch in AgentCoppTests

### DIFF
--- a/fboss/agent/MultiHwSwitchHandler.cpp
+++ b/fboss/agent/MultiHwSwitchHandler.cpp
@@ -291,15 +291,32 @@ bool MultiHwSwitchHandler::sendPacketSwitchedSync(
 }
 
 bool MultiHwSwitchHandler::sendPacketSwitchedAsync(
-    std::unique_ptr<TxPacket> pkt) noexcept {
+    std::unique_ptr<TxPacket> pkt,
+    std::optional<SwitchID> switchId) noexcept {
   CHECK_GE(hwSwitchSyncers_.size(), 1);
-  // use first available connected switch to send pkt
-  for (auto& hwSwitchHandler : hwSwitchSyncers_) {
-    if (isHwSwitchConnected(hwSwitchHandler.first)) {
-      return hwSwitchHandler.second->sendPacketSwitchedAsync(std::move(pkt));
+  if (switchId) {
+    auto iter = hwSwitchSyncers_.find(*switchId);
+    if (iter == hwSwitchSyncers_.end()) {
+      XLOG(ERR) << " hw switch syncer for switch id " << *switchId
+                << " not found";
+      return false;
     }
+    if (isHwSwitchConnected(iter->first)) {
+      return iter->second->sendPacketSwitchedAsync(std::move(pkt));
+    }
+    XLOG(WARNING) << "HwSwitch " << *switchId
+                  << " is not connected, dropping packet";
+    return false;
+  } else {
+    // use first available connected switch to send pkt
+    for (auto& hwSwitchHandler : hwSwitchSyncers_) {
+      if (isHwSwitchConnected(hwSwitchHandler.first)) {
+        return hwSwitchHandler.second->sendPacketSwitchedAsync(std::move(pkt));
+      }
+    }
+    XLOG(WARNING) << "No connected HwSwitch found, dropping packet";
+    return false;
   }
-  return false;
 }
 
 bool MultiHwSwitchHandler::sendPacketOutOfPortSyncForPktType(

--- a/fboss/agent/MultiHwSwitchHandler.h
+++ b/fboss/agent/MultiHwSwitchHandler.h
@@ -80,7 +80,9 @@ class MultiHwSwitchHandler {
 
   bool sendPacketSwitchedSync(std::unique_ptr<TxPacket> pkt) noexcept;
 
-  bool sendPacketSwitchedAsync(std::unique_ptr<TxPacket> pkt) noexcept;
+  bool sendPacketSwitchedAsync(
+      std::unique_ptr<TxPacket> pkt,
+      std::optional<SwitchID> switchId = std::nullopt) noexcept;
 
   bool transactionsSupported() const;
 

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -3325,9 +3325,12 @@ bool SwSwitch::sendPacketOutViaThriftStream(
   return true;
 }
 
-bool SwSwitch::sendPacketSwitchedAsync(std::unique_ptr<TxPacket> pkt) noexcept {
+bool SwSwitch::sendPacketSwitchedAsync(
+    std::unique_ptr<TxPacket> pkt,
+    std::optional<SwitchID> switchId) noexcept {
   pcapMgr_->packetSent(pkt.get());
-  if (!multiHwSwitchHandler_->sendPacketSwitchedAsync(std::move(pkt))) {
+  if (!multiHwSwitchHandler_->sendPacketSwitchedAsync(
+          std::move(pkt), switchId)) {
     // Just log an error for now.  There's not much the caller can do about
     // send failures--even on successful return from sendPacketSwitchedAsync()
     // the send may ultimately fail since it occurs asynchronously in the

--- a/fboss/agent/SwSwitch.h
+++ b/fboss/agent/SwSwitch.h
@@ -669,7 +669,9 @@ class SwSwitch : public HwSwitchCallback {
    * Send a packet, using switching logic to send it out the correct port(s)
    * for the specified VLAN and destination MAC.
    */
-  bool sendPacketSwitchedAsync(std::unique_ptr<TxPacket> pkt) noexcept;
+  bool sendPacketSwitchedAsync(
+      std::unique_ptr<TxPacket> pkt,
+      std::optional<SwitchID> switchId = std::nullopt) noexcept;
 
   /**
    * Send out L3 packet through HW

--- a/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
@@ -232,7 +232,8 @@ class AgentCoppTest : public AgentHwTest {
     if (outOfPort) {
       getSw()->sendPacketOutOfPortAsync(std::move(pkt), portIdsForTest()[0]);
     } else {
-      getSw()->sendPacketSwitchedAsync(std::move(pkt));
+      getSw()->sendPacketSwitchedAsync(
+          std::move(pkt), getCurrentSwitchIdForTesting());
     }
     if (expectRxPacket) {
       WITH_RETRIES({


### PR DESCRIPTION
**Pre-submission checklist**
- [✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [✓ ] `pre-commit run`
clang-format.............................................................Passed
black................................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped

# Summary
Test case AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp and AgentCoppTest/1.NdpSolicitNeighbor failed and report:
```
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp:242: Failure
Value of: frameRx.has_value()
Actual: false
Expected: true
```
# Motivation
When sending packets from the CPU, the test case always transmits via the first connected switch found. When switch 1 is specified in the command line and configured accordingly, the packets are actually sent to Switch 0, resulting in a traffic loss.

# Test Plan
## command
```
for switch in 0 1; do
  for filter in AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp AgentCoppTest/1.NdpSolicitNeighbor; do
    TS=$(date +%Y%m%d_%H%M%S)
    LD_LIBRARY_PATH=/opt/fboss/lib/ /root/gangtao/img/multi_switch_agent_hw_test \
    --gtest_filter=${filter} \
    --config /root/gangtao/cfg/link_test_config  \
    --platform_mapping_override_path /root/gangtao/cfg/ladakh800bc_platform_mapping_is_multi_npu.json-no-65 \
    --multi_npu_platform_mapping \
    --switch_id_for_testing ${switch} \
    --logging=DBG5 \
    2>&1 | tee /root/gangtao/log/case_rerun/multi_switch_agent-${TS}.log
  done
done
```
## result
```
[root@localhost case_rerun3]# grep OK *
multi_switch_agent-20260210_105243.log:[       OK ] AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp (32457 ms)
multi_switch_agent-20260210_105328.log:[       OK ] AgentCoppTest/1.NdpSolicitNeighbor (36942 ms)
multi_switch_agent-20260210_105418.log:[       OK ] AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp (32419 ms)
multi_switch_agent-20260210_105504.log:[       OK ] AgentCoppTest/1.NdpSolicitNeighbor (35515 ms)
```