### PR TITLE
[Nexthop] Ignore non-VLAN interfaces when searching vlan -> intf

### DIFF
--- a/fboss/agent/state/InterfaceMap.cpp
+++ b/fboss/agent/state/InterfaceMap.cpp
@@ -45,6 +45,9 @@ std::shared_ptr<Interface> InterfaceMap::getInterfaceInVlanIf(
     VlanID vlan) const {
   for (const auto& itr : std::as_const(*this)) {
     const auto& intf = itr.second;
+    if (intf->getType() != cfg::InterfaceType::VLAN) {
+      continue;
+    }
     if (intf->getVlanID() == vlan) {
       return intf;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

fboss_sw_agent was crashing after a few minutes with a backtrace like:
```
W0424 17:27:33.705686  3155 LldpManager.cpp:51] Port 242: 2: Not present in config
W0424 17:27:33.711497  3155 LldpManager.cpp:51] Port 261: 5: Not present in config
W0424 17:27:33.711507  3155 LldpManager.cpp:51] Port 261: 2: Not present in config
V0424 17:27:35.887204  3155 ThriftHandler.cpp:2711] [0x7fe95801fef0] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:27:35.887224  3155 ThriftHandler.cpp:2711] [0x7fe95801fef0] getConfigAppliedInfo thrift request succeeded in 0ms
V0424 17:27:40.897064  3155 ThriftHandler.cpp:2711] [0x7fe950017790] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:27:40.897077  3155 ThriftHandler.cpp:2711] [0x7fe950017790] getConfigAppliedInfo thrift request succeeded in 0ms
V0424 17:27:45.886797  3159 ThriftHandler.cpp:2711] [0x7fe94c00dda0] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:27:45.886816  3159 ThriftHandler.cpp:2711] [0x7fe94c00dda0] getConfigAppliedInfo thrift request succeeded in 0ms
V0424 17:27:50.897421  3159 ThriftHandler.cpp:2711] [0x7fe944010570] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:27:50.897436  3159 ThriftHandler.cpp:2711] [0x7fe944010570] getConfigAppliedInfo thrift request succeeded in 0ms
V0424 17:27:55.887481  3159 ThriftHandler.cpp:2711] [0x7fe94001a460] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:27:55.887500  3159 ThriftHandler.cpp:2711] [0x7fe94001a460] getConfigAppliedInfo thrift request succeeded in 0ms
V0424 17:28:00.897801  3159 ThriftHandler.cpp:2711] [0x7fe938017a00] getConfigAppliedInfo thrift request received from ::1 (unknown)
V0424 17:28:00.897815  3159 ThriftHandler.cpp:2711] [0x7fe938017a00] getConfigAppliedInfo thrift request succeeded in 0ms
F20260424 17:28:01.061798  3159 Interface.h:108] Check failed: getType() == cfg::InterfaceType::VLAN
*** Check failure stack trace: ***
*** Aborted at 1777051681 (Unix time, try 'date -d @1777051681') ***
*** Signal 6 (SIGABRT) (0xbc3) received by PID 3011 (pthread TID 0x7fe96cc00640) (linux TID 3159) (maybe from PID 3011, UID 0) (code: sent by tkill or tgkill), stack trace: ***
    @ 00000000002c936a folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
                       /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/debugging/symbolizer/SignalHandler.cpp:545
    @ 000000000003fc2f (unknown)
    @ 000000000008d05c __pthread_kill_implementation
    @ 000000000003fb85 raise
    @ 0000000000029872 abort
    @ 0000000000240fd2 folly::(anonymous namespace)::wrapped_abort()
                       /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/init/Init.cpp:53
    @ 000000000000c707 google::LogMessage::SendToLog()
    @ 000000000000cb5a google::LogMessage::Flush()
    @ 000000000000f50f google::LogMessageFatal::~LogMessageFatal()
    @ 000000000106a986 facebook::fboss::Interface::getVlanID() const
    @ 0000000002513ef0 facebook::fboss::InterfaceMap::getInterfaceInVlanIf(facebook::fboss::VlanID) const
    @ 0000000002514164 facebook::fboss::MultiSwitchInterfaceMap::getInterfaceInVlanIf(facebook::fboss::VlanID) const
    @ 0000000001176874 facebook::fboss::IPv6Handler::resolveDestAndHandlePacket(facebook::fboss::IPv6Hdr, std::unique_ptr<facebook::fboss::RxPacket, std::default_delete<facebook::fboss::RxPacket> >, folly::MacAddress, folly::MacAddress, folly::io::Cursor)
    @ 000000000117dc33 void facebook::fboss::IPv6Handler::handlePacket<facebook::fboss::Interface>(std::unique_ptr<facebook::fboss::RxPacket, std::default_delete<facebook::fboss::RxPacket> >, folly::MacAddress, folly::MacAddress, folly::io::Cursor, std::shared_ptr<facebook::fboss::Interface> const&)
    @ 00000000011c1d18 void facebook::fboss::SwSwitch::handlePacketImpl<facebook::fboss::Interface>(std::unique_ptr<facebook::fboss::RxPacket, std::default_delete<facebook::fboss::RxPacket> >, std::shared_ptr<facebook::fboss::Interface> const&)
    @ 00000000011b2408 facebook::fboss::SwSwitch::handlePacket(std::unique_ptr<facebook::fboss::RxPacket, std::default_delete<facebook::fboss::RxPacket> >)
    @ 00000000011b2117 facebook::fboss::SwSwitch::packetReceived(std::unique_ptr<facebook::fboss::RxPacket, std::default_delete<facebook::fboss::RxPacket> >)
    @ 00000000011006a2 facebook::fboss::MultiSwitchThriftHandler::co_notifyRxPacket(long)::$_0::operator()(folly::coro::AsyncGenerator<facebook::fboss::multiswitch::RxPacket&&, facebook::fboss::multiswitch::RxPacket, false>) const [clone .resume]
    @ 00000000003eac79 folly::resumeCoroutineWithNewAsyncStackRoot(std::__n4861::coroutine_handle<void>, folly::AsyncStackFrame&)
                       /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/coroutine:135
                       -> /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/tracing/AsyncStack.cpp
    @ 0000000001469af8 folly::coro::detail::ViaCoroutinePromiseBase::executeContinuation()
    @ 00000000002ffc9b folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
                       /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/Function.h:370
                       -> /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/executors/ThreadPoolExecutor.cpp
    @ 00000000002d9a2b folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
                       /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/executors/CPUThreadPoolExecutor.cpp:357
    @ 00000000003014d1 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::Thr
eadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
                       /opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12/../../../../include/c++/12/bits/invoke.h:74
                       -> /src/.build_dir/platform-stack/repos/github.com-facebook-folly.git/folly/executors/ThreadPoolExecutor.cpp
    @ 00000000031226e1 void folly::detail::function::call_<folly::InitThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}, false, false, void>(, folly::detail::function::Data&)
    @ 00000000000dbae3 (unknown)
    @ 000000000008b319 start_thread
The issue is that we have configured our interfaces as L3 interfaces, so when resolveDestAndHandlePacket() goes to find the interface which matches the source VLAN, getInterfaceInVlanIf() finds a non-VLAN interface and asserts.
```
Instead of crashing, skip non-VLAN interfaces as not possible to match.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

With this fboss_sw_agent stayed up for 10 minutes on a dut with the config from https://github.com/facebook/fboss/pull/1074