### PR TITLE
[Nexthop] Add default netops user

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -44,7 +44,8 @@
         </type>
     </preferences>
     <users>
-        <user name="root" password="$1$wYJUgpM5$YNklayYndL8.nnIpR/Fze0" groups="root" home="/root"/>
+        <user name="root" password="root" pwdformat="plain" groups="root" home="/root"/>
+        <user name="netops" password="netops" pwdformat="plain" groups="netops,wheel" home="/home/netops"/>
     </users>
 
     <repository type="rpm-md" alias="CentOS9-ExtrasCommon" sourcetype="metalink">

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/etc/sudoers.d/passwordless_wheel
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/etc/sudoers.d/passwordless_wheel
@@ -1,0 +1,1 @@
+%wheel        ALL=(ALL)       NOPASSWD: ALL


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Add a non-root user as the default shared user on FBOSS Distro systems. Create it with the netops password as part of a passwordless sudoers group to give users a non-root user to use.

The root user is dealt with differently by many components in standard CentOS. This creates friction when using the root user. Further, mistakes made as the root user can have a very large blast radius. A default non-root user avoids these various small issues.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Login as netops and verify sudo access:
```
$ sudo cat /etc/sudoers
...
[netops@gold407 ~]$ ls -l /etc/sudoers
-r--r----- 1 root root 4328 Nov 18 11:09 /etc/sudoers
```