### PR TITLE
Adjust kDefaultPayload from 256 to 384

### DIFF
--- a/fboss/agent/packet/PktFactory.cpp
+++ b/fboss/agent/packet/PktFactory.cpp
@@ -16,7 +16,7 @@
 
 namespace facebook::fboss::utility {
 namespace {
-static auto kDefaultPayload = std::vector<uint8_t>(256, 0xff);
+static auto kDefaultPayload = std::vector<uint8_t>(384, 0xff);
 
 template <typename CursorType>
 void writeEthHeader(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

For the following tests running at 800G, we are oversubscribing supported packet processing rate.

LinkSanityTestDataPlaneFlood.ptpEnableIsHitless
LinkSanityTestDataPlaneFlood.qsfpWarmbootIsHitLess
LinkSanityTestDataPlaneFlood.warmbootIsHitLess
MacLearningTest.l2EntryFlap

Adjusting kDefaultPayload from 256B to 384B would bring L3 Flood traffic rate to the supported range and all Hitless tests passed after we lower the flood packet rate.

When we use all ports in L3 Flood tests, ASIC has specific maximum rate it can store packets into packet memory. When this rate got oversubscribed, we will have to drop packets before entering NPU. This drop counter is now reported as part of SAI_PORT_STAT_IF_IN_DISCARDS. Tests above check this counter for hit-less pass/fail criteria

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

We use the tests above and full lnik test regression for verification of this change.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
