### PR TITLE
[Celestica] Icecube: Config: Align TMP432 OTP threshold to 95°C per the latest thermal specification (was 100°C)

### DIFF
--- a/fboss/platform/configs/icecube/platform_manager.json
+++ b/fboss/platform/configs/icecube/platform_manager.json
@@ -1089,7 +1089,7 @@
               "__comment__": "Local temp high limit setting for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1103,7 +1103,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1117,7 +1117,7 @@
               "__comment__": "Remote temp2 high limit setting for high byte.",
               "regOffset": 21,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1171,7 +1171,7 @@
               "__comment__": "Local temp high limit setting for high byte.",
               "regOffset": 11,
               "ioBuf": [
-                100
+                95
               ]
             },
             {
@@ -1185,7 +1185,7 @@
               "__comment__": "Remote temp1 high limit setting for high byte.",
               "regOffset": 13,
               "ioBuf": [
-                100
+                95
               ]
             },
             {

--- a/fboss/platform/configs/icecube/sensor_service.json
+++ b/fboss/platform/configs/icecube/sensor_service.json
@@ -903,7 +903,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100
+            "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
         },
@@ -912,7 +912,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100
+            "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
         },
@@ -921,7 +921,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp3_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100
+            "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
         },
@@ -930,7 +930,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100
+            "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
         },
@@ -939,7 +939,7 @@
           "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp2_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 100
+            "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
<img width="974" height="276" alt="icecube_log_2026_4_23" src="https://github.com/user-attachments/assets/9d5956df-cc7f-4195-94b6-c2542ddb6ebf" />




# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR updates the TMP432 over-temperature protection (OTP) high-limit threshold from 100°C to 95°C in both `platform_manager.json` and `sensor_service.json`, aligning the software configuration with the latest thermal engineering specifications post-OS boot.

Based on recent findings and discussions between the EE and Thermal teams, the operational high-limit thresholds for the TMP432 sensors must be strictly set to 95°C after the OS boots. While the previous configuration allowed temperatures up to 100°C, the updated design requirement mandates that the hardware triggers Over-Temperature Protection (OTP) at 95°C to ensure system safety and compliance with the thermal design envelope.

<img width="1152" height="380" alt="image" src="https://github.com/user-attachments/assets/45890a23-2cc2-4256-8136-77ecfd44f74e" />


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
1. **Syntax Validation**: Validated JSON syntax using JSONLint.
2. **Formatting**: Pretty-printed configurations using the jq command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Service Verification**: Confirmed that the following services start and run without errors:
    - platform_manager
    - platform_hw_test
    - platform_manager_hw_test
    - sensor_service
    - sensor_service_client
    - sensor_service_hw_test
5. **Threshold Verification**: Executed `sensors tmp432-*` to verify the applied limits.
    - Expected Result: All channels report high = +95.0°C.
    - Previous State: Channels reported high = +100.0°C.
Test Output Screenshot:
<img width="1090" height="520" alt="image" src="https://github.com/user-attachments/assets/013e2dae-aa8c-4ec5-ae37-7edc8d5b089e" />

Attachments:

[icecube_platform_hw_test_2026_04_23_log.txt](https://github.com/user-attachments/files/26995132/icecube_platform_hw_test_2026_04_23_log.txt)
[icecube_platform_manager_2026_04_23_log.txt](https://github.com/user-attachments/files/26995133/icecube_platform_manager_2026_04_23_log.txt)
[icecube_platform_manager_hw_test_2026_04_23_log.txt](https://github.com/user-attachments/files/26995134/icecube_platform_manager_hw_test_2026_04_23_log.txt)
[icecube_sensor_service_2026_04_23_log.txt](https://github.com/user-attachments/files/26995135/icecube_sensor_service_2026_04_23_log.txt)
[icecube_sensor_service_client_2026_04_23_log.txt](https://github.com/user-attachments/files/26995136/icecube_sensor_service_client_2026_04_23_log.txt)
[icecube_sensor_service_hw_test_2026_04_23_log.txt](https://github.com/user-attachments/files/26995137/icecube_sensor_service_hw_test_2026_04_23_log.txt)


Notes:
  - Impact: The system will now trigger thermal protection earlier (at 95°C instead of 100°C), adhering to the stricter thermal safety margin defined in the latest thermal specification.
  - Compatibility: This is a configuration-only change; no code logic or hardware modifications are required.
