### PR TITLE
[Nexthop][fboss2-dev] Add fboss2-dev config arp CLI subcommands

### DIFF
--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -692,6 +692,8 @@ add_library(fboss2_config_lib
   fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.cpp
   fboss/cli/fboss2/commands/config/CmdConfigReload.h
   fboss/cli/fboss2/commands/config/CmdConfigReload.cpp
+  fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
+  fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.cpp

--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -698,6 +698,8 @@ add_library(fboss2_config_lib
   fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.cpp
   fboss/cli/fboss2/commands/config/CmdConfigReload.h
   fboss/cli/fboss2/commands/config/CmdConfigReload.cpp
+  fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
+  fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
   fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.cpp

--- a/cmake/CliFboss2TestConfig.cmake
+++ b/cmake/CliFboss2TestConfig.cmake
@@ -5,6 +5,7 @@ add_executable(fboss2_cmd_config_test
   fboss/util/oss/TestMain.cpp
   fboss/cli/fboss2/oss/config/CmdListImpl.cpp
   fboss/cli/fboss2/test/config/CmdConfigAppliedInfoTest.cpp
+  fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigHistoryTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceSwitchportAccessVlanTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp

--- a/cmake/CliFboss2TestIntegrationTest.cmake
+++ b/cmake/CliFboss2TestIntegrationTest.cmake
@@ -8,6 +8,7 @@
 add_executable(fboss2_integration_test
   fboss/cli/fboss2/oss/config/CmdListImpl.cpp
   fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceDescriptionTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigQosPolicyMapTest.cpp

--- a/cmake/CliFboss2TestIntegrationTest.cmake
+++ b/cmake/CliFboss2TestIntegrationTest.cmake
@@ -8,6 +8,7 @@
 add_executable(fboss2_integration_test
   fboss/cli/fboss2/oss/config/CmdListImpl.cpp
   fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigConcurrentSessionsTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceDescriptionTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceMtuTest.cpp

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -972,6 +972,7 @@ cpp_library(
         "CmdListConfig.cpp",
         "commands/config/CmdConfigAppliedInfo.cpp",
         "commands/config/CmdConfigReload.cpp",
+        "commands/config/arp/CmdConfigArp.cpp",
         "commands/config/history/CmdConfigHistory.cpp",
         "commands/config/interface/CmdConfigInterface.cpp",
         "commands/config/interface/CmdConfigInterfaceQueuingPolicy.cpp",
@@ -1068,6 +1069,7 @@ cpp_library(
     headers = [
         "commands/config/CmdConfigAppliedInfo.h",
         "commands/config/CmdConfigReload.h",
+        "commands/config/arp/CmdConfigArp.h",
         "commands/config/history/CmdConfigHistory.h",
         "commands/config/interface/CmdConfigInterface.h",
         "commands/config/interface/CmdConfigInterfaceQueuingPolicy.h",

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -1019,6 +1019,7 @@ cpp_library(
         "CmdListConfig.cpp",
         "commands/config/CmdConfigAppliedInfo.cpp",
         "commands/config/CmdConfigReload.cpp",
+        "commands/config/arp/CmdConfigArp.cpp",
         "commands/config/history/CmdConfigHistory.cpp",
         "commands/config/interface/CmdConfigInterface.cpp",
         "commands/config/interface/CmdConfigInterfaceQueuingPolicy.cpp",
@@ -1115,6 +1116,7 @@ cpp_library(
     headers = [
         "commands/config/CmdConfigAppliedInfo.h",
         "commands/config/CmdConfigReload.h",
+        "commands/config/arp/CmdConfigArp.h",
         "commands/config/history/CmdConfigHistory.h",
         "commands/config/interface/CmdConfigInterface.h",
         "commands/config/interface/CmdConfigInterfaceQueuingPolicy.h",

--- a/fboss/cli/fboss2/CmdListConfig.cpp
+++ b/fboss/cli/fboss2/CmdListConfig.cpp
@@ -13,6 +13,7 @@
 
 #include "fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h"
 #include "fboss/cli/fboss2/commands/config/CmdConfigReload.h"
+#include "fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h"
 #include "fboss/cli/fboss2/commands/config/history/CmdConfigHistory.h"
 #include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h"
 #include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.h"
@@ -110,6 +111,12 @@ const CommandTree& kConfigCommandTree() {
        "Show config applied information",
        commandHandler<CmdConfigAppliedInfo>,
        argTypeHandler<CmdConfigAppliedInfoTraits>},
+
+      {"config",
+       "arp",
+       "Configure ARP/NDP settings",
+       commandHandler<CmdConfigArp>,
+       argTypeHandler<CmdConfigArpTraits>},
 
       {"config",
        "history",

--- a/fboss/cli/fboss2/CmdListConfig.cpp
+++ b/fboss/cli/fboss2/CmdListConfig.cpp
@@ -13,6 +13,7 @@
 
 #include "fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h"
 #include "fboss/cli/fboss2/commands/config/CmdConfigReload.h"
+#include "fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h"
 #include "fboss/cli/fboss2/commands/config/history/CmdConfigHistory.h"
 #include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h"
 #include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.h"
@@ -110,6 +111,12 @@ const CommandTree& kConfigCommandTree() {
        "Show config applied information",
        commandHandler<CmdConfigAppliedInfo>,
        argRegistrar<CmdConfigAppliedInfoTraits>},
+
+      {"config",
+       "arp",
+       "Configure ARP settings",
+       commandHandler<CmdConfigArp>,
+       argRegistrar<CmdConfigArpTraits>},
 
       {"config",
        "history",

--- a/fboss/cli/fboss2/CmdSubcommands.cpp
+++ b/fboss/cli/fboss2/CmdSubcommands.cpp
@@ -346,6 +346,13 @@ CLI::App* CmdSubcommands::addCommand(
               "<port-list> [<attr> <value> ...] where <attr> is one "
               "of: description, mtu");
           break;
+        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ARP_CONFIG:
+          subCmd->add_option(
+              "arp_attr_value",
+              args,
+              "<attr> <value> where <attr> is one of: "
+              "timeout, age-interval, max-probes, stale-interval");
+          break;
         case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_UNINITIALIZE:
         case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE:
           break;

--- a/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
+++ b/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h"
+
+#include "fboss/cli/fboss2/CmdHandler.cpp"
+
+#include <fmt/format.h>
+#include <folly/Conv.h>
+#include <folly/String.h>
+#include <cstdint>
+#include <iostream>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include "fboss/cli/fboss2/gen-cpp2/cli_metadata_types.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+namespace facebook::fboss {
+
+namespace {
+constexpr std::string_view kAttrTimeout = "timeout";
+constexpr std::string_view kAttrAgeInterval = "age-interval";
+constexpr std::string_view kAttrMaxProbes = "max-probes";
+constexpr std::string_view kAttrStaleInterval = "stale-interval";
+/* arpRefreshSeconds is defined in switch_config.thrift yet not implemented
+constexpr std::string_view kAttrRefresh = "refresh";
+*/
+
+// Valid ARP/NDP attribute names accepted by `fboss2-dev config arp <attr>`.
+const std::set<std::string_view> kArpValidAttrs = {
+    kAttrTimeout,
+    kAttrAgeInterval,
+    kAttrMaxProbes,
+    kAttrStaleInterval,
+};
+} // namespace
+
+ArpConfigArgs::ArpConfigArgs(std::vector<std::string> v) {
+  if (v.size() != 2) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Expected <attr> <value>, got {} argument(s). Valid attrs: {}",
+            v.size(),
+            folly::join(", ", kArpValidAttrs)));
+  }
+
+  if (kArpValidAttrs.find(v[0]) == kArpValidAttrs.end()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Unknown ARP attribute '{}'. Valid attrs: {}",
+            v[0],
+            folly::join(", ", kArpValidAttrs)));
+  }
+
+  int32_t parsed = 0;
+  try {
+    parsed = folly::to<int32_t>(v[1]);
+  } catch (const folly::ConversionError&) {
+    throw std::invalid_argument(
+        fmt::format("Value for '{}' must be an integer, got '{}'", v[0], v[1]));
+  }
+
+  if (parsed < 0) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Value for '{}' must be non-negative, got {}", v[0], parsed));
+  }
+
+  attribute_ = v[0];
+  value_ = parsed;
+  data_ = std::move(v);
+}
+
+CmdConfigArpTraits::RetType CmdConfigArp::queryClient(
+    const HostInfo& /* hostInfo */,
+    const ObjectArgType& args) {
+  auto& session = ConfigSession::getInstance();
+  auto& config = session.getAgentConfig();
+  auto& swConfig = *config.sw();
+
+  const auto& attr = args.getAttribute();
+  int32_t value = args.getValue();
+
+  if (attr == kAttrTimeout) {
+    swConfig.arpTimeoutSeconds() = value;
+  } else if (attr == kAttrAgeInterval) {
+    swConfig.arpAgerInterval() = value;
+  } else if (attr == kAttrMaxProbes) {
+    swConfig.maxNeighborProbes() = value;
+  } else if (attr == kAttrStaleInterval) {
+    swConfig.staleEntryInterval() = value;
+  } else {
+    // ArpConfigArgs validates this; defensive guard in case kArpValidAttrs
+    // drifts from the dispatch switch here.
+    throw std::runtime_error(fmt::format("Unhandled ARP attribute '{}'", attr));
+  }
+
+  // All ARP/NDP timer attributes are applied hitlessly by
+  // ThriftConfigApplier::updateSwitchSettings (no SAI ChangeProhibited guard).
+  session.saveConfig(cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+
+  return fmt::format("Set arp {} to {}", attr, value);
+}
+
+void CmdConfigArp::printOutput(const RetType& logMsg) {
+  std::cout << logMsg << std::endl;
+}
+
+// Explicit template instantiation
+template void CmdHandler<CmdConfigArp, CmdConfigArpTraits>::run();
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
+++ b/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "fboss/cli/fboss2/CmdHandler.h"
+#include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+namespace facebook::fboss {
+
+// Argument for `config arp <attr> <value>`.
+// Validates that v[0] is one of the valid ARP attribute names and v[1] is a
+// non-negative int32.
+class ArpConfigArgs : public utils::BaseObjectArgType<std::string> {
+ public:
+  /* implicit */ ArpConfigArgs( // NOLINT(google-explicit-constructor)
+      std::vector<std::string> v);
+
+  const std::string& getAttribute() const {
+    return attribute_;
+  }
+
+  int32_t getValue() const {
+    return value_;
+  }
+
+  const static utils::ObjectArgTypeId id =
+      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ARP_CONFIG;
+
+ private:
+  std::string attribute_;
+  int32_t value_ = 0;
+};
+
+struct CmdConfigArpTraits : public WriteCommandTraits {
+  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
+      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ARP_CONFIG;
+  using ObjectArgType = ArpConfigArgs;
+  using RetType = std::string;
+};
+
+class CmdConfigArp : public CmdHandler<CmdConfigArp, CmdConfigArpTraits> {
+ public:
+  using ObjectArgType = CmdConfigArpTraits::ObjectArgType;
+  using RetType = CmdConfigArpTraits::RetType;
+
+  RetType queryClient(const HostInfo& hostInfo, const ObjectArgType& args);
+
+  void printOutput(const RetType& logMsg);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
+++ b/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "fboss/cli/fboss2/CmdHandler.h"
+#include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+namespace facebook::fboss {
+
+// Argument for `config arp <attr> <value>`.
+// Validates that v[0] is one of the valid ARP attribute names and v[1] is a
+// non-negative int32.
+class ArpConfigArgs : public utils::BaseObjectArgType<std::string> {
+ public:
+  /* implicit */ ArpConfigArgs( // NOLINT(google-explicit-constructor)
+      std::vector<std::string> v);
+
+  const std::string& getAttribute() const {
+    return attribute_;
+  }
+
+  int32_t getValue() const {
+    return value_;
+  }
+
+ private:
+  std::string attribute_;
+  int32_t value_ = 0;
+};
+
+struct CmdConfigArpTraits : public WriteCommandTraits {
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "arp_attr_value",
+        args,
+        "<attr> <value> where <attr> is one of: "
+        "timeout, age-interval, max-probes, stale-interval");
+  }
+  using ObjectArgType = ArpConfigArgs;
+  using RetType = std::string;
+};
+
+class CmdConfigArp : public CmdHandler<CmdConfigArp, CmdConfigArpTraits> {
+ public:
+  using ObjectArgType = CmdConfigArpTraits::ObjectArgType;
+  using RetType = CmdConfigArpTraits::RetType;
+
+  RetType queryClient(const HostInfo& hostInfo, const ObjectArgType& args);
+
+  void printOutput(const RetType& logMsg);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/BUCK
+++ b/fboss/cli/fboss2/test/config/BUCK
@@ -7,6 +7,7 @@ cpp_unittest(
     srcs = [
         "BgpConfigSessionTest.cpp",
         "CmdConfigAppliedInfoTest.cpp",
+        "CmdConfigArpTest.cpp",
         "CmdConfigHistoryTest.cpp",
         "CmdConfigInterfaceSwitchportAccessVlanTest.cpp",
         "CmdConfigInterfaceTest.cpp",

--- a/fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
@@ -1,0 +1,165 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+
+#include "fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+class CmdConfigArpTestFixture : public CmdConfigTestBase {
+ public:
+  CmdConfigArpTestFixture()
+      : CmdConfigTestBase(
+            "fboss_arp_config_test_%%%%-%%%%-%%%%-%%%%",
+            R"({
+  "sw": {
+    "arpTimeoutSeconds": 60,
+    "arpAgerInterval": 5,
+    "maxNeighborProbes": 300,
+    "staleEntryInterval": 10
+  }
+})") {}
+
+ protected:
+  const std::string cmdPrefix_ = "config arp";
+};
+
+// =============================================================
+// ArpConfigArgs validation tests
+// =============================================================
+
+TEST_F(CmdConfigArpTestFixture, argValidation_valid) {
+  ArpConfigArgs a({"timeout", "45"});
+  EXPECT_EQ(a.getAttribute(), "timeout");
+  EXPECT_EQ(a.getValue(), 45);
+
+  ArpConfigArgs b({"age-interval", "3"});
+  EXPECT_EQ(b.getAttribute(), "age-interval");
+  EXPECT_EQ(b.getValue(), 3);
+
+  ArpConfigArgs c({"max-probes", "1000"});
+  EXPECT_EQ(c.getAttribute(), "max-probes");
+  EXPECT_EQ(c.getValue(), 1000);
+
+  ArpConfigArgs d({"stale-interval", "0"});
+  EXPECT_EQ(d.getAttribute(), "stale-interval");
+  EXPECT_EQ(d.getValue(), 0);
+}
+
+TEST_F(CmdConfigArpTestFixture, argValidation_badArity) {
+  EXPECT_THROW(ArpConfigArgs({}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"timeout"}), std::invalid_argument);
+  EXPECT_THROW(
+      ArpConfigArgs({"timeout", "45", "extra"}), std::invalid_argument);
+}
+
+TEST_F(CmdConfigArpTestFixture, argValidation_unknownAttr) {
+  EXPECT_THROW(ArpConfigArgs({"unknown", "10"}), std::invalid_argument);
+  // refresh is intentionally NOT in the valid set — deferred (NOS-5734)
+  EXPECT_THROW(ArpConfigArgs({"refresh", "20"}), std::invalid_argument);
+  // Case-sensitive: "Timeout" not accepted
+  EXPECT_THROW(ArpConfigArgs({"Timeout", "10"}), std::invalid_argument);
+}
+
+TEST_F(CmdConfigArpTestFixture, argValidation_nonInteger) {
+  EXPECT_THROW(ArpConfigArgs({"timeout", "abc"}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"timeout", "3.14"}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"timeout", ""}), std::invalid_argument);
+}
+
+TEST_F(CmdConfigArpTestFixture, argValidation_negative) {
+  EXPECT_THROW(ArpConfigArgs({"timeout", "-1"}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"age-interval", "-5"}), std::invalid_argument);
+}
+
+// =============================================================
+// queryClient() tests — one per attribute
+// =============================================================
+
+TEST_F(CmdConfigArpTestFixture, setTimeout) {
+  setupTestableConfigSession(cmdPrefix_, "timeout 120");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+  ArpConfigArgs args({"timeout", "120"});
+
+  auto result = cmd.queryClient(hostInfo, args);
+  EXPECT_THAT(result, HasSubstr("timeout"));
+  EXPECT_THAT(result, HasSubstr("120"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  EXPECT_EQ(*config.sw()->arpTimeoutSeconds(), 120);
+}
+
+TEST_F(CmdConfigArpTestFixture, setAgeInterval) {
+  setupTestableConfigSession(cmdPrefix_, "age-interval 7");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+  ArpConfigArgs args({"age-interval", "7"});
+
+  auto result = cmd.queryClient(hostInfo, args);
+  EXPECT_THAT(result, HasSubstr("age-interval"));
+  EXPECT_THAT(result, HasSubstr("7"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  EXPECT_EQ(*config.sw()->arpAgerInterval(), 7);
+}
+
+TEST_F(CmdConfigArpTestFixture, setMaxProbes) {
+  setupTestableConfigSession(cmdPrefix_, "max-probes 500");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+  ArpConfigArgs args({"max-probes", "500"});
+
+  auto result = cmd.queryClient(hostInfo, args);
+  EXPECT_THAT(result, HasSubstr("max-probes"));
+  EXPECT_THAT(result, HasSubstr("500"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  EXPECT_EQ(*config.sw()->maxNeighborProbes(), 500);
+}
+
+TEST_F(CmdConfigArpTestFixture, setStaleInterval) {
+  setupTestableConfigSession(cmdPrefix_, "stale-interval 15");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+  ArpConfigArgs args({"stale-interval", "15"});
+
+  auto result = cmd.queryClient(hostInfo, args);
+  EXPECT_THAT(result, HasSubstr("stale-interval"));
+  EXPECT_THAT(result, HasSubstr("15"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  EXPECT_EQ(*config.sw()->staleEntryInterval(), 15);
+}
+
+TEST_F(CmdConfigArpTestFixture, idempotentSameValue) {
+  // Setting the same value twice should succeed without error.
+  setupTestableConfigSession(cmdPrefix_, "timeout 90");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+  ArpConfigArgs args({"timeout", "90"});
+
+  cmd.queryClient(hostInfo, args);
+  cmd.queryClient(hostInfo, args);
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  EXPECT_EQ(*config.sw()->arpTimeoutSeconds(), 90);
+}
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -17,6 +17,7 @@ oncall("fboss_oss")
 cpp_binary(
     name = "fboss2_integration_test",
     srcs = [
+        "ConfigArpTest.cpp",
         "ConfigInterfaceDescriptionTest.cpp",
         "ConfigInterfaceMtuTest.cpp",
         "ConfigQosPolicyMapTest.cpp",

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -16,6 +16,7 @@ oncall("fboss_oss")
 cpp_binary(
     name = "fboss2_integration_test",
     srcs = [
+        "ConfigArpTest.cpp",
         "ConfigConcurrentSessionsTest.cpp",
         "ConfigInterfaceDescriptionTest.cpp",
         "ConfigInterfaceMtuTest.cpp",

--- a/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
@@ -1,0 +1,117 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end tests for `fboss2-dev config arp <attr> <value>` commands.
+ *
+ * Covers the 4 hitless ARP/NDP tunables:
+ *   - timeout         -> arpTimeoutSeconds
+ *   - age-interval    -> arpAgerInterval
+ *   - max-probes      -> maxNeighborProbes
+ *   - stale-interval  -> staleEntryInterval
+ *
+ * For each attribute, the test:
+ *   1. Reads the current value from the agent's running config
+ *   2. Sets a new value via `config arp <attr> <new>`
+ *   3. Commits the session (HITLESS — no agent restart)
+ *   4. Verifies the running config reflects the new value
+ *   5. Restores the original value
+ *
+ * Requirements:
+ *   - FBOSS agent is running with a valid configuration
+ *   - Test is run as root (or with sudo) on a DUT
+ */
+
+#include <fmt/format.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/logging/xlog.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include "fboss/agent/if/gen-cpp2/FbossCtrlAsyncClient.h"
+#include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+using namespace facebook::fboss;
+using ::testing::HasSubstr;
+
+class ConfigArpTest : public Fboss2IntegrationTest {
+ protected:
+  folly::dynamic getRunningConfig() const {
+    HostInfo hostInfo("localhost");
+    auto client =
+        utils::createClient<apache::thrift::Client<FbossCtrl>>(hostInfo);
+    std::string configStr;
+    client->sync_getRunningConfig(configStr);
+    return folly::parseJson(configStr);
+  }
+
+  // Read a top-level int field from sw (the field is only present when set).
+  int getSwField(const std::string& field) const {
+    auto config = getRunningConfig();
+    if (!config.isObject() || !config.count("sw")) {
+      throw std::runtime_error("Running config missing 'sw' object");
+    }
+    const auto& sw = config["sw"];
+    if (!sw.isObject() || !sw.count(field)) {
+      throw std::runtime_error(
+          fmt::format("Running config 'sw' missing field '{}'", field));
+    }
+    return sw[field].asInt();
+  }
+
+  void setAndVerify(
+      const std::string& attr,
+      const std::string& swField,
+      int newValue) {
+    XLOG(INFO) << "========================================";
+    XLOG(INFO) << "  arp " << attr << " -> " << newValue;
+    XLOG(INFO) << "========================================";
+
+    int originalValue = getSwField(swField);
+    XLOG(INFO) << "[Step 1] Original " << swField << " = " << originalValue;
+    ASSERT_NE(originalValue, newValue)
+        << "Test value " << newValue << " must differ from original "
+        << originalValue;
+
+    XLOG(INFO) << "[Step 2] Running: config arp " << attr << " " << newValue;
+    auto result = runCli({"config", "arp", attr, std::to_string(newValue)});
+    ASSERT_EQ(result.exitCode, 0)
+        << "stdout=" << result.stdout << " stderr=" << result.stderr;
+    EXPECT_THAT(result.stdout, HasSubstr(attr));
+
+    XLOG(INFO) << "[Step 3] Committing (expect HITLESS, no restart)...";
+    commitConfig();
+
+    XLOG(INFO) << "[Step 4] Verifying running config...";
+    int observed = getSwField(swField);
+    EXPECT_EQ(observed, newValue) << "Expected running config " << swField
+                                  << "=" << newValue << ", got " << observed;
+
+    XLOG(INFO) << "[Step 5] Restoring original value " << originalValue;
+    result = runCli({"config", "arp", attr, std::to_string(originalValue)});
+    ASSERT_EQ(result.exitCode, 0) << result.stderr;
+    commitConfig();
+    EXPECT_EQ(getSwField(swField), originalValue);
+
+    XLOG(INFO) << "  PASSED: " << attr;
+  }
+};
+
+TEST_F(ConfigArpTest, SetTimeout) {
+  setAndVerify("timeout", "arpTimeoutSeconds", 75);
+}
+
+TEST_F(ConfigArpTest, SetAgeInterval) {
+  setAndVerify("age-interval", "arpAgerInterval", 8);
+}
+
+TEST_F(ConfigArpTest, SetMaxProbes) {
+  setAndVerify("max-probes", "maxNeighborProbes", 250);
+}
+
+TEST_F(ConfigArpTest, SetStaleInterval) {
+  setAndVerify("stale-interval", "staleEntryInterval", 15);
+}

--- a/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
@@ -1,0 +1,151 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end tests for `fboss2-dev config arp <attr> <value>` commands.
+ *
+ * Covers the 4 hitless ARP/NDP tunables. Each `<attr>` maps to one
+ * `cfg::SwitchConfig.sw.<field>` and one `switchSettings.<field>`:
+ *   - timeout        -> arpTimeoutSeconds  / arpTimeout
+ *   - age-interval   -> arpAgerInterval    / arpAgerInterval
+ *   - max-probes     -> maxNeighborProbes  / maxNeighborProbes
+ *   - stale-interval -> staleEntryInterval / staleEntryInterval
+ *
+ * For each attribute, the test:
+ *   1. Reads the current value from the agent's running config + switch state
+ *   2. Sets a new value via `config arp <attr> <new>`
+ *   3. Commits the session (HITLESS — no agent restart)
+ *   4. Verifies the running config reflects the new value
+ *   5. Verifies the agent's programmed switch state reflects the new value
+ *   6. Restores the original value
+ *
+ * Requirements:
+ *   - FBOSS agent is running with a valid configuration
+ *   - Test is run as root (or with sudo) on a DUT
+ */
+
+#include <fmt/format.h>
+#include <folly/json/dynamic.h>
+#include <folly/json/json.h>
+#include <folly/logging/xlog.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <stdexcept>
+#include <string>
+#include "fboss/agent/if/gen-cpp2/FbossCtrlAsyncClient.h"
+#include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/HostInfo.h"
+
+using namespace facebook::fboss;
+using ::testing::HasSubstr;
+
+class ConfigArpTest : public Fboss2IntegrationTest {
+ protected:
+  folly::dynamic getRunningConfig() const {
+    HostInfo hostInfo("localhost");
+    auto client =
+        utils::createClient<apache::thrift::Client<FbossCtrl>>(hostInfo);
+    std::string configStr;
+    client->sync_getRunningConfig(configStr);
+    return folly::parseJson(configStr);
+  }
+
+  // Fetch the agent's programmed switchSettings from the live switch state.
+  // Defined in switch_state.thrift::SwitchSettingsFields.
+  folly::dynamic getSwitchSettings() const {
+    HostInfo hostInfo("localhost");
+    auto client =
+        utils::createClient<apache::thrift::Client<FbossCtrl>>(hostInfo);
+    std::string settingsJson;
+    client->sync_getCurrentStateJSON(settingsJson, "switchSettings");
+    return folly::parseJson(settingsJson);
+  }
+
+  // Read a top-level int field from sw (the field is only present when set).
+  int getSwField(const std::string& field) const {
+    auto config = getRunningConfig();
+    if (!config.isObject() || !config.count("sw")) {
+      throw std::runtime_error("Running config missing 'sw' object");
+    }
+    const auto& sw = config["sw"];
+    if (!sw.isObject() || !sw.count(field)) {
+      throw std::runtime_error(
+          fmt::format("Running config 'sw' missing field '{}'", field));
+    }
+    return sw[field].asInt();
+  }
+
+  // Read a field from switchSettings in the agent's switch state. The field is
+  // only present in the JSON once it has been programmed by the agent.
+  int getSwitchSettingsField(const std::string& field) const {
+    auto settings = getSwitchSettings();
+    if (!settings.isObject() || !settings.count(field)) {
+      throw std::runtime_error(
+          fmt::format("switchSettings missing field '{}'", field));
+    }
+    return settings[field].asInt();
+  }
+
+  void setAndVerify(
+      const std::string& attr,
+      const std::string& swField,
+      const std::string& switchStateField,
+      int newValue) {
+    XLOG(INFO) << "========================================";
+    XLOG(INFO) << "  arp " << attr << " -> " << newValue;
+    XLOG(INFO) << "========================================";
+
+    int originalValue = getSwField(swField);
+    XLOG(INFO) << "[Step 1] Original " << swField << " = " << originalValue;
+    ASSERT_NE(originalValue, newValue)
+        << "Test value " << newValue << " must differ from original "
+        << originalValue;
+
+    XLOG(INFO) << "[Step 2] Running: config arp " << attr << " " << newValue;
+    auto result = runCli({"config", "arp", attr, std::to_string(newValue)});
+    ASSERT_EQ(result.exitCode, 0)
+        << "stdout=" << result.stdout << " stderr=" << result.stderr;
+    EXPECT_THAT(result.stdout, HasSubstr(attr));
+
+    XLOG(INFO) << "[Step 3] Committing (expect HITLESS, no restart)...";
+    commitConfig();
+
+    XLOG(INFO) << "[Step 4] Verifying running config...";
+    int observed = getSwField(swField);
+    EXPECT_EQ(observed, newValue) << "Expected running config " << swField
+                                  << "=" << newValue << ", got " << observed;
+
+    XLOG(INFO) << "[Step 5] Verifying switch state switchSettings."
+               << switchStateField;
+    int programmed = getSwitchSettingsField(switchStateField);
+    EXPECT_EQ(programmed, newValue)
+        << "Expected switchSettings." << switchStateField << "=" << newValue
+        << ", got " << programmed;
+
+    XLOG(INFO) << "[Step 6] Restoring original value " << originalValue;
+    result = runCli({"config", "arp", attr, std::to_string(originalValue)});
+    ASSERT_EQ(result.exitCode, 0) << result.stderr;
+    commitConfig();
+    EXPECT_EQ(getSwField(swField), originalValue);
+    EXPECT_EQ(getSwitchSettingsField(switchStateField), originalValue);
+
+    XLOG(INFO) << "  PASSED: " << attr;
+  }
+};
+
+TEST_F(ConfigArpTest, SetTimeout) {
+  setAndVerify("timeout", "arpTimeoutSeconds", "arpTimeout", 75);
+}
+
+TEST_F(ConfigArpTest, SetAgeInterval) {
+  setAndVerify("age-interval", "arpAgerInterval", "arpAgerInterval", 8);
+}
+
+TEST_F(ConfigArpTest, SetMaxProbes) {
+  setAndVerify("max-probes", "maxNeighborProbes", "maxNeighborProbes", 250);
+}
+
+TEST_F(ConfigArpTest, SetStaleInterval) {
+  setAndVerify(
+      "stale-interval", "staleEntryInterval", "staleEntryInterval", 15);
+}

--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
@@ -22,6 +22,7 @@
 
 #include <chrono>
 #include <fstream>
+#include <iostream>
 #include <string>
 
 using folly::ByteRange;

--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.h
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-#include <CLI/App.hpp>
 #include <bits/types/struct_timeval.h>
 #include <folly/IPAddress.h>
 #include <folly/stop_watch.h>
@@ -91,6 +90,7 @@ enum class ObjectArgTypeId : uint8_t {
   OBJECT_ARG_TYPE_PORT_AND_TAGGING_MODE,
   OBJECT_ARG_TYPE_L2_LEARNING_MODE,
   OBJECT_ARG_TYPE_ID_INTERFACES_CONFIG,
+  OBJECT_ARG_TYPE_ARP_CONFIG,
 };
 
 template <typename T>

--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.h
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.h
@@ -9,7 +9,6 @@
  */
 #pragma once
 
-#include <CLI/App.hpp>
 #include <bits/types/struct_timeval.h>
 #include <folly/IPAddress.h>
 #include <folly/stop_watch.h>


### PR DESCRIPTION
# Summary

Adds a new `fboss2-dev config arp <attr> <value>` command family for tuning the FBOSS agent's ARP/NDP neighbor-table timers at runtime. Four attributes are supported, all can be set in a hitless config reload (no agent restart required):

- `timeout`        -> SwitchConfig.arpTimeoutSeconds
- `age-interval`   -> SwitchConfig.arpAgerInterval
- `max-probes`     -> SwitchConfig.maxNeighborProbes
- `stale-interval` -> SwitchConfig.staleEntryInterval

Note: I was going to implement a `refresh` subcommand as well, to set `arpRefreshSeconds`. That field is declared in `switch_config.thrift` but is **not** read by `ApplyThriftConfig.cpp` and is absent from `switch_state.thrift`, so setting it would be a no-op in the agent. It is explicitly excluded from `kArpValidAttrs` and ignored for now.

# Test Plan

## Unit tests

```
$ ./fboss/oss/scripts/bazel.sh test \
    //fboss/cli/fboss2/test/config:cmd_config_test \
    --test_filter='CmdConfigArpTestFixture.*'

[==========] Running 10 tests from 1 test suite.
[ RUN      ] CmdConfigArpTestFixture.argValidation_valid
[       OK ] CmdConfigArpTestFixture.argValidation_valid (84 ms)
[ RUN      ] CmdConfigArpTestFixture.argValidation_badArity
[       OK ] CmdConfigArpTestFixture.argValidation_badArity (30 ms)
[ RUN      ] CmdConfigArpTestFixture.argValidation_unknownAttr
[       OK ] CmdConfigArpTestFixture.argValidation_unknownAttr (34 ms)
[ RUN      ] CmdConfigArpTestFixture.argValidation_nonInteger
[       OK ] CmdConfigArpTestFixture.argValidation_nonInteger (32 ms)
[ RUN      ] CmdConfigArpTestFixture.argValidation_negative
[       OK ] CmdConfigArpTestFixture.argValidation_negative (31 ms)
[ RUN      ] CmdConfigArpTestFixture.setTimeout
[       OK ] CmdConfigArpTestFixture.setTimeout (82 ms)
[ RUN      ] CmdConfigArpTestFixture.setAgeInterval
[       OK ] CmdConfigArpTestFixture.setAgeInterval (103 ms)
[ RUN      ] CmdConfigArpTestFixture.setMaxProbes
[       OK ] CmdConfigArpTestFixture.setMaxProbes (75 ms)
[ RUN      ] CmdConfigArpTestFixture.setStaleInterval
[       OK ] CmdConfigArpTestFixture.setStaleInterval (76 ms)
[ RUN      ] CmdConfigArpTestFixture.idempotentSameValue
[       OK ] CmdConfigArpTestFixture.idempotentSameValue (85 ms)
[----------] 10 tests from CmdConfigArpTestFixture (636 ms total)
[  PASSED  ] 10 tests.
```

## Integration tests (on gold405 / NH-4010-F)

```
$ sudo /tmp/fboss2_integration_test --gtest_filter='ConfigArpTest.*'

[==========] Running 4 tests from 1 test suite.
[ RUN      ] ConfigArpTest.SetTimeout
[       OK ] ConfigArpTest.SetTimeout (173 ms)
[ RUN      ] ConfigArpTest.SetAgeInterval
[       OK ] ConfigArpTest.SetAgeInterval (108 ms)
[ RUN      ] ConfigArpTest.SetMaxProbes
[       OK ] ConfigArpTest.SetMaxProbes (141 ms)
[ RUN      ] ConfigArpTest.SetStaleInterval
[       OK ] ConfigArpTest.SetStaleInterval (108 ms)
[----------] 4 tests from ConfigArpTest (531 ms total)
[  PASSED  ] 4 tests.
```

Each test reads the current value via the agent's thrift `getRunningConfig()`, sets a new value via the CLI, commits the session (HITLESS), verifies the running config reflects the change, then restores the original value.

## Sample usage

```
$ fboss2-dev config arp timeout 90
Set arp timeout to 90
$ fboss2-dev config arp age-interval 7
Set arp age-interval to 7
$ fboss2-dev config arp max-probes 400
Set arp max-probes to 400
$ fboss2-dev config arp stale-interval 30
Set arp stale-interval to 30

$ fboss2-dev config session diff
--- current live config
+++ session config
@@ -29,9 +29,9 @@
   "sw": {
     "acls": [],
     "aggregatePorts": [],
-    "arpAgerInterval": 5,
+    "arpAgerInterval": 7,
     "arpRefreshSeconds": 20,
-    "arpTimeoutSeconds": 60,
+    "arpTimeoutSeconds": 90,
     "clientIdToAdminDistance": {
 ...
-    "maxNeighborProbes": 300,
+    "maxNeighborProbes": 400,
 ...
-    "staleEntryInterval": 10,
+    "staleEntryInterval": 30,
 ...

$ fboss2-dev config session commit
Config session committed successfully as 280a583 and config reloaded for fboss_sw_agent.
```