### PR TITLE
Test changes for fboss neighbor scale 

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMacLearningAndNeighborResolutionTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMacLearningAndNeighborResolutionTests.cpp
@@ -555,11 +555,11 @@ class AgentNeighborResolutionOverFlowTest : public AgentNeighborResolutionTest {
     });
   }
 
+  // HwAsic::getMaxNdpTableSize() — e.g. Yuba/G202x (Tajo-based) return 512.
   uint32_t getAsicNeighborTableSize() {
-    uint32_t ndpTableSize = 0;
     auto hwAsic = checkSameAndGetAsic(getAgentEnsemble()->getL3Asics());
     CHECK(hwAsic->getMaxNdpTableSize().has_value());
-    ndpTableSize = hwAsic->getMaxNdpTableSize().value();
+    uint32_t ndpTableSize = hwAsic->getMaxNdpTableSize().value();
     CHECK(ndpTableSize > 0);
     return ndpTableSize;
   }
@@ -580,7 +580,16 @@ class AgentNeighborResolutionOverFlowTest : public AgentNeighborResolutionTest {
   }
 
  private:
-  // program neighbor entries with neighbor updater
+  // Same pattern as AgentMacLearningTests::generateMacs: MacAddressGenerator
+  // with a fixed base; get(base + 1 + i) matches startOver(base) then i+1 x
+  // getNext()
+  static folly::MacAddress macFromNeighborIndex(uint32_t i) {
+    const uint64_t kBaseHbo = folly::MacAddress("02:00:00:0a:00:00").u64HBO();
+    return utility::MacAddressGenerator().get(kBaseHbo + 1 + i);
+  }
+
+  // program neighbor entries with neighbor updater (entries from
+  // getBulkProgramCount() onward)
   template <typename AddrT>
   void programNeighborsWithNeighborUpdater(
       const PortDescriptor& port,
@@ -588,13 +597,24 @@ class AgentNeighborResolutionOverFlowTest : public AgentNeighborResolutionTest {
     for (int i = getBulkProgramCount(); i < ipAddresses.size(); i++) {
       XLOG(DBG2) << "Programming neighbor " << i << ": "
                  << ipAddresses[i].str();
-      getSw()->getNeighborUpdater()->receivedNdpMineForIntf(
-          kIntfID,
-          ipAddresses[i],
-          kNeighborMac,
-          port,
-          ICMPv6Type::ICMPV6_TYPE_NDP_NEIGHBOR_SOLICITATION,
-          0);
+      folly::MacAddress mac = macFromNeighborIndex(static_cast<uint32_t>(i));
+      if (FLAGS_intf_nbr_tables) {
+        getSw()->getNeighborUpdater()->receivedNdpMineForIntf(
+            kIntfID,
+            ipAddresses[i],
+            mac,
+            port,
+            ICMPv6Type::ICMPV6_TYPE_NDP_NEIGHBOR_SOLICITATION,
+            0);
+      } else {
+        getSw()->getNeighborUpdater()->receivedNdpMine(
+            kVlanID,
+            ipAddresses[i],
+            mac,
+            port,
+            ICMPv6Type::ICMPV6_TYPE_NDP_NEIGHBOR_SOLICITATION,
+            0);
+      }
 
       // wait for neighbor update to complete before enqueuing next neighbor
       // update
@@ -621,9 +641,9 @@ class AgentNeighborResolutionOverFlowTest : public AgentNeighborResolutionTest {
       std::optional<cfg::AclLookupClass> lookupClass = std::nullopt) {
     auto state = in->clone();
     CHECK_LE(startIndex + count, ipAddressesV6.size());
-    for (int i = startIndex; i < startIndex + count; i++) {
+    for (uint32_t i = startIndex; i < startIndex + count; i++) {
       state = updateNeighborEntry<AddrT>(
-          state, port, ipAddressesV6[i], kNeighborMac, lookupClass);
+          state, port, ipAddressesV6[i], macFromNeighborIndex(i), lookupClass);
     }
     return state;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
In the fboss test logs there are 1024 SAI_API_CREATE::create_neighbor_entry calls, all successful (no OOR).
They create all 1024 neighbors with same dst MAC (logged as 02:03:04:05:06:07).

Why no OOR

The SDK’s get_next_hop_host() reuses one nexthop host for all neighbors with the same MAC.
So it allocates one GID per unique MAC (one host nexthop per MAC).
Creating 1024 neighbors all with the same destination MAC uses only one host nexthop (one GID).

The limit is applied to number of host nexthops (GIDs), not number of neighbor entries, so the 1024th create still succeeds and we never see OOR.

With the changes in PR: 512 neighbors were created and programmed in hardware. The 513th and 514th add attempts hit OOR and did not create new entries.

Different MAC per neighbor

SAI: create_neighbor_entry shows DST_MAC increasing by index, e.g.
1::2 → 02:00:00:00:00:00, 1::3 → 02:00:00:00:00:01, 1::4 → 02:00:00:00:00:02, … up to 02:00:00:00:01:ff for the last successful one.
SDK: add_ipv6_host shows mac_addr= (flat=0x20000000000), 0x20000000001, 0x20000000002, … (same pattern: one MAC per IP).
So all created neighbors use unique MACs (one IP host / GID per neighbor).

Results: the 513th (1::204) and 514th (1::205) attempts hit IP_HOSTS OOR; the test sees the OOR via getNeighborTableUpdateFailure() = 1 and passes.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Manually verified the neighbor test - 
AgentNeighborResolutionOverFlowTest.neighborResolutionOverFlow
<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
