### PR TITLE
[PlatformManager] allow embeddedSensorConfigs diff across versioned PmUnits

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1400,10 +1400,15 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
 
     bool fieldMismatch = false;
     apache::thrift::op::for_each_field_id<PmUnitConfig>([&]<class Id>(Id) {
-      // i2cDeviceConfigs are allowed to differ between versioned and default
-      if constexpr (std::is_same_v<
-                        apache::thrift::op::get_ident<PmUnitConfig, Id>,
-                        ident::i2cDeviceConfigs>) {
+      // i2cDeviceConfigs and embeddedSensorConfigs are allowed to differ
+      // between versioned and default configs
+      if constexpr (
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::i2cDeviceConfigs> ||
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::embeddedSensorConfigs>) {
         return;
       }
 

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -211,16 +211,7 @@ TEST(ConfigValidatorTest, InvalidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));
 
-  // Test 6: Mismatched embeddedSensorConfigs
-  versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs() = {};
-  auto sensorConfig = EmbeddedSensorConfig();
-  sensorConfig.pmUnitScopedName() = "SENSOR_1";
-  versionedPmUnitConfig.pmUnitConfig()->embeddedSensorConfigs() = {
-      sensorConfig};
-  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
-  EXPECT_FALSE(ConfigValidator().isValid(config));
-
-  // Test 7: Mismatched pciDeviceConfigs (via differing ledCtrlBlockConfigs)
+  // Test 6: Mismatched pciDeviceConfigs (via differing ledCtrlBlockConfigs)
   versionedPmUnitConfig.pmUnitConfig()->embeddedSensorConfigs() = {};
   config.numXcvrs() = 1;
   auto defaultPciDev = getValidPciDeviceConfig();


### PR DESCRIPTION
# Summary

Allow a pmunit's content to differ across default and  versioned PmUnits. Changes in this PR depend on #1065 

# Test Plan


Created a versioned pmunit with `CPU_CORE_TEMP` removed from i2cDeviceConfigs and `NVME_TEMP` removed from embeddedSensorConfigs
```
...
  "versionedPmUnitConfigs": {
    "SCM": [
      {
        "pmUnitConfig":         {
          "pluggedInSlotType": "SCM_SLOT",
          "i2cDeviceConfigs": [
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶{̶
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶b̶u̶s̶N̶a̶m̶e̶"̶:̶ ̶"̶S̶C̶M̶_̶I̶2̶C̶_̶M̶A̶S̶T̶E̶R̶_̶0̶@̶0̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶a̶d̶d̶r̶e̶s̶s̶"̶:̶ ̶"̶0̶x̶4̶0̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶k̶e̶r̶n̶e̶l̶D̶e̶v̶i̶c̶e̶N̶a̶m̶e̶"̶:̶ ̶"̶p̶m̶b̶u̶s̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶m̶U̶n̶i̶t̶S̶c̶o̶p̶e̶d̶N̶a̶m̶e̶"̶:̶ ̶"̶S̶C̶M̶_̶M̶P̶S̶_̶P̶M̶B̶U̶S̶"̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶}̶
          ],
          "embeddedSensorConfigs": [
            {
              "pmUnitScopedName": "CPU_CORE_TEMP",
              "sysfsPath": "/sys/bus/platform/devices/coretemp.0"
            },
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶{̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶m̶U̶n̶i̶t̶S̶c̶o̶p̶e̶d̶N̶a̶m̶e̶"̶:̶ ̶"̶N̶V̶M̶E̶_̶T̶E̶M̶P̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶s̶y̶s̶f̶s̶P̶a̶t̶h̶"̶:̶ ̶"̶/̶s̶y̶s̶/̶c̶l̶a̶s̶s̶/̶n̶v̶m̶e̶/̶n̶v̶m̶e̶0̶"̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶}̶
          ]
        },
        "pmUnitVersion": {
          "productProductionState": 1,
          "productVersion": 2,
          "productSubVersion": 3
        }
      },
    ]
  },
...
```

Testing on matching HW
```
# weutil --eeprom scm
...
Product Production State: 1
Product Version: 2
Product Sub-Version: 3
...

DataStore.cpp:171] Resolved / to versioned PmUnitConfig of SCM with version 1.2.3
...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56] /[CPU_CORE_TEMP]: Failed to create symlink /run/devmap/sensors/CPU_CORE_TEMP for DevicePath /[CPU_CORE_TEMP]. Reason: Could not find SysfsPath for /[CPU_CORE_TEMP]
ExplorationSummary.cpp:56] /[NVME_TEMP]: Failed to create symlink /run/devmap/sensors/NVME_TEMP for DevicePath /[NVME_TEMP]. Reason: Could not find SysfsPath for /[NVME_TEMP]

```


On on a non matching HW
```
# weutil --eeprom scm
...
Product Production State: 4
Product Version: 5
Product Sub-Version: 6
...


...
DataStore.cpp:182] Resolved / to default PmUnitConfig of SCM. No versioned config matches version 4.5.6
...

# ls /run/devmap/sensors/CPU_CORE_TEMP
device name ...

# ls /run/devmap/sensors/NVME_TEMP
device name ...

```

## Hw & Sw Tests

```
Passed:
xgs_psamp_mod_test weutil_crc16_ccitt_test platform_helpers_platform_fs_utils_test platform_helpers_platform_utils_test platform_helpers_platform_name_lib_test async_logger_test transceiver_properties_manager_test rackmon_test weutil_fboss_eeprom_interface_test weutil_parser_utils_test platform_manager_data_store_test platform_manager_utils_test platform_manager_i2c_explorer_test platform_manager_cpld_manager_test platform_manager_pci_explorer_test platform_manager_device_path_resolver_test platform_manager_presence_checker_test thrift_node_tests thrift_cow_visitor_tests fboss2_framework_test fboss2_cmd_config_test fboss2_cmd_test fsdb_cgo_wrapper_test platform_manager_config_validator_test cross_config_validator_test platform_config_lib_config_lib_test runtime_config_builder_test platform_data_corral_sw_test fan_service_sw_test pci_device_check_test mac_address_check_test sensor_service_utils_test xcvr_lib_test build_from_xcvr_lib_test sensor_service_sw_test platform_manager_platform_explorer_test platform_manager_handler_test
```


platform_manager_hw_test ran against default & versioned PmUnit 
```
platform_manager_hw_test
[       OK ] PlatformManagerHwTest.XcvrLedFiles (5306 ms)
[----------] 8 tests from PlatformManagerHwTest (39049 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (39049 ms total)
[  PASSED  ] 8 tests.
```

```
platform_hw_test
[       OK ] PlatformHwTest.PCIDevicesPresent (34 ms)
[----------] 2 tests from PlatformHwTest (512 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (512 ms total)
[  PASSED  ] 2 tests.
```

```
sensor_service_hw_test
[       OK ] SensorServiceHwTest.CheckAllSensors (93 ms)
[----------] 6 tests from SensorServiceHwTest (1728 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (1728 ms total)
[  PASSED  ] 6 tests.
```

```
data_corral_service_hw_test
[       OK ] DataCorralServiceHwTest.getUncachedFruid (450 ms)
[----------] 4 tests from DataCorralServiceHwTest (910 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (910 ms total)
[  PASSED  ] 4 tests.
```

```
weutil_hw_test
[       OK ] WeutilTest.getInfoJson (893 ms)
[----------] 4 tests from WeutilTest (1788 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1788 ms total)
[  PASSED  ] 4 tests.
```
