### PR TITLE
[META] Fix Python lint violations in OSS scripts to align with ruff pre-commit checks (#1130)

### DIFF
--- a/fboss/oss/scripts/github_actions/docker-unittest.py
+++ b/fboss/oss/scripts/github_actions/docker-unittest.py
@@ -89,7 +89,8 @@ def use_stable_hashes():
 
 
 def is_container_running() -> bool:
-    cmd = _docker_cmd() + [
+    cmd = [
+        *_docker_cmd(),
         "ps",
         "--filter",
         f"name=^/{FBOSS_CONTAINER_NAME}$",
@@ -101,7 +102,7 @@ def is_container_running() -> bool:
 
 
 def does_image_exist() -> bool:
-    cmd = _docker_cmd() + ["images", "-q", FBOSS_IMAGE_NAME]
+    cmd = [*_docker_cmd(), "images", "-q", FBOSS_IMAGE_NAME]
     cp = subprocess.run(cmd, capture_output=True, text=True, check=False)
     return len(cp.stdout.strip()) > 0
 
@@ -113,7 +114,8 @@ def build_docker_image(docker_dir_path: str):
     )
     with os.fdopen(fd, "w") as output:
         dockerfile_path = os.path.join(docker_dir_path, "Dockerfile")
-        cmd = _docker_cmd() + [
+        cmd = [
+            *_docker_cmd(),
             "build",
             ".",
             "-t",
@@ -192,10 +194,7 @@ def is_test(path: str) -> bool:
 
 
 def is_excluded_test(path):
-    for regex in EXCLUDED_TEST_REGEXES:
-        if regex.match(path):
-            return True
-    return False
+    return any(regex.match(path) for regex in EXCLUDED_TEST_REGEXES)
 
 
 def is_e2e_test(path: str) -> bool:
@@ -220,7 +219,7 @@ def is_integration_test(path: str) -> bool:
 
 def run_test(test: str, output_dir: str) -> bool:
     use_stable_hashes()
-    cmd_args = _docker_cmd() + ["run"]
+    cmd_args = [*_docker_cmd(), "run"]
     lib_path = os.path.join(output_dir, "lib")
     cmd_args.extend(["-e", f"LD_LIBRARY_PATH={lib_path}"])
     # Mount fboss repository in container
@@ -263,7 +262,7 @@ def run_test_local(test: str, output_dir: str) -> bool:
 
 def run_test_exec(test: str, output_dir: str) -> bool:
     use_stable_hashes()
-    cmd_args = _docker_cmd() + ["exec"]
+    cmd_args = [*_docker_cmd(), "exec"]
     lib_path = os.path.join(output_dir, "lib")
     test_path = os.path.join(output_dir, "bin", test)
     cmd_args.extend(["-e", f"LD_LIBRARY_PATH={lib_path}"])
@@ -306,8 +305,8 @@ def main():
     if container_running:
         print(f"Copying test artifacts into container '{FBOSS_CONTAINER_NAME}'...")
         subprocess.run(
-            _docker_cmd()
-            + [
+            [
+                *_docker_cmd(),
                 "cp",
                 output_dir,
                 f"{FBOSS_CONTAINER_NAME}:{output_dir}",
@@ -317,26 +316,21 @@ def main():
 
     tests = find_tests(output_dir, args.excludes)
 
-    failed_tests = []
-
-    for test in tests:
-        if inside_container:
-            is_pass = run_test_local(test, output_dir)
-        elif container_running:
-            is_pass = run_test_exec(test, output_dir)
-        else:
-            is_pass = run_test(test, output_dir)
-        if not is_pass:
-            failed_tests.append(test)
-
-    failed_test_string = ", ".join(failed_tests)
-
-    exit_code = 0
-    if len(failed_tests) == 0:
-        print("All tests passed!")
+    if inside_container:
+        run_fn = run_test_local
+    elif container_running:
+        run_fn = run_test_exec
     else:
-        print(f"The following tests failed: {failed_test_string}")
+        run_fn = run_test
+
+    failed_tests = [test for test in tests if not run_fn(test, output_dir)]
+
+    if failed_tests:
+        print(f"The following tests failed: {', '.join(failed_tests)}")
         exit_code = 1
+    else:
+        print("All tests passed!")
+        exit_code = 0
 
     cleanup(output_dir)
     return exit_code

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -1049,17 +1049,19 @@ class QsfpTestRunner(TestRunner):
         return tests
 
 
+_YELLOW = "\033[1;33m"
+_RED = "\033[1;31m"
+_RESET = "\033[0m"
+
+
 def _print_deprecation_banner(lines):
     """Print a highly visible warning banner with color and box formatting."""
-    YELLOW = "\033[1;33m"  # Bold yellow
-    RED = "\033[1;31m"  # Bold red
-    RESET = "\033[0m"
     width = max(len(line) for line in lines) + 4
     border = "*" * width
-    print(f"\n{RED}{border}")
+    print(f"\n{_RED}{border}")
     for line in lines:
-        print(f"* {YELLOW}{line.ljust(width - 4)}{RED} *")
-    print(f"{border}{RESET}\n", flush=True)
+        print(f"* {_YELLOW}{line.ljust(width - 4)}{_RED} *")
+    print(f"{border}{_RESET}\n", flush=True)
 
 
 class LinkTestRunner(TestRunner):


### PR DESCRIPTION
Summary:

[FBOSS][OSS] Fix lint errors caught by ruff in the FBOSS OSS GitHub CI pre-commit workflow.

Changes:
- run_test.py: Move ANSI color constants to module level to fix N806 (variable in function should be lowercase)
- docker-unittest.py: Replace list concatenation with iterable unpacking to fix RUF005
- docker-unittest.py: Replace for-loop with any() to fix SIM110
- docker-unittest.py: Reduce branch count in main() to fix PLR0912

Differential Revision: D102362443


