### PR TITLE
[Nexthop] Allow speeding up the SAI preparation

### DIFF
--- a/fboss/oss/scripts/build-helper.py
+++ b/fboss/oss/scripts/build-helper.py
@@ -154,7 +154,12 @@ class BuildHelper:
         lib_path = os.path.join(self._output_path, "lib")
         os.makedirs(os.path.join(self._output_path, lib_path))
         headers_path = os.path.join(self._output_path, "include")
-        shutil.copy(self._libsai_impl_path, lib_path)
+        dst_libsai = os.path.join(lib_path, os.path.basename(self._libsai_impl_path))
+        # Try to create a hard link first (faster), fall back to copy if it fails.
+        try:
+            os.link(self._libsai_impl_path, dst_libsai)
+        except (OSError, NotImplementedError):
+            shutil.copy(self._libsai_impl_path, dst_libsai)
         shutil.copytree(self._experiments_path, headers_path)
 
     def _create_archive(self):
@@ -167,7 +172,8 @@ class BuildHelper:
                 self._output_path,
                 "lib",
                 "include",
-            ]
+            ],
+            check=False,
         )
 
     def _get_csum(self):
@@ -242,7 +248,12 @@ class BuildHelper:
 
     def _start_http_server(self):
         os.chdir(self._output_path)
-        subprocess.Popen(["python3", "-m", "http.server"])
+        subprocess.Popen(
+            ["python3", "-m", "http.server"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         os.chdir(self._script_dir)
 
     def run(self):

--- a/fboss/oss/scripts/run-getdeps.py
+++ b/fboss/oss/scripts/run-getdeps.py
@@ -14,6 +14,7 @@ import argparse
 import glob
 import os
 import re
+import shutil
 import subprocess
 import sys
 import sysconfig
@@ -34,6 +35,7 @@ ARG_NPU_SAI_IMPL = "--npu-sai-impl"
 ARG_NPU_SAI_VERSION = "--npu-sai-version"
 ARG_NPU_SAI_SDK_VERSION = "--npu-sai-sdk-version"
 ARG_NPU_LIBSAI_IMPL_PATH = "--npu-libsai-impl-path"
+ARG_NPU_LIBSAI_IMPL_TARBALL = "--npu-libsai-impl-tarball"
 ARG_NPU_EXPERIMENTS_PATH = "--npu-experiments-path"
 ARG_PHY_SAI_IMPL = "--phy-sai-impl"
 
@@ -133,6 +135,13 @@ def parse_args():
         "sai_dependencies.txt and any other SDK libs to stage alongside it).",
     )
     parser.add_argument(
+        ARG_NPU_LIBSAI_IMPL_TARBALL,
+        required=False,
+        help="Full path to a pre-built libsai_impl.tar.gz containing lib/ and include/ "
+        f"subdirectories. Mutually exclusive with {ARG_NPU_LIBSAI_IMPL_PATH} and "
+        f"{ARG_NPU_EXPERIMENTS_PATH}.",
+    )
+    parser.add_argument(
         ARG_NPU_EXPERIMENTS_PATH,
         required=False,
         help="Full path to SAI spec experiments directory.",
@@ -210,8 +219,8 @@ def detect_toolchain():
             timeout=5,
             check=False,
         )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        print_info(f"Warning: Could not detect compiler: {e}")
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        print(f"Warning: Could not detect compiler: {e}", file=sys.stderr)
         return None
 
     if gxx_version.returncode != 0:
@@ -361,7 +370,6 @@ def setup_clang_environment(toolchain_info):
         print_info("Warning: Could not determine target triple")
         return
 
-    # Read clang-specific CXXFLAGS from CMakeLists.txt using regex
     cxxflags = _extract_clang_cxxflags()
     if cxxflags is None:
         return
@@ -520,6 +528,53 @@ def _conditionally_prepare_sdk_artifacts(libsai_impl_path, experiments_path):
     )
 
 
