### PR TITLE
[Nexthop][fboss2-dev] Clear CmdArgsLists singleton between integration-test CLI invocations

### DIFF
--- a/fboss/cli/fboss2/CmdArgsLists.h
+++ b/fboss/cli/fboss2/CmdArgsLists.h
@@ -32,6 +32,17 @@ class CmdArgsLists {
     return data_[i];
   }
 
+  // Reset all depth levels to empty. Needed when the CLI is invoked multiple
+  // times in the same process (e.g. from the integration test harness), since
+  // CLI11's vector-backed add_option() appends to the vector rather than
+  // replacing it, and this singleton would otherwise accumulate stale args
+  // from previous invocations into subsequent parses.
+  void clear() {
+    for (auto& level : data_) {
+      level.clear();
+    }
+  }
+
   template <typename UnfilteredTypes, typename Types>
   Types getTypedArgs() {
     const auto& unfiltered =

--- a/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
@@ -16,6 +16,7 @@
 #include <chrono>
 #include <thread>
 
+#include "fboss/cli/fboss2/CmdArgsLists.h"
 #include "fboss/cli/fboss2/utils/CmdInitUtils.h"
 
 namespace fs = std::filesystem;
@@ -65,6 +66,12 @@ void Fboss2IntegrationTest::discardSession() const {
 
 Fboss2IntegrationTest::Result Fboss2IntegrationTest::executeCliCommand(
     const std::vector<std::string>& args) const {
+  // CLI11 add_option() appends to the vector it's bound to rather than
+  // replacing it. CmdArgsLists is a process-wide singleton, so without this
+  // reset args from a previous executeCliCommand() call would bleed into the
+  // current parse and typically cause nonsensical positional arg values.
+  CmdArgsLists::getInstance()->clear();
+
   // Create a new CLI::App for this command
   CLI::App app{"FBOSS CLI Test"};
   utils::initApp(app);


### PR DESCRIPTION
# Summary

`Fboss2IntegrationTest::executeCliCommand()` drives the CLI in-process by creating a fresh `CLI::App`, calling `utils::initApp(app)`, and parsing the provided argv. `initApp()` hooks CLI11's `add_option(...)` callbacks to positional-argument vectors owned by the **`CmdArgsLists` singleton** (process-wide) at various depths.

CLI11's `add_option(name, std::vector<T>&, ...)` appends to the vector rather than replacing it. The singleton therefore accumulates parsed args from every previous `runCli()` call in the same process. As a result, a sequence like:

```cpp
    runCli({"config", "arp", "timeout", "75"});  // leaves data_[0] = {"timeout", "75"}
    runCli({"show", "interface"});               // silently inherits {"timeout", "75"}
```

leaves the second `show interface` looking up interfaces named "timeout" and "75", which returns an empty list — downstream helpers like `findFirstEthInterface()` then throw "No suitable ethernet interface found".

The failure is latent for test sequences where the leftover args happen to still be plausible interface names (e.g. back-to-back `config interface ethN/1/1 mtu ...` calls), which is why existing tests did not catch it. Adding `ConfigArpTest` — the first suite to write non-interface-name values at depth 0 — surfaced 6 tests breaking in the full `fboss2_integration_test` run.

## Fix

- Add `CmdArgsLists::clear()` that resets every depth vector.
- Call it at the top of `Fboss2IntegrationTest::executeCliCommand()` so each simulated CLI invocation starts from a clean slate, matching the behaviour of a fresh subprocess invocation of `fboss2-dev`.

# Test Plan

Before this fix, on NH-4010-F with a healthy agent:

```
$ /tmp/fboss2_integration_test
[==========] 14 tests from 8 test suites ran.
[  PASSED  ] 7 tests.
[  FAILED  ] 7 tests, listed below:
[  FAILED  ] ConfigInterfaceDescriptionTest.SetAndVerifyDescription
[  FAILED  ] ConfigInterfaceMtuTest.SetAndVerifyMtu
[  FAILED  ] ConfigInterfaceSpeedTest.SetValidSpeedSuccess
[  FAILED  ] ConfigInterfaceSpeedTest.SetUnsupportedSpeedFails
[  FAILED  ] ConfigInterfaceSpeedTest.VerifySpeedValidationExecuted
[  FAILED  ] ConfigSessionClearTest.CreateAndClearSession
[  FAILED  ] ConfigSessionWarmbootTest.CommitTriggersWarmboot
```

After this fix, all tests pass.