### PR TITLE
[Celestica] Minerva: fan_service: Implement Minerva rack FSC new requ…

### DIFF
--- a/fboss/platform/configs/janga800bic/fan_service.json
+++ b/fboss/platform/configs/janga800bic/fan_service.json
@@ -2,11 +2,14 @@
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 80,
+  "pwmBoostValue": 100,
+  "pwmSpecialModeNumDeadFan": 2,
+  "pwmSpecialModeValue": 30,
   "pwmTransitionValue": 55,
   "pwmLowerThreshold": 20,
   "pwmUpperThreshold": 100,
   "shutdownCmd": "echo 0 > /run/devmap/cplds/JANGA_SMB_CPLD/j3a_pwr_en;echo 0 > /run/devmap/cplds/JANGA_SMB_CPLD/j3b_pwr_en",
+  "shutdownCOMeCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD_1/come_pwr_ctrl",
   "controlInterval": {
     "sensorReadInterval": 5,
     "pwmUpdateInterval": 5
@@ -17,36 +20,36 @@
       "aggregationType": "OPTIC_AGGREGATION_TYPE_INCREMENTAL_PID",
       "pidSettings": {
         "OPTIC_TYPE_800_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_400_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_200_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_100_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         }
       }
     }
@@ -68,20 +71,6 @@
         "33": 50,
         "38": 60,
         "48": 100
-      },
-      "failUpTable": {
-        "25": 80,
-        "30": 80,
-        "35": 80,
-        "40": 80,
-        "50": 80
-      },
-      "failDownTable": {
-        "23": 80,
-        "28": 80,
-        "33": 80,
-        "38": 80,
-        "48": 80
       }
     },
     {
@@ -100,20 +89,6 @@
         "88": 40,
         "93": 50,
         "97": 80
-      },
-      "failUpTable": {
-        "80": 80,
-        "85": 80,
-        "90": 80,
-        "95": 80,
-        "99": 80
-      },
-      "failDownTable": {
-        "78": 80,
-        "83": 80,
-        "88": 80,
-        "93": 80,
-        "97": 80
       }
     },
     {
@@ -129,18 +104,6 @@
         "53": 20,
         "63": 30,
         "73": 40,
-        "78": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "80": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
         "78": 80
       }
     },
@@ -162,22 +125,6 @@
         "83": 35,
         "93": 40,
         "98": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "85": 80,
-        "95": 80,
-        "100": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
-        "83": 80,
-        "93": 80,
-        "98": 80
       }
     },
     {
@@ -197,22 +144,6 @@
         "73": 30,
         "83": 35,
         "93": 40,
-        "98": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "85": 80,
-        "95": 80,
-        "100": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
-        "83": 80,
-        "93": 80,
         "98": 80
       }
     }

--- a/fboss/platform/configs/tahan800bc/fan_service.json
+++ b/fboss/platform/configs/tahan800bc/fan_service.json
@@ -2,10 +2,14 @@
   "pwmBoostOnNumDeadFan": 1,
   "pwmBoostOnNumDeadSensor": 0,
   "pwmBoostOnNoQsfpAfterInSec": 55,
-  "pwmBoostValue": 80,
+  "pwmBoostValue": 100,
+  "pwmSpecialModeNumDeadFan": 2,
+  "pwmSpecialModeValue": 30,
   "pwmTransitionValue": 55,
   "pwmLowerThreshold": 20,
   "pwmUpperThreshold": 100,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/TAHAN_SMB_CPLD/th5_pwr_en",
+  "shutdownCOMeCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD_1/come_pwr_ctrl",
   "controlInterval": {
     "sensorReadInterval": 5,
     "pwmUpdateInterval": 5
@@ -16,36 +20,36 @@
       "aggregationType": "OPTIC_AGGREGATION_TYPE_INCREMENTAL_PID",
       "pidSettings": {
         "OPTIC_TYPE_800_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_400_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_200_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         },
         "OPTIC_TYPE_100_GENERIC": {
-          "kp": 2,
+          "kp": 6,
           "ki": 0.6,
           "kd": 0,
           "setPoint": 65.0,
           "posHysteresis": 0.0,
-          "negHysteresis": 2.0
+          "negHysteresis": 3.0
         }
       }
     }
@@ -67,20 +71,6 @@
         "33": 50,
         "38": 60,
         "48": 100
-      },
-      "failUpTable": {
-        "25": 80,
-        "30": 80,
-        "35": 80,
-        "40": 80,
-        "50": 80
-      },
-      "failDownTable": {
-        "23": 80,
-        "28": 80,
-        "33": 80,
-        "38": 80,
-        "48": 80
       }
     },
     {
@@ -99,20 +89,6 @@
         "88": 40,
         "93": 50,
         "97": 80
-      },
-      "failUpTable": {
-        "80": 80,
-        "85": 80,
-        "90": 80,
-        "95": 80,
-        "99": 80
-      },
-      "failDownTable": {
-        "78": 80,
-        "83": 80,
-        "88": 80,
-        "93": 80,
-        "97": 80
       }
     },
     {
@@ -128,18 +104,6 @@
         "53": 20,
         "63": 30,
         "73": 40,
-        "78": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "80": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
         "78": 80
       }
     },
