### PR TITLE
[Nexthop] Fix missing CMake dependencies found by buck_cmake_dep_checker

### DIFF
--- a/cmake/Agent.cmake
+++ b/cmake/Agent.cmake
@@ -109,8 +109,10 @@ add_library(dsfnode_utils
 
 target_link_libraries(dsfnode_utils
   agent_config_cpp2
+  agent_features
   fboss_error
   load_agent_config
+  switch_asics
   switch_config_cpp2
 )
 

--- a/cmake/AgentRib.cmake
+++ b/cmake/AgentRib.cmake
@@ -44,6 +44,7 @@ add_library(fib_updater
 )
 
 target_link_libraries(fib_updater
+  fib_helpers
   network_to_route_map
   nexthop_id_manager
   standalone_rib

--- a/cmake/AgentTestAgentHwTests.cmake
+++ b/cmake/AgentTestAgentHwTests.cmake
@@ -18,6 +18,7 @@ add_library(agent_qos_test_src
 
 target_link_libraries(agent_qos_test_src
   agent_hw_test
+  aqm_test_utils
   config_factory
   copp_test_utils
   ecmp_helper


### PR DESCRIPTION
# Summary

This commit adds missing dependencies to CMake targets to match their corresponding Buck build definitions, ensuring build consistency between the two build systems.

1. `cmake/Agent.cmake` - `dsfnode_utils` target:
   - Added: `agent_features` because the Buck target `//fboss/agent:dsfnode_utils` has exported_dep `:agent_features`. The `DsfNodeUtils.cpp` code uses `AgentFeatures` class to check feature flags.

   - Added: `switch_asics` because the Buck target has exported_dep `//fboss/agent/hw/switch_asics:switch_asics`. The code needs to query ASIC-specific capabilities for DSF node configuration.

2. `cmake/AgentRib.cmake` - `fib_updater` target:
   - Added: `fib_helpers` because the Buck target `//fboss/agent/rib:fib_updater` has exported_dep `//fboss/agent:fib_helpers`. The `FibUpdateHelpers.cpp` and `ForwardingInformationBaseUpdater.cpp` use FIB helper functions for route updates.

3. `cmake/AgentTestAgentHwTests.cmake` - `agent_qos_test_src` target:
   - Added: `aqm_test_utils` because the Buck target `//fboss/agent/test/agent_hw_tests:agent_qos_test_src` has exported_dep `//fboss/agent/test/utils:aqm_test_utils`. The QoS tests use AQM (Active Queue Management) test utilities for testing queue behavior and ECN marking.

# Test Plan

Verification: After these changes, `buck_cmake_dep_checker.py` reports "No missing dependencies found!"