### PR TITLE
[Accton][wedge800cact] Enable QSFP remediaiton.

### DIFF
--- a/fboss/oss/qsfp_test_configs/wedge800cact.materialized_JSON
+++ b/fboss/oss/qsfp_test_configs/wedge800cact.materialized_JSON
@@ -5,10 +5,10 @@
     "firmware_upgrade_on_tcvr_insert": "true",
     "firmware_upgrade_supported": "true",
     "mode": "wedge800cact",
-    "remediation_enabled": "false"
+    "remediation_enabled": "true"
   },
   "transceiverConfigOverrides": [
-    
+
   ],
   "qsfpTestConfig": {
     "cabledPortPairs": [


### PR DESCRIPTION
Modify the config file to let QSFP enable the remediation function.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
`pip install -r requirements-dev.txt && pre-commit install`
`pre-commit run --files fboss/oss/qsfp_test_configs/wedge800cact.materialized_JSON`

# Summary
Just modify the config file to let QSFP enable the remediation function to pass the two following tests.

# Test Plan
   Full EVT test:
   [       OK ] warm_boot.AgentEnsembleLinkTest.testOpticsRemediation (207175 ms)
   [       OK ] warm_boot.AgentEnsembleLinkTest.testOpticsRemediation (207175 ms)
