### PR TITLE
[Accton][wedge800bact] Add PLATFORM_WEDGE800BACT to ProdConfigFactory

### DIFF
--- a/fboss/agent/hw/test/ProdConfigFactory.cpp
+++ b/fboss/agent/hw/test/ProdConfigFactory.cpp
@@ -101,7 +101,6 @@ uint16_t uplinksCountFromSwitch(PlatformType mode) {
     case PM::PLATFORM_WEDGE100:
     case PM::PLATFORM_WEDGE400C:
     case PM::PLATFORM_WEDGE800CACT:
-    case PM::PLATFORM_WEDGE800BACT:
     case PM::PLATFORM_WEDGE400:
     case PM::PLATFORM_YAMP:
     case PM::PLATFORM_MORGAN800CC:
@@ -118,6 +117,8 @@ uint16_t uplinksCountFromSwitch(PlatformType mode) {
     case PM::PLATFORM_ICETEA800BC:
     case PM::PLATFORM_MONTBLANC:
       return 4;
+    case PM::PLATFORM_WEDGE800BACT:
+      return 16;
     case PM::PLATFORM_MINIPACK3N:
     case PM::PLATFORM_YANGRA:
     case PM::PLATFORM_YANGRA2:


### PR DESCRIPTION
# Summary
PLATFORM_WEDGE800BACT (platformType 41) was missing from the test utility functions in ProdConfigFactory.cpp. This caused HwProdInvariantsFswStrictPriorityTest.verifyInvariants to throw an exception in the sai_test-sai_impl with: "provided PlatformType: 41 has not been defined for uplinksCountFromSwitch"

PLATFORM_WEDGE800BACT has 16 uplinks when operating at 800G, so we added the corresponding definition to fix the test failure.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
```


<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
```
[       OK ] HwProdInvariantsFswStrictPriorityTest.verifyInvariants (42435 ms)
[----------] 1 test from HwProdInvariantsFswStrictPriorityTest (42435 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (42435 ms total)
[  PASSED  ] 1 test.
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
