### PR TITLE
[Cisco][G200/G202x] Device watermark test fixes for G200/G202x

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
@@ -158,8 +158,9 @@ class AgentWatermarkTest : public AgentHwTest {
 
   uint64_t getMinDeviceWatermarkValue(SwitchID switchId) {
     uint64_t minDeviceWatermarkBytes{0};
-    if (getSw()->getHwAsicTable()->getHwAsic(switchId)->getAsicType() ==
-        cfg::AsicType::ASIC_TYPE_EBRO) {
+    const auto asicType =
+        getSw()->getHwAsicTable()->getHwAsic(switchId)->getAsicType();
+    if (asicType == cfg::AsicType::ASIC_TYPE_EBRO) {
       /*
        * Ebro will always have some internal buffer utilization even
        * when there is no traffic in the ASIC. The recommendation is
@@ -168,38 +169,74 @@ class AgentWatermarkTest : public AgentHwTest {
        */
       constexpr auto kEbroMinDeviceWatermarkBytes = 38400;
       minDeviceWatermarkBytes = kEbroMinDeviceWatermarkBytes;
+    } else if (
+        asicType == cfg::AsicType::ASIC_TYPE_G202X ||
+        asicType == cfg::AsicType::ASIC_TYPE_YUBA) {
+      /*
+       * GR2 / Yuba / SAI: ingress buffer pool high-watermark may not read back
+       * as exactly zero after traffic stops; allow residual up to 173 KiB for
+       * the "idle" phase of the test.
+       */
+      constexpr auto kResidualDeviceWatermarkBytes = 173 * 1024;
+      minDeviceWatermarkBytes = kResidualDeviceWatermarkBytes;
     }
     return minDeviceWatermarkBytes;
   }
 
   bool gotExpectedDeviceWatermark(bool expectZero, SwitchID switchId) {
-    XLOG(DBG0) << "Expect zero watermark: " << std::boolalpha << expectZero;
+    static constexpr char kFb303DeviceWatermarkCtr[] =
+        "buffer_watermark_device.p100.60";
+    XLOG(DBG0) << "Expect zero watermark: " << std::boolalpha << expectZero
+               << " switchId=" << switchId;
     bool watermarkAsExpected = false;
+    uint64_t lastDeviceWatermarkBytes{0};
+    bool sawSwitchWatermarkStats{false};
+    bool fb303DeviceCtrPresent{false};
+    const auto asicType =
+        getSw()->getHwAsicTable()->getHwAsic(switchId)->getAsicType();
+    const bool skipFb303DeviceWatermarkCtr =
+        asicType == cfg::AsicType::ASIC_TYPE_G202X ||
+        asicType == cfg::AsicType::ASIC_TYPE_YUBA ||
+        asicType == cfg::AsicType::ASIC_TYPE_EBRO;
     WITH_RETRIES({
       auto switchWatermarkStats = getAllSwitchWatermarkStats();
       if (!switchWatermarkStats.contains(switchId)) {
         continue;
       }
+      sawSwitchWatermarkStats = true;
       auto deviceWatermarkBytes =
           *switchWatermarkStats.at(switchId).deviceWatermarkBytes();
+      lastDeviceWatermarkBytes = deviceWatermarkBytes;
       XLOG(DBG0) << "Device watermark bytes: " << deviceWatermarkBytes;
+      const auto minWatermarkBytes = getMinDeviceWatermarkValue(switchId);
       watermarkAsExpected |=
-          (expectZero &&
-           (deviceWatermarkBytes <= getMinDeviceWatermarkValue(switchId))) ||
-          (!expectZero &&
-           (deviceWatermarkBytes > getMinDeviceWatermarkValue(switchId)));
+          (expectZero && (deviceWatermarkBytes <= minWatermarkBytes)) ||
+          (!expectZero && (deviceWatermarkBytes > minWatermarkBytes));
       EXPECT_EVENTUALLY_TRUE(watermarkAsExpected);
-      if (!FLAGS_multi_switch) {
+      if (!FLAGS_multi_switch && !skipFb303DeviceWatermarkCtr) {
         auto allCtrs = facebook::fb303::fbData->getCounters();
-        auto ctr = allCtrs.find("buffer_watermark_device.p100.60");
+        auto ctr = allCtrs.find(kFb303DeviceWatermarkCtr);
         // We cant look for the exact value of the watermark counter,
         // but make sure the device watermark counter is available.
+        fb303DeviceCtrPresent = (ctr != allCtrs.end());
         EXPECT_EVENTUALLY_TRUE(ctr != allCtrs.end());
-        XLOG(DBG0) << ctr->first << " : " << ctr->second;
+        if (ctr != allCtrs.end()) {
+          XLOG(DBG0) << ctr->first << " : " << ctr->second;
+        }
       }
     });
     if (!watermarkAsExpected) {
-      XLOG(DBG2) << "Did not get expected device watermark value";
+      XLOG(DBG2) << "Device watermark bytes check failed: switchId=" << switchId
+                 << " expectZero=" << std::boolalpha << expectZero
+                 << " minWatermarkBytes="
+                 << getMinDeviceWatermarkValue(switchId)
+                 << " lastDeviceWatermarkBytes=" << lastDeviceWatermarkBytes
+                 << " sawSwitchWatermarkStats=" << std::boolalpha
+                 << sawSwitchWatermarkStats;
+      if (!FLAGS_multi_switch && !skipFb303DeviceWatermarkCtr) {
+        XLOG(DBG2) << "fb303 counter '" << kFb303DeviceWatermarkCtr
+                   << "' present=" << std::boolalpha << fb303DeviceCtrPresent;
+      }
     }
     return watermarkAsExpected;
   }
@@ -236,8 +273,11 @@ class AgentWatermarkTest : public AgentHwTest {
 
     if (!statsConditionMet) {
       auto expectation = expectZero ? "zero" : "non-zero";
-      XLOG(DBG2) << " Did not get expected " << expectation
-                 << " watermark value!";
+      XLOG(ERR) << "Queue watermark check failed: port=" << portName
+                << " queueId=" << queueId << " isVoq=" << std::boolalpha
+                << isVoq << " expectZero=" << expectZero << " expected "
+                << expectation
+                << " queueWatermarkBytes=" << queueWaterMarks[queueId];
     } else {
       XLOG(DBG2) << "Port: " << portName << queueTypeStr << queueId
                  << " got expected queue watermarks of "


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

1. G200/G202x/Q200 supports SAI_BUFFER_POOL_STAT_WATERMARK_BYTES. The test validates this after sending traffic.
2. After the port flap, it is expected to have a min buffer and hence add a minimum buffer value for G200/G202x. Q200 already had a check with min buffer value. 
3. Exclude counter check for buffer_watermark_device.p100.60 that is not applicable for G200/G202x/Q200.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
Verified running the test manually - AgentWatermarkTest.VerifyDeviceWatermark