### PR TITLE
[Nexthop] Make Python3.12 the default in Lab Distro

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/config.sh
@@ -9,6 +9,15 @@ mkdir -p "$LOCAL_RPM_REPO_DIR"
 sed -i 's/^PRETTY_NAME=.*/PRETTY_NAME="FBOSS Distro Image"/' /usr/lib/os-release
 sed -i 's/^NAME=.*/NAME="FBOSS Distro Image"/' /usr/lib/os-release
 
+echo "Creating FBOSS log directories..."
+mkdir -p /var/facebook/logs/fboss/sdk
+semanage fcontext -a -t var_log_t '/var/facebook/logs/fboss(/.*)?'
+restorecon -Rv /var/facebook/logs/fboss
+
+# Default to python 3.12, also simulate the Debian python-is-python3 package
+update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
+
 # All dnf invocations with an invalid RPM repo configured will fail. Create the
 # metadata for the local_rpm_repo now to prevent that.
 createrepo /usr/local/share/local_rpm_repo
@@ -357,11 +366,6 @@ systemctl enable fsdb.service
 systemctl enable qsfp_service.service
 systemctl enable fboss_sw_agent.service
 systemctl enable fboss_hw_agents.target
-
-echo "Creating FBOSS log directories..."
-mkdir -p /var/facebook/logs/fboss/sdk
-semanage fcontext -a -t var_log_t '/var/facebook/logs/fboss(/.*)?'
-restorecon -Rv /var/facebook/logs/fboss
 
 # 8. Fix NetworkManager connection profile permissions
 # NM ignores profiles that are world-readable


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The various FBOSS python scripts all assume Python 3.10 or newer. The CentOS Stream 9 system python is 3.9, which is not new enough.

Make 3.12 the default for users.

It is necessary to make this change after creating the FBOSS log directory because semanage does not correctly default to the system python (3.9) instead of the default python (3.12) and thus fails to set the log directory permissions correctly, resulting in agent startup failures.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

`python --version` should return a 3.12 version string.