### PR TITLE
[Cisco][G200 & G202x] Fix for PFC test cases

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
@@ -297,8 +297,8 @@ class AgentTrafficPfcTest : public AgentHwTest {
      */
     FLAGS_ingress_egress_buffer_pool_size = kGlobalIngressEgressBufferPoolSize;
     // Some platforms (TH4, TH5) requires same egress/ingress buffer pool sizes.
-    FLAGS_egress_buffer_pool_size = PfcBufferParams::kGlobalSharedBytes +
-        PfcBufferParams::kGlobalHeadroomBytes;
+    // Use dedicated egress pool size (256 MB) for PFC tests
+    FLAGS_egress_buffer_pool_size = PfcBufferParams::kEgressPoolSize;
     FLAGS_skip_buffer_reservation = true;
     FLAGS_qgroup_guarantee_enable = true;
   }
@@ -572,7 +572,7 @@ class AgentTrafficPfcTest : public AgentHwTest {
     pumpTraffic(
         priority,
         std::nullopt /* vlanId */,
-        std::nullopt /* queue */,
+        7 /* queue - inject to CPU queue 7 which maps to egress Queue 1 */,
         portIds,
         getDestinationIps(static_cast<int>(portIds.size())));
   }
@@ -796,7 +796,8 @@ class AgentTrafficPfcZeroGlobalHeadroomTest : public AgentTrafficPfcTest {
     AgentTrafficPfcTest::setCmdLineFlagOverrides();
     // Some platforms (TH4, TH5) requires same egress/ingress buffer pool sizes.
     // Global headroom will be 0 in this test.
-    FLAGS_egress_buffer_pool_size = PfcBufferParams::kGlobalSharedBytes;
+    // Use dedicated egress pool size (256 MB) for PFC tests
+    FLAGS_egress_buffer_pool_size = PfcBufferParams::kEgressPoolSize;
   }
 };
 

--- a/fboss/agent/test/utils/ConfigUtils.cpp
+++ b/fboss/agent/test/utils/ConfigUtils.cpp
@@ -1630,6 +1630,8 @@ void setupMultipleEgressPoolAndQueueConfigs(
     if (std::find(losslessQueueIds.begin(), losslessQueueIds.end(), qid) !=
         losslessQueueIds.end()) {
       queueCfg.bufferPoolName() = kLosslessPoolName;
+      // Use static threshold for lossless queues
+      queueCfg.sharedBytes() = mmuSizeBytes;
     } else {
       queueCfg.bufferPoolName() = kLossyPoolName;
     }

--- a/fboss/agent/test/utils/PfcTestUtils.h
+++ b/fboss/agent/test/utils/PfcTestUtils.h
@@ -17,6 +17,8 @@ struct PfcBufferParams {
   // TODO(maxgg): Change this back 85344 once CS00012382848 is fixed.
   static constexpr auto kGlobalSharedBytes{1500000};
   static constexpr auto kGlobalHeadroomBytes{5000}; // keep this small
+  // Egress pool size for PFC tests (256 MB)
+  static constexpr auto kEgressPoolSize{268435456};
 
   int globalShared{0};
   int globalHeadroom{0};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
black................................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Manual test run:
AgentTrafficPfcZeroPgHeadroomTest.verifyPfcWithZeroPgHeadRoomCfg.    -> PASS 
AgentTrafficPfcTest.verifyPfcWithDefaultCfg.  - PASS
AgentTrafficPfcTest.verifyIngressPriorityGroupWatermarks.   - PASS 
AgentTrafficPfcTest.verifyPfcWithZeroGlobalHeadRoomCfg - PASS 
AgentTrafficPfcTest.verifyBufferPoolWatermarks - PASS 
AgentTrafficPfcTest.verifyPfcWithMapChanges_0.    - PASS
AgentTrafficPfcTest.verifyPfcWithMapChanges_1.  - PASS 
HwVerifyPfcConfigInHwTest.PfcRxEnabledTxEnabled - PASS
HwVerifyPfcConfigInHwTest.PfcWatchdogProgrammingSequence - PASS

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
