### PR TITLE
[Nexthop] Fixup Distro Image service dependencies

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/fboss_init.service
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/fboss_init.service
@@ -2,7 +2,8 @@
 [Unit]
 Description=FBOSS Initialization
 DefaultDependencies=no
-Before=platform_manager.service
+After=platform_manager.service
+Requires=platform_manager.service
 After=local-fs.target
 
 [Service]

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/platform_manager.service
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/platform_manager.service
@@ -8,7 +8,7 @@ Before=led_service.service
 Before=qsfp_service.service
 Before=fruid.service
 After=rc-local.service
-After=fboss_init.service
+Before=fboss_init.service
 Wants=local_rpm_repo.service
 Wants=fboss_init.service
 

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/qsfp_service.service
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/lib/systemd/system/qsfp_service.service
@@ -3,6 +3,8 @@
 Description=FBOSS QSFP Service
 After=platform_manager.service
 After=rc-local.service
+Wants=fboss_init.service
+After=fboss_init.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Avoid service startup succeeding through retries.

fboss_init uses weutil to produce fruid.json. weutil first requires that platform_manager is up so it can access the EEPROMs via the devmap.

Thus here we fix the dependency order and make platform_manager a hard dependency of fboss_init.

qsfp_service gets a similar treatment with fboss_init so it had fruid.json available at the first start.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

See that the services start up reliably when booting Distro Image. Without this change, the FBOSS services and agents would occasionally fail to load when the retry timing did not line up.