### PR TITLE
[Celestica] Support long duration test for AgentEnsembleLinkSanityTestDataPlaneFlood and ASIC-ASIC PRBS Tests

### DIFF
--- a/fboss/agent/AgentFeatures.cpp
+++ b/fboss/agent/AgentFeatures.cpp
@@ -270,6 +270,11 @@ DEFINE_bool(
     false,
     "enable to run stress tests (longer duration + more iterations)");
 
+DEFINE_uint32(
+    link_stress_duration,
+    0,
+    "run link stress tests for a given time in minutes, default 0 means no stress tests.");
+
 DEFINE_int32(
     ecmp_resource_percentage,
     75,

--- a/fboss/agent/AgentFeatures.h
+++ b/fboss/agent/AgentFeatures.h
@@ -91,6 +91,7 @@ DECLARE_int32(max_mac_address_to_block);
 DECLARE_int32(max_neighbors_to_block);
 
 DECLARE_bool(link_stress_test);
+DECLARE_uint32(link_stress_duration);
 DECLARE_int32(ecmp_resource_percentage);
 DECLARE_int32(ars_resource_percentage);
 DECLARE_bool(enable_mysid_resource_protection);

--- a/fboss/agent/test/link_tests/AgentEnsembleLinkSanityTests.cpp
+++ b/fboss/agent/test/link_tests/AgentEnsembleLinkSanityTests.cpp
@@ -187,7 +187,10 @@ TEST_F(AgentEnsembleLinkSanityTestDataPlaneFlood, warmbootIsHitLess) {
   // traffic bearing ports loss traffic.
   // TODO: Assert that all (non downlink) cabled ports get traffic.
   verifyAcrossWarmBoots(
-      [this]() { createL3DataplaneFlood(); },
+      [this]() {
+        XLOG(DBG2) << "Test duration flag set: " << FLAGS_link_stress_duration;
+        createL3DataplaneFlood(FLAGS_link_stress_duration);
+      },
       [this]() {
         // Assert no traffic loss and no ecmp shrink. If ports flap
         // these conditions will not be true
@@ -213,7 +216,8 @@ TEST_F(AgentEnsembleLinkSanityTestDataPlaneFlood, qsfpWarmbootIsHitLess) {
   // that none of the traffic bearing ports loss traffic.
   verifyAcrossWarmBoots(
       [this]() {
-        createL3DataplaneFlood();
+        XLOG(DBG2) << "Test duration flag set: " << FLAGS_link_stress_duration;
+        createL3DataplaneFlood(FLAGS_link_stress_duration);
         utility::restartQsfpService(false /* coldboot */);
         // Wait for all transceivers to converge to Active state
         EXPECT_NO_THROW(

--- a/fboss/agent/test/link_tests/AgentEnsembleLinkTest.cpp
+++ b/fboss/agent/test/link_tests/AgentEnsembleLinkTest.cpp
@@ -417,6 +417,7 @@ void AgentEnsembleLinkTest::programDefaultRouteWithDisableTTLDecrement(
 }
 
 void AgentEnsembleLinkTest::createL3DataplaneFlood(
+    uint32_t duration,
     const boost::container::flat_set<PortDescriptor>& ecmpPorts) {
   auto switchId = scope(ecmpPorts);
   utility::EcmpSetupTargetedPorts6 ecmp6(
@@ -436,12 +437,26 @@ void AgentEnsembleLinkTest::createL3DataplaneFlood(
     utility::disableTTLDecrements(getSw(), ecmpPorts);
   }
   auto vlanID = getAgentEnsemble()->getVlanIDForTx();
-  utility::pumpTraffic(
-      true,
-      utility::getAllocatePktFn(getSw()),
-      utility::getSendPktFunc(getSw()),
-      getSw()->getLocalMac(switchId),
-      vlanID);
+
+  auto timeForTest = duration * 60s;
+  XLOG(DBG2) << "Test duration:" << timeForTest.count();
+
+  auto startTime = std::time(nullptr);
+  auto timeNow = std::time(nullptr);
+
+  do {
+    utility::pumpTraffic(
+        true,
+        utility::getAllocatePktFn(getSw()),
+        utility::getSendPktFunc(getSw()),
+        getSw()->getLocalMac(switchId),
+        vlanID);
+    timeNow = std::time(nullptr);
+    if (duration) {
+      std::this_thread::sleep_for(10s);
+    }
+  } while (duration && (timeNow < timeForTest.count() + startTime));
+
   // TODO: Assert that traffic reached a certain rate
   XLOG(DBG2) << "Created L3 Data Plane Flood";
 }

--- a/fboss/agent/test/link_tests/AgentEnsembleLinkTest.h
+++ b/fboss/agent/test/link_tests/AgentEnsembleLinkTest.h
@@ -123,9 +123,13 @@ class AgentEnsembleLinkTest : public AgentEnsembleTest {
    * Create a L3 data plane loop and seed it with traffic
    */
   void createL3DataplaneFlood(
+      uint32_t duration,
       const boost::container::flat_set<PortDescriptor>& inPorts);
+  void createL3DataplaneFlood(uint32_t duration) {
+    createL3DataplaneFlood(duration, getSingleVlanOrRoutedCabledPorts());
+  }
   void createL3DataplaneFlood() {
-    createL3DataplaneFlood(getSingleVlanOrRoutedCabledPorts());
+    createL3DataplaneFlood(0, getSingleVlanOrRoutedCabledPorts());
   }
 
   std::optional<PortID> getPeerPortID(

--- a/fboss/agent/test/link_tests/AgentEnsemblePrbsTest.cpp
+++ b/fboss/agent/test/link_tests/AgentEnsemblePrbsTest.cpp
@@ -176,14 +176,22 @@ class AgentEnsemblePrbsTest : public AgentEnsembleLinkTest {
 
     // 6. Let PRBS run for 10 seconds for regular link test or 10 mins for a
     // stress test so that we can check the BER later
-    auto timeForTest = FLAGS_link_stress_test ? 600s : 10s;
+    auto timeForTest = FLAGS_link_stress_test
+        ? 600s
+        : (FLAGS_link_stress_duration ? FLAGS_link_stress_duration * 60s : 10s);
+    XLOG(DBG2) << "PRBS timeForTest:" << timeForTest.count();
+    auto sleep_time = 10s;
+    // if stress test more than 10 minutes, check every 3 minutes.
+    if (timeForTest.count() > 600) {
+      sleep_time = 180s;
+    }
 
     // 7. Check PRBS stats, expect no loss of lock
     XLOG(DBG2) << "Verifying PRBS stats";
     auto startTime = std::time(nullptr);
     auto timeNow = std::time(nullptr);
     while (timeNow < timeForTest.count() + startTime) {
-      /* sleep override */ std::this_thread::sleep_for(10s);
+      /* sleep override */ std::this_thread::sleep_for(sleep_time);
       checkPrbsStatsOnAllInterfaces(false, testStartTime);
       timeNow = std::time(nullptr);
     }
@@ -218,7 +226,7 @@ class AgentEnsemblePrbsTest : public AgentEnsembleLinkTest {
 
     // 12. Link and traffic should come back up now
     XLOG(DBG2) << "Waiting for links and traffic to come back up";
-    EXPECT_NO_THROW(waitForAllCabledPorts(true));
+    EXPECT_NO_THROW(waitForAllCabledPorts(true, 60, 5s));
     waitForLldpOnCabledPorts();
   }
 
@@ -876,6 +884,7 @@ class AsicToAsicPrbsTest : public AgentEnsemblePrbsTest {
       PRBS_TRANSCEIVER_TEST_NAME(                                      \
           MEDIA, TCVR_L, TCVR_L, POLYNOMIAL, POLYNOMIAL),              \
       prbsSanity) {                                                    \
+    FLAGS_link_stress_duration = 0;                                    \
     runTest();                                                         \
   }
 
@@ -892,6 +901,7 @@ class AsicToAsicPrbsTest : public AgentEnsemblePrbsTest {
       PRBS_TRANSCEIVER_TEST_NAME(                               \
           MEDIA, COMPONENTA, TCVR_S, POLYNOMIALA, POLYNOMIALB), \
       prbsSanity) {                                             \
+    FLAGS_link_stress_duration = 0;                             \
     runTest();                                                  \
   }
 

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -109,6 +109,7 @@ OPT_ARG_FBOSS_LOGGING = "--fboss_logging"
 OPT_ARG_PRODUCTION_FEATURES = "--production-features"
 OPT_ARG_ENABLE_PRODUCTION_FEATURES = "--enable-production-features"
 OPT_ARG_LIST_TESTS_FOR_FEATURE = "--list-tests-for-features"
+OPT_ARG_LINK_STRESS_DURATION = "--link_stress_duration"
 OPT_KNOWN_BAD_TESTS_FILE = "--known-bad-tests-file"
 OPT_UNSUPPORTED_TESTS_FILE = "--unsupported-tests-file"
 OPT_ARG_SETUP_CB = "--setup-for-coldboot"
@@ -741,7 +742,7 @@ class TestRunner(abc.ABC):
                 args.sai_logging,
                 args.fboss_logging,
                 sai_replayer_log_path,
-                args.test_run_timeout,
+                args.test_run_timeout + args.link_stress_duration * 60,
             )
             output = test_output.decode("utf-8")
             print(
@@ -1097,6 +1098,12 @@ class LinkTestRunner(TestRunner):
             type=int,
             help="Specify number of npus to run in multi switch mode. Default is 1.",
         )
+        sub_parser.add_argument(
+            OPT_ARG_LINK_STRESS_DURATION,
+            type=int,
+            default=0,
+            help="Specify link stress test run duration in minutes.",
+        )
 
     def _get_config_path(self):
         return ""
@@ -1144,6 +1151,13 @@ class LinkTestRunner(TestRunner):
             )
 
         arg_list.extend(["--fsdb_client_ssl_preferred=false"])
+        if args.link_stress_duration is not None:
+            arg_list.extend(
+                [
+                    "--link_stress_duration",
+                    str(args.link_stress_duration),
+                ]
+            )
 
         return arg_list
 


### PR DESCRIPTION
**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

```
[INFO] Stashing unstaged files to /root/.cache/pre-commit/patch1775635465-3066528.
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
[INFO] Restored changes from /root/.cache/pre-commit/patch1775635465-3066528.
```

# Summary

Modify below tests to support a long duration tests, i.e: 48-hour continuous run:

Prbs_ASIC_P31_TO_ASIC_P31.prbsSanity
AgentEnsembleLinkSanityTestDataPlaneFlood.warmbootIsHitLess
AgentEnsembleLinkSanityTestDataPlaneFlood.qsfpWarmbootIsHitLess

# Solution

1. add a flag "--link_stress_duration <time in minutes>" for both run_test.py and single binary run, which will be used to specify the time duration (in minutes) the case running.

   **Note:** There's already another flag --link_stress_test which will run Prbs Test for 10 minutes. If both "link_stress_test" and "link_stress_duration" specified, only the old one "link_stress_test" will take effect to keep the behavior no change. If no "link_stress_duration" specified, the behavior keep no change as before.

2. Longer the Prbs check interval (previously was 10s) to 3 minutes if duration more than 10 minutes.

3. For DataPlaneFlood test cases, periodically pump traffic every 10 seconds during the test, until the duration timeout.

4. In run_test.py, overwrite the test_run_timeout so that the case won't be timeout.

# Test Plan

1. run single binary with link_stress_duration for the 3 cases, ensure the run duration matches the expected value.
2. run single binary with link_stress_duration for other cases, ensure the parameter won't take effect
3. run single binary without link_stress_duration, ensure the parameter won't take effect, behavior is the same as before.
4. use run_test.py to test 1~3, ensure the results are the same.
5. 24 hours duration test for the 3 cases, ensure they all passed

# Test Result

```
[       OK ] cold_boot.Prbs_ASIC_P31_TO_ASIC_P31.prbsSanity (86569893 ms)
[       OK ] cold_boot.AgentEnsembleLinkSanityTestDataPlaneFlood.warmbootIsHitLess (86485485 ms)
[       OK ] cold_boot.AgentEnsembleLinkSanityTestDataPlaneFlood.qsfpWarmbootIsHitLess (86507338 ms)

```

Full logs in [Gdrive](https://drive.google.com/drive/folders/1iS975WLSQP-gPdtk7Npt8V3Gvm2DlRB4)
