### PR TITLE
[Nexthop] Install flashrom, libgpio-utils, libaio in distro image

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -113,6 +113,8 @@
         <package name="sudo"/>
         <package name="wget"/>
         <package name="vim"/>
+        <package name="flashrom"/>
+        <package name="libgpiod-utils"/>
         <package name="vi"/>
         <package name="btrfs-progs"/>
         <package name="libnl3"/>
@@ -131,6 +133,7 @@
         <package name="zstd"/>
         <package name="libusbx"/>
         <package name="dmidecode"/>
+        <package name="libaio"/>
     </packages>
 
     <packages type="bootstrap">


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Installing the following packages into the Centos 9.0 distro image:
- flashrom and libgpiod-utils needed to run fw_utils binary
- libaio needed to run fixmyfboss binary

# Test Plan
Loaded image on a device and verified the packages are installed.