### PR TITLE
[Nexthop][fboss2-dev] Replace central ObjectArgTypeId enum with per-Traits addCliArg method

### DIFF
--- a/fboss/agent/wiki/static_docs/docs/Features/FBOSS2_CLI/adding-new-subcommand.mdx
+++ b/fboss/agent/wiki/static_docs/docs/Features/FBOSS2_CLI/adding-new-subcommand.mdx
@@ -15,16 +15,16 @@ To keep the CLI syntax tree consistent, review requests that extend the CLI synt
 
 See CmdShowExample (D30268450) for end-to-end implementation of a subcommand. You can copy and edit this sample subcommand when adding new commands.
 
-Other examples: 
+Other examples:
 
-- Sample subcommand implementation (open source): [P407640625](https://www.internalfb.com/phabricator/paste/view/P407640625) 
+- Sample subcommand implementation (open source): [P407640625](https://www.internalfb.com/phabricator/paste/view/P407640625)
 - Sample subcommand implementation (FB-internal): [P407649437](https://www.internalfb.com/phabricator/paste/view/P407649437)
 
 ## What to Edit?
 
 **Define Traits and Command**
 
-Define a traits class deriving BaseCommandTraits and specify argument and return types. To specify argument types, define both ObjectArgType and ObjectArgTypeId.
+Define a traits class deriving BaseCommandTraits and specify argument and return types. To declare a positional argument, set `ObjectArgType` to the argument class and provide a `static void addCliArg(CLI::App& cmd, std::vector<std::string>& args)` method that calls `cmd.add_option(...)` with the positional name and help text.
 
 In the traits class, you can specify ParentCmd which lets you “inherit” parameters from the parent. As an example: CmdShowInterfaceCountersTraits has ParentCmd = CmdShowInterface, which enables the syntax `fboss2 interface [infIDs...] counters`. If CmdShowInterfaceCountersTraits defines its own param as well then we can get `fboss2 interace [intfIDs...] counters [counterIDs...]`. queryClient will get all paramenters in the parent command heirarchy in order.
 
@@ -119,4 +119,3 @@ If the subcommand talks with an agent not available in the open source e.g. show
 * [Building FBOSS2 CLI](/Features/FBOSS2_CLI/building.mdx)
 
 * [FBOSS2 CLI Design](Features/FBOSS2_CLI/design.mdx)
-

--- a/fboss/agent/wiki/static_docs/docs/Features/FBOSS2_CLI/args-validation.mdx
+++ b/fboss/agent/wiki/static_docs/docs/Features/FBOSS2_CLI/args-validation.mdx
@@ -13,19 +13,17 @@ In this article, we will look at how argument parsing of subcommand works and ho
 
 The below shows a step-by-step instruction on how to add a new type of argument.
 
-1. Define a new type of argument id in [CmdCommonUtils.h::ObjectArgTypeId](https://www.internalfb.com/code/fbsource/[e5984a8d19eebbaac834e47b5372e9a6a39bd41b]/fbcode/fboss/cli/fboss2/utils/CmdCommonUtils.h?lines=33).
+1. Subclass `utils::BaseObjectArgType` and implement validation rules in the class constructor.
 
-2. Subclass [BaseObjectArgType](https://www.internalfb.com/code/fbsource/[e5984a8d19eebbaac834e47b5372e9a6a39bd41b]/fbcode/fboss/cli/fboss2/utils/CmdCommonUtils.h?lines=60) with the argument id defined in step 1 and implement validation rules in the class constructor.
+2. Add unit test for the newly created argument type in `CmdArgsTest.cpp`.
 
-3. Add unit test for the newly created argument type in `CmdArgsTest.cpp` (For example [D37385960](https://www.internalfb.com/diff/D37385960)/[D37329534](https://www.internalfb.com/diff/D37329534)).
+3. Register your command in `fboss/cli/fboss2/CmdList.cpp`.
 
-4. Register your command in `fboss/cli/fboss2/CmdList.cpp`.
-
-5. Use the newly created type in your command file (For example [D37411284](https://www.internalfb.com/diff/D37411284)). Be sure to specify ObjectArgTypeId in the command traits class with the new argument type.
-Although the `BaseObjectArgType` has implemented interface including `empty()`, `size()`, iterator and indexing, you could also access the original data and utilize the feature of `std::vector` by calling `.data()`.
-For old type migration, you will need to modify `ObjectArgType` under `CmdXXXTraits` and adjust the argument type in `queryClient`.
-
-6. Add a subcommand option to process the new argument type in [CmdSubcommands.cpp](https://www.internalfb.com/code/fbsource/[29256fef57b039281881805f7698decb12d688a3]/fbcode/fboss/cli/fboss2/CmdSubcommands.cpp?lines=49).
+4. In the command's traits struct, set `ObjectArgType` to the new class and
+   add a `static void addCliArg(CLI::App& cmd, std::vector<std::string>& args)`
+   method that registers the positional option with CLI11 (e.g.
+   `cmd.add_option("ports", args, "Port(s)")`). There is no central enum or
+   switch — each command owns its argument registration.
 
 
 ## How Subcommand Arg Parsing Works
@@ -40,16 +38,16 @@ In this section, we will use the command`fboss2 set interface prbs state [OPTION
   "interface",
   "Set Interface information",
   commandHandler<CmdSetInterface>,
-  argTypeHandler<CmdSetInterfaceTraits>,
+  argRegistrar<CmdSetInterfaceTraits>,
   {{
     "prbs",
     "Set PRBS properties",
     commandHandler<CmdSetInterfacePrbs>,
-    argTypeHandler<CmdSetInterfacePrbsTraits>,
+    argRegistrar<CmdSetInterfacePrbsTraits>,
     {{"state",
       "Set PRBS state",
       commandHandler<CmdSetInterfacePrbsState>,
-      argTypeHandler<CmdSetInterfacePrbsStateTraits>}},
+      argRegistrar<CmdSetInterfacePrbsStateTraits>}},
   }},
 }
 ```
@@ -62,25 +60,32 @@ By specifying `ParentCmd`, the subcommands are able to inherit the argument from
 ```
 // fboss/cli/fboss2/commands/set/interface/CmdSetInterface.h
 struct CmdSetInterfaceTraits : public BaseCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PORT_LIST;
-  using ObjectArgType = utils::PortList; // used to be std::vector<std::string>;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("ports", args, "Port(s)");
+  }
+  using ObjectArgType = utils::PortList;
   using RetType = std::string;
 };
 // fboss/cli/fboss2/commands/set/interface/prbs/CmdSetInterfacePrbs.h
 struct CmdSetInterfacePrbsTraits : public BaseCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_PRBS_COMPONENT;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "component",
+        args,
+        "name(s) of PRBS component, one or multiple of "
+        "asic/xphy_system/xphy_line/transceiver_system/transceiver_line");
+  }
   using ParentCmd = CmdSetInterface;
-  using ObjectArgType = utils::PrbsComponent; // used to be std::vector<std::string>
+  using ObjectArgType = utils::PrbsComponent;
   using RetType = std::string;
 };
 // fboss/cli/fboss2/commands/set/interface/prbs/CmdSetInterfacePrbsState.h
 struct CmdSetInterfacePrbsStateTraits : public BaseCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_PRBS_STATE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("state", args, "PRBS state to set");
+  }
   using ParentCmd = CmdSetInterfacePrbs;
-  using ObjectArgType = utils::PrbsState; // used to be std::vector<std::string>
+  using ObjectArgType = utils::PrbsState;
   using RetType = std::string;
 };
 ```

--- a/fboss/cli/fboss2/CmdHandler.h
+++ b/fboss/cli/fboss2/CmdHandler.h
@@ -10,14 +10,13 @@
 #pragma once
 
 #include "fboss/cli/fboss2/CmdArgsLists.h"
-#include "fboss/cli/fboss2/CmdSubcommands.h"
 #include "fboss/cli/fboss2/utils/AggregateUtils.h"
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 #include "fboss/cli/fboss2/utils/FilterUtils.h"
 #include "fboss/cli/fboss2/utils/HostInfo.h"
 
-#include <fmt/color.h>
-#include <fmt/format.h>
+#include <CLI/App.hpp>
+
 #include <folly/logging/xlog.h>
 #include <thrift/lib/thrift/gen-cpp2/metadata_types.h>
 
@@ -76,14 +75,18 @@ enum class CliReadWriteMode {
 struct BaseCommandTraits {
   // Only for top level commands, nested subcommands will override this
   using ParentCmd = void;
+  using ObjectArgType = std::monostate;
   static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
       utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
-  using ObjectArgType = std::monostate;
   static constexpr bool ALLOW_FILTERING = false;
   static constexpr bool ALLOW_AGGREGATION = false;
   static constexpr CliReadWriteMode CLI_READ_WRITE_MODE =
       CliReadWriteMode::CLI_MODE_WRITE;
   std::vector<utils::LocalOption> LocalOptions = {};
+
+  // Default: no positional argument. Config commands override this.
+  static void addCliArg(CLI::App& /*cmd*/, std::vector<std::string>& /*args*/) {
+  }
 };
 
 struct ReadCommandTraits : public BaseCommandTraits {
@@ -103,9 +106,9 @@ class CmdHandler {
       "CmdTypeTraits needs to subclass BaseCommandTraits");
 
  public:
+  using Traits = CmdTypeTraits;
   static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
       CmdTypeTraits::ObjectArgTypeId;
-  using Traits = CmdTypeTraits;
   using ObjectArgType = typename CmdTypeTraits::ObjectArgType;
   using RetType = typename CmdTypeTraits::RetType;
   using ThriftPrimitiveType = apache::thrift::metadata::ThriftPrimitiveType;

--- a/fboss/cli/fboss2/CmdList.h
+++ b/fboss/cli/fboss2/CmdList.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <vector>
 
+#include <CLI/App.hpp>
+
 #include "fboss/cli/fboss2/CmdGlobalOptions.h"
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 
@@ -25,6 +27,8 @@ using ValidFilterMapType = std::unordered_map<
 using CommandHandlerFn = std::function<void()>;
 using ValidFilterHandlerFn = std::function<ValidFilterMapType()>;
 using ArgTypeHandlerFn = std::function<utils::ObjectArgTypeId()>;
+using ArgRegistrarFn =
+    std::function<void(CLI::App&, std::vector<std::string>&)>;
 using LocalOptionsHandlerFn = std::function<std::vector<utils::LocalOption>()>;
 
 using CmdVerb = std::string;
@@ -33,6 +37,7 @@ using CmdSubCmd = std::string;
 using CmdHelpMsg = std::string;
 
 struct Command {
+  // Non-config commands: use ArgTypeHandlerFn (enum-based dispatch via switch)
   Command(
       const std::string& name,
       const std::string& help,
@@ -92,6 +97,71 @@ struct Command {
         commandHandler{commandHandler},
         validFilterHandler{validFilterHandler},
         argTypeHandler{argTypeHandler},
+        localOptionsHandler{localOptionsHandler},
+        subcommands{subcommands} {
+    sort(this->subcommands.begin(), this->subcommands.end());
+  }
+
+  // Config commands: use ArgRegistrarFn (direct addCliArg dispatch)
+  Command(
+      const std::string& name,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const std::vector<Command>& subcommands = {})
+      : name{name},
+        help{help},
+        commandHandler{commandHandler},
+        argRegistrar{argRegistrar},
+        subcommands{subcommands} {
+    sort(this->subcommands.begin(), this->subcommands.end());
+  }
+
+  Command(
+      const std::string& name,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ValidFilterHandlerFn& validFilterHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const std::vector<Command>& subcommands = {})
+      : name{name},
+        help{help},
+        commandHandler{commandHandler},
+        validFilterHandler{validFilterHandler},
+        argRegistrar{argRegistrar},
+        subcommands{subcommands} {
+    sort(this->subcommands.begin(), this->subcommands.end());
+  }
+
+  Command(
+      const std::string& name,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const LocalOptionsHandlerFn& localOptionsHandler,
+      const std::vector<Command>& subcommands = {})
+      : name{name},
+        help{help},
+        commandHandler{commandHandler},
+        argRegistrar{argRegistrar},
+        localOptionsHandler{localOptionsHandler},
+        subcommands{subcommands} {
+    sort(this->subcommands.begin(), this->subcommands.end());
+  }
+
+  Command(
+      const std::string& name,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ValidFilterHandlerFn& validFilterHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const LocalOptionsHandlerFn& localOptionsHandler,
+      const std::vector<Command>& subcommands = {})
+      : name{name},
+        help{help},
+        commandHandler{commandHandler},
+        validFilterHandler{validFilterHandler},
+        argRegistrar{argRegistrar},
         localOptionsHandler{localOptionsHandler},
         subcommands{subcommands} {
     sort(this->subcommands.begin(), this->subcommands.end());
@@ -115,11 +185,13 @@ struct Command {
   std::optional<CommandHandlerFn> commandHandler;
   std::optional<ValidFilterHandlerFn> validFilterHandler;
   std::optional<ArgTypeHandlerFn> argTypeHandler;
+  std::optional<ArgRegistrarFn> argRegistrar;
   std::optional<LocalOptionsHandlerFn> localOptionsHandler;
   std::vector<Command> subcommands;
 };
 
 struct RootCommand : public Command {
+  // Non-config commands: use ArgTypeHandlerFn
   RootCommand(
       const std::string& verb,
       const std::string& object,
@@ -179,6 +251,70 @@ struct RootCommand : public Command {
             commandHandler,
             validFilterHandler,
             argTypeHandler,
+            localOptionsHandler,
+            subcommands),
+        verb{verb} {}
+
+  // Config commands: use ArgRegistrarFn
+  RootCommand(
+      const std::string& verb,
+      const std::string& object,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const std::vector<Command>& subcommands = {})
+      : Command(object, help, commandHandler, argRegistrar, subcommands),
+        verb{verb} {}
+
+  RootCommand(
+      const std::string& verb,
+      const std::string& object,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ValidFilterHandlerFn& validFilterHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const std::vector<Command>& subcommands = {})
+      : Command(
+            object,
+            help,
+            commandHandler,
+            validFilterHandler,
+            argRegistrar,
+            subcommands),
+        verb{verb} {}
+
+  RootCommand(
+      const std::string& verb,
+      const std::string& object,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const LocalOptionsHandlerFn& localOptionsHandler,
+      const std::vector<Command>& subcommands = {})
+      : Command(
+            object,
+            help,
+            commandHandler,
+            argRegistrar,
+            localOptionsHandler,
+            subcommands),
+        verb{verb} {}
+
+  RootCommand(
+      const std::string& verb,
+      const std::string& object,
+      const std::string& help,
+      const CommandHandlerFn& commandHandler,
+      const ValidFilterHandlerFn& validFilterHandler,
+      const ArgRegistrarFn& argRegistrar,
+      const LocalOptionsHandlerFn& localOptionsHandler,
+      const std::vector<Command>& subcommands = {})
+      : Command(
+            object,
+            help,
+            commandHandler,
+            validFilterHandler,
+            argRegistrar,
             localOptionsHandler,
             subcommands),
         verb{verb} {}
@@ -251,6 +387,11 @@ ValidFilterMapType validFilterHandler() {
 template <typename T>
 utils::ObjectArgTypeId argTypeHandler() {
   return T().ObjectArgTypeId;
+}
+
+template <typename Traits>
+void argRegistrar(CLI::App& cmd, std::vector<std::string>& args) {
+  Traits::addCliArg(cmd, args);
 }
 
 template <typename T>

--- a/fboss/cli/fboss2/CmdListConfig.cpp
+++ b/fboss/cli/fboss2/CmdListConfig.cpp
@@ -109,47 +109,47 @@ const CommandTree& kConfigCommandTree() {
        "applied-info",
        "Show config applied information",
        commandHandler<CmdConfigAppliedInfo>,
-       argTypeHandler<CmdConfigAppliedInfoTraits>},
+       argRegistrar<CmdConfigAppliedInfoTraits>},
 
       {"config",
        "history",
        "Show history of committed config revisions",
        commandHandler<CmdConfigHistory>,
-       argTypeHandler<CmdConfigHistoryTraits>},
+       argRegistrar<CmdConfigHistoryTraits>},
 
       {
           "config",
           "interface",
           "Configure interface settings",
           commandHandler<CmdConfigInterface>,
-          argTypeHandler<CmdConfigInterfaceTraits>,
+          argRegistrar<CmdConfigInterfaceTraits>,
           {{
                "pfc-config",
                "Configure PFC settings for interface",
                commandHandler<CmdConfigInterfacePfcConfig>,
-               argTypeHandler<CmdConfigInterfacePfcConfigTraits>,
+               argRegistrar<CmdConfigInterfacePfcConfigTraits>,
            },
            {
                "queuing-policy",
                "Set queuing policy for interface",
                commandHandler<CmdConfigInterfaceQueuingPolicy>,
-               argTypeHandler<CmdConfigInterfaceQueuingPolicyTraits>,
+               argRegistrar<CmdConfigInterfaceQueuingPolicyTraits>,
            },
            {
                "switchport",
                "Configure switchport settings",
                commandHandler<CmdConfigInterfaceSwitchport>,
-               argTypeHandler<CmdConfigInterfaceSwitchportTraits>,
+               argRegistrar<CmdConfigInterfaceSwitchportTraits>,
                {{
                    "access",
                    "Configure access mode settings",
                    commandHandler<CmdConfigInterfaceSwitchportAccess>,
-                   argTypeHandler<CmdConfigInterfaceSwitchportAccessTraits>,
+                   argRegistrar<CmdConfigInterfaceSwitchportAccessTraits>,
                    {{
                        "vlan",
                        "Set access VLAN (ingressVlan) for the interface",
                        commandHandler<CmdConfigInterfaceSwitchportAccessVlan>,
-                       argTypeHandler<
+                       argRegistrar<
                            CmdConfigInterfaceSwitchportAccessVlanTraits>,
                    }},
                }},
@@ -161,12 +161,12 @@ const CommandTree& kConfigCommandTree() {
           "l2",
           "Configure L2 settings",
           commandHandler<CmdConfigL2>,
-          argTypeHandler<CmdConfigL2Traits>,
+          argRegistrar<CmdConfigL2Traits>,
           {{
               "learning-mode",
               "Set L2 learning mode (hardware, software, or disabled)",
               commandHandler<CmdConfigL2LearningMode>,
-              argTypeHandler<CmdConfigL2LearningModeTraits>,
+              argRegistrar<CmdConfigL2LearningModeTraits>,
           }},
       },
 
@@ -175,26 +175,26 @@ const CommandTree& kConfigCommandTree() {
           "protocol",
           "Configure protocol settings",
           commandHandler<CmdConfigProtocol>,
-          argTypeHandler<CmdConfigProtocolTraits>,
+          argRegistrar<CmdConfigProtocolTraits>,
           {
               {
                   "bgp",
                   "Configure BGP protocol",
                   commandHandler<CmdConfigProtocolBgp>,
-                  argTypeHandler<CmdConfigProtocolBgpTraits>,
+                  argRegistrar<CmdConfigProtocolBgpTraits>,
                   {
                       {
                           "global",
                           "Configure BGP global settings",
                           commandHandler<CmdConfigProtocolBgpGlobal>,
-                          argTypeHandler<CmdConfigProtocolBgpGlobalTraits>,
+                          argRegistrar<CmdConfigProtocolBgpGlobalTraits>,
                           {
                               {
                                   "router-id",
                                   "Set BGP router identifier",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalRouterId>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalRouterIdTraits>,
                               },
                               {
@@ -202,7 +202,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set local AS number",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalLocalAsn>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalLocalAsnTraits>,
                               },
                               {
@@ -210,7 +210,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set BGP hold time in seconds",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalHoldTime>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalHoldTimeTraits>,
                               },
                               {
@@ -218,7 +218,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set BGP confederation AS number",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalConfedAsn>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalConfedAsnTraits>,
                               },
                               {
@@ -226,7 +226,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set route reflector cluster ID",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalClusterId>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalClusterIdTraits>,
                               },
                               {
@@ -234,7 +234,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Add IPv6 network to advertise",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalNetwork6Add>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalNetwork6AddTraits>,
                               },
                               {
@@ -242,7 +242,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set switch limit prefix-limit",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalSwitchLimitPrefixLimit>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalSwitchLimitPrefixLimitTraits>,
                               },
                               {
@@ -250,7 +250,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set switch limit total-path-limit",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalSwitchLimitTotalPathLimit>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalSwitchLimitTotalPathLimitTraits>,
                               },
                               {
@@ -258,7 +258,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set switch limit max-golden-vips",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalSwitchLimitMaxGoldenVips>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalSwitchLimitMaxGoldenVipsTraits>,
                               },
                               {
@@ -266,7 +266,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set switch limit overload-protection-mode",
                                   commandHandler<
                                       CmdConfigProtocolBgpGlobalSwitchLimitOverloadProtectionMode>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpGlobalSwitchLimitOverloadProtectionModeTraits>,
                               },
                           },
@@ -275,14 +275,14 @@ const CommandTree& kConfigCommandTree() {
                           "peer-group",
                           "Configure BGP peer group",
                           commandHandler<CmdConfigProtocolBgpPeerGroup>,
-                          argTypeHandler<CmdConfigProtocolBgpPeerGroupTraits>,
+                          argRegistrar<CmdConfigProtocolBgpPeerGroupTraits>,
                           {
                               {
                                   "description",
                                   "Set peer group description",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupDescription>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupDescriptionTraits>,
                               },
                               {
@@ -290,7 +290,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set remote AS number",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupRemoteAsn>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupRemoteAsnTraits>,
                               },
                               {
@@ -298,7 +298,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable next-hop-self",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupNextHopSelf>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupNextHopSelfTraits>,
                               },
                               {
@@ -306,7 +306,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable confederation peer",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupConfedPeer>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupConfedPeerTraits>,
                               },
                               {
@@ -314,7 +314,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable IPv4 AFI",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupDisableIpv4Afi>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupDisableIpv4AfiTraits>,
                               },
                               {
@@ -322,7 +322,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable v4-over-v6 next-hop",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupV4OverV6Nh>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupV4OverV6NhTraits>,
                               },
                               {
@@ -330,7 +330,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable route reflector client",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupRrClient>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupRrClientTraits>,
                               },
                               {
@@ -338,7 +338,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set ingress policy",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupIngressPolicy>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupIngressPolicyTraits>,
                               },
                               {
@@ -346,7 +346,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set egress policy",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupEgressPolicy>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupEgressPolicyTraits>,
                               },
                               {
@@ -354,7 +354,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set maximum routes",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupMaxRoutes>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupMaxRoutesTraits>,
                               },
                               {
@@ -362,7 +362,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set peer tag",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupPeerTag>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupPeerTagTraits>,
                               },
                               {
@@ -370,7 +370,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable warning-only mode",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupWarningOnly>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupWarningOnlyTraits>,
                               },
                               {
@@ -378,7 +378,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set warning limit percentage",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupWarningLimit>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupWarningLimitTraits>,
                               },
                               {
@@ -386,7 +386,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Configure BGP timers",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerGroupTimers>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerGroupTimersTraits>,
                                   {
                                       {
@@ -394,7 +394,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set hold time",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerGroupTimersHoldTime>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerGroupTimersHoldTimeTraits>,
                                       },
                                       {
@@ -402,7 +402,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set keepalive interval",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerGroupTimersKeepalive>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerGroupTimersKeepaliveTraits>,
                                       },
                                       {
@@ -410,7 +410,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set output delay",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerGroupTimersOutDelay>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerGroupTimersOutDelayTraits>,
                                       },
                                       {
@@ -418,7 +418,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set withdraw unprogrammed delay",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerGroupTimersWithdrawUnprogDelay>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerGroupTimersWithdrawUnprogDelayTraits>,
                                       },
                                   },
@@ -429,14 +429,14 @@ const CommandTree& kConfigCommandTree() {
                           "peer",
                           "Configure BGP peer",
                           commandHandler<CmdConfigProtocolBgpPeer>,
-                          argTypeHandler<CmdConfigProtocolBgpPeerTraits>,
+                          argRegistrar<CmdConfigProtocolBgpPeerTraits>,
                           {
                               {
                                   "peer-group",
                                   "Set peer group",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerPeerGroup>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerPeerGroupTraits>,
                               },
                               {
@@ -444,7 +444,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set peer description",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerDescription>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerDescriptionTraits>,
                               },
                               {
@@ -452,7 +452,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set remote AS number",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerRemoteAsn>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerRemoteAsnTraits>,
                               },
                               {
@@ -460,7 +460,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set local address",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerLocalAddr>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerLocalAddrTraits>,
                               },
                               {
@@ -468,7 +468,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set IPv4 next-hop",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerNextHop4>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerNextHop4Traits>,
                               },
                               {
@@ -476,7 +476,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set IPv6 next-hop",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerNextHop6>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerNextHop6Traits>,
                               },
                               {
@@ -484,7 +484,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable next-hop-self",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerNextHopSelf>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerNextHopSelfTraits>,
                               },
                               {
@@ -492,7 +492,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable IPv4 AFI",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerDisableIpv4Afi>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerDisableIpv4AfiTraits>,
                               },
                               {
@@ -500,7 +500,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable v4-over-v6 next-hop",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerV4OverV6Nh>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerV4OverV6NhTraits>,
                               },
                               {
@@ -508,7 +508,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable route reflector client",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerRrClient>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerRrClientTraits>,
                               },
                               {
@@ -516,14 +516,14 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable passive mode",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerPassive>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerPassiveTraits>,
                               },
                               {
                                   "type",
                                   "Set peer type",
                                   commandHandler<CmdConfigProtocolBgpPeerType>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerTypeTraits>,
                               },
                               {
@@ -531,7 +531,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set ingress policy",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerIngressPolicy>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerIngressPolicyTraits>,
                               },
                               {
@@ -539,7 +539,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set egress policy",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerEgressPolicy>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerEgressPolicyTraits>,
                               },
                               {
@@ -547,7 +547,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set maximum routes",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerMaxRoutes>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerMaxRoutesTraits>,
                               },
                               {
@@ -555,7 +555,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set peer identifier",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerPeerId>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerPeerIdTraits>,
                               },
                               {
@@ -563,7 +563,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable link bandwidth advertisement",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerAdvertiseLbw>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerAdvertiseLbwTraits>,
                               },
                               {
@@ -571,7 +571,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set link bandwidth",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerLinkBandwidth>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerLinkBandwidthTraits>,
                               },
                               {
@@ -579,7 +579,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set hold time",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerHoldTime>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerHoldTimeTraits>,
                               },
                               {
@@ -587,7 +587,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Enable/disable warning-only mode",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerWarningOnly>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerWarningOnlyTraits>,
                               },
                               {
@@ -595,7 +595,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Set warning limit percentage",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerWarningLimit>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerWarningLimitTraits>,
                               },
                               {
@@ -603,7 +603,7 @@ const CommandTree& kConfigCommandTree() {
                                   "Configure BGP timers",
                                   commandHandler<
                                       CmdConfigProtocolBgpPeerTimers>,
-                                  argTypeHandler<
+                                  argRegistrar<
                                       CmdConfigProtocolBgpPeerTimersTraits>,
                                   {
                                       {
@@ -611,7 +611,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set keepalive interval",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerTimersKeepalive>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerTimersKeepaliveTraits>,
                                       },
                                       {
@@ -619,7 +619,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set output delay",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerTimersOutDelay>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerTimersOutDelayTraits>,
                                       },
                                       {
@@ -627,7 +627,7 @@ const CommandTree& kConfigCommandTree() {
                                           "Set withdraw unprogrammed delay",
                                           commandHandler<
                                               CmdConfigProtocolBgpPeerTimersWithdrawUnprogDelay>,
-                                          argTypeHandler<
+                                          argRegistrar<
                                               CmdConfigProtocolBgpPeerTimersWithdrawUnprogDelayTraits>,
                                       },
                                   },
@@ -644,45 +644,45 @@ const CommandTree& kConfigCommandTree() {
           "qos",
           "Configure QoS settings",
           commandHandler<CmdConfigQos>,
-          argTypeHandler<CmdConfigQosTraits>,
+          argRegistrar<CmdConfigQosTraits>,
           {{
                "buffer-pool",
                "Configure buffer pool settings",
                commandHandler<CmdConfigQosBufferPool>,
-               argTypeHandler<CmdConfigQosBufferPoolTraits>,
+               argRegistrar<CmdConfigQosBufferPoolTraits>,
            },
            {
                "policy",
                "Configure QoS policy settings",
                commandHandler<CmdConfigQosPolicy>,
-               argTypeHandler<CmdConfigQosPolicyTraits>,
+               argRegistrar<CmdConfigQosPolicyTraits>,
                {{
                    "map",
                    "Set QoS map entry (tc-to-queue, pfc-pri-to-queue, tc-to-pg, pfc-pri-to-pg)",
                    commandHandler<CmdConfigQosPolicyMap>,
-                   argTypeHandler<CmdConfigQosPolicyMapTraits>,
+                   argRegistrar<CmdConfigQosPolicyMapTraits>,
                }},
            },
            {
                "priority-group-policy",
                "Configure priority group policy settings",
                commandHandler<CmdConfigQosPriorityGroupPolicy>,
-               argTypeHandler<CmdConfigQosPriorityGroupPolicyTraits>,
+               argRegistrar<CmdConfigQosPriorityGroupPolicyTraits>,
                {{"group-id",
                  "Specify priority group ID (0-7)",
                  commandHandler<CmdConfigQosPriorityGroupPolicyGroupId>,
-                 argTypeHandler<CmdConfigQosPriorityGroupPolicyGroupIdTraits>}},
+                 argRegistrar<CmdConfigQosPriorityGroupPolicyGroupIdTraits>}},
            },
            {
                "queuing-policy",
                "Configure queuing policy settings",
                commandHandler<CmdConfigQosQueuingPolicy>,
-               argTypeHandler<CmdConfigQosQueuingPolicyTraits>,
+               argRegistrar<CmdConfigQosQueuingPolicyTraits>,
                {{
                    "queue-id",
                    "Specify queue ID and attributes",
                    commandHandler<CmdConfigQosQueuingPolicyQueueId>,
-                   argTypeHandler<CmdConfigQosQueuingPolicyQueueIdTraits>,
+                   argRegistrar<CmdConfigQosQueuingPolicyQueueIdTraits>,
                }},
            }},
       },
@@ -695,25 +695,25 @@ const CommandTree& kConfigCommandTree() {
                "clear",
                "Clear the current config session",
                commandHandler<CmdConfigSessionClear>,
-               argTypeHandler<CmdConfigSessionClearTraits>,
+               argRegistrar<CmdConfigSessionClearTraits>,
            },
            {
                "commit",
                "Commit the current config session",
                commandHandler<CmdConfigSessionCommit>,
-               argTypeHandler<CmdConfigSessionCommitTraits>,
+               argRegistrar<CmdConfigSessionCommitTraits>,
            },
            {
                "diff",
                "Show diff between configs (session vs live, session vs revision, or revision vs revision)",
                commandHandler<CmdConfigSessionDiff>,
-               argTypeHandler<CmdConfigSessionDiffTraits>,
+               argRegistrar<CmdConfigSessionDiffTraits>,
            },
            {
                "rebase",
                "Rebase session changes onto current HEAD",
                commandHandler<CmdConfigSessionRebase>,
-               argTypeHandler<CmdConfigSessionRebaseTraits>,
+               argRegistrar<CmdConfigSessionRebaseTraits>,
            }},
       },
 
@@ -721,48 +721,48 @@ const CommandTree& kConfigCommandTree() {
        "reload",
        "Reload agent configuration",
        commandHandler<CmdConfigReload>,
-       argTypeHandler<CmdConfigReloadTraits>},
+       argRegistrar<CmdConfigReloadTraits>},
 
       {"config",
        "rollback",
        "Rollback to a previous config revision",
        commandHandler<CmdConfigRollback>,
-       argTypeHandler<CmdConfigRollbackTraits>},
+       argRegistrar<CmdConfigRollbackTraits>},
 
       {
           "config",
           "vlan",
           "Configure VLAN settings",
           commandHandler<CmdConfigVlan>,
-          argTypeHandler<CmdConfigVlanTraits>,
+          argRegistrar<CmdConfigVlanTraits>,
           {{
                "port",
                "Configure VLAN port settings",
                commandHandler<CmdConfigVlanPort>,
-               argTypeHandler<CmdConfigVlanPortTraits>,
+               argRegistrar<CmdConfigVlanPortTraits>,
                {{
                    "taggingMode",
                    "Set VLAN port tagging mode (tagged, untagged, priority-tagged)",
                    commandHandler<CmdConfigVlanPortTaggingMode>,
-                   argTypeHandler<CmdConfigVlanPortTaggingModeTraits>,
+                   argRegistrar<CmdConfigVlanPortTaggingModeTraits>,
                }},
            },
            {
                "static-mac",
                "Manage static MAC entries for VLANs",
                commandHandler<CmdConfigVlanStaticMac>,
-               argTypeHandler<CmdConfigVlanStaticMacTraits>,
+               argRegistrar<CmdConfigVlanStaticMacTraits>,
                {{
                     "add",
                     "Add a static MAC entry to a VLAN",
                     commandHandler<CmdConfigVlanStaticMacAdd>,
-                    argTypeHandler<CmdConfigVlanStaticMacAddTraits>,
+                    argRegistrar<CmdConfigVlanStaticMacAddTraits>,
                 },
                 {
                     "delete",
                     "Delete a static MAC entry from a VLAN",
                     commandHandler<CmdConfigVlanStaticMacDelete>,
-                    argTypeHandler<CmdConfigVlanStaticMacDeleteTraits>,
+                    argRegistrar<CmdConfigVlanStaticMacDeleteTraits>,
                 }},
            }},
       },
@@ -771,7 +771,7 @@ const CommandTree& kConfigCommandTree() {
        "config",
        "Delete config objects",
        commandHandler<CmdDeleteConfig>,
-       argTypeHandler<CmdDeleteConfigTraits>},
+       argRegistrar<CmdDeleteConfigTraits>},
   };
   sort(root.begin(), root.end());
   return root;

--- a/fboss/cli/fboss2/CmdSubcommands.cpp
+++ b/fboss/cli/fboss2/CmdSubcommands.cpp
@@ -96,7 +96,12 @@ CLI::App* CmdSubcommands::addCommand(
         }
       }
     }
-    if (auto& argTypeHandler = cmd.argTypeHandler) {
+    if (auto& argRegistrar = cmd.argRegistrar) {
+      // Config commands: direct dispatch via addCliArg
+      auto& args = CmdArgsLists::getInstance()->refAt(depth);
+      (*argRegistrar)(*subCmd, args);
+    } else if (auto& argTypeHandler = cmd.argTypeHandler) {
+      // Non-config commands: enum-based dispatch via switch
       auto& args = CmdArgsLists::getInstance()->refAt(depth);
       auto& argType = *argTypeHandler;
       switch (argType()) {
@@ -245,109 +250,7 @@ CLI::App* CmdSubcommands::addCommand(
         case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_INTERFACE_LIST:
           subCmd->add_option("interfaces", args, "Interface(s)");
           break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_REVISION_LIST:
-          subCmd->add_option(
-              "revisions",
-              args,
-              "Git revision(s) as sha1 or other git ref, or 'current'");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_BUFFER_POOL_NAME:
-          subCmd->add_option(
-              "buffer_pool_config",
-              args,
-              "<name> <attr> <value> [<attr> <value> ...] where <attr> is one "
-              "of: shared-bytes, headroom-bytes, reserved-bytes");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_VLAN_ID:
-          subCmd->add_option("vlan_id", args, "VLAN ID (1-4094)");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_MAC_AND_PORT:
-          subCmd->add_option(
-              "mac_and_port",
-              args,
-              "MAC address and port name (e.g., AA:BB:CC:DD:EE:FF eth1/1/1)");
-          break;
-        case utils::ObjectArgTypeId::
-            OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_POLICY_NAME:
-          subCmd->add_option(
-              "priority_group_policy_name", args, "Priority group policy name");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_ID:
-          subCmd->add_option(
-              "group_config",
-              args,
-              "<group-id> [min-limit-bytes <bytes>] [headroom-limit-bytes <bytes>] "
-              "[resume-offset-bytes <bytes>] [static-limit-bytes <bytes>] "
-              "[scaling-factor <factor>] [buffer-pool-name <name>]");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_SCALING_FACTOR:
-          subCmd->add_option(
-              "scaling_factor",
-              args,
-              "MMU scaling factor (ONE, EIGHT, ONE_128TH, ONE_64TH, ONE_32TH, "
-              "ONE_16TH, ONE_8TH, ONE_QUARTER, ONE_HALF, TWO, FOUR, ONE_32768TH, "
-              "ONE_HUNDRED_TWENTY_EIGHT)");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PFC_CONFIG_ATTRS:
-          subCmd->add_option(
-              "pfc_config_attrs",
-              args,
-              "<attr> <value> [<attr> <value> ...] where <attr> is one of: "
-              "rx, tx, rx-duration, tx-duration, priority-group-policy, "
-              "watchdog-detection-time, watchdog-recovery-action, "
-              "watchdog-recovery-time");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUING_POLICY_NAME:
-          subCmd->add_option(
-              "queuing_policy_name", args, "Queuing policy name");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUE_ID:
-          subCmd->add_option(
-              "queue_config",
-              args,
-              "Queue ID followed by key-value pairs: <queue-id> <attr> <value> "
-              "[<attr> <value> ...] where <attr> is one of: reserved-bytes, "
-              "shared-bytes, weight, scaling-factor, scheduling, stream-type, "
-              "buffer-pool-name, active-queue-management");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_POLICY_NAME:
-          subCmd->add_option("qos_policy_name", args, "QoS policy name");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_MAP_ENTRY:
-          subCmd->add_option(
-              "map_entry",
-              args,
-              "<map-type> ... where map-type is one of:\n"
-              "  tc-to-queue (traffic class to queue)\n"
-              "  pfc-pri-to-queue (PFC priority to queue)\n"
-              "  tc-to-pg (traffic class to priority group)\n"
-              "  pfc-pri-to-pg (PFC priority to priority group)\n"
-              "  dscp (DSCP marking)\n"
-              "  mpls-exp (MPLS EXP bits)\n"
-              "  dot1p (802.1p priority)\n"
-              "  traffic-class");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_PORT_AND_TAGGING_MODE:
-          subCmd->add_option(
-              "port_and_tagging_mode",
-              args,
-              "Port name and tagging mode (e.g., eth1/1/1 tagged|untagged|priority-tagged)");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_L2_LEARNING_MODE:
-          subCmd->add_option(
-              "learning_mode",
-              args,
-              "L2 learning mode (hardware|software|disabled)");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_INTERFACES_CONFIG:
-          subCmd->add_option(
-              "interface_config",
-              args,
-              "<port-list> [<attr> <value> ...] where <attr> is one "
-              "of: description, mtu");
-          break;
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_UNINITIALIZE:
-        case utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE:
+        default:
           break;
       }
     }

--- a/fboss/cli/fboss2/commands/bounce/interface/CmdBounceInterface.cpp
+++ b/fboss/cli/fboss2/commands/bounce/interface/CmdBounceInterface.cpp
@@ -14,6 +14,8 @@
 #include "fboss/agent/if/gen-cpp2/FbossCtrl.h"
 #include "fboss/agent/if/gen-cpp2/ctrl_types.h"
 
+#include <fmt/color.h>
+
 namespace facebook::fboss {
 
 CmdBounceInterface::RetType CmdBounceInterface::queryClient(

--- a/fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.cpp
+++ b/fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.cpp
@@ -10,10 +10,13 @@
 
 #include "fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h"
 
+#include "fboss/agent/if/gen-cpp2/FbossCtrlAsyncClient.h"
 #include "fboss/cli/fboss2/CmdHandler.cpp"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
 
 #include <ctime>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
 namespace facebook::fboss {

--- a/fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h
+++ b/fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h
@@ -20,8 +20,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigAppliedInfoTraits : public BaseCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = ConfigAppliedInfo;
 };

--- a/fboss/cli/fboss2/commands/config/CmdConfigReload.cpp
+++ b/fboss/cli/fboss2/commands/config/CmdConfigReload.cpp
@@ -10,7 +10,11 @@
 
 #include "fboss/cli/fboss2/commands/config/CmdConfigReload.h"
 
+#include "fboss/agent/if/gen-cpp2/FbossCtrlAsyncClient.h"
 #include "fboss/cli/fboss2/CmdHandler.cpp"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
+
+#include <iostream>
 
 namespace facebook::fboss {
 

--- a/fboss/cli/fboss2/commands/config/CmdConfigReload.h
+++ b/fboss/cli/fboss2/commands/config/CmdConfigReload.h
@@ -19,8 +19,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigReloadTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/history/CmdConfigHistory.h
+++ b/fboss/cli/fboss2/commands/config/history/CmdConfigHistory.h
@@ -17,8 +17,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigHistoryTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
@@ -59,9 +59,6 @@ class InterfacesConfig : public utils::BaseObjectArgType<std::string> {
     return !attributes_.empty();
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_INTERFACES_CONFIG;
-
  private:
   utils::InterfaceList interfaces_;
   std::vector<std::pair<std::string, std::string>> attributes_;
@@ -71,8 +68,13 @@ class InterfacesConfig : public utils::BaseObjectArgType<std::string> {
 };
 
 struct CmdConfigInterfaceTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_INTERFACES_CONFIG;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "interface_config",
+        args,
+        "<port-list> [<attr> <value> ...] where <attr> is one "
+        "of: description, mtu");
+  }
   using ObjectArgType = InterfacesConfig;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.h
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterfaceQueuingPolicy.h
@@ -22,8 +22,9 @@ namespace facebook::fboss {
 
 struct CmdConfigInterfaceQueuingPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigInterface;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/pfc_config/CmdConfigInterfacePfcConfig.h
+++ b/fboss/cli/fboss2/commands/config/interface/pfc_config/CmdConfigInterfacePfcConfig.h
@@ -22,8 +22,15 @@ namespace facebook::fboss {
 
 struct CmdConfigInterfacePfcConfigTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigInterface;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PFC_CONFIG_ATTRS;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "pfc_config_attrs",
+        args,
+        "<attr> <value> [<attr> <value> ...] where <attr> is one of: "
+        "rx, tx, rx-duration, tx-duration, priority-group-policy, "
+        "watchdog-detection-time, watchdog-recovery-action, "
+        "watchdog-recovery-time");
+  }
   using ObjectArgType = utils::PfcConfigAttrs;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/pfc_config/PfcConfigUtils.h
+++ b/fboss/cli/fboss2/commands/config/interface/pfc_config/PfcConfigUtils.h
@@ -33,9 +33,6 @@ class PfcConfigAttrs : public BaseObjectArgType<std::string> {
     return attributes_;
   }
 
-  const static ObjectArgTypeId id =
-      ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PFC_CONFIG_ATTRS;
-
  private:
   std::vector<std::pair<std::string, std::string>> attributes_;
 };

--- a/fboss/cli/fboss2/commands/config/interface/switchport/CmdConfigInterfaceSwitchport.h
+++ b/fboss/cli/fboss2/commands/config/interface/switchport/CmdConfigInterfaceSwitchport.h
@@ -18,8 +18,6 @@ namespace facebook::fboss {
 
 struct CmdConfigInterfaceSwitchportTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigInterface;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/switchport/access/CmdConfigInterfaceSwitchportAccess.h
+++ b/fboss/cli/fboss2/commands/config/interface/switchport/access/CmdConfigInterfaceSwitchportAccess.h
@@ -18,8 +18,6 @@ namespace facebook::fboss {
 
 struct CmdConfigInterfaceSwitchportAccessTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigInterfaceSwitchport;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/interface/switchport/access/vlan/CmdConfigInterfaceSwitchportAccessVlan.h
+++ b/fboss/cli/fboss2/commands/config/interface/switchport/access/vlan/CmdConfigInterfaceSwitchportAccessVlan.h
@@ -23,8 +23,9 @@ using VlanIdValue = utils::VlanIdValue;
 struct CmdConfigInterfaceSwitchportAccessVlanTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigInterfaceSwitchportAccess;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_VLAN_ID;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("vlan_id", args, "VLAN ID (1-4094)");
+  }
   using ObjectArgType = VlanIdValue;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/l2/CmdConfigL2.h
+++ b/fboss/cli/fboss2/commands/config/l2/CmdConfigL2.h
@@ -15,8 +15,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigL2Traits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = utils::NoneArgType;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/l2/learning_mode/CmdConfigL2LearningMode.h
+++ b/fboss/cli/fboss2/commands/config/l2/learning_mode/CmdConfigL2LearningMode.h
@@ -26,17 +26,16 @@ class L2LearningModeArg : public utils::BaseObjectArgType<std::string> {
     return l2LearningMode_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_L2_LEARNING_MODE;
-
  private:
   cfg::L2LearningMode l2LearningMode_ = cfg::L2LearningMode::HARDWARE;
 };
 
 struct CmdConfigL2LearningModeTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigL2;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_L2_LEARNING_MODE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "learning_mode", args, "L2 learning mode (hardware|software|disabled)");
+  }
   using ObjectArgType = L2LearningModeArg;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/CmdConfigProtocol.h
+++ b/fboss/cli/fboss2/commands/config/protocol/CmdConfigProtocol.h
@@ -15,8 +15,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigProtocolTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/CmdConfigProtocolBgp.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/CmdConfigProtocolBgp.h
@@ -17,8 +17,6 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocol;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobal.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobal.h
@@ -17,8 +17,6 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgp;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalClusterId.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalClusterId.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalClusterIdTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_IP_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("ipAddrs", args, "IPv4 or IPv6 addr(s)");
+  }
   using ObjectArgType = utils::IPList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalConfedAsn.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalConfedAsn.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalConfedAsnTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalHoldTime.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalHoldTime.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalHoldTimeTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalLocalAsn.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalLocalAsn.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalLocalAsnTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalNetwork6Add.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalNetwork6Add.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalNetwork6AddTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalRouterId.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalRouterId.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpGlobalRouterIdTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_IP_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("ipAddrs", args, "IPv4 or IPv6 addr(s)");
+  }
   using ObjectArgType = utils::IPList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitMaxGoldenVips.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitMaxGoldenVips.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpGlobalSwitchLimitMaxGoldenVipsTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitOverloadProtectionMode.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitOverloadProtectionMode.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpGlobalSwitchLimitOverloadProtectionModeTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitPrefixLimit.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitPrefixLimit.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpGlobalSwitchLimitPrefixLimitTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitTotalPathLimit.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/global/CmdConfigProtocolBgpGlobalSwitchLimitTotalPathLimit.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpGlobalSwitchLimitTotalPathLimitTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpGlobal;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroup.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroup.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerGroupTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgp;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupConfedPeer.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupConfedPeer.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupConfedPeerTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupDescription.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupDescription.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupDescriptionTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupDisableIpv4Afi.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupDisableIpv4Afi.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupDisableIpv4AfiTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupEgressPolicy.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupEgressPolicy.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupEgressPolicyTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupIngressPolicy.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupIngressPolicy.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupIngressPolicyTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupMaxRoutes.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupMaxRoutes.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupMaxRoutesTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupNextHopSelf.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupNextHopSelf.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupNextHopSelfTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupPeerTag.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupPeerTag.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerGroupPeerTagTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupRemoteAsn.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupRemoteAsn.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupRemoteAsnTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupRrClient.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupRrClient.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerGroupRrClientTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimers.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimers.h
@@ -18,8 +18,6 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerGroupTimersTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersHoldTime.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersHoldTime.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupTimersHoldTimeTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroupTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersKeepalive.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersKeepalive.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupTimersKeepaliveTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroupTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersOutDelay.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersOutDelay.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupTimersOutDelayTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroupTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersWithdrawUnprogDelay.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupTimersWithdrawUnprogDelay.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupTimersWithdrawUnprogDelayTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroupTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupV4OverV6Nh.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupV4OverV6Nh.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupV4OverV6NhTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupWarningLimit.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupWarningLimit.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupWarningLimitTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupWarningOnly.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer-group/CmdConfigProtocolBgpPeerGroupWarningOnly.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerGroupWarningOnlyTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerGroup;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeer.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeer.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgp;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_IP_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("ipAddrs", args, "IPv4 or IPv6 addr(s)");
+  }
   using ObjectArgType = utils::IPList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerAdvertiseLbw.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerAdvertiseLbw.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerAdvertiseLbwTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerDescription.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerDescription.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerDescriptionTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerDisableIpv4Afi.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerDisableIpv4Afi.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerDisableIpv4AfiTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerEgressPolicy.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerEgressPolicy.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerEgressPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerHoldTime.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerHoldTime.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerHoldTimeTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerIngressPolicy.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerIngressPolicy.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerIngressPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerLinkBandwidth.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerLinkBandwidth.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerLinkBandwidthTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerLocalAddr.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerLocalAddr.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerLocalAddrTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerMaxRoutes.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerMaxRoutes.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerMaxRoutesTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHop4.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHop4.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerNextHop4Traits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHop6.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHop6.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerNextHop6Traits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHopSelf.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerNextHopSelf.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerNextHopSelfTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPassive.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPassive.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerPassiveTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPeerGroup.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPeerGroup.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerPeerGroupTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPeerId.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerPeerId.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerPeerIdTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerRemoteAsn.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerRemoteAsn.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerRemoteAsnTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerRrClient.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerRrClient.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerRrClientTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimers.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimers.h
@@ -18,8 +18,6 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerTimersTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersKeepalive.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersKeepalive.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerTimersKeepaliveTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersOutDelay.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersOutDelay.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerTimersOutDelayTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersWithdrawUnprogDelay.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerTimersWithdrawUnprogDelay.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 struct CmdConfigProtocolBgpPeerTimersWithdrawUnprogDelayTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeerTimers;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerType.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerType.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerTypeTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerV4OverV6Nh.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerV4OverV6Nh.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerV4OverV6NhTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerWarningLimit.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerWarningLimit.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerWarningLimitTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerWarningOnly.h
+++ b/fboss/cli/fboss2/commands/config/protocol/bgp/peer/CmdConfigProtocolBgpPeerWarningOnly.h
@@ -18,8 +18,9 @@ namespace facebook::fboss {
 
 struct CmdConfigProtocolBgpPeerWarningOnlyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigProtocolBgpPeer;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = utils::Message;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/CmdConfigQos.h
+++ b/fboss/cli/fboss2/commands/config/qos/CmdConfigQos.h
@@ -16,8 +16,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigQosTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/buffer_pool/CmdConfigQosBufferPool.h
+++ b/fboss/cli/fboss2/commands/config/qos/buffer_pool/CmdConfigQosBufferPool.h
@@ -37,9 +37,6 @@ class BufferPoolConfig : public utils::BaseObjectArgType<std::string> {
     return attributes_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_BUFFER_POOL_NAME;
-
  private:
   std::string name_;
   std::vector<std::pair<std::string, std::string>> attributes_;
@@ -47,8 +44,13 @@ class BufferPoolConfig : public utils::BaseObjectArgType<std::string> {
 
 struct CmdConfigQosBufferPoolTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQos;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_BUFFER_POOL_NAME;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "buffer_pool_config",
+        args,
+        "<name> <attr> <value> [<attr> <value> ...] where <attr> is one "
+        "of: shared-bytes, headroom-bytes, reserved-bytes");
+  }
   using ObjectArgType = BufferPoolConfig;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/policy/CmdConfigQosPolicy.h
+++ b/fboss/cli/fboss2/commands/config/qos/policy/CmdConfigQosPolicy.h
@@ -33,15 +33,13 @@ class QosPolicyName : public utils::BaseObjectArgType<std::string> {
   std::string getName() const {
     return data_.empty() ? "" : data_[0];
   }
-
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_POLICY_NAME;
 };
 
 struct CmdConfigQosPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQos;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_POLICY_NAME;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("qos_policy_name", args, "QoS policy name");
+  }
   using ObjectArgType = QosPolicyName;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/policy/CmdConfigQosPolicyMap.h
+++ b/fboss/cli/fboss2/commands/config/qos/policy/CmdConfigQosPolicyMap.h
@@ -95,9 +95,6 @@ class QosMapConfig : public utils::BaseObjectArgType<std::string> {
    */
   bool isListMapType() const;
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_MAP_ENTRY;
-
  private:
   void parseListMapType(const std::vector<std::string>& v);
 
@@ -111,8 +108,20 @@ class QosMapConfig : public utils::BaseObjectArgType<std::string> {
 
 struct CmdConfigQosPolicyMapTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQosPolicy;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QOS_MAP_ENTRY;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "map_entry",
+        args,
+        "<map-type> ... where map-type is one of:\n"
+        "  tc-to-queue (traffic class to queue)\n"
+        "  pfc-pri-to-queue (PFC priority to queue)\n"
+        "  tc-to-pg (traffic class to priority group)\n"
+        "  pfc-pri-to-pg (PFC priority to priority group)\n"
+        "  dscp (DSCP marking)\n"
+        "  mpls-exp (MPLS EXP bits)\n"
+        "  dot1p (802.1p priority)\n"
+        "  traffic-class");
+  }
   using ObjectArgType = QosMapConfig;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/priority_group_policy/CmdConfigQosPriorityGroupPolicy.h
+++ b/fboss/cli/fboss2/commands/config/qos/priority_group_policy/CmdConfigQosPriorityGroupPolicy.h
@@ -52,15 +52,14 @@ class PriorityGroupPolicyName : public utils::BaseObjectArgType<std::string> {
   const std::string& getName() const {
     return data_[0];
   }
-
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_POLICY_NAME;
 };
 
 struct CmdConfigQosPriorityGroupPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQos;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_POLICY_NAME;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "priority_group_policy_name", args, "Priority group policy name");
+  }
   using ObjectArgType = PriorityGroupPolicyName;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/priority_group_policy/CmdConfigQosPriorityGroupPolicyGroupId.h
+++ b/fboss/cli/fboss2/commands/config/qos/priority_group_policy/CmdConfigQosPriorityGroupPolicyGroupId.h
@@ -44,9 +44,6 @@ class PriorityGroupConfig : public utils::BaseObjectArgType<std::string> {
     return attributes_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_ID;
-
  private:
   int16_t groupId_{0};
   std::vector<std::pair<std::string, std::string>> attributes_;
@@ -55,8 +52,14 @@ class PriorityGroupConfig : public utils::BaseObjectArgType<std::string> {
 struct CmdConfigQosPriorityGroupPolicyGroupIdTraits
     : public WriteCommandTraits {
   using ParentCmd = CmdConfigQosPriorityGroupPolicy;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PRIORITY_GROUP_ID;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "group_config",
+        args,
+        "<group-id> [min-limit-bytes <bytes>] [headroom-limit-bytes <bytes>] "
+        "[resume-offset-bytes <bytes>] [static-limit-bytes <bytes>] "
+        "[scaling-factor <factor>] [buffer-pool-name <name>]");
+  }
   using ObjectArgType = PriorityGroupConfig;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/queuing_policy/CmdConfigQosQueuingPolicy.h
+++ b/fboss/cli/fboss2/commands/config/qos/queuing_policy/CmdConfigQosQueuingPolicy.h
@@ -51,15 +51,13 @@ class QueuingPolicyName : public utils::BaseObjectArgType<std::string> {
   const std::string& getName() const {
     return data_[0];
   }
-
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUING_POLICY_NAME;
 };
 
 struct CmdConfigQosQueuingPolicyTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQos;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUING_POLICY_NAME;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("queuing_policy_name", args, "Queuing policy name");
+  }
   using ObjectArgType = QueuingPolicyName;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/qos/queuing_policy/CmdConfigQosQueuingPolicyQueueId.h
+++ b/fboss/cli/fboss2/commands/config/qos/queuing_policy/CmdConfigQosQueuingPolicyQueueId.h
@@ -48,9 +48,6 @@ class QueueConfig : public utils::BaseObjectArgType<std::string> {
     return aqmAttributes_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUE_ID;
-
  private:
   int16_t queueId_{0};
   std::vector<std::pair<std::string, std::string>> attributes_;
@@ -59,8 +56,15 @@ class QueueConfig : public utils::BaseObjectArgType<std::string> {
 
 struct CmdConfigQosQueuingPolicyQueueIdTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigQosQueuingPolicy;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_QUEUE_ID;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "queue_config",
+        args,
+        "Queue ID followed by key-value pairs: <queue-id> <attr> <value> "
+        "[<attr> <value> ...] where <attr> is one of: reserved-bytes, "
+        "shared-bytes, weight, scaling-factor, scheduling, stream-type, "
+        "buffer-pool-name, active-queue-management");
+  }
   using ObjectArgType = QueueConfig;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/rollback/CmdConfigRollback.h
+++ b/fboss/cli/fboss2/commands/config/rollback/CmdConfigRollback.h
@@ -17,8 +17,12 @@
 namespace facebook::fboss {
 
 struct CmdConfigRollbackTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_REVISION_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "revisions",
+        args,
+        "Git revision(s) as sha1 or other git ref, or 'current'");
+  }
   using ObjectArgType = utils::RevisionList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionClear.h
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionClear.h
@@ -19,8 +19,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigSessionClearTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate; // no arg
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionCommit.h
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionCommit.h
@@ -17,8 +17,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigSessionCommitTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.h
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.h
@@ -17,8 +17,12 @@
 namespace facebook::fboss {
 
 struct CmdConfigSessionDiffTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_REVISION_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "revisions",
+        args,
+        "Git revision(s) as sha1 or other git ref, or 'current'");
+  }
   using ObjectArgType = utils::RevisionList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionRebase.h
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionRebase.h
@@ -19,8 +19,6 @@
 namespace facebook::fboss {
 
 struct CmdConfigSessionRebaseTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate; // no arg
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.h
+++ b/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.h
@@ -19,8 +19,9 @@ namespace facebook::fboss {
 using VlanId = utils::VlanIdValue;
 
 struct CmdConfigVlanTraits : public WriteCommandTraits {
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_VLAN_ID;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("vlan_id", args, "VLAN ID (1-4094)");
+  }
   using ObjectArgType = VlanId;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/port/CmdConfigVlanPort.h
+++ b/fboss/cli/fboss2/commands/config/vlan/port/CmdConfigVlanPort.h
@@ -17,8 +17,9 @@ namespace facebook::fboss {
 
 struct CmdConfigVlanPortTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigVlan;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_PORT_LIST;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("ports", args, "Port(s)");
+  }
   using ObjectArgType = utils::PortList;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/port/tagging_mode/CmdConfigVlanPortTaggingMode.h
+++ b/fboss/cli/fboss2/commands/config/vlan/port/tagging_mode/CmdConfigVlanPortTaggingMode.h
@@ -58,9 +58,6 @@ class TaggingModeArg : public utils::BaseObjectArgType<std::string> {
     return emitPriorityTags_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_PORT_AND_TAGGING_MODE;
-
  private:
   bool emitTags_ = false;
   bool emitPriorityTags_ = false;
@@ -68,8 +65,12 @@ class TaggingModeArg : public utils::BaseObjectArgType<std::string> {
 
 struct CmdConfigVlanPortTaggingModeTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigVlanPort;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_PORT_AND_TAGGING_MODE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "port_and_tagging_mode",
+        args,
+        "Port name and tagging mode (e.g., eth1/1/1 tagged|untagged|priority-tagged)");
+  }
   using ObjectArgType = TaggingModeArg;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/static_mac/CmdConfigVlanStaticMac.h
+++ b/fboss/cli/fboss2/commands/config/vlan/static_mac/CmdConfigVlanStaticMac.h
@@ -17,8 +17,6 @@ namespace facebook::fboss {
 
 struct CmdConfigVlanStaticMacTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigVlan;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
   using ObjectArgType = std::monostate;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/static_mac/add/CmdConfigVlanStaticMacAdd.h
+++ b/fboss/cli/fboss2/commands/config/vlan/static_mac/add/CmdConfigVlanStaticMacAdd.h
@@ -46,9 +46,6 @@ class MacAndPortArg : public utils::BaseObjectArgType<std::string> {
     return portName_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_MAC_AND_PORT;
-
  private:
   std::string macAddress_;
   std::string portName_;
@@ -56,8 +53,12 @@ class MacAndPortArg : public utils::BaseObjectArgType<std::string> {
 
 struct CmdConfigVlanStaticMacAddTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigVlanStaticMac;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_MAC_AND_PORT;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "mac_and_port",
+        args,
+        "MAC address and port name (e.g., AA:BB:CC:DD:EE:FF eth1/1/1)");
+  }
   using ObjectArgType = MacAndPortArg;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/config/vlan/static_mac/delete/CmdConfigVlanStaticMacDelete.h
+++ b/fboss/cli/fboss2/commands/config/vlan/static_mac/delete/CmdConfigVlanStaticMacDelete.h
@@ -41,17 +41,15 @@ class MacAddressArg : public utils::BaseObjectArgType<std::string> {
     return macAddress_;
   }
 
-  const static utils::ObjectArgTypeId id =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
-
  private:
   std::string macAddress_;
 };
 
 struct CmdConfigVlanStaticMacDeleteTraits : public WriteCommandTraits {
   using ParentCmd = CmdConfigVlanStaticMac;
-  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
-      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_MESSAGE;
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option("msg", args, "Message");
+  }
   using ObjectArgType = MacAddressArg;
   using RetType = std::string;
 };

--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
@@ -13,7 +13,8 @@
 
 #include "fboss/cli/fboss2/utils/Table.h"
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <fmt/color.h>
 #include <re2/re2.h>
 
 namespace facebook::fboss {

--- a/fboss/cli/fboss2/oss/CmdList.cpp
+++ b/fboss/cli/fboss2/oss/CmdList.cpp
@@ -19,14 +19,14 @@ const CommandTree& kBaseAdditionalCommandTree() {
              {"agent",
               "Show Agent running config",
               commandHandler<CmdShowConfigRunningAgent>,
-              argTypeHandler<CmdShowConfigDynamicTraits>},
+              argRegistrar<CmdShowConfigDynamicTraits>},
          }},
         {"history",
          "Show history of changes to the current config",
          {{"agent",
            "Show history of changes to the current Agent config",
            commandHandler<CmdShowConfigHistoryAgent>,
-           argTypeHandler<CmdShowConfigTraits>}}}}},
+           argRegistrar<CmdShowConfigTraits>}}}}},
   };
   return tree;
 }


### PR DESCRIPTION
# Summary

Every new `fboss2-dev` config subcommand that takes a positional argument used to touch three centralized spots:

1. A new enumerator in `utils::ObjectArgTypeId` (fboss/cli/fboss2/utils/CmdUtilsCommon.h).
2. A new `case` in the ~330-line `switch` in `CmdSubcommands::addCommand` that called `subCmd->add_option(...)` for that enumerator.
3. A `static constexpr utils::ObjectArgTypeId ObjectArgTypeId = ...` on the command's Traits struct plus a matching `static ObjectArgTypeId id = ...` on the arg class.

The enum and the switch are merge-conflict magnets — any two teams adding config subcommands in parallel hit the same two spots. The `ObjectArgTypeId` tag itself is only consumed by that switch for config commands; no other code reads it.

**This PR migrates config commands only** (those under `fboss/cli/fboss2/commands/config/`) to the new `addCliArg` pattern as a first step. Non-config commands (show, clear, set, bounce, get, start, stop, stream, delete) retain the existing `ObjectArgTypeId` enum + central switch approach unchanged and will be migrated in a follow-up.

The new pattern moves the CLI11 positional registration into each config command's own Traits struct via a new `static void addCliArg(CLI::App&, std::vector<std::string>&)` method, dispatched through a `std::function<void(CLI::App&, std::vector<std::string>&)>` slot on `Command`. Adding or editing a config command no longer touches any centrally-shared file:

- `BaseCommandTraits` in `CmdHandler.h` provides a no-op `addCliArg` default.
- `CmdList.h` gains an `ArgRegistrarFn` / `argRegistrar<T>` type alongside the existing `ArgTypeHandlerFn` / `argTypeHandler<T>`; `Command` carries both as optional fields.
- `CmdSubcommands::addCommand` checks `argRegistrar` first (config path → direct `addCliArg` call), then falls through to the existing `argTypeHandler` switch (non-config path).
- Each config Traits that took a positional gets a local `addCliArg` method holding the exact `add_option(...)` chain that used to live in the switch.
- Config-specific `ObjectArgTypeId` enum values (e.g. `OBJECT_ARG_TYPE_ID_INTERFACES_CONFIG`, `OBJECT_ARG_TYPE_VLAN_ID`, etc.) are retained in the enum for now to avoid churn on the non-config migration; the switch cases for these values become no-ops since they are reached only via `argRegistrar` now.

**Future work:** once all non-config commands are migrated to `addCliArg` in a follow-up PR, the entire `ObjectArgTypeId` enum, `BaseObjectArgType::id`, per-arg-class `id` statics, and the central switch can be deleted.

# Test plan

Build clean with the project's bazel wrapper:

```
$ ./fboss/oss/scripts/bazel.sh build //fboss/cli/...
INFO: Build completed successfully, 1605 total actions
```

Run the full CLI test suite:

```
$ ./fboss/oss/scripts/bazel.sh test //fboss/cli/...
//fboss/cli/fboss2/test:cmd_test                                         PASSED in 2.0s
//fboss/cli/fboss2/test:framework_test                                   PASSED in 0.1s
//fboss/cli/fboss2/test/config:cmd_config_test                           PASSED in 9.2s

Executed 3 out of 3 tests: 3 tests pass.
```

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`