### PR TITLE
[Nexthop] Add pre-commit hook to prevent committing sai_impl in fboss manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,18 @@ repos:
       # Ruff formatter for all Python files in fboss/
       - id: ruff-format
         files: ^fboss/
+  - repo: local
+    hooks:
+      - id: do-not-change-fboss-manifests
+        name: Prevent sai_impl in fboss manifest
+        language: system
+        entry: >-
+          bash -c 'if git diff --cached -- build/fbcode_builder/manifests/fboss
+          | grep -q "^+.*sai_impl"; then echo "ERROR: Do not commit changes to
+          build/fbcode_builder/manifests (common mistake with git commit -a)"
+          >&2; exit 1; fi'
+        pass_filenames: false
+        # always_run is required because the top-level "exclude: ^build/.*"
+        # would suppress this hook if we used "files:" to scope it instead.
+        # The git diff --cached inside the entry does the scoping itself.
+        always_run: true


### PR DESCRIPTION
## Summary

This catches a common mistake where `git commit -a` is used and changes to `build/fbcode_builder/manifests` files are mistakenly committed, which they shouldn't. It's annoying that the build is changing those files but until we find a way to fix it, it's better to have a pre-commit hook to catch this mistake early.

- Adds a `local` pre-commit hook that blocks any commit adding `sai_impl` to `build/fbcode_builder/manifests/fboss`
- The check is a single inline `bash -c` in `.pre-commit-config.yaml` — no separate script file needed
- Works with both `git commit` and `git commit -a`

## Test plan

- [x] Clean commit (no manifest change) passes the hook
- [x] Commit adding `sai_impl` to the manifest is blocked with a clear error message