### PR TITLE
[Accton][wedge800bact] Fix useQueueStatsForAqm flag in AgentAqmTest for non-VOQ ASICs

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
@@ -644,10 +644,14 @@ class AgentAqmTest : public AgentHwTest {
       HwPortStats beforePortStats =
           getAgentEnsemble()->getLatestPortStats(portId);
       AqmTestStats beforeAqmQueueStats{};
+      auto useQueueStatsForAqm =
+          checkSameAndGetAsic(getAgentEnsemble()->getL3Asics())
+              ->getSwitchType() == cfg::SwitchType::VOQ;
+
       extractAqmTestStats(
           beforePortStats,
           silverQueueId,
-          true /*useQueueStatsForAqm*/,
+          useQueueStatsForAqm,
           beforeAqmQueueStats);
 
       // Send traffic
@@ -667,7 +671,7 @@ class AgentAqmTest : public AgentHwTest {
         extractAqmTestStats(
             afterPortStats,
             silverQueueId,
-            true /*useQueueStatsForAqm*/,
+            useQueueStatsForAqm,
             afterAqmQueueStats);
 
         uint64_t deltaQueueEcnMarkedPackets = afterAqmQueueStats.outEcnCounter -


### PR DESCRIPTION
# Summary

Updated the `extractAqmTestStats` call to determine `useQueueStatsForAqm` dynamically based on whether the ASIC switch type is VOQ, rather than hardcoding it to `true`.

This fixes the following failure in Agent HW test cases:
- AgentAqmEcnOnlyTest.verifyPerQueueEcnMarkedStats

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
```

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
```
[       OK ] AgentAqmEcnOnlyTest.verifyPerQueueEcnMarkedStats (13412 ms)
[----------] 1 test from AgentAqmEcnOnlyTest (13412 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (13412 ms total)
[  PASSED  ] 1 test.
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
