### PR TITLE
[Celestica] Tahansb800bc: Config: TH6 ASIC over temperature protection via CPLD monitor

### DIFF
--- a/fboss/platform/configs/tahansb800bc/fan_service.json
+++ b/fboss/platform/configs/tahansb800bc/fan_service.json
@@ -6,6 +6,7 @@
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD/th6_pwr_en",
   "watchdog": {
     "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
@@ -13,6 +14,16 @@
   "controlInterval": {
     "sensorReadInterval": 5,
     "pwmUpdateInterval": 5
+  },
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 1,
+    "conditions": [
+      {
+        "sensorName": "SMB_U2_TH6_TEMP",
+        "overtempThreshold": 103,
+        "slidingWindowSize": 1
+      }
+    ]
   },
   "sensors": [
     {

--- a/fboss/platform/configs/tahansb800bc/platform_manager.json
+++ b/fboss/platform/configs/tahansb800bc/platform_manager.json
@@ -943,6 +943,7 @@
     "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_INLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TH6_TSENSOR]",
     "/run/devmap/sensors/SMB_VDDCORE": "/SMB_SLOT@0/[SMB_VDDCORE]",
+    "/run/devmap/sensors/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
     "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",

--- a/fboss/platform/configs/tahansb800bc/sensor_service.json
+++ b/fboss/platform/configs/tahansb800bc/sensor_service.json
@@ -4082,6 +4082,16 @@
             "lowerCriticalVal": 0
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U2_TH6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 103
+          },
+          "compute": "@/1000.0"
         }
       ],
       "versionedSensors": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="879" height="218" alt="image" src="https://github.com/user-attachments/assets/5b722505-bdd6-4255-b149-21f973334b13" />


# Summary
This PR introduces the necessary configurations to enable Over-Temperature Protection (OTP) for the TH6 ASIC on the Tahansb800bc platform, utilizing SMB CPLD monitoring.
<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Motivation
The feature design is:
1. SW gets temperature from CPLD (MIN/MAX_TEMP_CLK) through sensor service. 
2. The OTP function is implemented in the fan service of FBOSS. Sensor service keeps polling the VTMON temperature. When the temperature exceeds 103°C, fan service powers off the TH6 ASIC.

Based on the design and the thermal team's validation, we have the following changes:
1. Created a sensor symbolic Link for smb_cpld in platform_manager.json
2. Added the MIN/MAX_TEMP_CLK sensor (/run/devmap/sensors/SMB_CPLD/temp1_input) for active monitoring to snesor_service.json
3. Defined the specific shutdown command and condition in fan_service.json

# Test Plan
1.Passed the config validation

2.Run platform_manager/sensor_service/fan_service/data_corral_service on the device successfully, used sensor_service_client to catch the snapshot of sensors
Pls refer the full logs: [PM Services.zip](https://github.com/user-attachments/files/26955511/PM.Services.zip)

3.Run all hw_test cases, passed.
Pls refer the full logs:  [HwTest.zip](https://github.com/user-attachments/files/26955530/HwTest.zip)

4.TH6 ASIC thermal shutdown validation, worked as designed:
**Scenario:**
a. Set overtempThreshold as 66°C
b. Run platform_manager/sensor_service/fan_service/data_corral_service on the device successfully.
c. Executed SDK stress tests to drive a steady increase in ASIC temperature
**Result:**
Once the ASIC temperature exceeded the 66°C threshold for a while, the fan_service successfully initiated a protective shutdown. The TH6 ASIC was removed from the PCIe tree
<img width="1484" height="408" alt="image" src="https://github.com/user-attachments/assets/975bc17f-a92c-4df5-82e3-53be56630b56" />

Logs from fan_service:
<img width="2183" height="91" alt="image" src="https://github.com/user-attachments/assets/33a79a09-cda2-4c74-8391-0bc872c9bba0" />

Pls refer the full logs:  [OTP_Trigger_TH6_Shutdown.zip](https://github.com/user-attachments/files/26955495/abnormal.zip)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
