### PR TITLE
[Nexthop] Add 'hostname' package to FBOSS build container

### DIFF
--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN if [ "$USE_CLANG" = "true" ]; then \
     rm -rf build
 
 # The following libraries are needed for building SDK
-RUN dnf install -y doxygen aspell libyaml-devel vim-common libnsl libnsl2-devel glibc-static libstdc++-static
+RUN dnf install -y doxygen aspell libyaml-devel vim-common libnsl libnsl2-devel glibc-static libstdc++-static hostname
 
 # Install libyaml.a for SDK purposes
 RUN git clone https://github.com/yaml/libyaml.git && \


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The build container image was missing the `hostname` utility, requiring a manual `sudo dnf install hostname` after entering the container. 

it was observed while trying to generate `asic_config_v2` ouput
```
./fboss/lib/asic_config_v2/run-helper.sh
...
...
FileNotFoundError: [Errno 2] No such file or directory: 'hostname'
```

In this PR:
- Install it at image-build time alongside the other packages.

# Test Plan

Docker container built with new image contains `hostname` utility.
When `hostname` utility is available, `asic_config_v2/run-helper.sh` moves past this initial failure mentioned above in the description.