@@ -161,22 +125,6 @@
         "83": 35,
         "93": 40,
         "98": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "85": 80,
-        "95": 80,
-        "100": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
-        "83": 80,
-        "93": 80,
-        "98": 80
       }
     },
     {
@@ -196,22 +144,6 @@
         "73": 30,
         "83": 35,
         "93": 40,
-        "98": 80
-      },
-      "failUpTable": {
-        "55": 80,
-        "65": 80,
-        "75": 80,
-        "85": 80,
-        "95": 80,
-        "100": 80
-      },
-      "failDownTable": {
-        "53": 80,
-        "63": 80,
-        "73": 80,
-        "83": 80,
-        "93": 80,
         "98": 80
       }
     }

--- a/fboss/platform/fan_service/Bsp.cpp
+++ b/fboss/platform/fan_service/Bsp.cpp
@@ -135,6 +135,24 @@ int Bsp::emergencyShutdown(bool enable) {
         PlatformUtils().execCommand(*config_.shutdownCmd());
     rc = exitStatus;
     setEmergencyState(enable);
+    XLOG(INFO) << "ASIC has been shutdown!";
+  }
+  return rc;
+}
+
+int Bsp::COMeShutdown(bool enable) {
+  int rc = 0;
+  if (enable) {
+    if (config_.shutdownCOMeCmd()->empty()) {
+      XLOG(ERR)
+          << "Emergency shutdown COMe called but shutdownCOMeCmd is empty!";
+      return -1;
+    }
+    auto [exitStatus, standardOut] =
+        PlatformUtils().execCommand(*config_.shutdownCOMeCmd());
+    rc = exitStatus;
+    setEmergencyState(enable);
+    XLOG(INFO) << "In special mode, COMe has been shutdown!";
   }
   return rc;
 }

--- a/fboss/platform/fan_service/Bsp.h
+++ b/fboss/platform/fan_service/Bsp.h
@@ -31,6 +31,7 @@ class Bsp {
   virtual void getOpticsData(std::shared_ptr<SensorData> pSensorData);
   virtual void getAsicTempData(const std::shared_ptr<SensorData>& pSensorData);
   virtual int emergencyShutdown(bool enable);
+  virtual int COMeShutdown(bool enable);
   void kickWatchdog();
   void closeWatchdog();
   virtual bool setFanPwmSysfs(const std::string& path, int pwm);

--- a/fboss/platform/fan_service/ConfigValidator.cpp
+++ b/fboss/platform/fan_service/ConfigValidator.cpp
@@ -96,6 +96,19 @@ bool ConfigValidator::isValid(const FanServiceConfig& config) {
     }
   }
 
