### PR TITLE
[Accton][wedge800cact] Fix Agent SAI HwTest profile test for TX FIR parameters

### DIFF
--- a/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
@@ -266,13 +266,24 @@ void verifyTxSettting(
     if (asicVendor != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
       post2 = portApi.getAttribute(
           serdes->adapterKey(), SaiPortSerdesTraits::Attributes::TxFirPost2{});
-      EXPECT_EQ(post2, GET_OPT_ATTR(PortSerdes, TxFirPost2, expectedTx));
+
+      if (auto expectedPost2 = std::get<
+              std::optional<SaiPortSerdesTraits::Attributes::TxFirPost2>>(
+              expectedTx)) {
+        EXPECT_EQ(post2, GET_OPT_ATTR(PortSerdes, TxFirPost2, expectedTx));
+      }
+
       // TH6 SDK does not support POST3 readback (returns sentinel 32767)
       if (asicType != cfg::AsicType::ASIC_TYPE_TOMAHAWK6) {
         post3 = portApi.getAttribute(
             serdes->adapterKey(),
             SaiPortSerdesTraits::Attributes::TxFirPost3{});
-        EXPECT_EQ(post3, GET_OPT_ATTR(PortSerdes, TxFirPost3, expectedTx));
+
+        if (auto expectedPost3 = std::get<
+                std::optional<SaiPortSerdesTraits::Attributes::TxFirPost3>>(
+                expectedTx)) {
+          EXPECT_EQ(post3, GET_OPT_ATTR(PortSerdes, TxFirPost3, expectedTx));
+        }
       }
     }
   }
@@ -281,16 +292,40 @@ void verifyTxSettting(
   EXPECT_EQ(pre.size(), txSettings.size());
   for (int i = 0; i < txSettings.size(); ++i) {
     auto expectedTxFromPin = txSettings[i];
-    EXPECT_EQ(pre[i], expectedTxFromPin.pre());
-    EXPECT_EQ(main[i], expectedTxFromPin.main());
-    EXPECT_EQ(post[i], expectedTxFromPin.post());
+    if (expectedTxFromPin.firPre1().has_value()) {
+      EXPECT_EQ(pre[i], expectedTxFromPin.firPre1());
+    } else {
+      EXPECT_EQ(pre[i], expectedTxFromPin.pre());
+    }
+    if (expectedTxFromPin.firMain().has_value()) {
+      EXPECT_EQ(main[i], expectedTxFromPin.firMain());
+    } else {
+      EXPECT_EQ(main[i], expectedTxFromPin.main());
+    }
+    if (expectedTxFromPin.firPost1().has_value()) {
+      EXPECT_EQ(post[i], expectedTxFromPin.firPost1());
+    } else {
+      EXPECT_EQ(post[i], expectedTxFromPin.post());
+    }
     if (saiPlatform->getAsic()->isSupported(
             HwAsic::Feature::SAI_CONFIGURE_SIX_TAP)) {
-      EXPECT_EQ(pre2[i], expectedTxFromPin.pre2());
+      if (expectedTxFromPin.firPre2().has_value()) {
+        EXPECT_EQ(pre2[i], expectedTxFromPin.firPre2());
+      } else {
+        EXPECT_EQ(pre2[i], expectedTxFromPin.pre2());
+      }
       if (asicVendor != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-        EXPECT_EQ(post2[i], expectedTxFromPin.post2());
+        if (expectedTxFromPin.firPost2().has_value()) {
+          EXPECT_EQ(post2[i], expectedTxFromPin.firPost2());
+        } else {
+          EXPECT_EQ(post2[i], expectedTxFromPin.post2());
+        }
         if (asicType != cfg::AsicType::ASIC_TYPE_TOMAHAWK6) {
-          EXPECT_EQ(post3[i], expectedTxFromPin.post3());
+          if (expectedTxFromPin.firPost3().has_value()) {
+            EXPECT_EQ(post3[i], expectedTxFromPin.firPost3());
+          } else {
+            EXPECT_EQ(post3[i], expectedTxFromPin.post3());
+          }
         }
       }
     }


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
[root@5935f4abe1de fboss.pr]# pre-commit run --files fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped


# Summary

Add TX FIR pre-emphasis parameter type for port pre-emphasis verification in gtest profile-based tests.

**Root Cause:**
The test programm does not include FIR-xx parameters in the test procedure. When the platform configures FIR-xx parameters in platform_mapping.json, the port pre-emphasis verification fails.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

**FBOSS Agent SAI Test**

- Agent SAI HwTest passes with the profile test.
  - PROFILE_100G_4_NRZ_RS528_COPPER
  - PROFILE_200G_4_PAM4_RS544X2N_OPTICAL

Running all tests took 0:00:22.920437 between 2024-11-07 06:09:17.473181 and 2024-11-07 06:09:40.393618
[       OK ] cold_boot.HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.TestProfile (15107 ms)
[       OK ] warm_boot.HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.TestProfile (7501 ms)

[       OK ] cold_boot.HwTest_PROFILE_200G_4_PAM4_RS544X2N_OPTICAL.TestProfile (15146 ms)
[       OK ] warm_boot.HwTest_PROFILE_200G_4_PAM4_RS544X2N_OPTICAL.TestProfile (7778 ms)

Test Log
[20241107_060456_W800C_agent-sai_HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.log](https://github.com/user-attachments/files/26772557/20241107_060456_W800C_agent-sai_HwTest_PROFILE_100G_4_NRZ_RS528_COPPER.log)
[20241107_060456_W800C_agent-sai_HwTest_PROFILE_200G_4_PAM4_RS544X2N_OPTICAL.log](https://github.com/user-attachments/files/26772559/20241107_060456_W800C_agent-sai_HwTest_PROFILE_200G_4_PAM4_RS544X2N_OPTICAL.log)

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
