### PR TITLE
[LinkTest] Fix speed change (200G->400g) test issue

### DIFF
--- a/fboss/agent/test/link_tests/AgentEnsembleLinkTest.h
+++ b/fboss/agent/test/link_tests/AgentEnsembleLinkTest.h
@@ -157,6 +157,19 @@ class AgentEnsembleLinkTest : public AgentEnsembleTest {
 
   void printProductionFeatures() const;
 
+  void updateCablePorts() {
+    cabledPorts_.clear();
+    auto swConfig = getSw()->getConfig();
+
+    for (const auto& port : *swConfig.ports()) {
+      if (!(*port.expectedLLDPValues()).empty() ||
+          !(*port.expectedNeighborReachability()).empty()) {
+        auto portID = *port.logicalID();
+        cabledPorts_.emplace_back(portID);
+      }
+    }
+  }
+
  private:
   void initializeCabledPorts();
   void logLinkDbgMessage(std::vector<PortID>& portIDs) const override;

--- a/fboss/agent/test/link_tests/AgentEnsembleSpeedChangeTest.cpp
+++ b/fboss/agent/test/link_tests/AgentEnsembleSpeedChangeTest.cpp
@@ -142,6 +142,7 @@ class AgentEnsembleSpeedChangeTest : public AgentEnsembleLinkTest {
       // updated
       applyNewConfig(newConfig);
 
+      updateCablePorts();
       EXPECT_NO_THROW(waitForAllCabledPorts(true, 60, 5s););
       createL3DataplaneFlood();
     };

--- a/fboss/agent/test/link_tests/AgentEnsembleSpeedChangeTest.cpp
+++ b/fboss/agent/test/link_tests/AgentEnsembleSpeedChangeTest.cpp
@@ -142,6 +142,8 @@ class AgentEnsembleSpeedChangeTest : public AgentEnsembleLinkTest {
       // updated
       applyNewConfig(newConfig);
 
+      // Speed change may alter the number of logical ports,
+      // so we need to refresh the cabledPorts_.
       updateCablePorts();
       EXPECT_NO_THROW(waitForAllCabledPorts(true, 60, 5s););
       createL3DataplaneFlood();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The **AgentEnsembleSpeedChangeTest.TWOHUNDREDGToFOURHUNDREDG** test case in the link test failed.

The root cause is that after the flex port configuration is applied, the variable **cablePorts_** is not updated. As a result , FBOSS attempts to access ports that have already been removed, which leads to a crash.

For example, a port is configured in 8x200G mode, with port IDs 1, 2, 3, 4, 5, 6, 7, and 8.
After performing a speed change to switch it to 2x400G mode, only port IDs 1 and 5 remain.
However, since cabledPorts_ is not updated, the system still attempts to check the non-existent ports 2, 3, 4, 6, 7, and 8.

Updating the cabledPorts_ variable after applying the new configuration resolves the issue.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

All the `pre-commit run` checks have passed.
```
[root github-rancho]# git commit -m "[LinkTest] Fix speed change (200G->400g) test issue"                          
clang-format.............................................................Passed                                   
black................................................(no files to check)Skipped                                   
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped                                   
trim trailing whitespace.................................................Passed                                   
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed                                   
ruff check...........................................(no files to check)Skipped
```

After rebuilding the sai_mono_link_test-sai_impl binary, the test result is PASSED.
```
[       OK ] AgentEnsembleSpeedChangeTest.TWOHUNDREDGToFOURHUNDREDG (99844 ms)
[----------] 1 test from AgentEnsembleSpeedChangeTest (99844 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (99844 ms total)
[  PASSED  ] 1 test.
```
Please find the complete test [log](https://github.com/user-attachments/files/25675603/200Gto400G.txt) here.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
