### PR TITLE
[PlatformManager] pmUnitVersion support for versionedPmUnitConfigs

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1417,9 +1417,22 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
   }
 
   for (const auto& versionedPmUnitConfig : versionedPmUnitConfigs) {
-    if (*versionedPmUnitConfig.productSubVersion() < 0) {
+    if (const auto& pmUv = versionedPmUnitConfig.pmUnitVersion(); pmUv &&
+        (*pmUv->productionState() < 0 || *pmUv->productionSubState() < 0 ||
+         *pmUv->respinVariantIndicator() < 0)) {
       XLOG(ERR) << fmt::format(
-          "One of PmUnit {}'s VersionedPmUnitConfig has a negative ProductSubVersion",
+          "PmUnit {}'s VersionedPmUnitConfig has invalid pmUnitVersion "
+          "{}.{}.{}: all fields must be >= 0",
+          pmUnitName,
+          *pmUv->productionState(),
+          *pmUv->productionSubState(),
+          *pmUv->respinVariantIndicator());
+      return false;
+    } else if (
+        versionedPmUnitConfig.respinVariantIndicator() &&
+        *versionedPmUnitConfig.respinVariantIndicator() < 0) {
+      XLOG(ERR) << fmt::format(
+          "One of PmUnit {}'s VersionedPmUnitConfig has a negative respinVariantIndicator",
           pmUnitName);
       return false;
     }

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1426,9 +1426,9 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
               "PmUnit {}'s VersionedPmUnitConfig has invalid pmUnitVersion "
               "{}.{}.{}: all fields must be >= 0",
               pmUnitName,
-              *pmUv->productionState(),
-              *pmUv->productionSubState(),
-              *pmUv->respinVariantIndicator());
+              *pmUv.productionState(),
+              *pmUv.productionSubState(),
+              *pmUv.respinVariantIndicator());
           return false;
         }
       }

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1433,10 +1433,10 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
         }
       }
     } else if (
-        versionedPmUnitConfig.respinVariantIndicator() &&
-        *versionedPmUnitConfig.respinVariantIndicator() < 0) {
+        versionedPmUnitConfig.productSubVersion() &&
+        *versionedPmUnitConfig.productSubVersion() < 0) {
       XLOG(ERR) << fmt::format(
-          "One of PmUnit {}'s VersionedPmUnitConfig has a negative respinVariantIndicator",
+          "One of PmUnit {}'s VersionedPmUnitConfig has a negative productSubVersion",
           pmUnitName);
       return false;
     }

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1417,17 +1417,21 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
   }
 
   for (const auto& versionedPmUnitConfig : versionedPmUnitConfigs) {
-    if (const auto& pmUv = versionedPmUnitConfig.pmUnitVersion(); pmUv &&
-        (*pmUv->productionState() < 0 || *pmUv->productionSubState() < 0 ||
-         *pmUv->respinVariantIndicator() < 0)) {
-      XLOG(ERR) << fmt::format(
-          "PmUnit {}'s VersionedPmUnitConfig has invalid pmUnitVersion "
-          "{}.{}.{}: all fields must be >= 0",
-          pmUnitName,
-          *pmUv->productionState(),
-          *pmUv->productionSubState(),
-          *pmUv->respinVariantIndicator());
-      return false;
+    if (const auto& pmUvs = versionedPmUnitConfig.pmUnitVersions();
+        pmUvs && !pmUvs->empty()) {
+      for (const auto& pmUv : *pmUvs) {
+        if (*pmUv.productionState() < 0 || *pmUv.productionSubState() < 0 ||
+            *pmUv.respinVariantIndicator() < 0) {
+          XLOG(ERR) << fmt::format(
+              "PmUnit {}'s VersionedPmUnitConfig has invalid pmUnitVersion "
+              "{}.{}.{}: all fields must be >= 0",
+              pmUnitName,
+              *pmUv->productionState(),
+              *pmUv->productionSubState(),
+              *pmUv->respinVariantIndicator());
+          return false;
+        }
+      }
     } else if (
         versionedPmUnitConfig.respinVariantIndicator() &&
         *versionedPmUnitConfig.respinVariantIndicator() < 0) {

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1436,7 +1436,7 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
         versionedPmUnitConfig.productSubVersion() &&
         *versionedPmUnitConfig.productSubVersion() < 0) {
       XLOG(ERR) << fmt::format(
-          "One of PmUnit {}'s VersionedPmUnitConfig has a negative productSubVersion",
+          "One of PmUnit {}'s VersionedPmUnitConfig has a negative ProductSubVersion",
           pmUnitName);
       return false;
     }

--- a/fboss/platform/platform_manager/DataStore.cpp
+++ b/fboss/platform/platform_manager/DataStore.cpp
@@ -166,12 +166,18 @@ PmUnitConfig DataStore::resolvePmUnitConfig(const std::string& slotPath) const {
   if (platformConfig_.versionedPmUnitConfigs()->contains(pmUnitName)) {
     for (const auto& versionedPmUnitConfig :
          platformConfig_.versionedPmUnitConfigs()->at(pmUnitName)) {
-      bool matches;
-      if (const auto& pmUv = versionedPmUnitConfig.pmUnitVersion(); pmUv) {
-        matches = *pmUv->productionState() ==
-                *version->productionState() &&
-            *pmUv->productionSubState() == *version->productionSubState() &&
-            *pmUv->respinVariantIndicator() == *version->respinVariantIndicator();
+      bool matches = false;
+      if (const auto& pmUvs = versionedPmUnitConfig.pmUnitVersions();
+          pmUvs && !pmUvs->empty()) {
+        for (const auto& pmUv : *pmUvs) {
+          if (*pmUv.productionState() == *version->productionState() &&
+              *pmUv.productionSubState() == *version->productionSubState() &&
+              *pmUv.respinVariantIndicator() ==
+                  *version->respinVariantIndicator()) {
+            matches = true;
+            break;
+          }
+        }
       } else {
         matches = versionedPmUnitConfig.respinVariantIndicator() &&
             *versionedPmUnitConfig.respinVariantIndicator() ==

--- a/fboss/platform/platform_manager/DataStore.cpp
+++ b/fboss/platform/platform_manager/DataStore.cpp
@@ -163,27 +163,40 @@ PmUnitConfig DataStore::resolvePmUnitConfig(const std::string& slotPath) const {
         pmUnitName);
     return platformConfig_.pmUnitConfigs()->at(pmUnitName);
   }
-  auto respinVariantIndicator = *version->respinVariantIndicator();
   if (platformConfig_.versionedPmUnitConfigs()->contains(pmUnitName)) {
     for (const auto& versionedPmUnitConfig :
          platformConfig_.versionedPmUnitConfigs()->at(pmUnitName)) {
-      if (*versionedPmUnitConfig.productSubVersion() ==
-          respinVariantIndicator) {
+      bool matches;
+      if (const auto& pmUv = versionedPmUnitConfig.pmUnitVersion(); pmUv) {
+        matches = *pmUv->productionState() ==
+                *version->productionState() &&
+            *pmUv->productionSubState() == *version->productionSubState() &&
+            *pmUv->respinVariantIndicator() == *version->respinVariantIndicator();
+      } else {
+        matches = versionedPmUnitConfig.respinVariantIndicator() &&
+            *versionedPmUnitConfig.respinVariantIndicator() ==
+                *version->respinVariantIndicator();
+      }
+      if (matches) {
         XLOG(INFO) << fmt::format(
-            "Resolved {} to PmUnitConfig of {} with RespinVariantIndicator {}",
+            "Resolved {} to versioned PmUnitConfig of {} with version {}.{}.{}",
             slotPath,
             pmUnitName,
-            respinVariantIndicator);
+            *version->productionState(),
+            *version->productionSubState(),
+            *version->respinVariantIndicator());
         return *versionedPmUnitConfig.pmUnitConfig();
       }
     }
   }
   XLOG(INFO) << fmt::format(
-      "Resolved {} to default PmUnitConfig of {}. No versioned config for "
-      "RespinVariantIndicator {}",
+      "Resolved {} to default PmUnitConfig of {}. No versioned config matches "
+      "version {}.{}.{}",
       slotPath,
       pmUnitName,
-      respinVariantIndicator);
+      *version->productionState(),
+      *version->productionSubState(),
+      *version->respinVariantIndicator());
   return platformConfig_.pmUnitConfigs()->at(pmUnitName);
 }
 

--- a/fboss/platform/platform_manager/DataStore.cpp
+++ b/fboss/platform/platform_manager/DataStore.cpp
@@ -179,8 +179,8 @@ PmUnitConfig DataStore::resolvePmUnitConfig(const std::string& slotPath) const {
           }
         }
       } else {
-        matches = versionedPmUnitConfig.respinVariantIndicator() &&
-            *versionedPmUnitConfig.respinVariantIndicator() ==
+        matches = versionedPmUnitConfig.productSubVersion() &&
+            *versionedPmUnitConfig.productSubVersion() ==
                 *version->respinVariantIndicator();
       }
       if (matches) {

--- a/fboss/platform/platform_manager/DataStore.h
+++ b/fboss/platform/platform_manager/DataStore.h
@@ -82,8 +82,7 @@ class DataStore {
       const std::string& slotPath,
       const PresenceInfo& presenceInfo);
 
-  // Resolve PmUnitConfig based on the platformSubVersion from eeprom.
-  // Throws if none of the VersionedPmUnitConfig matches the version.
+  // Resolve PmUnitConfig based on the version from eeprom.
   PmUnitConfig resolvePmUnitConfig(const std::string& slotPath) const;
 
   // Store eeprom contents at the given DevicePath.

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -746,13 +746,14 @@ struct PmUnitConfig {
 // backwards compatibility with configs that predate the pmUnitVersion field.
 // This refers to field Type 10 in Meta EEPROM V5.
 //
-// `pmUnitVersion`: Minimum version of the PmUnit this config applies to.
+// `pmUnitVersions`: List of PmUnit versions this config applies to. A system
+// matching any version in this list will use this config.
 // `productSubVersion` is ignored when `pmUnitVersion` is present. At least
 // one of `productSubVersion` or `pmUnitVersion` must be set.
 struct VersionedPmUnitConfig {
   1: PmUnitConfig pmUnitConfig;
   3: optional i16 productSubVersion;
-  4: optional PmUnitVersion pmUnitVersion;
+  4: optional list<PmUnitVersion> pmUnitVersions;
 }
 
 // `PmUnitInfo`: Details of a PmUnit.

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -742,14 +742,14 @@ struct PmUnitConfig {
 //
 // `PmUnitConfig`: PmUnit configuration. Refer to PmUnitConfig definition above.
 //
-// `productSubVersion`: Deprecated. Use `pmUnitVersion` instead. Retained for
-// backwards compatibility with configs that predate the pmUnitVersion field.
+// `productSubVersion`: Deprecated. Use `pmUnitVersions` instead. Retained for
+// backwards compatibility with configs that predate the pmUnitVersions field.
 // This refers to field Type 10 in Meta EEPROM V5.
 //
 // `pmUnitVersions`: List of PmUnit versions this config applies to. A system
 // matching any version in this list will use this config.
-// `productSubVersion` is ignored when `pmUnitVersion` is present. At least
-// one of `productSubVersion` or `pmUnitVersion` must be set.
+// `productSubVersion` is ignored when `pmUnitVersions` is present. At least
+// one of `productSubVersion` or `pmUnitVersions` must be set.
 struct VersionedPmUnitConfig {
   1: PmUnitConfig pmUnitConfig;
   3: optional i16 productSubVersion;

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -742,12 +742,17 @@ struct PmUnitConfig {
 //
 // `PmUnitConfig`: PmUnit configuration. Refer to PmUnitConfig definition above.
 //
-// `productSubVersion`: The platformVersion of the switch which this PmUnit
-// belongs to. This refers to field Type 10 in Meta EEPROM V5
-// TODO: Replace it with PmUnitVersion struct below.
+// `productSubVersion`: Deprecated. Use `pmUnitVersion` instead. Retained for
+// backwards compatibility with configs that predate the pmUnitVersion field.
+// This refers to field Type 10 in Meta EEPROM V5.
+//
+// `pmUnitVersion`: Minimum version of the PmUnit this config applies to.
+// `productSubVersion` is ignored when `pmUnitVersion` is present. At least
+// one of `productSubVersion` or `pmUnitVersion` must be set.
 struct VersionedPmUnitConfig {
   1: PmUnitConfig pmUnitConfig;
-  3: i16 productSubVersion;
+  3: optional i16 productSubVersion;
+  4: optional PmUnitVersion pmUnitVersion;
 }
 
 // `PmUnitInfo`: Details of a PmUnit.

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -195,7 +195,7 @@ TEST(ConfigValidatorTest, InvalidVersionedPmUnitConfigs) {
   negPmUv.productionState() = 0;
   negPmUv.productionSubState() = -1;
   negPmUv.respinVariantIndicator() = 0;
-  versionedPmUnitConfigNegPmUv.pmUnitVersion() = negPmUv;
+  versionedPmUnitConfigNegPmUv.pmUnitVersions() = {negPmUv};
   versionedPmUnitConfigNegPmUv.pmUnitConfig()->pluggedInSlotType() = "SCM_SLOT";
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfigNegPmUv}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -189,13 +189,24 @@ TEST(ConfigValidatorTest, InvalidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));
 
-  // Test 3: Mismatched pluggedInSlotType
+  // Test 3: Negative field in pmUnitVersion
+  auto versionedPmUnitConfigNegPmUv = VersionedPmUnitConfig();
+  PmUnitVersion negPmUv;
+  negPmUv.productionState() = 0;
+  negPmUv.productionSubState() = -1;
+  negPmUv.respinVariantIndicator() = 0;
+  versionedPmUnitConfigNegPmUv.pmUnitVersion() = negPmUv;
+  versionedPmUnitConfigNegPmUv.pmUnitConfig()->pluggedInSlotType() = "SCM_SLOT";
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfigNegPmUv}}};
+  EXPECT_FALSE(ConfigValidator().isValid(config));
+
+  // Test 4: Mismatched pluggedInSlotType
   versionedPmUnitConfig.productSubVersion() = 1;
   versionedPmUnitConfig.pmUnitConfig()->pluggedInSlotType() = "PIM_SLOT";
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));
 
-  // Test 4: Mismatched outgoingSlotConfigs
+  // Test 5: Mismatched outgoingSlotConfigs
   versionedPmUnitConfig.pmUnitConfig()->pluggedInSlotType() = "SCM_SLOT";
   auto slotConfig = SlotConfig();
   slotConfig.slotType() = "EXTRA_SLOT";
@@ -204,7 +215,7 @@ TEST(ConfigValidatorTest, InvalidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));
 
