### PR TITLE
[Nexthop][fboss2-dev] Add test to cover default constructor of ConfigSession (#526)

### DIFF
--- a/fboss/agent/AgentDirectoryUtil.cpp
+++ b/fboss/agent/AgentDirectoryUtil.cpp
@@ -54,13 +54,26 @@ DEFINE_string(
 using namespace std;
 
 namespace {
-static auto constexpr kPkgDir =
-    "/etc/packages/neteng-fboss-wedge_agent/current";
-static auto constexpr kSystemdDir = "/etc/systemd/system";
-static auto constexpr kCoopAgentDir = "/etc/coop/agent";
-static auto constexpr kCoopAgentDrainDir = "/etc/coop/agent_drain";
-static auto constexpr kSwAgentService = "fboss_sw_agent.service";
-static auto constexpr kHwAgentService = "fboss_hw_agent@.service";
+auto constexpr kPkgDir = "/etc/packages/neteng-fboss-wedge_agent/current";
+auto constexpr kSystemdDir = "/etc/systemd/system";
+auto constexpr kCoopAgentDir = "/etc/coop/agent";
+auto constexpr kCoopAgentDrainDir = "/etc/coop/agent_drain";
+auto constexpr kSwAgentService = "fboss_sw_agent.service";
+auto constexpr kHwAgentService = "fboss_hw_agent@.service";
+
+// Helper function to get base config directory with environment variable
+// override This allows tests to redirect config paths to temporary directories
+// by setting FBOSS_CONFIG_BASE_DIR environment variable. If not set, defaults
+// to "/etc/coop"
+std::string getBaseConfigDir() {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): Used only during initialization
+  const char* envOverride = std::getenv("FBOSS_CONFIG_BASE_DIR");
+  if (envOverride != nullptr && !std::string(envOverride).empty()) {
+    return {envOverride};
+  }
+  return "/etc/coop";
+}
+
 } // namespace
 
 namespace facebook::fboss {
@@ -73,8 +86,8 @@ AgentDirectoryUtil::AgentDirectoryUtil(
           persistentStateDir,
           kPkgDir, // packageDirectory_
           kSystemdDir, // systemdDirectory_
-          kCoopAgentDir, // configDirectory_
-          kCoopAgentDrainDir // drainConfigDirectory_
+          getBaseConfigDir() + "/agent", // configDirectory_
+          getBaseConfigDir() + "/agent_drain" // drainConfigDirectory_
       ) {}
 
 AgentDirectoryUtil::AgentDirectoryUtil()

--- a/fboss/agent/AgentDirectoryUtil.cpp
+++ b/fboss/agent/AgentDirectoryUtil.cpp
@@ -53,29 +53,6 @@ DEFINE_string(
 
 using namespace std;
 
-namespace {
-auto constexpr kPkgDir = "/etc/packages/neteng-fboss-wedge_agent/current";
-auto constexpr kSystemdDir = "/etc/systemd/system";
-auto constexpr kCoopAgentDir = "/etc/coop/agent";
-auto constexpr kCoopAgentDrainDir = "/etc/coop/agent_drain";
-auto constexpr kSwAgentService = "fboss_sw_agent.service";
-auto constexpr kHwAgentService = "fboss_hw_agent@.service";
-
-// Helper function to get base config directory with environment variable
-// override This allows tests to redirect config paths to temporary directories
-// by setting FBOSS_CONFIG_BASE_DIR environment variable. If not set, defaults
-// to "/etc/coop"
-std::string getBaseConfigDir() {
-  // NOLINTNEXTLINE(concurrency-mt-unsafe): Used only during initialization
-  const char* envOverride = std::getenv("FBOSS_CONFIG_BASE_DIR");
-  if (envOverride != nullptr && !std::string(envOverride).empty()) {
-    return {envOverride};
-  }
-  return "/etc/coop";
-}
-
-} // namespace
-
 namespace facebook::fboss {
 
 AgentDirectoryUtil::AgentDirectoryUtil(
@@ -86,8 +63,8 @@ AgentDirectoryUtil::AgentDirectoryUtil(
           persistentStateDir,
           kPkgDir, // packageDirectory_
           kSystemdDir, // systemdDirectory_
-          getBaseConfigDir() + "/agent", // configDirectory_
-          getBaseConfigDir() + "/agent_drain" // drainConfigDirectory_
+          kCoopAgentDir, // configDirectory_
+          kCoopAgentDrainDir // drainConfigDirectory_
       ) {}
 
 AgentDirectoryUtil::AgentDirectoryUtil()

--- a/fboss/agent/AgentDirectoryUtil.h
+++ b/fboss/agent/AgentDirectoryUtil.h
@@ -23,6 +23,18 @@ DECLARE_string(volatile_state_dir_phy);
 DECLARE_string(persistent_state_dir_phy);
 
 namespace facebook::fboss {
+
+// Directory path constants
+inline constexpr auto kPkgDir =
+    "/etc/packages/neteng-fboss-wedge_agent/current";
+inline constexpr auto kSystemdDir = "/etc/systemd/system";
+inline constexpr auto kCoopAgentDir = "/etc/coop/agent";
+inline constexpr auto kCoopAgentDrainDir = "/etc/coop/agent_drain";
+
+// Service name constants
+inline constexpr auto kSwAgentService = "fboss_sw_agent.service";
+inline constexpr auto kHwAgentService = "fboss_hw_agent@.service";
+
 class AgentDirectoryUtil {
  public:
   AgentDirectoryUtil();

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -126,6 +126,19 @@ std::string getHomeDirectory() {
   return std::string(home);
 }
 
+// Helper function to get base config directory with environment variable
+// override. This allows tests to redirect config paths to temporary directories
+// by setting FBOSS_CONFIG_BASE_DIR environment variable. If not set, defaults
+// to "/etc/coop"
+std::string getBaseConfigDir() {
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): Used only during initialization
+  const char* envOverride = std::getenv("FBOSS_CONFIG_BASE_DIR");
+  if (envOverride != nullptr && !std::string(envOverride).empty()) {
+    return {envOverride};
+  }
+  return "/etc/coop";
+}
+
 void ensureDirectoryExists(const std::string& dirPath) {
   std::error_code ec;
   fs::create_directories(dirPath, ec);
@@ -284,10 +297,19 @@ ConfigSession::ConfigSession() {
   username_ = getUsername();
   std::string homeDir = getHomeDirectory();
 
-  // Use AgentDirectoryUtil to get the config directory path
-  // getConfigDirectory() returns /etc/coop/agent, so we get the parent to get
-  // /etc/coop
-  AgentDirectoryUtil dirUtil;
+  // Create AgentDirectoryUtil with environment-aware config directory
+  // This allows tests to override config paths via FBOSS_CONFIG_BASE_DIR
+  std::string baseConfigDir = getBaseConfigDir();
+  AgentDirectoryUtil dirUtil(
+      FLAGS_volatile_state_dir,
+      FLAGS_persistent_state_dir,
+      kPkgDir,
+      kSystemdDir,
+      getBaseConfigDir() + "/agent", // configDirectory_
+      getBaseConfigDir() + "/agent_drain"); // drainConfigDirectory_
+
+  // getConfigDirectory() returns /etc/coop/agent (or override), get parent to
+  // get /etc/coop
   std::string coopDir =
       fs::path(dirUtil.getConfigDirectory()).parent_path().string();
 

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
@@ -775,6 +775,44 @@ TEST_F(ConfigSessionTestFixture, commandTrackingBasic) {
       json["commands"][0].asString());
 }
 
+TEST_F(ConfigSessionTestFixture, defaultConstructorWithEnvOverride) {
+  // Test that the default constructor works with FBOSS_CONFIG_BASE_DIR
+  // environment variable override
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  fs::path sessionConfig = sessionDir / "agent.conf";
+  fs::path cliConfigPath = getTestEtcDir() / "coop" / "cli" / "agent.conf";
+
+  // Set environment variable to redirect config base directory
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): Test code, single-threaded
+  setenv("FBOSS_CONFIG_BASE_DIR", (getTestEtcDir() / "coop").c_str(), 1);
+
+  // Reset singleton to force re-initialization
+  TestableConfigSession::setInstance(nullptr);
+
+  // Now getInstance() will use the default constructor with test paths!
+  auto& session = ConfigSession::getInstance();
+
+  // Verify session was created successfully
+  EXPECT_TRUE(session.sessionExists());
+  EXPECT_TRUE(fs::exists(sessionDir));
+  EXPECT_TRUE(fs::exists(sessionConfig));
+
+  // Verify the system config path uses the overridden base directory
+  EXPECT_EQ(
+      session.getSystemConfigPath(),
+      (getTestEtcDir() / "coop" / "agent.conf").string());
+
+  // Verify content was copied correctly
+  std::string systemContent = readFile(cliConfigPath);
+  std::string sessionContent = readFile(sessionConfig);
+  EXPECT_EQ(systemContent, sessionContent);
+
+  // Cleanup
+  // NOLINTNEXTLINE(concurrency-mt-unsafe): Test code, single-threaded
+  unsetenv("FBOSS_CONFIG_BASE_DIR");
+  TestableConfigSession::setInstance(nullptr);
+}
+
 TEST_F(ConfigSessionTestFixture, commandTrackingMultipleCommands) {
   fs::path sessionDir = getTestHomeDir() / ".fboss2";
 


### PR DESCRIPTION
# Summary
There was no way to test the default constructor of ConfigSession in UT. The change is made to extend the coverge.
Implemented environment variable override (`FBOSS_CONFIG_BASE_DIR`) for `AgentDirectoryUtil` to enable testing of `ConfigSession` default constructor.

## Changes Made

### 1. AgentDirectoryUtil.cpp

Added a helper function `getBaseConfigDir()` that checks for the `FBOSS_CONFIG_BASE_DIR` environment variable:

### 2. CmdConfigSessionTest.cpp

Added test `defaultConstructorWithEnvOverride` that:
- Sets `FBOSS_CONFIG_BASE_DIR` to a test directory
- Calls `ConfigSession::getInstance()` which uses the default constructor
- Verifies the session is created with the test paths
- Confirms the default constructor is now fully testable

## Benefits

✅ **Backward Compatible**: Production code unchanged - defaults to `/etc/coop` if env var not set
✅ **Test-Friendly**: Tests can now use the default constructor by setting `FBOSS_CONFIG_BASE_DIR`
✅ **No API Changes**: Existing code continues to work without modifications
✅ **Follows Existing Patterns**: Similar to `FLAGS_volatile_state_dir` and `FLAGS_persistent_state_dir`


## Production Behavior

In production, `FBOSS_CONFIG_BASE_DIR` is not set, so the default `/etc/coop` path is used. No changes to production deployment or configuration required.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

# Test Plan
The change is primarily to extend testing.
