### PR TITLE
[Nexthop] Resubmit missing distro cli component update bits

### DIFF
--- a/fboss-image/distro_cli/lib/device_update.py
+++ b/fboss-image/distro_cli/lib/device_update.py
@@ -178,8 +178,12 @@ class DeviceUpdater:
                     f"Failed to create remote directory: {result.stderr.decode()}"
                 )
 
-            # SCP artifact and update script to device
-            scp_files = [str(artifact_path), str(UPDATE_SCRIPT_PATH)]
+            # SCP artifact(s) and update script to device
+            # Handle both single artifact (Path) and multiple artifacts (list of Paths)
+            artifacts = (
+                artifact_path if isinstance(artifact_path, list) else [artifact_path]
+            )
+            scp_files = [str(a) for a in artifacts] + [str(UPDATE_SCRIPT_PATH)]
 
             result = subprocess.run(
                 [

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/lib/fboss_cmd_find.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/lib/fboss_cmd_find.sh
@@ -3,10 +3,6 @@
 # Usage: fboss_cmd_find.sh <binary_name> [args...]
 set -e
 
-# Install locations during image build
-default_forwarding_stack_path="/opt/fboss/bin"
-default_platform_stack_path="/opt/fboss/bin"
-
 if [ -z "$1" ]; then
   echo "No command specified" >&2
   exit 1
@@ -18,12 +14,12 @@ shift
 case "$cmd" in
 fboss2 | fboss2-dev | diag_shell_client)
   # Forwarding stack commands
-  stack_path=${default_forwarding_stack_path}
+  update_prefix="fboss-forwarding"
   ;;
 
-fw_util | sensor_service_client | showtech | weutil)
+fw_util | sensor_service_client | rma-showtech | weutil)
   # Platform stack commands
-  stack_path=${default_platform_stack_path}
+  update_prefix="fboss-platform_stack"
   ;;
 
 *)
@@ -32,4 +28,24 @@ fw_util | sensor_service_client | showtech | weutil)
   ;;
 esac
 
-exec "${stack_path}/${cmd}" "$@"
+update_path=$(ls -1 /updates/${update_prefix}-*/opt/fboss/bin/${cmd} 2>/dev/null | head -n 1)
+if [ -x "$update_path" ]; then
+  update_base=$(dirname "$(dirname "$update_path")")
+  if [ -f "${update_base}/bin/setup_fboss_env" ]; then
+    pushd "$update_base" >/dev/null
+    # shellcheck source=/opt/fboss/bin/setup_fboss_env
+    source ./bin/setup_fboss_env
+    popd >/dev/null
+  fi
+  exec "$update_path" "$@"
+else
+  if [ -f /opt/fboss/bin/setup_fboss_env ]; then
+    pushd /opt/fboss >/dev/null
+    # shellcheck source=/opt/fboss/bin/setup_fboss_env
+    source ./bin/setup_fboss_env
+    popd >/dev/null
+  fi
+  exec "/opt/fboss/bin/${cmd}" "$@"
+fi
+echo "Failed to find fboss command"
+exit 1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

These two bits were lost in the shuffle.

The changes to fboss-image/distro_cli/lib/device_update.py enable support for updating a 'component' with multiple artifacts, such as other_dependencies.

The changes to fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/lib/fboss_cmd_find.sh update the command wrapper to look for updated component locations first.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Tested as part of the original Distro CLI Update PRs where they were submitted the first time.