### PR TITLE
[Nexthop] Support larger Distro Images with PXE boot

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -32,7 +32,7 @@
             kernelcmdline="nomodeset console=ttyS0,57600n8 8250.nr_uarts=1 biosdevname=0 net.ifnames=0 quiet rootfstype=btrfs">
 
             <bootloader name="grub2" console="serial" serial_line="ttyS0,57600n8"/>
-            <size unit="G">16</size>
+            <size unit="G">64</size>
             <oemconfig>
                 <!-- The oem-resize element should be false for a fixed-size disk -->
                 <oem-resize>true</oem-resize>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

During image construction, the PXE installer starts as a statically-sized btrfs image. All the binaries and tools must fit within the size of this minimum-size image.

Increase that size from 16G  up to 64G to support including debug FBOSS binaries.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Enable building of debug FBOSs binaries, ensure that the Distro build succeeds without seeing ESPACE errors building the PXE installer.