### PR TITLE
[Celestica] Tahansb800bc: qsfp service: restore the combination of 2x400G-DR4 to the smfTransceiver of DR4_2x800G

### DIFF
--- a/fboss/qsfp_service/module/properties/TransceiverPropertiesDefault.h
+++ b/fboss/qsfp_service/module/properties/TransceiverPropertiesDefault.h
@@ -294,6 +294,13 @@ constexpr auto kDefaultTransceiverPropertiesJson = R"({
           ]
         },
         {
+          "combinationName": "2x400G-DR4",
+          "ports": [
+            {"speed": 400000, "hostLanes": {"start": 0, "count": 4}, "mediaLanes": {"start": 0, "count": 4}, "mediaLaneCode": {"smfCode": 0x1C}, "mediaInterfaceCode": 14},
+            {"speed": 400000, "hostLanes": {"start": 4, "count": 4}, "mediaLanes": {"start": 4, "count": 4}, "mediaLaneCode": {"smfCode": 0x1C}, "mediaInterfaceCode": 14}
+          ]
+        },
+        {
           "combinationName": "8x100G-DR1",
           "ports": [
             {"speed": 100000, "hostLanes": {"start": 0, "count": 1}, "mediaLanes": {"start": 0, "count": 1}, "mediaLaneCode": {"smfCode": 0x14}, "mediaInterfaceCode": 28},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
<img width="818" height="199" alt="image" src="https://github.com/user-attachments/assets/48ab6b7c-91c3-480a-bbda-5255bf087161" />

# Summary
This PR restores support for the 2x400G-DR4 combination within the DR4_2x800G smfTransceiver configuration.
<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Motivation
The DR4-2x800G smfTransceiver supports five modes : 
0x77: DR4_800G
0x75: DR2_400G
0x73: DR1_200G
0x1c: DR4_400G
0x14: DR1_100G
However, the combination of 2x400G_DR4(i.e smfCode 0x1c) was missed after introducing the feature “Config-driven TransceiverProperties schema and manager" by the [commit] (https://github.com/facebook/fboss/commit/802d998c6c506fd58b2c70a45bfb68d8c19ffce0) . 
Therefore, Tahansb800BC QSFP HW Tests failed. Added this missing combination to solve it.

# Test Plan
1.Run transceiver_properties_manager_test, all cases passed
<img width="763" height="105" alt="image" src="https://github.com/user-attachments/assets/e0764a5c-a368-4a1f-b4d9-b986afa48485" />


2.Run all QSFP HW Test cases, passed

Pls refer the full logs: 
[QSFP_HWTest_Profile_38_47_51_52.zip](https://github.com/user-attachments/files/26738039/QSFP_HWTest_Profile_38_47_51_52.zip)
[QSFP_HWTest_Profile_38_51_52_53.zip](https://github.com/user-attachments/files/26738041/QSFP_HWTest_Profile_38_51_52_53.zip)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
