### PR TITLE
[Nexthop] Distro copy build artifact

### DIFF
--- a/fboss-image/distro_cli/lib/artifact.py
+++ b/fboss-image/distro_cli/lib/artifact.py
@@ -181,13 +181,13 @@ class ArtifactStore:
         """
         dest_path = dest_dir / source.name
         if source.is_dir():
-            # For directories, move the entire tree
+            # For directories, copy the entire tree
             if dest_path.exists():
                 shutil.rmtree(dest_path)
-            shutil.move(str(source), str(dest_path))
+            shutil.copytree(str(source), str(dest_path))
         else:
-            # For files, move directly
-            shutil.move(str(source), str(dest_path))
+            # For files, copy directly
+            shutil.copy(str(source), str(dest_path))
 
     def invalidate(self, store_key: str) -> None:
         """Remove an artifact from the store.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

When integrating the Distro Image component builder into another CI system where you want to publish the per-component build artifacts, it is much more convenient to NOT move those artifacts into the Artifact Cache.

Instead copy it into the Artifact Cache so the original file is available in a consistent place to be picked up by the CI system and either published or used in later CI stages.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Build a Distro Image using `fboss-image build` and check that for each component, the component build script left a copy of the component artifact in the filesystem.