### PR TITLE
[Nexthop][fboss2-dev] The maximum MTU is 9416.

### DIFF
--- a/fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
@@ -18,8 +18,10 @@
 
 #include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <string>
 #include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+#include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 
 using namespace facebook::fboss;
 
@@ -46,6 +48,9 @@ TEST_F(ConfigInterfaceMtuTest, SetAndVerifyMtu) {
   XLOG(INFO) << "[Step 2] Getting current MTU...";
   int originalMtu = interface.mtu;
   XLOG(INFO) << "  Current MTU: " << originalMtu;
+
+  // Clamp originalMtu to valid range in case it was set out of band
+  originalMtu = std::clamp(originalMtu, utils::kMtuMin, utils::kMtuMax);
 
   // Step 3: Set a new MTU (toggle between 1500 and 9000)
   int newMtu = (originalMtu != 9000) ? 9000 : 1500;

--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.h
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.h
@@ -27,7 +27,7 @@ namespace facebook::fboss::utils {
 
 // MTU bounds constants
 constexpr int kMtuMin = 68;
-constexpr int kMtuMax = 9216;
+constexpr int kMtuMax = 9416;
 
 struct LocalOption {
   std::string name;


### PR DESCRIPTION
# Summary

This is true on the previous, current, and next gen NPUs. The CLI doesn't need to know the exact limit of the underlying platform, just the highest valid value among all supported platforms, as the CLI isn't in the business of enforcing platform-specific limits, that's the agent's responsibility.

# Test Plan

This fixes `ConfigInterfaceMtuTest.SetAndVerifyMtu` on a NH-4010-F with the default distro config.
