### PR TITLE
Fix packaging and test execution for directory-type Python executables (#1113)

### DIFF
--- a/.github/workflows/platform-mapping-verification.yml
+++ b/.github/workflows/platform-mapping-verification.yml
@@ -44,13 +44,20 @@ jobs:
           --name
           FBOSS_PACKAGE_CONTAINER
           fboss_image:latest
-          python3
-          /var/FBOSS/fboss/fboss/oss/scripts/package-fboss.py
-          --copy-root-libs
-          --scratch-path=/var/FBOSS/tmp_bld_dir
-          --compress
-      - name: Save Docker image
-        run: sudo docker save fboss_image:latest | zstd -o ${{ github.workspace }}/build-output/fboss_docker_image.tar.zst
+          bash -c
+          "set -ex &&
+          python3 /var/FBOSS/fboss/fboss/oss/scripts/package-fboss.py --copy-root-libs --scratch-path=/var/FBOSS/tmp_bld_dir --compress &&
+          python3 -m pip install --no-deps /var/FBOSS/tmp_bld_dir/installed/fbthrift-python/share/thrift/wheels/*.whl &&
+          mkdir -p /usr/local/lib64/python3.12/site-packages &&
+          cp -r /var/FBOSS/tmp_bld_dir/installed/folly-python/lib64/python3.12/site-packages/folly /usr/local/lib64/python3.12/site-packages/ &&
+          for d in /var/FBOSS/tmp_bld_dir/installed/*/lib /var/FBOSS/tmp_bld_dir/installed/*/lib64; do
+            if [ -d \"\$d\" ]; then find \"\$d\" -maxdepth 1 -name '*.so*' -exec cp -an {} /usr/local/lib64/ \\; ; fi; done &&
+          ldconfig"
+      - name: Save Docker image with Python runtime
+        run: |
+          sudo docker commit FBOSS_PACKAGE_CONTAINER fboss_image:latest
+          sudo docker rm FBOSS_PACKAGE_CONTAINER
+          sudo docker save fboss_image:latest | zstd -o ${{ github.workspace }}/build-output/fboss_docker_image.tar.zst
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:

--- a/fboss/oss/scripts/github_actions/docker-unittest.py
+++ b/fboss/oss/scripts/github_actions/docker-unittest.py
@@ -176,10 +176,17 @@ def find_tests(output_dir, excludes=None):
     return tests
 
 
+def is_python_dir_test(path: str) -> bool:
+    return os.path.isdir(path) and os.path.isfile(os.path.join(path, "__main__.py"))
+
+
 def is_test(path: str) -> bool:
     match = TEST_PATH_REGEX.match(path)
     if not match:
         return False
+
+    if is_python_dir_test(path):
+        return True
 
     return os.path.isfile(path) and os.access(path, os.X_OK)
 
@@ -225,7 +232,16 @@ def run_test(test: str, output_dir: str) -> bool:
     cmd_args.append("--network=host")
     cmd_args.append(f"{FBOSS_IMAGE_NAME}:latest")
     test_path = os.path.join(output_dir, "bin", test)
-    cmd_args.append(test_path)
+    if is_python_dir_test(test_path):
+        cmd_args.extend(
+            [
+                "bash",
+                "-c",
+                f"LD_LIBRARY_PATH={lib_path}:/usr/local/lib64 python3 {test_path}",
+            ]
+        )
+    else:
+        cmd_args.append(test_path)
     cp = subprocess.run(cmd_args, check=False)
     return cp.returncode == 0
 
@@ -235,8 +251,13 @@ def run_test_local(test: str, output_dir: str) -> bool:
     lib_path = os.path.join(output_dir, "lib")
     test_path = os.path.join(output_dir, "bin", test)
     env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = lib_path
-    cp = subprocess.run([test_path], env=env, check=False)
+    if is_python_dir_test(test_path):
+        env["LD_LIBRARY_PATH"] = f"{lib_path}:/usr/local/lib64"
+        cmd = ["python3", test_path]
+    else:
+        env["LD_LIBRARY_PATH"] = lib_path
+        cmd = [test_path]
+    cp = subprocess.run(cmd, env=env, check=False)
     return cp.returncode == 0
 
 
@@ -244,10 +265,19 @@ def run_test_exec(test: str, output_dir: str) -> bool:
     use_stable_hashes()
     cmd_args = _docker_cmd() + ["exec"]
     lib_path = os.path.join(output_dir, "lib")
+    test_path = os.path.join(output_dir, "bin", test)
     cmd_args.extend(["-e", f"LD_LIBRARY_PATH={lib_path}"])
     cmd_args.append(FBOSS_CONTAINER_NAME)
-    test_path = os.path.join(output_dir, "bin", test)
-    cmd_args.append(test_path)
+    if is_python_dir_test(test_path):
+        cmd_args.extend(
+            [
+                "bash",
+                "-c",
+                f"LD_LIBRARY_PATH={lib_path}:/usr/local/lib64 python3 {test_path}",
+            ]
+        )
+    else:
+        cmd_args.append(test_path)
     cp = subprocess.run(cmd_args, check=False)
     return cp.returncode == 0
 

--- a/fboss/oss/scripts/package-fboss.py
+++ b/fboss/oss/scripts/package-fboss.py
@@ -247,6 +247,14 @@ class PackageFboss:
 
                 for binary in effective_binaries:
                     bin_abs_path = os.path.join(project_dir, binary)
+                    if self._is_python_dir_executable(bin_abs_path):
+                        dst = os.path.join(bin_pkg_path, binary)
+                        shutil.copytree(
+                            bin_abs_path, dst, symlinks=True, dirs_exist_ok=True
+                        )
+                        print(f"Copied directory executable {bin_abs_path} to {dst}")
+                        continue
+
                     try:
                         shutil.copy(bin_abs_path, bin_pkg_path)
                         print(f"Copied {bin_abs_path} to {bin_pkg_path}")
@@ -269,6 +277,10 @@ class PackageFboss:
         self._copy_known_bad_tests(tmp_dir_name)
         self._copy_unsupported_tests(tmp_dir_name)
         self._copy_production_features(tmp_dir_name)
+
+    @staticmethod
+    def _is_python_dir_executable(path: str) -> bool:
+        return os.path.isdir(path) and os.path.isfile(os.path.join(path, "__main__.py"))
 
     def _update_ld_library_path(self) -> None:
         find_cmd = [


### PR DESCRIPTION
Summary:

D98059537 migrated from `add_fb_python_executable` (single-file zipapp) to
`add_fb_thrift_python_executable` (directory with `__main__.py`) for thrift-python
support. This broke the GitHub Actions platform-mapping-verification workflow:

1. `package-fboss.py` used `shutil.copy()` which silently skipped directories,
   so test executables never made it into the tarball.
2. `docker-unittest.py` only detected executable files via `os.path.isfile()`,
   missing directory-type Python tests entirely.
3. The Docker image saved for the test job lacked the thrift-python wheel and
   folly C extensions needed at runtime.

Changes:
- `package-fboss.py`: Detect directories with `__main__.py` and use
  `shutil.copytree` instead of `shutil.copy`.
- `docker-unittest.py`: Add `is_python_dir_test()` to detect directory-type
  tests. Run them with `python3` and include `/usr/local/lib64` in
  `LD_LIBRARY_PATH` for C extension shared library resolution.
- `platform-mapping-verification.yml`: After packaging, install the thrift
  wheel, copy folly site-packages and shared libraries into the container,
  then `docker commit` to bake the Python runtime into the saved image.

Differential Revision: D101854033
