### PR TITLE
[Nexthop][Distro] Fix fboss_init.sh startup and package missing shared libs

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
@@ -3,6 +3,9 @@
 
 set -e
 
+# shellcheck source=/opt/fboss/bin/setup_fboss_env
+source /opt/fboss/bin/setup_fboss_env
+
 FBOSS_SHARE="/opt/fboss/share"
 COOP_DIR="/etc/coop"
 FRUID_FILE="/var/facebook/fboss/fruid.json"
@@ -61,11 +64,12 @@ generate_fruid() {
 
   mkdir -p "$(dirname "$FRUID_FILE")"
 
-  if /opt/fboss/bin/weutil --json >"$FRUID_FILE" 2>/dev/null; then
+  if weutil --json >"$FRUID_FILE"; then
     log "Generated fruid.json: $FRUID_FILE"
   else
     error "Failed to generate fruid.json"
     rm -f "$FRUID_FILE"
+    return 1
   fi
 }
 
@@ -125,7 +129,9 @@ main() {
 
   create_distro_base_snapshot
   setup_coop_configs "$platform_dir"
-  generate_fruid
+  if ! generate_fruid; then
+    exit 1
+  fi
   enable_hw_agents "$platform_dir"
 
   log "FBOSS initialization complete"

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/lib/fboss_cmd_find.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/lib/fboss_cmd_find.sh
@@ -40,10 +40,8 @@ if [ -x "$update_path" ]; then
   exec "$update_path" "$@"
 else
   if [ -f /opt/fboss/bin/setup_fboss_env ]; then
-    pushd /opt/fboss >/dev/null
     # shellcheck source=/opt/fboss/bin/setup_fboss_env
-    source ./bin/setup_fboss_env
-    popd >/dev/null
+    source /opt/fboss/bin/setup_fboss_env
   fi
   exec "/opt/fboss/bin/${cmd}" "$@"
 fi

--- a/fboss/oss/scripts/package.py
+++ b/fboss/oss/scripts/package.py
@@ -5,6 +5,7 @@
 
 import argparse
 import concurrent.futures
+import glob
 import os
 import pathlib
 import sys
@@ -19,7 +20,21 @@ BUILD_DIR = "--build-dir"
 TARGET_NAMES = ("agent-benchmarks", "forwarding-stack", "platform-stack")
 
 
+# Maps getdeps package name to library name when they differ.
+LIB_NAME_OVERRIDES = {
+    "fmt-python": "fmt",
+}
+
 # Global definitions describing what we package for each target.
+
+COMMON_LIBS = [
+    "glog",
+    "folly",
+    "fmt-python",
+    "wangle",
+    "fizz",
+    "mvfst",
+]
 
 FORWARDING_BINARIES = [
     "diag_shell_client",
@@ -51,6 +66,8 @@ FORWARDING_EXTRA = {
     RUN_CONFIGS_DIR / "th4": "share/th4",
     RUN_CONFIGS_DIR / "th5": "share/th5",
 }
+
+FORWARDING_LIBS = []
 
 FORWARDING_TEST_BINARIES = [
     "fboss-platform-mapping-gen",
@@ -135,6 +152,8 @@ PLATFORM_EXTRA = {
     / "hw_sanity_tests/bsp_sanity_tests.conf": "share/hw_sanity_tests/bsp_sanity_tests.conf",
 }
 
+PLATFORM_LIBS = []
+
 PLATFORM_TEST_BINARIES = [
     "bsp_tests",
     "data_corral_service_hw_test",
@@ -160,6 +179,41 @@ PLATFORM_TEST_EXTRA = {
 }
 
 
+def _find_getdeps_libs(
+    build_dir: pathlib.Path, packages: list[str]
+) -> dict[pathlib.Path, str]:
+    """Find shared libraries for the given packages under the getdeps installed directory."""
+    installed_dir = build_dir / "installed"
+    libs = {}
+    for pkg in packages:
+        pkg_dirs = sorted(
+            installed_dir.glob(f"{pkg}-*"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        if not pkg_dirs:
+            print(f"Warning: no .so libraries found for {pkg}")
+            continue
+
+        pkg_dir = pkg_dirs[0]
+        if len(pkg_dirs) > 1:
+            print(
+                f"Multiple directories found for {pkg}, using most recent: {pkg_dir.name}"
+            )
+
+        lib_name = LIB_NAME_OVERRIDES.get(pkg, pkg)
+        matches = []
+        for lib_dir in ("lib64", "lib"):
+            pattern = str(pkg_dir / lib_dir / f"lib{lib_name}*.so*")
+            matches.extend(glob.glob(pattern))
+        if matches:
+            for path in matches:
+                libs[pathlib.Path(path)] = f"lib/{os.path.basename(path)}"
+        else:
+            print(f"Warning: no .so libraries found for {pkg}")
+    return libs
+
+
 def write_tar(filename: str, contents: dict[str, str]) -> None:
     if not contents:
         return
@@ -172,6 +226,13 @@ def write_tar(filename: str, contents: dict[str, str]) -> None:
                 continue
             tar.add(src, dest)
 
+        # Add lib64 -> lib symlink so binaries with RPATH/RUNPATH pointing to
+        # lib64/ can find libraries packaged under lib/ (e.g. fboss2-dev).
+        tarinfo = tarfile.TarInfo(name="lib64")
+        tarinfo.type = tarfile.SYMTYPE
+        tarinfo.linkname = "lib"
+        tar.addfile(tarinfo)
+
 
 def _build_target(target: str, build_dir: pathlib.Path):
     """Return mappings for a given target and build_dir
@@ -182,17 +243,20 @@ def _build_target(target: str, build_dir: pathlib.Path):
 
     bins = []
     extras = {}
+    libs = []
     test_bins = {}
     test_extras = {}
 
     if target == "forwarding-stack":
         bins = FORWARDING_BINARIES
         extras = FORWARDING_EXTRA
+        libs = FORWARDING_LIBS + COMMON_LIBS
         test_bins = FORWARDING_TEST_BINARIES
         test_extras = FORWARDING_TEST_EXTRA
     elif target == "platform-stack":
         bins = PLATFORM_BINARIES
         extras = PLATFORM_EXTRA
+        libs = PLATFORM_LIBS + COMMON_LIBS
         test_bins = PLATFORM_TEST_BINARIES
         test_extras = PLATFORM_TEST_EXTRA
     elif target == "agent-benchmarks":
@@ -205,6 +269,16 @@ def _build_target(target: str, build_dir: pathlib.Path):
 
     prod_files = {fboss_build_dir / bin_name: f"bin/{bin_name}" for bin_name in bins}
     prod_files.update(extras)
+    prod_files.update(_find_getdeps_libs(build_dir, libs))
+
+    # Include libunwind from llvm locally installed in the build container because CentOS does not have an equivalent
+    # version and it is not installed by getdeps to be handled in _find_getdeps_libs().
+    for ext in ("so", "so.1", "so.1.0"):
+        prod_files[
+            pathlib.Path(
+                f"/usr/local/llvm/lib/x86_64-unknown-linux-gnu/libunwind.{ext}"
+            )
+        ] = f"lib/libunwind.{ext}"
 
     test_files = {
         fboss_build_dir / bin_name: f"bin/{bin_name}" for bin_name in test_bins

--- a/fboss/oss/scripts/run_scripts/setup_fboss_env
+++ b/fboss/oss/scripts/run_scripts/setup_fboss_env
@@ -1,4 +1,13 @@
-export FBOSS=$PWD
+# Derive FBOSS root from this script's location (script lives at $FBOSS/bin/setup_fboss_env)
+_FBOSS_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# Idempotent: skip if already sourced with the same root
+if [[ "${FBOSS:-}" == "$_FBOSS_ROOT" ]]; then
+  unset _FBOSS_ROOT
+  return 0 2>/dev/null || true
+fi
+
+export FBOSS=$_FBOSS_ROOT
 export FBOSS_BIN=${FBOSS}/bin
 export FBOSS_LIB=${FBOSS}/lib
 export FBOSS_LIB64=${FBOSS}/lib64
@@ -8,3 +17,5 @@ export FBOSS_DATA=${FBOSS}/share
 export PATH=${FBOSS_BIN}${PATH:+:${PATH}}
 export LD_LIBRARY_PATH=${FBOSS_LIB}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 export LD_LIBRARY_PATH=${FBOSS_LIB64}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
+
+unset _FBOSS_ROOT


### PR DESCRIPTION
# Summary

`fboss_init.sh` wasn't sourcing `setup_fboss_env`, so `weutil` couldn't find its shared libraries and silently failed to generate `fruid.json`. Downstream services would then crash on startup because `fruid.json` was missing.

`setup_fboss_env`: derive FBOSS root from the script's own location instead of `$PWD`, and add an idempotency guard to prevent duplicate `PATH` and `LD_LIBRARY_PATH` prepends when the script is sourced multiple times.

`fboss_init.sh`: `source setup_fboss_env` at startup so `weutil` resolves its shared libraries; make `generate_fruid()` propagate failure with `return 1`; make `main()` exit 1 if fruid generation fails so systemd marks `fboss_init.service` as failed rather than succeeded.

`fboss_cmd_find.sh`: `source setup_fboss_env` before exec so every FBOSS command runs with the correct `PATH` and `LD_LIBRARY_PATH`.

`package.py`: the thrift-python migration (commit f9d8d65) switched FBOSS's manifest dependencies from the base variants (folly, wangle, fizz, mvfst, fmt, zstd, fbthrift) to their `-python` variants, which are built with `BUILD_SHARED_LIBS=ON`. As a result, every FBOSS binary (`platform_manager`, `weutil`, `fsdb`, ...) now links against `libfolly.so`, `libwangle.so`, `libfmt.so`, `libfizz.so`, `libmvfst.so` at runtime, not just Python extensions. Bundle these shared libraries in the forwarding-stack and platform-stack tarballs via a new `_find_getdeps_libs()` helper that locates `.so` files under each package's getdeps install prefix. `LIB_NAME_OVERRIDES` handles packages whose getdeps name differs from the library filename (e.g. `fmt-python` builds `libfmt.so`). Also add a `lib64` -> `lib` symlink in each tarball so binaries with `RPATH`/`RUNPATH` pointing to `lib64/` resolve correctly, and bundle `libunwind.so` from the LLVM build container since CentOS does not ship a compatible version and getdeps does not install it.

# Test Plan

These fixes were needed to properly image DUTs with the latest distro image build. Without them no FBOSS agent would come up.