### PR TITLE
[Nexthop] Don't fail dnf when mirrors are unreachable

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/config.sh
@@ -434,4 +434,9 @@ if [ "$JQ_INSTALLED" = true ]; then
   dnf remove -y jq
 fi
 
+# Make all yum repos optional. The network is not available in all deployments or early in boot. The CentOS default is
+# to fail out if any RPM repo is not available, but that can cause platform_manager to fail to install the BSP RPM and
+# thus fail booting.
+sed -i 's/skip_if_unavailable=False/skip_if_unavailable=True/' /etc/dnf/dnf.conf
+
 exit 0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

During early boot or in some lab scenarios there is no external network connectivity and querying external RPM mirror will fail. By default CentOS treats this as a fatal failure and will refuse to continue dnf processing, even if the necessary packages are available in an RPM repo which can be accessed.

This is a problem because platform_manager uses dnf to install the BSP RPM which comes from the local_rpm_repo. We need this to succeed to have a usable system where platform_manager and therefore the FBOSS agents and services come up.

This change makes all RPM repos optional so a failure to connect will not cancel dnf operations. Thus platform_manager will succeed in installing the BSP RPM even when there is no external connectivity.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

This was tested as a fresh install on a dut installed in an isolated network where there is no external network access.