### PR TITLE
[Nexthop] Support legacy and non-legacy UARTs

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -29,9 +29,9 @@
             primary="true"
             installiso="true"
             bootpartition="false"
-            kernelcmdline="nomodeset console=ttyS4,57600n8 biosdevname=0 net.ifnames=0 quiet rootfstype=btrfs">
+            kernelcmdline="nomodeset console=ttyS0,57600n8 8250.nr_uarts=1 biosdevname=0 net.ifnames=0 quiet rootfstype=btrfs">
 
-            <bootloader name="grub2" console="serial" serial_line="ttyS4,57600n8"/>
+            <bootloader name="grub2" console="serial" serial_line="ttyS0,57600n8"/>
             <size unit="G">16</size>
             <oemconfig>
                 <!-- The oem-resize element should be false for a fixed-size disk -->


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The FBOSS-OSS kernel config causes the Linux kernel to reserve the first 4 ttyS numbers for legacy UARTs. Many systems these days do not use a legacy UART, but instead use some other UART type. Minipack3 is an example of one such system.

On these systems the console would end up as ttyS4, even if there are no legacy UARTs at all. However, setting ttyS4 is incompatible with other systems which detect the console UART as ttyS0.

Resolve this by setting the kernel option 8250.nr_uarts=1 which disables the legacy reservation. With this, the setting ttyS0 is compatible with the common system designs where the console is the first UART, irrespective of the UART type.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Load Distro Image onto a Minipack3 and confirm that the console still works.