### PR TITLE
[Nexthop] Add other_dependency RPM build example

### DIFF
--- a/fboss-image/examples/thirdparty_build.sh
+++ b/fboss-image/examples/thirdparty_build.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Sample thirdparty build script
+
+echo "Executing --- ${BASH_SOURCE[0]} $* ----"
+
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# Perform thirdparty build here ----
+
+# Generate the artifact rpm package in dist directory
+rpmdir=$(pwd)/rpmbuild
+mkdir -p ${rpmdir}/{SOURCES,SPECS,RPMS,SRPMS,BUILD,BUILDROOT}
+
+# Create the blank spec file
+cat <<EOF >${rpmdir}/SPECS/thirdparty.spec
+Name: thirdparty-pkg
+Version: 1.0
+Release: 1
+Summary: Empty
+License: GPL
+BuildArch: noarch
+%description
+Empty
+%files
+EOF
+
+# Build the rpm
+rpmbuild -bb --define "_topdir ${rpmdir}" ${rpmdir}/SPECS/thirdparty.spec
+
+# Copy the rpm to dist directory
+mkdir -p ${SCRIPT_DIR}/dist
+cp ${rpmdir}/RPMS/noarch/thirdparty-pkg-1.0-1.noarch.rpm ${SCRIPT_DIR}/dist
+
+# Cleanup - remove the rpmbuild directory
+rm -rf ${rpmdir}
+exit 0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This example shows how to build an RPM to be used as an "other_dependency" in the manifest. It create an empty RPM which can be installed.

This also serves as a CI fixture to ensure that other_dependencies are build and installed correctly during an image build.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

This file is already referenced in from_source.json due to a merge error. See that the Distro Build GHA does not fail like in https://github.com/facebook/fboss/actions/runs/22879359535/job/66378473243?pr=991 with the error:
```
distro_cli.lib.exceptions.ComponentError: Build script not found: /home/runner/work/fboss/fboss/fboss-image/examples/thirdparty_build.sh (from manifest path: examples/thirdparty_build.sh)
```

The build will likely fail due to other missing fixes however.