### PR TITLE
[Accton] Fix libraries linking error for the executable multi_switch_…

### DIFF
--- a/cmake/AgentTestAgentHwTests.cmake
+++ b/cmake/AgentTestAgentHwTests.cmake
@@ -234,6 +234,8 @@ add_executable(multi_switch_agent_hw_test
   fboss/agent/test/agent_hw_tests/MultiSwitchAgentHwTest.cpp
 )
 
+add_sai_sdk_dependencies(multi_switch_agent_hw_test)
+
 target_link_libraries(multi_switch_agent_hw_test
   -Wl,--whole-archive
   acl_test_utils


### PR DESCRIPTION
Description:
This fixes the libraries' linking issue for the executable multi_switch_agent_hw_test when linking SAI libraries.

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
pre-commit run --files cmake/AgentTestAgentHwTests.cmake
# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
When building, linking SAI libraries can succeed.
