### PR TITLE
[arista] Sync rma_showtech.json configs for Arista platforms

### DIFF
--- a/fboss/platform/configs/darwin48v/rma_showtech.json
+++ b/fboss/platform/configs/darwin48v/rma_showtech.json
@@ -70,14 +70,7 @@
       ]
     }
   ],
-  "pems": [
-    {
-      "name": "PEM1",
-      "presenceSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_present",
-      "statusSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_status",
-      "inputOkSysfsPath": "/run/devmap/fpgas/SCD_FPGA/pem_input_ok"
-    }
-  ],
+  "pems": [],
   "fanspinners": [
     {
       "path": "/run/devmap/sensors/FS_FAN_SLG4F4527",

--- a/fboss/platform/configs/meru800bfa/rma_showtech.json
+++ b/fboss/platform/configs/meru800bfa/rma_showtech.json
@@ -3,20 +3,20 @@
     "SMBus iSMT adapter at 914c1000"
   ],
   "i2cDumpDevices": [
-    "/run/devmap/cplds/MERU800BFA_SMB_CPLD",
     "/run/devmap/cplds/FAN0_CPLD",
     "/run/devmap/cplds/FAN1_CPLD",
     "/run/devmap/cplds/FAN2_CPLD",
-    "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE",
-    "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0",
-    "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1",
-    "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE",
-    "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0",
-    "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1",
+    "/run/devmap/cplds/MERU800BFA_SMB_CPLD",
+    "/run/devmap/sensors/SMB_ISL68226_OSFP_BL",
+    "/run/devmap/sensors/SMB_ISL68226_OSFP_BR",
     "/run/devmap/sensors/SMB_ISL68226_OSFP_TL",
     "/run/devmap/sensors/SMB_ISL68226_OSFP_TR",
-    "/run/devmap/sensors/SMB_ISL68226_OSFP_BL",
-    "/run/devmap/sensors/SMB_ISL68226_OSFP_BR"
+    "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG0",
+    "/run/devmap/sensors/SMB_ISL68226_R3R0_ANLG1",
+    "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG0",
+    "/run/devmap/sensors/SMB_ISL68226_R3R1_ANLG1",
+    "/run/devmap/sensors/SMB_RAA228926_R3R0_CORE",
+    "/run/devmap/sensors/SMB_RAA228926_R3R1_CORE"
   ],
   "psus": [
     "/run/devmap/sensors/PSU1_PMBUS",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Sync `rma_showtech.json` configs for Arista platforms:
 - darwin48v: PEM is not relevant
 - meru800bfa: re-ording of fields only due to our internal config generator

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

showtech regression testing internally at Arista

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