+def _get_scratch_path(getdeps_args):
+    """Extract --scratch-path from getdeps args, or return the conventional default."""
+    for i, arg in enumerate(getdeps_args):
+        if arg == "--scratch-path" and i + 1 < len(getdeps_args):
+            return getdeps_args[i + 1]
+        if arg.startswith("--scratch-path="):
+            return arg.split("=", 1)[1]
+    return "/var/FBOSS/tmp_bld_dir"
+
+
+def _prepare_sdk_from_tarball(tarball_path, scratch_path):
+    """Extract a pre-built SDK tarball and prepend its root to CMAKE_PREFIX_PATH.
+
+    The tarball must contain lib/ and include/ subdirectories, as produced by
+    build-helper.py (tar czvf libsai_impl.tar.gz -C output_path lib include).
+
+    Files are extracted to <scratch_path>/installed/sai_impl_tarball/ so they
+    live alongside other getdeps-installed packages rather than in /tmp.
+    """
+    if not os.path.isfile(tarball_path):
+        print_error(
+            f"Error: {ARG_NPU_LIBSAI_IMPL_TARBALL} path does not exist "
+            f"or is not a file: {tarball_path}"
+        )
+        sys.exit(1)
+    if os.path.getsize(tarball_path) == 0:
+        print_error(
+            f"Error: {ARG_NPU_LIBSAI_IMPL_TARBALL} file is empty: {tarball_path}"
+        )
+        sys.exit(1)
+
+    extract_dir = os.path.join(scratch_path, "installed", "sai_impl_tarball")
+    if os.path.exists(extract_dir):
+        shutil.rmtree(extract_dir)
+    os.makedirs(extract_dir)
+    subprocess.run(
+        ["tar", "xzf", tarball_path, "-C", extract_dir],
+        check=True,
+    )
+    print_info(f"Extracted SDK tarball {tarball_path} to {extract_dir}")
+
+    existing = os.environ.get("CMAKE_PREFIX_PATH", "")
+    os.environ["CMAKE_PREFIX_PATH"] = (
+        f"{extract_dir}:{existing}" if existing else extract_dir
+    )
+
+
 def _warn_if_unsupported(flag_name, value, supported_values):
     """Print an info message if value is not in the set of officially supported values."""
     if value not in supported_values:
@@ -602,9 +657,23 @@ def main():
 
     _set_build_env_vars(args)
 
-    _conditionally_prepare_sdk_artifacts(
-        args.npu_libsai_impl_path, args.npu_experiments_path
-    )
+    if args.npu_libsai_impl_tarball is not None:
+        if (
+            args.npu_libsai_impl_path is not None
+            or args.npu_experiments_path is not None
+        ):
+            print_error(
+                f"Error: {ARG_NPU_LIBSAI_IMPL_TARBALL} is mutually exclusive with "
+                f"{ARG_NPU_LIBSAI_IMPL_PATH} and {ARG_NPU_EXPERIMENTS_PATH}."
+            )
+            sys.exit(1)
+        _prepare_sdk_from_tarball(
+            args.npu_libsai_impl_tarball, _get_scratch_path(args.getdeps_args)
+        )
+    else:
+        _conditionally_prepare_sdk_artifacts(
+            args.npu_libsai_impl_path, args.npu_experiments_path
+        )
 
     if args.npu_sai_version is not None:
         _edit_libsai_manifest(args.npu_sai_version)


### PR DESCRIPTION
# Summary

`build-helper.py` creates a tarball and then serves it to getdeps using a local HTTP server. In order to speed things up, we can re-use an existing tarball instead of creating it each time. Add a flag that allows skipping archive creation as an optional optimization.

# Test Plan

Not needed: existing uses of `build-helper.py` don't need to change. Users can optionally save the tarball created by `build-helper.py` and re-use it later with the `--skip-archive-creation` flag to speed things up. We rely on this in our CI to save a minute or so per build.