### PR TITLE
[Celestica] Ladakh800bcls: Config: Modify SMB tmp432 register thresholds

### DIFF
--- a/fboss/platform/configs/ladakh800bcls/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bcls/platform_manager.json
@@ -1037,7 +1037,7 @@
               "__comment__": "Local temperature high limit for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1051,7 +1051,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1065,7 +1065,7 @@
               "__comment__": "Remote temp2 high limit setting for high byte.",
               "regOffset": 21,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1119,7 +1119,7 @@
               "__comment__": "Local temperature high limit for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1133,7 +1133,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1309,7 +1309,7 @@
               "__comment__": "Local temperature high limit for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1323,7 +1323,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1337,7 +1337,7 @@
               "__comment__": "Remote temp2 high limit setting for high byte.",
               "regOffset": 21,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1391,7 +1391,7 @@
               "__comment__": "Local temperature high limit for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1405,7 +1405,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.........................................(no files to check)Skipped
black................................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR is to modify the tmp432 sensor register thresholds on SMB.
According to Thermal team latest test result, need to update the tmp432 sensor register thresholds on SMB from 100 to 95.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

initial
```bash
[root@localhost fboss]# sensors tmp432-*
tmp432-i2c-100-4c
Adapter: i2c-25-mux (chan_id 3)
temp1:        +42.0°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +41.1°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:         +0.0°C  (low  =  +0.0°C, high = +85.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-98-4c
Adapter: i2c-25-mux (chan_id 1)
temp1:        +47.0°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +39.2°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:        +40.0°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-92-4c
Adapter: i2c-8-mux (chan_id 3)
temp1:        +40.2°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +41.9°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:         +0.0°C  (low  =  +0.0°C, high = +85.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-90-4c
Adapter: i2c-8-mux (chan_id 1)
temp1:        +46.9°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +41.2°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:        +43.1°C  (low  =  +0.0°C, high = +100.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
```
After running `platform_manager`
```bash
[root@localhost fboss]# sensors tmp432-*
tmp432-i2c-100-4c
Adapter: i2c-25-mux (chan_id 3)
temp1:        +39.5°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +40.6°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:         +0.0°C  (low  =  +0.0°C, high = +85.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-98-4c
Adapter: i2c-25-mux (chan_id 1)
temp1:        +45.9°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +39.4°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:        +40.2°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-92-4c
Adapter: i2c-8-mux (chan_id 3)
temp1:        +37.5°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +40.5°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:         +0.0°C  (low  =  +0.0°C, high = +85.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)

tmp432-i2c-90-4c
Adapter: i2c-8-mux (chan_id 1)
temp1:        +45.2°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp2:        +40.4°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
temp3:        +42.0°C  (low  =  +0.0°C, high = +95.0°C)
                       (crit = +85.0°C, hyst = +75.0°C)
```
[platform_manager.log](https://github.com/user-attachments/files/25887701/platform_manager.log)