+  if (config.pwmSpecialModeNumDeadFan()) {
+    if (!config.pwmSpecialModeValue()) {
+      XLOG(ERR)
+          << "pwmSpecialModeValue must be set when pwmSpecialModeNumDeadFan is defined";
+      return false;
+    }
+    if (!config.shutdownCOMeCmd() || config.shutdownCOMeCmd()->empty()) {
+      XLOG(ERR)
+          << "shutdownCOMeCmd must be set when pwmSpecialModeNumDeadFan is defined";
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/fboss/platform/fan_service/ControlLogic.cpp
+++ b/fboss/platform/fan_service/ControlLogic.cpp
@@ -214,13 +214,30 @@ void ControlLogic::updateTargetPwm(const Sensor& sensor, int numFanFailed) {
       tableToUse =
           accelerate ? *sensor.normalUpTable() : *sensor.normalDownTable();
     } else if (moreThanOneDeadFanExists) {
-      tableToUse = accelerate
-          ? (sensor.twoRotorsFailUpTable() ? *sensor.twoRotorsFailUpTable()
-                                           : *sensor.failUpTable())
-          : (sensor.twoRotorsFailDownTable() ? *sensor.twoRotorsFailDownTable()
-                                             : *sensor.failDownTable());
+      if (accelerate) {
+        if (sensor.twoRotorsFailUpTable().has_value())
+          tableToUse = *sensor.twoRotorsFailUpTable();
+        else if (sensor.failUpTable().has_value())
+          tableToUse = *sensor.failUpTable();
+        else
+          tableToUse = *sensor.normalUpTable();
+      } else {
+        if (sensor.twoRotorsFailDownTable().has_value())
+          tableToUse = *sensor.twoRotorsFailDownTable();
+        else if (sensor.failDownTable().has_value())
+          tableToUse = *sensor.failDownTable();
+        else
+          tableToUse = *sensor.normalDownTable();
+      }
     } else {
-      tableToUse = accelerate ? *sensor.failUpTable() : *sensor.failDownTable();
+      if (accelerate) {
+        tableToUse = sensor.failUpTable().has_value() ? *sensor.failUpTable()
+                                                      : *sensor.normalUpTable();
+      } else {
+        tableToUse = sensor.failDownTable().has_value()
+            ? *sensor.failDownTable()
+            : *sensor.normalDownTable();
+      }
     }
 
     // Start with the lowest value
@@ -491,7 +508,10 @@ void ControlLogic::programLed(const Fan& fan, bool fanFailed) {
       fmt::format(kLedWriteFailure, *fan.fanName()), !ret);
 }
 
-int16_t ControlLogic::calculateZonePwm(const Zone& zone, bool boostMode) {
+int16_t ControlLogic::calculateZonePwm(
+    const Zone& zone,
+    bool boostMode,
+    bool specialMode) {
   auto zoneType = *zone.zoneType();
   int16_t zonePwm{0};
   int totalPwmConsidered{0};
@@ -520,6 +540,9 @@ int16_t ControlLogic::calculateZonePwm(const Zone& zone, bool boostMode) {
   }
   if (boostMode) {
     zonePwm = std::max(zonePwm, *config_.pwmBoostValue());
+  }
+  if (specialMode) {
+    zonePwm = *config_.pwmSpecialModeValue();
   }
 
   XLOG(INFO) << fmt::format(
@@ -623,7 +646,7 @@ void ControlLogic::updateControl(std::shared_ptr<SensorData> pS) {
   XLOG(INFO) << "Processing Optics ...";
   updateOpticsPwms(*pS);
 
-  // STEP 3.5: Shutdown the system if overtemp is detected
+  // STEP 3.5: Shutdown the ASIC if overtemp is detected
   for (auto& sensorName : overtempWatchList_) {
     auto sensorEntry = pS->getSensorEntry(sensorName);
     if (sensorEntry) {
@@ -631,10 +654,10 @@ void ControlLogic::updateControl(std::shared_ptr<SensorData> pS) {
     }
   }
   if (overtempCondition_.checkIfOvertemp()) {
-    XLOG(ERR) << fmt::format("Running shutdown command");
+    XLOG(ERR) << fmt::format("Running shutdown ASIC command");
     structuredLogger_.logAlert(
         "emergency_shutdown",
-        "System overtemp detected, running shutdown command",
+        "System overtemp detected, running shutdown ASIC command",
         {{}});
     pBsp_->emergencyShutdown(true);
   }
@@ -682,10 +705,25 @@ void ControlLogic::updateControl(std::shared_ptr<SensorData> pS) {
         "boost_mode_activated", {{"reason", boostModeReason}});
   }
 
-  // STEP 5: Calculate and program fan PWMs
+  // STEP 5: Determine whether special mode is necessary
+  std::string specialModeReason;
+  if (config_.pwmSpecialModeNumDeadFan() &&
+      *config_.pwmSpecialModeNumDeadFan() != 0 &&
+      numFanFailed >= *config_.pwmSpecialModeNumDeadFan()) {
+    specialMode_ = true;
+    specialModeReason =
+        fmt::format("Special mode enabled for {} fan failures", numFanFailed);
+    XLOG(INFO) << specialModeReason;
+  }
+  if (specialMode_) {
+    structuredLogger_.logEvent(
+        "special_mode_activated", {{"reason", specialModeReason}});
+  }
+
+  // STEP 6: Calculate and program fan PWMs
   fanStatuses_.withWLock([&](auto& fanStatuses) {
     for (const auto& zone : *config_.zones()) {
-      int16_t zonePwm = calculateZonePwm(zone, boostMode_);
+      int16_t zonePwm = calculateZonePwm(zone, boostMode_, specialMode_);
       std::unordered_set<std::string> zoneFans(
           zone.fanNames()->begin(), zone.fanNames()->end());
       for (const auto& fan : *config_.fans()) {
@@ -693,10 +731,15 @@ void ControlLogic::updateControl(std::shared_ptr<SensorData> pS) {
           continue;
         }
 
-        int16_t fanPwm = calculateFanPwm(
-            *zone.slope(),
-            *fanStatuses[*fan.fanName()].pwmToProgram(),
-            zonePwm);
+        int16_t fanPwm;
+        if (specialMode_) {
+          fanPwm = zonePwm;
+        } else {
+          fanPwm = calculateFanPwm(
+              *zone.slope(),
+              *fanStatuses[*fan.fanName()].pwmToProgram(),
+              zonePwm);
+        }
         bool fanFailed = programFan(zone, fan, fanPwm);
         updatePwmState(zone, fanPwm);
 
@@ -708,11 +751,18 @@ void ControlLogic::updateControl(std::shared_ptr<SensorData> pS) {
       }
     }
 
-    // STEP 6: Program fan LEDs
+    // STEP 7: Program fan LEDs
     for (const auto& fan : *config_.fans()) {
       programLed(fan, *fanStatuses[*fan.fanName()].fanFailed());
     }
   });
+
+  // STEP 8: Shutdown the ASIC and COMe if special mode is enabled
+  if (specialMode_) {
+    XLOG(INFO) << fmt::format("Running shutdown ASIC and COMe command");
+    pBsp_->emergencyShutdown(true);
+    pBsp_->COMeShutdown(true);
+  }
 }
 
 int16_t ControlLogic::calculateFanPwm(

--- a/fboss/platform/fan_service/ControlLogic.h
+++ b/fboss/platform/fan_service/ControlLogic.h
@@ -73,7 +73,7 @@ class ControlLogic {
   void updateOpticsPwms(SensorData& sensorData);
   bool /* pwm update fail */
   programFan(const Zone& zone, const Fan& fan, int16_t fanPwm);
-  int16_t calculateZonePwm(const Zone& zone, bool boostMode);
+  int16_t calculateZonePwm(const Zone& zone, bool boostMode, bool specialMode);
   void updateTargetPwm(const Sensor& sensorItem, int numFanFailed);
   void programLed(const Fan& fan, bool fanFailed);
   bool isFanPresentInDevice(const Fan& fan);
@@ -90,5 +90,6 @@ class ControlLogic {
       pidLogics_;
   std::shared_ptr<SensorData> pSensorData_{nullptr};
   bool boostMode_{false};
+  bool specialMode_{false};
 };
 } // namespace facebook::fboss::platform::fan_service

--- a/fboss/platform/fan_service/if/fan_service_config.thrift
+++ b/fboss/platform/fan_service/if/fan_service_config.thrift
@@ -87,8 +87,8 @@ struct Sensor {
   6: string pwmCalcType;
   8: TempToPwmMap normalUpTable;
   9: TempToPwmMap normalDownTable;
-  10: TempToPwmMap failUpTable;
-  11: TempToPwmMap failDownTable;
+  10: optional TempToPwmMap failUpTable;
+  11: optional TempToPwmMap failDownTable;
   12: PidSetting pidSetting;
   13: optional TempToPwmMap twoRotorsFailUpTable;
   14: optional TempToPwmMap twoRotorsFailDownTable;
@@ -110,6 +110,9 @@ struct ShutdownCondition {
   2: list<OvertempEntry> conditions;
 }
 
+# If the number of failed fans exceeds pwmSpecialModeNumDeadFan,
+# all fan PWMs will be set to pwmSpecialModeValue.
+# and system will enter special mode, will shutdown the COMe and ASIC.
 struct FanServiceConfig {
   1: optional ControlInterval controlInterval;
   2: string shutdownCmd;
@@ -126,4 +129,7 @@ struct FanServiceConfig {
   16: i16 pwmUpperThreshold;
   17: i16 pwmLowerThreshold;
   18: optional ShutdownCondition shutdownCondition;
+  19: optional i16 pwmSpecialModeNumDeadFan;
+  20: optional i16 pwmSpecialModeValue;
+  21: optional string shutdownCOMeCmd;
 }


### PR DESCRIPTION
…irement

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="496" height="134" alt="image" src="https://github.com/user-attachments/assets/30f60efb-17fe-4884-98d2-0055c0097050" />

# Summary

Quanta thermal team and Meta thermal team have reached an agreement on the new requirements for Minerva rack FSC. Modify code and fan_service config file to implement the requirement as below:
<img width="1456" height="182" alt="image" src="https://github.com/user-attachments/assets/7b6d3a9d-1c99-477b-99ce-afb698381a3a" />

<img width="352" height="196" alt="image" src="https://github.com/user-attachments/assets/23990dad-b8d2-4ee1-8dff-6807faa7112b" />


# Test Plan

Quanta thermal team has verified this modification on Minerva rack and it meets their requirements.
<img width="1478" height="323" alt="image" src="https://github.com/user-attachments/assets/80a3f1aa-c9a3-4364-8366-97ce4993660c" />

Also attach the Fan_service unit test logs on IceCube, SantaBarbara and Anacapa25:
[Icecube_fan_service_log.txt](https://github.com/user-attachments/files/26785250/Icecube_fan_service_log.txt)
[Santa_fan_service_log.txt](https://github.com/user-attachments/files/26785258/Santa_fan_service_log.txt)
[Anacapa25_fan_service_log.txt](https://github.com/user-attachments/files/26785260/Anacapa25_fan_service_log.txt)
