### PR TITLE
[Celestica] Montblanc: Config: Add missing temperature thresholds except PSUs

### DIFF
--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -2459,7 +2459,8 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM1/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 115
+            "upperCriticalVal": 95,
+            "maxAlarmVal": 90
           },
           "compute": "@/1000"
         },
@@ -2491,6 +2492,10 @@
           "name": "SMB_0V75_0V9_R_VRM1_TEMP",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM2/temp1_input",
           "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95,
+            "maxAlarmVal": 90
+          },
           "compute": "@/1000"
         },
         {
@@ -2521,6 +2526,10 @@
           "name": "SMB_0V75_0V9_L_VRM0_TEMP",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/temp1_input",
           "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95,
+            "maxAlarmVal": 90
+          },
           "compute": "@/1000"
         }
       ],
@@ -5512,6 +5521,10 @@
           "name": "SMB_3V3_L_VRM_TEMP",
           "sysfsPath": "/run/devmap/sensors/3V3_L_MONITOR/temp1_input",
           "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
           "compute": "@/1000"
         }
       ],
@@ -6260,6 +6273,10 @@
           "name": "SMB_3V3_R_VRM_TEMP",
           "sysfsPath": "/run/devmap/sensors/3V3_R_MONITOR/temp1_input",
           "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 85,
+            "maxAlarmVal": 80
+          },
           "compute": "@/1000"
         }
       ],


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped


# Summary

This PR is to add and update temperature sensors' thresholds.

- Several temperature sensors lacked configured thresholds. This PR addresses that by defining them (except PSUs'):
  - `SMB_0V75_0V9_L_VRM0_TEMP`
  - `SMB_0V75_0V9_R_VRM1_TEMP`
  - `SMB_3V3_L_VRM_TEMP`
  - `SMB_3V3_R_VRM_TEMP`
- Add `SMB_VDDC_VRM_TEMP` sensor's `upperCriticalVal` threshold, and updating `maxAlarmVal` from 115 to 90, according to the latest HW sensor table.

# Test Plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
1. All sensors work well. Log:
[sensor_service_client.txt](https://github.com/user-attachments/files/26885375/sensor_service_client.txt)
2. This PR's related sensors in above log:

-  `SMB_0V75_0V9_L_VRM0_TEMP` and `SMB_0V75_0V9_R_VRM1_TEMP` :

<img width="955" height="264" alt="image" src="https://github.com/user-attachments/assets/546110ef-4120-4068-8106-5334edd9cf49" />

- `SMB_3V3_L_VRM_TEMP` and `SMB_3V3_R_VRM_TEMP` :

<img width="882" height="605" alt="image" src="https://github.com/user-attachments/assets/a92034e4-4cd3-45d0-a0a4-0466f10f97cc" />

- `SMB_VDDC_VRM_TEMP` :

<img width="956" height="151" alt="image" src="https://github.com/user-attachments/assets/66ef99cd-a7cd-4c39-9f10-1e9cf842445c" />





<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
