### PR TITLE
[Nexthop] Enable Distro Image btrfs boot

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -29,6 +29,7 @@
             primary="true"
             installiso="true"
             bootpartition="false"
+            editbootinstall="editbootinstall.sh"
             kernelcmdline="nomodeset console=ttyS0,57600n8 8250.nr_uarts=1 biosdevname=0 net.ifnames=0 quiet rootfstype=btrfs">
 
             <bootloader name="grub2" console="serial" serial_line="ttyS0,57600n8"/>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

This change was supposed to have been part of
https://github.com/facebook/fboss/pull/780 but got missed somehow.

It enables the already-added editbootinstall.sh script which modifies
the upstream CentOS Grub installer to support booting directly off
btrfs partitions instead of needing an initial non-btrfs /boot
partition.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

This has been in our produced and shared distro images for months.