-  // Test 5: Mismatched pciDeviceConfigs
+  // Test 6: Mismatched pciDeviceConfigs
   versionedPmUnitConfig.pmUnitConfig()->outgoingSlotConfigs() = {};
   versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs() = {
       getValidPciDeviceConfig()};

--- a/fboss/platform/platform_manager/utilities/ConfigDiffer.cpp
+++ b/fboss/platform/platform_manager/utilities/ConfigDiffer.cpp
@@ -176,14 +176,16 @@ void ConfigDiffer::compareVersionedConfigs(
   // Compare each versioned config against the default config
   for (const auto& versionedConfig : versionedConfigs) {
     auto versionInfo = fmt::format(
-        "default{}v{}", kArrow, *versionedConfig.respinVariantIndicator());
-    if (const auto& pmUv = versionedConfig.pmUnitVersion(); pmUv) {
+        "default{}v{}", kArrow, *versionedConfig.productSubVersion());
+    if (const auto& pmUvs = versionedConfig.pmUnitVersions();
+        pmUvs && !pmUvs->empty()) {
+      const auto& pmUv = pmUvs->front();
       versionInfo = fmt::format(
           "default{}v{}.{}.{}",
           kArrow,
-          *pmUv->productionState(),
-          *pmUv->productionSubState(),
-          *pmUv->respinVariantIndicator());
+          *pmUv.productionState(),
+          *pmUv.productionSubState(),
+          *pmUv.respinVariantIndicator());
     }
 
     comparePmUnitConfigs(

--- a/fboss/platform/platform_manager/utilities/ConfigDiffer.cpp
+++ b/fboss/platform/platform_manager/utilities/ConfigDiffer.cpp
@@ -176,7 +176,15 @@ void ConfigDiffer::compareVersionedConfigs(
   // Compare each versioned config against the default config
   for (const auto& versionedConfig : versionedConfigs) {
     auto versionInfo = fmt::format(
-        "default{}v{}", kArrow, *versionedConfig.productSubVersion());
+        "default{}v{}", kArrow, *versionedConfig.respinVariantIndicator());
+    if (const auto& pmUv = versionedConfig.pmUnitVersion(); pmUv) {
+      versionInfo = fmt::format(
+          "default{}v{}.{}.{}",
+          kArrow,
+          *pmUv->productionState(),
+          *pmUv->productionSubState(),
+          *pmUv->respinVariantIndicator());
+    }
 
     comparePmUnitConfigs(
         defaultConfig,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Platform manager has a versionedPmUnitConfigs attribute, which allows certain pmUnit configs to be overridden. However, it is only limited to changes "Product Sub-Version". 

This proposal adds support for all 3 version attributes in meta-eeprom to be used in versionedPmUnitConfigs. To do that, the `PmUnitVersion` struct is used as suggested by the TODO comment in the thrift config.

# Test Plan

- All Swtests pass

### Manual Testing of The Feature

We will be working with these set of versions on the SMB pmunit
```
...
Product Production State: 1
Product Version: 2
Product Sub-Version: 3
...
```

No versionedPmUnitConfigs present
```
...
DataStore.cpp:182] Resolved /SMB_SLOT@0 to default PmUnitConfig of SMB. No versioned config matches version 1.2.3
...
```


Testing versionedPmUnitConfigs with a duplicated SMB pmunit but removing `SMB_CPLD`. Setting `productSubVersion` set to 2 (NOT MATCHING).
```
  "versionedPmUnitConfigs": {
    "SMB": [
      {
        "pmUnitConfig": {
            ...
        },
        "productSubVersion": 2,
      }
    ]
  },
```
```
...
DataStore.cpp:182] Resolved /SMB_SLOT@0 to default PmUnitConfig of SMB. No versioned config matches version 1.2.3
...
# ls /run/devmap/cplds/MERU800BIA_SMB_CPLD/
driver uevent ...
...
```


Setting `productSubVersion` set to 4 (MATCHING).
```
...
Resolved /SMB_SLOT@0 to versioned PmUnitConfig of SMB with version 1.2.3
...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56]  /SMB_SLOT@0/[SMB_CPLD]: Failed to create symlink /run/devmap/cplds/MERU800BIA_SMB_CPLD for DevicePath /SMB_SLOT@0/[SMB_CPLD]. Reason: Couldn't find PciDeviceConfig for SMB_CPLD at /SMB_SLOT@0
...
# ls /run/devmap/cplds/MERU800BIA_SMB_CPLD/
ls: cannot access '/run/devmap/cplds/MERU800BIA_SMB_CPLD/': No such file or directory
...
```



Using `PmUnitVersion` setting to random version below (NOT MATCHING).
```
  "versionedPmUnitConfigs": {
    "SMB": [
      {
        "pmUnitConfig": {
            ...
        },
        "pmUnitVersion": {
            "productProductionState": 0,
            "productVersion": 2,
            "productSubVersion": 3
        }
      }
    ]
  },
```
```
...
DataStore.cpp:182] Resolved /SMB_SLOT@0 to default PmUnitConfig of SMB. No versioned config matches version 1.2.3
...
# ls /run/devmap/cplds/MERU800BIA_SMB_CPLD/
driver uevent ...
```


Updating `PmUnitVersion` to match SMB idprom (MATCHING)
```
"pmUnitVersion": {
    "productProductionState": 1,
    "productVersion": 2,
    "productSubVersion": 3
}
```
```
DataStore.cpp:171] Resolved /SMB_SLOT@0 to versioned PmUnitConfig of SMB with version 1.2.3
...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56]  /SMB_SLOT@0/[SMB_CPLD]: Failed to create symlink /run/devmap/cplds/MERU800BIA_SMB_CPLD for DevicePath /SMB_SLOT@0/[SMB_CPLD]. Reason: Couldn't find PciDeviceConfig for SMB_CPLD at /SMB_SLOT@0
...
# ls /run/devmap/cplds/MERU800BIA_SMB_CPLD/
ls: cannot access '/run/devmap/cplds/MERU800BIA_SMB_CPLD/': No such file or directory
```