### PR TITLE
[PlatformManager] allow pciDeviceConfigs diff across versioned PmUnits

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1102,6 +1102,11 @@ bool ConfigValidator::isValid(const PlatformConfig& config) {
     return false;
   }
 
+  XLOG(INFO) << "Validating versioned PCI device coverage...";
+  if (!isValidVersionedPciDeviceCoverage(config)) {
+    return false;
+  }
+
   return true;
 }
 
@@ -1450,8 +1455,8 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
 
     bool fieldMismatch = false;
     apache::thrift::op::for_each_field_id<PmUnitConfig>([&]<class Id>(Id) {
-      // i2cDeviceConfigs, embeddedSensorConfigs, and pciDeviceConfigs
-      // are allowed to differ between versioned and default configs
+      // i2cDeviceConfigs and embeddedSensorConfigs are allowed to differ
+      // between versioned and default configs
       if constexpr (
           std::is_same_v<
               apache::thrift::op::get_ident<PmUnitConfig, Id>,
@@ -1498,12 +1503,12 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
 }
 
 bool ConfigValidator::isValidLedCtrlBlockXcvrCoverage(
-    const PlatformConfig& config) {
-  if (*config.numXcvrs() == 0) {
+    const std::map<std::string, PmUnitConfig>& pmUnitConfigs,
+    int16_t numXcvrs,
+    const std::string& platformName) {
+  if (numXcvrs == 0) {
     return true;
   }
-
-  const auto& platformName = *config.platformName();
 
   // TODO: Remove once ladakh/leh ledCtrlBlockConfigs cover all xcvrs
   if (platformName == "LADAKH800BCLS" || platformName == "LEH800BCLS" ||
@@ -1511,28 +1516,21 @@ bool ConfigValidator::isValidLedCtrlBlockXcvrCoverage(
     return true;
   }
 
-  // Collect all ledCtrlBlockConfigs across all PmUnits/PciDevices
-  std::vector<const LedCtrlBlockConfig*> allLedBlocks;
-  for (const auto& [_, pmUnitConfig] : *config.pmUnitConfigs()) {
+  std::set<int16_t> coveredPorts;
+  for (const auto& [_, pmUnitConfig] : pmUnitConfigs) {
     for (const auto& pciDev : *pmUnitConfig.pciDeviceConfigs()) {
       for (const auto& block : *pciDev.ledCtrlBlockConfigs()) {
-        allLedBlocks.push_back(&block);
+        for (int16_t port = *block.startPort();
+             port < *block.startPort() + *block.numPorts();
+             ++port) {
+          coveredPorts.insert(port);
+        }
       }
     }
   }
 
-  // Check that every xcvr port [1, numXcvrs] is covered by ledCtrlBlockConfigs
-  std::set<int16_t> coveredPorts;
-  for (const auto* block : allLedBlocks) {
-    for (int16_t port = *block->startPort();
-         port < *block->startPort() + *block->numPorts();
-         ++port) {
-      coveredPorts.insert(port);
-    }
-  }
-
   bool valid = true;
-  for (int16_t xcvrId = 1; xcvrId <= *config.numXcvrs(); ++xcvrId) {
+  for (int16_t xcvrId = 1; xcvrId <= numXcvrs; ++xcvrId) {
     if (coveredPorts.find(xcvrId) == coveredPorts.end()) {
       XLOG(ERR) << fmt::format(
           "Platform {}: xcvr {} is not covered by any ledCtrlBlockConfig",
@@ -1545,16 +1543,22 @@ bool ConfigValidator::isValidLedCtrlBlockXcvrCoverage(
   return valid;
 }
 
-bool ConfigValidator::isValidXcvrCtrlBlockXcvrCoverage(
+bool ConfigValidator::isValidLedCtrlBlockXcvrCoverage(
     const PlatformConfig& config) {
-  if (*config.numXcvrs() == 0) {
+  return isValidLedCtrlBlockXcvrCoverage(
+      *config.pmUnitConfigs(), *config.numXcvrs(), *config.platformName());
+}
+
+bool ConfigValidator::isValidXcvrCtrlBlockXcvrCoverage(
+    const std::map<std::string, PmUnitConfig>& pmUnitConfigs,
+    int16_t numXcvrs,
+    const std::string& platformName) {
+  if (numXcvrs == 0) {
     return true;
   }
 
-  const auto& platformName = *config.platformName();
-
   std::set<int16_t> coveredPorts;
-  for (const auto& [_, pmUnitConfig] : *config.pmUnitConfigs()) {
+  for (const auto& [_, pmUnitConfig] : pmUnitConfigs) {
     for (const auto& pciDev : *pmUnitConfig.pciDeviceConfigs()) {
       for (const auto& block : *pciDev.xcvrCtrlBlockConfigs()) {
         for (int16_t port = *block.startPort();
@@ -1567,7 +1571,7 @@ bool ConfigValidator::isValidXcvrCtrlBlockXcvrCoverage(
   }
 
   bool valid = true;
-  for (int16_t xcvrId = 1; xcvrId <= *config.numXcvrs(); ++xcvrId) {
+  for (int16_t xcvrId = 1; xcvrId <= numXcvrs; ++xcvrId) {
     if (coveredPorts.find(xcvrId) == coveredPorts.end()) {
       XLOG(ERR) << fmt::format(
           "Platform {}: xcvr {} is not covered by any xcvrCtrlBlockConfig",
@@ -1578,6 +1582,49 @@ bool ConfigValidator::isValidXcvrCtrlBlockXcvrCoverage(
   }
 
   return valid;
+}
+
+bool ConfigValidator::isValidXcvrCtrlBlockXcvrCoverage(
+    const PlatformConfig& config) {
+  return isValidXcvrCtrlBlockXcvrCoverage(
+      *config.pmUnitConfigs(), *config.numXcvrs(), *config.platformName());
+}
+
+bool ConfigValidator::isValidVersionedPciDeviceCoverage(
+    const PlatformConfig& config) {
+  for (const auto& [pmUnitName, versionedPmUnitConfigs] :
+       *config.versionedPmUnitConfigs()) {
+    auto defaultIt = config.pmUnitConfigs()->find(pmUnitName);
+    if (defaultIt == config.pmUnitConfigs()->end()) {
+      continue;
+    }
+    for (const auto& versionedPmUnitConfig : versionedPmUnitConfigs) {
+      if (*versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs() ==
+          *defaultIt->second.pciDeviceConfigs()) {
+        continue;
+      }
+      auto modifiedPmUnitConfigs = *config.pmUnitConfigs();
+      modifiedPmUnitConfigs[pmUnitName].pciDeviceConfigs() =
+          *versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs();
+      if (!isValidLedCtrlBlockXcvrCoverage(
+              modifiedPmUnitConfigs,
+              *config.numXcvrs(),
+              *config.platformName())) {
+        XLOG(ERR) << fmt::format(
+            "Versioned PmUnit {} fails LED xcvr coverage check", pmUnitName);
+        return false;
+      }
+      if (!isValidXcvrCtrlBlockXcvrCoverage(
+              modifiedPmUnitConfigs,
+              *config.numXcvrs(),
+              *config.platformName())) {
+        XLOG(ERR) << fmt::format(
+            "Versioned PmUnit {} fails xcvr ctrl coverage check", pmUnitName);
+        return false;
+      }
+    }
+  }
+  return true;
 }
 
 bool ConfigValidator::isValidPortRanges(

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1450,15 +1450,18 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
 
     bool fieldMismatch = false;
     apache::thrift::op::for_each_field_id<PmUnitConfig>([&]<class Id>(Id) {
-      // i2cDeviceConfigs and embeddedSensorConfigs are allowed to differ
-      // between versioned and default configs
+      // i2cDeviceConfigs, embeddedSensorConfigs, and pciDeviceConfigs
+      // are allowed to differ between versioned and default configs
       if constexpr (
           std::is_same_v<
               apache::thrift::op::get_ident<PmUnitConfig, Id>,
               ident::i2cDeviceConfigs> ||
           std::is_same_v<
               apache::thrift::op::get_ident<PmUnitConfig, Id>,
-              ident::embeddedSensorConfigs>) {
+              ident::embeddedSensorConfigs> ||
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::pciDeviceConfigs>) {
         return;
       }
 

--- a/fboss/platform/platform_manager/ConfigValidator.h
+++ b/fboss/platform/platform_manager/ConfigValidator.h
@@ -70,7 +70,16 @@ class ConfigValidator {
   bool isValidPortRanges(
       const std::vector<std::pair<int16_t, int16_t>>& startPortAndNumPorts);
   bool isValidLedCtrlBlockXcvrCoverage(const PlatformConfig& config);
+  bool isValidLedCtrlBlockXcvrCoverage(
+      const std::map<std::string, PmUnitConfig>& pmUnitConfigs,
+      int16_t numXcvrs,
+      const std::string& platformName);
   bool isValidXcvrCtrlBlockXcvrCoverage(const PlatformConfig& config);
+  bool isValidXcvrCtrlBlockXcvrCoverage(
+      const std::map<std::string, PmUnitConfig>& pmUnitConfigs,
+      int16_t numXcvrs,
+      const std::string& platformName);
+  bool isValidVersionedPciDeviceCoverage(const PlatformConfig& config);
   bool isValidChassisEepromDevicePath(
       const PlatformConfig& platformConfig,
       const std::string& chassisEepromDevicePath);

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -328,7 +328,22 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
   EXPECT_TRUE(ConfigValidator().isValid(config));
 
-  // Test 10: Valid with differing pciDeviceConfigs (allowed to differ)
+  // Test 10: Valid with differing embeddedSensorConfigs (allowed to differ)
+  EmbeddedSensorConfig embeddedSensor1, embeddedSensor2;
+  embeddedSensor1.pmUnitScopedName() = "SENSOR_V1";
+  embeddedSensor1.sysfsPath() = "/sys/bus/platform/devices/coretemp.0";
+  embeddedSensor2.pmUnitScopedName() = "SENSOR_V2";
+  embeddedSensor2.sysfsPath() = "/sys/bus/platform/devices/coretemp.1";
+  versionedPmUnitConfig1.pmUnitConfig()->embeddedSensorConfigs() = {
+      embeddedSensor1};
+  pmUnitConfig = config.pmUnitConfigs()->at("SCM");
+  pmUnitConfig.embeddedSensorConfigs() = {embeddedSensor2};
+  config.pmUnitConfigs() = {{"SCM", pmUnitConfig}};
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
+  EXPECT_TRUE(ConfigValidator().isValid(config));
+
+
+  // Test 11: Valid with differing pciDeviceConfigs (allowed to differ)
   auto pciDev1 = getValidPciDeviceConfig();
   auto pciDev2 = getValidPciDeviceConfig();
   pciDev2.pmUnitScopedName() = "PCI_DEV_V2";
@@ -339,7 +354,7 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
   EXPECT_TRUE(ConfigValidator().isValid(config));
 
-  // Test 11: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
+  // Test 12: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
   auto pciDevWithLed = getValidPciDeviceConfig();
   pciDevWithLed.ledCtrlBlockConfigs() = {};
   pmUnitConfig = config.pmUnitConfigs()->at("SCM");

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -215,41 +215,6 @@ TEST(ConfigValidatorTest, InvalidVersionedPmUnitConfigs) {
       {"EXTRA_SLOT@0", slotConfig}};
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
   EXPECT_FALSE(ConfigValidator().isValid(config));
-
-  // Test 6: Mismatched pciDeviceConfigs
-  versionedPmUnitConfig.pmUnitConfig()->outgoingSlotConfigs() = {};
-  versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs() = {
-      getValidPciDeviceConfig()};
-  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
-  EXPECT_FALSE(ConfigValidator().isValid(config));
-
-  // Test 7: Mismatched pciDeviceConfigs (via differing ledCtrlBlockConfigs)
-  versionedPmUnitConfig.pmUnitConfig()->embeddedSensorConfigs() = {};
-  config.numXcvrs() = 1;
-  auto defaultPciDev = getValidPciDeviceConfig();
-  LedCtrlBlockConfig defaultLedCtrl;
-  defaultLedCtrl.pmUnitScopedNamePrefix() = "MCB_LED";
-  defaultLedCtrl.deviceName() = "port_led";
-  defaultLedCtrl.csrOffsetCalc() = "0x1000";
-  defaultLedCtrl.numPorts() = 1;
-  defaultLedCtrl.ledPerPort() = 1;
-  defaultLedCtrl.startPort() = 1;
-  defaultPciDev.ledCtrlBlockConfigs() = {defaultLedCtrl};
-  auto pmUnitCfg = config.pmUnitConfigs()->at("SCM");
-  pmUnitCfg.pciDeviceConfigs() = {defaultPciDev};
-  config.pmUnitConfigs() = {{"SCM", pmUnitCfg}};
-  auto versionedPciDev = getValidPciDeviceConfig();
-  LedCtrlBlockConfig versionedLedCtrl;
-  versionedLedCtrl.pmUnitScopedNamePrefix() = "MCB_LED";
-  versionedLedCtrl.deviceName() = "port_led";
-  versionedLedCtrl.csrOffsetCalc() = "0x2000";
-  versionedLedCtrl.numPorts() = 1;
-  versionedLedCtrl.ledPerPort() = 1;
-  versionedLedCtrl.startPort() = 1;
-  versionedPciDev.ledCtrlBlockConfigs() = {versionedLedCtrl};
-  versionedPmUnitConfig.pmUnitConfig()->pciDeviceConfigs() = {versionedPciDev};
-  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig}}};
-  EXPECT_FALSE(ConfigValidator().isValid(config));
 }
 
 TEST(ConfigValidatorTest, VersionedPmUnitConfigMissingVersion) {
@@ -363,7 +328,18 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
   EXPECT_TRUE(ConfigValidator().isValid(config));
 
-  // Test 10: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
+  // Test 10: Valid with differing pciDeviceConfigs (allowed to differ)
+  auto pciDev1 = getValidPciDeviceConfig();
+  auto pciDev2 = getValidPciDeviceConfig();
+  pciDev2.pmUnitScopedName() = "PCI_DEV_V2";
+  versionedPmUnitConfig1.pmUnitConfig()->pciDeviceConfigs() = {pciDev1};
+  pmUnitConfig = config.pmUnitConfigs()->at("SCM");
+  pmUnitConfig.pciDeviceConfigs() = {pciDev2};
+  config.pmUnitConfigs() = {{"SCM", pmUnitConfig}};
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
+  EXPECT_TRUE(ConfigValidator().isValid(config));
+
+  // Test 11: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
   auto pciDevWithLed = getValidPciDeviceConfig();
   pciDevWithLed.ledCtrlBlockConfigs() = {};
   pmUnitConfig = config.pmUnitConfigs()->at("SCM");

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -342,7 +342,6 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
   EXPECT_TRUE(ConfigValidator().isValid(config));
 
-
   // Test 11: Valid with differing pciDeviceConfigs (allowed to differ)
   auto pciDev1 = getValidPciDeviceConfig();
   auto pciDev2 = getValidPciDeviceConfig();

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -353,7 +353,55 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
   EXPECT_TRUE(ConfigValidator().isValid(config));
 
-  // Test 12: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
+  // Test 12: Valid with differing pciDeviceConfigs and full xcvr coverage
+  config.numXcvrs() = 4;
+  LedCtrlBlockConfig ledCtrl;
+  ledCtrl.pmUnitScopedNamePrefix() = "OSFP";
+  ledCtrl.deviceName() = "port_led";
+  ledCtrl.csrOffsetCalc() = "0x1000";
+  ledCtrl.startPort() = 1;
+  ledCtrl.numPorts() = 4;
+  ledCtrl.ledPerPort() = 1;
+  XcvrCtrlBlockConfig xcvrCtrl;
+  xcvrCtrl.pmUnitScopedNamePrefix() = "OSFP";
+  xcvrCtrl.deviceName() = "xcvr_ctrl";
+  xcvrCtrl.csrOffsetCalc() = "0x1000";
+  xcvrCtrl.startPort() = 1;
+  xcvrCtrl.numPorts() = 4;
+  auto defaultPciDev = getValidPciDeviceConfig();
+  defaultPciDev.ledCtrlBlockConfigs() = {ledCtrl};
+  defaultPciDev.xcvrCtrlBlockConfigs() = {xcvrCtrl};
+  pmUnitConfig = config.pmUnitConfigs()->at("SCM");
+  pmUnitConfig.pciDeviceConfigs() = {defaultPciDev};
+  config.pmUnitConfigs() = {{"SCM", pmUnitConfig}};
+  auto versionedLedCtrl1 = ledCtrl;
+  versionedLedCtrl1.numPorts() = 2;
+  auto versionedLedCtrl2 = ledCtrl;
+  versionedLedCtrl2.startPort() = 3;
+  versionedLedCtrl2.numPorts() = 2;
+  auto versionedPciDev = getValidPciDeviceConfig();
+  versionedPciDev.ledCtrlBlockConfigs() = {
+      versionedLedCtrl1, versionedLedCtrl2};
+  versionedPciDev.xcvrCtrlBlockConfigs() = {xcvrCtrl};
+  versionedPmUnitConfig1.pmUnitConfig()->pciDeviceConfigs() = {versionedPciDev};
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
+  EXPECT_TRUE(ConfigValidator().isValidVersionedPciDeviceCoverage(config));
+
+  // Test 13: Invalid versioned pciDeviceConfigs under-covers xcvrs
+  // (covers ports 1-2 but numXcvrs=4)
+  auto shortLedCtrl = ledCtrl;
+  shortLedCtrl.numPorts() = 2;
+  auto shortXcvrCtrl = xcvrCtrl;
+  shortXcvrCtrl.numPorts() = 2;
+  auto underCovPciDev = getValidPciDeviceConfig();
+  underCovPciDev.ledCtrlBlockConfigs() = {shortLedCtrl};
+  underCovPciDev.xcvrCtrlBlockConfigs() = {shortXcvrCtrl};
+  versionedPmUnitConfig1.pmUnitConfig()->pciDeviceConfigs() = {underCovPciDev};
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedPmUnitConfig1}}};
+  EXPECT_FALSE(ConfigValidator().isValidVersionedPciDeviceCoverage(config));
+
+  // Test 14: Valid with matching ledCtrlBlockConfigs in pciDeviceConfigs
+  config.numXcvrs() = 0;
   auto pciDevWithLed = getValidPciDeviceConfig();
   pciDevWithLed.ledCtrlBlockConfigs() = {};
   pmUnitConfig = config.pmUnitConfigs()->at("SCM");


### PR DESCRIPTION
# Summary

Allow a pmunit's pci Device content to differ across default and versioned PmUnits.

Depends on the changes here #1065 which add pmUnitVersion to versionedPmUnitConfigs

# Test Plan

## Testing on Typical SCM Configs
```
# weutil --eeprom scm
...
Product Production State: 1
Product Version: 2
Product Sub-Version: 3
...
```

Testing versioned pm unit (SCM) with modified configs
```
  "versionedPmUnitConfigs": {
    "SCM": [
      {
        "pmUnitConfig":         {
          "pluggedInSlotType": "SCM_SLOT",
          ...
          "pciDeviceConfigs": [
            {
              ...
              "i2cAdapterBlockConfigs": [
                {
                  "pmUnitScopedNamePrefix": "SCM_I2C_MASTER",
                  "deviceName": "i2c_master",
                  "csrOffsetCalc": "0x8000 + ({adapterIndex} - {startAdapterIndex})*0x80",
                  "startAdapterIndex": 0,
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶n̶u̶m̶A̶d̶a̶p̶t̶e̶r̶s̶"̶:̶ ̶2̶,̶
                  "numAdapters": 4,
                  "numBusesPerAdapter": 8
                }
              ],
            }
          ],
          "spiMasterConfigs": [],
          "infoRomConfigs": [
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶{̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶m̶U̶n̶i̶t̶S̶c̶o̶p̶e̶d̶N̶a̶m̶e̶"̶:̶ ̶"̶S̶C̶M̶_̶F̶P̶G̶A̶_̶I̶N̶F̶O̶_̶R̶O̶M̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶d̶e̶v̶i̶c̶e̶N̶a̶m̶e̶"̶:̶ ̶"̶f̶p̶g̶a̶_̶i̶n̶f̶o̶_̶i̶o̶b̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶c̶s̶r̶O̶f̶f̶s̶e̶t̶"̶:̶ ̶"̶0̶x̶1̶0̶0̶"̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶}̶
          ],
        ...
        },
        "pmUnitVersion": {
          "productProductionState": 1,
          "productVersion": 2,
          "productSubVersion": 3
        }
      }
    ]
  },
    ...
```

Observe SCM_FPGA_INFO_ROM is not created anymore and 4 i2c adapters are created.
```
...
DataStore.cpp:171] Resolved / to versioned PmUnitConfig of SCM with version 1.2.3
PlatformExplorer.cpp:188] Exploring PmUnit SCM at /
PlatformExplorer.cpp:191] Exploring PCI Devices for PmUnit SCM at SlotPath /. Count 1
...
PciExplorer.cpp:444] Successfully created device SCM_I2C_MASTER_0 ...
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0@0 in SlotPath / to bus number 2 (i2c-2)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@1](http://cl/1) in SlotPath / to bus number 3 (i2c-3)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@2](http://cl/2) in SlotPath / to bus number 4 (i2c-4)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@3](http://cl/3) in SlotPath / to bus number 5 (i2c-5)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@4](http://cl/4) in SlotPath / to bus number 6 (i2c-6)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@5](http://cl/5) in SlotPath / to bus number 7 (i2c-7)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@6](http://cl/6) in SlotPath / to bus number 8 (i2c-8)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_0[@7](http://cl/7) in SlotPath / to bus number 9 (i2c-9)
PciExplorer.cpp:358] Creating device SCM_I2C_MASTER_1 ...
PciExplorer.cpp:444] Successfully created device SCM_I2C_MASTER_1 ...
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_1@0 in SlotPath / to bus number 10 (i2c-10)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_1[@1](http://cl/1) in SlotPath / to bus number 11 (i2c-11)
DataStore.cpp:34] Updating bus SCM_I2C_MASTER_1[@2](http://cl/2) in SlotPath / to bus number 12 (i2c-12)
...
PciExplorer.cpp:358] Creating device SCM_I2C_MASTER_2...
PciExplorer.cpp:444] Successfully created device SCM_I2C_MASTER_2...
...
PciExplorer.cpp:358] Creating device SCM_I2C_MASTER_3...
PciExplorer.cpp:444] Successfully created device SCM_I2C_MASTER_3...
...

ExplorationSummary.cpp:47] Explored MERU800BIA with 2 unexpected errors and 0 expected errors...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56] /[SCM_FPGA_INFO_ROM]: Failed to create symlink /run/devmap/fpgas/MERU_SCM_CPLD_INFO_ROM for DevicePath /[SCM_FPGA_INFO_ROM]. Reason: Couldn't find PciDeviceConfig for SCM_FPGA_INFO_ROM at /
ExplorationSummary.cpp:56] /[SCM_FPGA_INFO_ROM]: Failed to create symlink /run/devmap/inforoms/MERU_SCM_CPLD_INFO_ROM for DevicePath /[SCM_FPGA_INFO_ROM]. Reason: Couldn't find PciDeviceConfig for SCM_FPGA_INFO_ROM at /
```


Changing versioned SCM to a non-matching version
```
        "pmUnitVersion": {
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶r̶o̶d̶u̶c̶t̶P̶r̶o̶d̶u̶c̶t̶i̶o̶n̶S̶t̶a̶t̶e̶"̶:̶ ̶1̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶r̶o̶d̶u̶c̶t̶S̶u̶b̶V̶e̶r̶s̶i̶o̶n̶"̶:̶ ̶3̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶r̶o̶d̶u̶c̶t̶V̶e̶r̶s̶i̶o̶n̶"̶:̶ ̶2̶,̶
          "productProductionState": 4,
          "productVersion": 5,
          "productSubVersion": 6
        }
```

As expected, platform manager loads the default PmUnits
```
DataStore.cpp:182] Resolved / to default PmUnitConfig of SCM. No versioned config matches version 1.2.3
```



## Testing on Typical SMB Configs
```
# weutil --eeprom smb
...
Product Production State: 1
Product Version: 2
Product Sub-Version: 3
...
```
Testing versioned pm unit (SMB) with modified configs. Add "TEST" suffix to pmUnitScopedNames
```
      "pciDeviceConfigs": [
        {
          ...
          "spiMasterConfigs": [
            {
              "fpgaIpBlockConfig": {
                "pmUnitScopedName": "SMB_SPI_MASTER0_TEST",
                ...
              },
              "spiDeviceConfigs": [
                {
                  "pmUnitScopedName": "SMB_SPI_MASTER0_DEVICE1_TEST",
                  ...
                }
              ]
            }
          ],
          "ledCtrlBlockConfigs": [
            {
              "pmUnitScopedNamePrefix": "OSFP_TEST",
              ...
            },
            {
              "pmUnitScopedNamePrefix": "QSFP_TEST",
              ...
            }
          ],
          "sysLedCtrlConfigs": [
            {
              "pmUnitScopedName": "SYSTEM_STATUS_LED_TEST",
              ...
            },
            ...
          ],
          "xcvrCtrlBlockConfigs": [
            {
              "pmUnitScopedNamePrefix": "OSFP_TEST",
              ...
            },
            {
              "pmUnitScopedNamePrefix": "QSFP_TEST",
              ...
            }
          ],
          ...
          "miscCtrlConfigs": [
 ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶{̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶"̶p̶m̶U̶n̶i̶t̶S̶c̶o̶p̶e̶d̶N̶a̶m̶e̶"̶:̶ ̶"̶S̶M̶B̶_̶A̶D̶C̶"̶,̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶.̶.̶.̶
̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶ ̶}̶
          ]
        }
      ]
```
SMB_ADC doesn't get created as expected when the versioned pmunit is used.
```
...
PciExplorer.cpp:444] Successfully created device SYSTEM_STATUS_LED_TEST at ...
...
PciExplorer.cpp:444] Successfully created device OSFP_TEST_XCVR_CTRL_PORT_38 at
...
PciExplorer.cpp:444] Successfully created device SMB_SPI_MASTER0_TEST ...
PciExplorer.cpp:608] Completed initializing SpiDevice spi2006.0 as /dev/spidev2006.0 for SpiDevice SMB_SPI_MASTER0_DEVICE1_TEST
DataStore.cpp:100] Updating CharDevPath for /SMB_SLOT@0/[SMB_SPI_MASTER0_DEVICE1_TEST] to /dev/spidev2006.0
...
DataStore.cpp:171] Resolved /SMB_SLOT@0 to versioned PmUnitConfig of SMB with version 1.2.3
mmary.cpp:47] Explored MERU800BIA with 40 unexpected errors and 0 expected errors...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56] /SMB_SLOT@0/[OSFP_XCVR_CTRL_PORT_10]: Failed to create symlink /run/devmap/xcvrs/xcvr_ctrl_
ExplorationSummary.cpp:56] /SMB_SLOT@0/[OSFP_XCVR_CTRL_PORT_11]: Failed to create symlink /run/devmap/xcvrs/xcvr_ctrl_
...
ExplorationSummary.cpp:56] /SMB_SLOT@0/[SMB_SPI_MASTER0_DEVICE1]: Failed to create symlink /run/devmap/flashes/SMB_SPI_MASTER0_DEVICE1 for DevicePath /SMB_SLOT@0/[SMB_SPI_MASTER0_DEVICE1]
...
```

## Hw & Sw Tests

```
Passed:
xgs_psamp_mod_test weutil_crc16_ccitt_test platform_helpers_platform_fs_utils_test platform_helpers_platform_utils_test platform_helpers_platform_name_lib_test async_logger_test transceiver_properties_manager_test rackmon_test weutil_fboss_eeprom_interface_test weutil_parser_utils_test platform_manager_data_store_test platform_manager_utils_test platform_manager_i2c_explorer_test platform_manager_cpld_manager_test platform_manager_pci_explorer_test platform_manager_device_path_resolver_test platform_manager_presence_checker_test thrift_node_tests thrift_cow_visitor_tests fboss2_framework_test fboss2_cmd_config_test fboss2_cmd_test fsdb_cgo_wrapper_test platform_manager_config_validator_test cross_config_validator_test platform_config_lib_config_lib_test runtime_config_builder_test platform_data_corral_sw_test fan_service_sw_test pci_device_check_test mac_address_check_test sensor_service_utils_test xcvr_lib_test build_from_xcvr_lib_test sensor_service_sw_test platform_manager_platform_explorer_test platform_manager_handler_test
```


platform_manager_hw_test ran against default & versioned PmUnit 
```
platform_manager_hw_test
[       OK ] PlatformManagerHwTest.XcvrLedFiles (5306 ms)
[----------] 8 tests from PlatformManagerHwTest (39049 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (39049 ms total)
[  PASSED  ] 8 tests.
```

```
platform_hw_test
[       OK ] PlatformHwTest.PCIDevicesPresent (34 ms)
[----------] 2 tests from PlatformHwTest (512 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (512 ms total)
[  PASSED  ] 2 tests.
```

```
sensor_service_hw_test
[       OK ] SensorServiceHwTest.CheckAllSensors (93 ms)
[----------] 6 tests from SensorServiceHwTest (1728 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (1728 ms total)
[  PASSED  ] 6 tests.
```

```
data_corral_service_hw_test
[       OK ] DataCorralServiceHwTest.getUncachedFruid (450 ms)
[----------] 4 tests from DataCorralServiceHwTest (910 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (910 ms total)
[  PASSED  ] 4 tests.
```

```
weutil_hw_test
[       OK ] WeutilTest.getInfoJson (893 ms)
[----------] 4 tests from WeutilTest (1788 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1788 ms total)
[  PASSED  ] 4 tests.
```
