### PR TITLE
[Meta] Add Meta in the validCompanies list for auto-label-vendor for PR

### DIFF
--- a/.github/workflows/auto-label-vendor.yml
+++ b/.github/workflows/auto-label-vendor.yml
@@ -26,6 +26,7 @@ jobs:
               'arista',
               'cisco',
               'nvidia',
+              'meta',
             ];
 
             // Extract company name from first [...]


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Sometimes Meta OSS teammates want to use PR to introduce changes instead of Meta internal phabricator workflow
so that we can verify some of PR checks logic.

# Test Plan

We should see meta automatically labeled and when we import such PR in phabricator, we won't see the linter error:
"facebook/fboss: Auto Label by Vendor Name / label-by-company"
