### PR TITLE
Only run distro image build GHA on fboss-image paths

### DIFF
--- a/.github/workflows/distro_image_build.yml
+++ b/.github/workflows/distro_image_build.yml
@@ -3,10 +3,14 @@ run-name: Distro Image Build
 
 on:
   pull_request:
+    paths:
+      - 'fboss-image/**'
   # Allow manually triggering the workflow
   workflow_dispatch:
   push:
     branches: [ main ]
+    paths:
+      - 'fboss-image/**'
 
 jobs:
   Distro-Image-Build:


### PR DESCRIPTION
Summary: We don't want to run this very long GHA job on PRs that dont touch fboss-image

Differential Revision: D102894712


