### PR TITLE
[Accton][minipack3bam] Set PlatformType for minipack3bam to support QSFP/LED HW tests

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -259,7 +259,9 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_WEDGE400C_VOQ;
     } else if (FLAGS_mode == "wedge400c_fabric") {
       type_ = PlatformType::PLATFORM_WEDGE400C_FABRIC;
-    } else if (FLAGS_mode == "montblanc" || FLAGS_mode == "minipack3ba") {
+    } else if (
+        FLAGS_mode == "montblanc" || FLAGS_mode == "minipack3ba" ||
+        FLAGS_mode == "minipack3bam") {
       type_ = PlatformType::PLATFORM_MONTBLANC;
     } else if (FLAGS_mode == "icecube800bc") {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;

--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -299,7 +299,7 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_WEDGE400C_FABRIC;
     } else if (
         FLAGS_mode == "montblanc" || FLAGS_mode == "montblancm" ||
-        FLAGS_mode == "minipack3ba") {
+        FLAGS_mode == "minipack3ba" || FLAGS_mode == "minipack3bam") {
       type_ = PlatformType::PLATFORM_MONTBLANC;
     } else if (FLAGS_mode == "icecube800bc" || FLAGS_mode == "icecube800bcm") {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;


### PR DESCRIPTION
**Pre-submission checklist**

- [ ]  I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running
pip install -r requirements-dev.txt && pre-commit install
- [ ] pre-commit run
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
```

# Summary
Since the Minipack3ba platform has migrated its COMe from the previous module to Netlake2 (AMD), the existing platform_manager.json is no longer compatible with the new CPU configuration. 
To support this transition while maintaining system identity, a new platform name, minipack3bam, has been introduced.

Given that the underlying hardware layout remains identical to the previous version, this update adds minipack3bam to PlatformProductInfo.cpp within the Montblanc framework. 
This allows the new platform to leverage existing `qsfp_service `and `led_service `logic, 
as well as pass `qsfp_hw_test` and `led_service_hw_test` through proper `PlatformType `identification without requiring redundant hardware-specific implementations.

# Test Plan
- qsfp_hw_test
step1. Copy [montblanc.materialized_JSON](https://github.com/facebook/fboss/blob/main/fboss/oss/qsfp_test_configs/montblanc.materialized_JSON) to `minipack3bam.materialized_JSON` in qsfp-config.
step2. Modify the mode in the new JSON from `montblanc `to `minipack3bam`.
step3. Goal: Confirm that the FBOSS framework can successfully recognize the `minipack3bam `platform identifier.
```
1. qsfp-hw-test command:
/opt/fboss/bin/run_test.py qsfp --filter_file=/opt/fboss/share/hw_sanity_tests/t0_qsfp_hw_tests.conf --qsfp-config /opt/fboss/share/qsfp_test_configs/minipack3bam.materialized_JSON
```
- led_service_hw_test
Generate led.conf with the mode field set to minipack3bam
```
/tmp/led.conf
{
  "defaultCommandLineArgs": {
    "mode": "minipack3bam"
  },
  "ledControlledThroughService": false
}

2-1. LED color change test command:
/opt/fboss/bin/led_service_hw_test --gtest_filter=LedServiceTest.checkLedBlinking --led-config /tmp/led.conf --visual_delay_sec 0

2-2. LED blinking test command:
/opt/fboss/bin/led_service_hw_test --gtest_filter=LedServiceTest.checkForceLed  --led-config /tmp/led.conf --visual_delay_sec 0
```
# Test Result:
1. **qsfp_hw_test t0 result:** [minipact3bam_t0_qsfp_hw_test.zip](https://github.com/user-attachments/files/26668889/minipact3bam_t0_qsfp_hw_test.zip)
```
Running all tests took 0:09:54.407704 between 2026-04-10 17:03:23.709998 and 2026-04-10 17:13:18.117702
[       OK ] cold_boot.EmptyHwTest.CheckInit (51467 ms)
[       OK ] warm_boot.EmptyHwTest.CheckInit (24536 ms)
[       OK ] cold_boot.HwTest.i2cStressRead (51760 ms)
[       OK ] warm_boot.HwTest.i2cStressRead (24800 ms)
[       OK ] cold_boot.HwTest.i2cStressWrite (55581 ms)
[       OK ] warm_boot.HwTest.i2cStressWrite (28740 ms)
[       OK ] cold_boot.HwTest.cmisPageChange (64714 ms)
[       OK ] warm_boot.HwTest.cmisPageChange (37784 ms)
[       OK ] cold_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (103198 ms)
[       OK ] warm_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (75712 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortsProgrammed (51402 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortsProgrammed (24575 ms)
Summary:
   OK : 12
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
2-1. **led_service_hw_test led color change test** result:[minipact3bam_led_color_change.log](https://github.com/user-attachments/files/26668447/minipact3bam_led_color_change.log)
```
[       OK ] LedServiceTest.checkLedColorChange (1263 ms)
[----------] 1 test from LedServiceTest (1263 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1263 ms total)
[  PASSED  ] 1 test.
```
2-2. **led_service_hw_test led blinking test** result:[minipact3bam_led_blinking_test.log](https://github.com/user-attachments/files/26668452/minipact3bam_led_blinking_test.log)
```
[       OK ] LedServiceTest.checkLedBlinking (17801 ms)
[----------] 1 test from LedServiceTest (17801 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (17801 ms total)
[  PASSED  ] 1 test.
```