### PR TITLE
[PlatformManager] Symlink creation to adapt to versioned devices

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -934,12 +934,6 @@ bool ConfigValidator::isValid(const PlatformConfig& config) {
     return false;
   }
 
-  // Validate chassisEepromDevicePath
-  if (!isValidChassisEepromDevicePath(
-          config, *config.chassisEepromDevicePath())) {
-    return false;
-  }
-
   // Validate SlotTypeConfigs.
   for (const auto& [slotName, slotTypeConfig] : *config.slotTypeConfigs()) {
     XLOG(INFO) << fmt::format(
@@ -1038,6 +1032,12 @@ bool ConfigValidator::isValid(const PlatformConfig& config) {
             *config.slotTypeConfigs())) {
       return false;
     }
+  }
+
+  // Validate chassisEepromDevicePath
+  if (!isValidChassisEepromDevicePath(
+          config, *config.chassisEepromDevicePath())) {
+    return false;
   }
 
   XLOG(INFO) << "Validating Symbolic links...";
@@ -1391,7 +1391,20 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
   }
 
   for (const auto& versionedPmUnitConfig : versionedPmUnitConfigs) {
-    if (*versionedPmUnitConfig.productSubVersion() < 0) {
+    if (const auto& pmUv = versionedPmUnitConfig.pmUnitVersion(); pmUv &&
+        (*pmUv->productProductionState() < 0 || *pmUv->productVersion() < 0 ||
+         *pmUv->productSubVersion() < 0)) {
+      XLOG(ERR) << fmt::format(
+          "PmUnit {}'s VersionedPmUnitConfig has invalid pmUnitVersion "
+          "{}.{}.{}: all fields must be >= 0",
+          pmUnitName,
+          *pmUv->productProductionState(),
+          *pmUv->productVersion(),
+          *pmUv->productSubVersion());
+      return false;
+    } else if (
+        versionedPmUnitConfig.productSubVersion() &&
+        *versionedPmUnitConfig.productSubVersion() < 0) {
       XLOG(ERR) << fmt::format(
           "One of PmUnit {}'s VersionedPmUnitConfig has a negative ProductSubVersion",
           pmUnitName);
@@ -1400,10 +1413,18 @@ bool ConfigValidator::isValidVersionedPmUnitConfig(
 
     bool fieldMismatch = false;
     apache::thrift::op::for_each_field_id<PmUnitConfig>([&]<class Id>(Id) {
-      // i2cDeviceConfigs are allowed to differ between versioned and default
-      if constexpr (std::is_same_v<
-                        apache::thrift::op::get_ident<PmUnitConfig, Id>,
-                        ident::i2cDeviceConfigs>) {
+      // i2cDeviceConfigs, embeddedSensorConfigs and pciDeviceConfigs are
+      // allowed to differ between versioned and default configs
+      if constexpr (
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::i2cDeviceConfigs> ||
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::embeddedSensorConfigs> ||
+          std::is_same_v<
+              apache::thrift::op::get_ident<PmUnitConfig, Id>,
+              ident::pciDeviceConfigs>) {
         return;
       }
 
@@ -1711,6 +1732,76 @@ void ConfigValidator::buildDeviceNameCache(
 
       for (const auto& mdioBusConfig : Utils::createMdioBusConfigs(pciConfig)) {
         cache[slotType].insert(*mdioBusConfig.pmUnitScopedName());
+      }
+    }
+  }
+
+  // Also add device names from versionedPmUnitConfigs. Only i2cDeviceConfigs,
+  // pciDeviceConfigs, and embeddedSensorConfigs may differ between versions;
+  // pluggedInSlotType cannot differ, so we inherit it from the default config.
+  for (const auto& [pmUnitName, versionedConfigs] :
+       *platformConfig.versionedPmUnitConfigs()) {
+    const auto& slotType =
+        *platformConfig.pmUnitConfigs()->at(pmUnitName).pluggedInSlotType();
+    for (const auto& versionedPmUnitConfig : versionedConfigs) {
+      const auto& pmUnitConfig = *versionedPmUnitConfig.pmUnitConfig();
+      for (const auto& i2cConfig : *pmUnitConfig.i2cDeviceConfigs()) {
+        cache[slotType].insert(*i2cConfig.pmUnitScopedName());
+      }
+      for (const auto& sensorConfig : *pmUnitConfig.embeddedSensorConfigs()) {
+        cache[slotType].insert(*sensorConfig.pmUnitScopedName());
+      }
+      for (const auto& pciConfig : *pmUnitConfig.pciDeviceConfigs()) {
+        cache[slotType].insert(*pciConfig.pmUnitScopedName());
+        for (const auto& adapterConfig : *pciConfig.i2cAdapterConfigs()) {
+          addI2cAdapterNames(slotType, adapterConfig);
+        }
+        for (const auto& spiMaster : *pciConfig.spiMasterConfigs()) {
+          addFromFpgaIpBlock(slotType, *spiMaster.fpgaIpBlockConfig());
+          for (const auto& spiDevice : *spiMaster.spiDeviceConfigs()) {
+            cache[slotType].insert(*spiDevice.pmUnitScopedName());
+          }
+        }
+        for (const auto& fanConfig : *pciConfig.fanTachoPwmConfigs()) {
+          addFromFpgaIpBlock(slotType, *fanConfig.fpgaIpBlockConfig());
+        }
+        for (const auto& ledConfig : *pciConfig.ledCtrlConfigs()) {
+          addFromFpgaIpBlock(slotType, *ledConfig.fpgaIpBlockConfig());
+        }
+        for (const auto& xcvrConfig : *pciConfig.xcvrCtrlConfigs()) {
+          addFromFpgaIpBlock(slotType, *xcvrConfig.fpgaIpBlockConfig());
+        }
+        for (const auto& gpioConfig : *pciConfig.gpioChipConfigs()) {
+          cache[slotType].insert(*gpioConfig.pmUnitScopedName());
+        }
+        for (const auto& watchdogConfig : *pciConfig.watchdogConfigs()) {
+          cache[slotType].insert(*watchdogConfig.pmUnitScopedName());
+        }
+        for (const auto& infoRomConfig : *pciConfig.infoRomConfigs()) {
+          cache[slotType].insert(*infoRomConfig.pmUnitScopedName());
+        }
+        for (const auto& miscConfig : *pciConfig.miscCtrlConfigs()) {
+          cache[slotType].insert(*miscConfig.pmUnitScopedName());
+        }
+        for (const auto& sysLedConfig : *pciConfig.sysLedCtrlConfigs()) {
+          cache[slotType].insert(*sysLedConfig.pmUnitScopedName());
+        }
+        for (const auto& ledCtrlConfig :
+             Utils::createLedCtrlConfigs(pciConfig)) {
+          addFromFpgaIpBlock(slotType, *ledCtrlConfig.fpgaIpBlockConfig());
+        }
+        for (const auto& xcvrCtrlConfig :
+             Utils::createXcvrCtrlConfigs(pciConfig)) {
+          addFromFpgaIpBlock(slotType, *xcvrCtrlConfig.fpgaIpBlockConfig());
+        }
+        for (const auto& i2cAdapterConfig :
+             Utils::createI2cAdapterConfigs(pciConfig)) {
+          addI2cAdapterNames(slotType, i2cAdapterConfig);
+        }
+        for (const auto& mdioBusConfig :
+             Utils::createMdioBusConfigs(pciConfig)) {
+          cache[slotType].insert(*mdioBusConfig.pmUnitScopedName());
+        }
       }
     }
   }

--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -829,6 +829,14 @@ void PlatformExplorer::createDeviceSymLink(
           fmt::format("Symbolic link {} is not supported.", linkPath));
     }
   } catch (const std::exception& ex) {
+    if (isSymlinkDeviceVersionedMiss(devicePath)) {
+      XLOG(INFO) << fmt::format(
+          "Skipping symlink {} for DevicePath {}. Device not present in "
+          "resolved PmUnit config for current hardware version.",
+          linkPath,
+          devicePath);
+      return;
+    }
     auto errMsg = fmt::format(
         "Failed to create symlink {} for DevicePath {}. Reason: {}",
         linkPath,
@@ -849,6 +857,62 @@ void PlatformExplorer::createDeviceSymLink(
   if (exitStatus != 0) {
     XLOG(ERR) << fmt::format("Failed to run command ({})", cmd);
     return;
+  }
+}
+
+bool PlatformExplorer::isSymlinkDeviceVersionedMiss(
+    const std::string& devicePath) const noexcept {
+  try {
+    const auto [slotPath, deviceName] = Utils().parseDevicePath(devicePath);
+    const auto& pmUnitInfoMap = dataStore_.getSlotPathToPmUnitInfo();
+    auto it = pmUnitInfoMap.find(slotPath);
+    if (it == pmUnitInfoMap.end()) {
+      return false;
+    }
+    const auto& pmUnitName = *it->second.name();
+    if (!platformConfig_.versionedPmUnitConfigs()->contains(pmUnitName)) {
+      return false;
+    }
+
+    auto isInConfig = [&deviceName](const PmUnitConfig& cfg) {
+      for (const auto& d : *cfg.i2cDeviceConfigs()) {
+        if (*d.pmUnitScopedName() == deviceName) {
+          return true;
+        }
+      }
+      for (const auto& d : *cfg.pciDeviceConfigs()) {
+        if (*d.pmUnitScopedName() == deviceName) {
+          return true;
+        }
+      }
+      for (const auto& d : *cfg.embeddedSensorConfigs()) {
+        if (*d.pmUnitScopedName() == deviceName) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // Device must exist in at least one version (default or any versioned)
+    bool existsInSomeVersion =
+        isInConfig(platformConfig_.pmUnitConfigs()->at(pmUnitName));
+    if (!existsInSomeVersion) {
+      for (const auto& vc :
+           platformConfig_.versionedPmUnitConfigs()->at(pmUnitName)) {
+        if (isInConfig(*vc.pmUnitConfig())) {
+          existsInSomeVersion = true;
+          break;
+        }
+      }
+    }
+    if (!existsInSomeVersion) {
+      return false;
+    }
+
+    // Skip gracefully if device is absent from the currently-resolved config.
+    return !isInConfig(dataStore_.resolvePmUnitConfig(slotPath));
+  } catch (const std::exception&) {
+    return false;
   }
 }
 

--- a/fboss/platform/platform_manager/PlatformExplorer.h
+++ b/fboss/platform/platform_manager/PlatformExplorer.h
@@ -125,6 +125,9 @@ class PlatformExplorer {
 
   std::optional<DataStore> getDataStore() const;
 
+  bool isSymlinkDeviceVersionedMiss(
+      const std::string& devicePath) const noexcept;
+
  protected:
   virtual void updatePmStatus(const PlatformManagerStatus& newStatus);
   // A thrift struct which contains the status of PM exploration.

--- a/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
+++ b/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
@@ -173,6 +173,9 @@ TEST_F(PlatformManagerHwTest, Symlinks) {
             devicePath)) {
       continue;
     }
+    if (platformExplorer_.isSymlinkDeviceVersionedMiss(devicePath)) {
+      continue;
+    }
     EXPECT_TRUE(fs::exists(symlink))
         << fmt::format("{} doesn't exist", symlink);
     EXPECT_TRUE(fs::is_symlink(symlink))

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -338,6 +338,35 @@ TEST(ConfigValidatorTest, ValidVersionedPmUnitConfigs) {
   EXPECT_TRUE(ConfigValidator().isValid(config));
 }
 
+TEST(ConfigValidatorTest, VersionedPmUnitConfigSymlinks) {
+  auto config = getBasicConfig();
+
+  I2cDeviceConfig versionedDevice;
+  versionedDevice.pmUnitScopedName() = "SCM_VERSIONED_SENSOR";
+  versionedDevice.address() = "0x48";
+  auto versionedCfg = VersionedPmUnitConfig();
+  versionedCfg.productSubVersion() = 1;
+  versionedCfg.pmUnitConfig()->pluggedInSlotType() = "SCM_SLOT";
+  versionedCfg.pmUnitConfig()->i2cDeviceConfigs() = {versionedDevice};
+  config.versionedPmUnitConfigs() = {{"SCM", {versionedCfg}}};
+
+  // Test 1: Symlink to a device that only exists in a versioned pmunit
+  config.symbolicLinkToDevicePath() = {
+      {"/run/devmap/sensors/SCM_VERSIONED_SENSOR", "/[SCM_VERSIONED_SENSOR]"}};
+  EXPECT_TRUE(ConfigValidator().isValid(config));
+
+  // Test 2: Symlink to a device present only in default pmunit
+  I2cDeviceConfig defaultDevice;
+  defaultDevice.pmUnitScopedName() = "SCM_DEFAULT_SENSOR";
+  defaultDevice.address() = "0x49";
+  auto pmUnitConfig = config.pmUnitConfigs()->at("SCM");
+  pmUnitConfig.i2cDeviceConfigs()->push_back(defaultDevice);
+  config.pmUnitConfigs() = {{"SCM", pmUnitConfig}};
+  config.symbolicLinkToDevicePath() = {
+      {"/run/devmap/sensors/SCM_DEFAULT_SENSOR", "/[SCM_DEFAULT_SENSOR]"}};
+  EXPECT_TRUE(ConfigValidator().isValid(config));
+}
+
 TEST(ConfigValidatorTest, PmUnitNameReferentialIntegrity) {
   auto config = getBasicConfig();
 


### PR DESCRIPTION
# Summary
- Add the ability to create symlinks to devices that only exist in versioned pmunits.
- Avoid reporting "unexpected errors" on symlinks created by default pmunit (or other versioned pmUnits) when matching to a versioned PmUnit.
- Testing (SW & HW) to account for the above two changes.

Depends on the following in order:
[[PlatformManager] allow pciDeviceConfigs diff across versioned PmUnits #1137](https://github.com/facebook/fboss/pull/1137)
[[PlatformManager] allow embeddedSensorConfigs diff across versioned PmUnits #1136](https://github.com/facebook/fboss/pull/1136)
[[PlatformManager] pmUnitVersion support for versionedPmUnitConfigs #1065](https://github.com/facebook/fboss/pull/1065)

# Testing

## Testing on Versioned PmUnit
When a symlink points to a device that doesn't exist at all
```
FAILS BUILD
ConfigValidator.cpp:1043] Validating Symbolic links...
ConfigValidator.cpp:857] Invalid DeviceName DOES_NOT_EXIST_ANYWHERE at SlotPath /
```
```
FAILS RUNNING PLATFORM_MANAGER
ConfigValidator.cpp:1043] Validating Symbolic links...
ConfigValidator.cpp:857] Invalid DeviceName DOES_NOT_EXIST_ANYWHERE at SlotPath /
```


Matching to a versioned PmUnit
```
# weutil scm
...
Product Production State: 1
Product Version: 2
Product Sub-Version: 3
...

DataStore.cpp:171] Resolved / to versioned PmUnitConfig of SCM with version 1.2.3
```

Where devices
- `/[DOES_NOT_EXIST_IN_DEFAULT]` only exists in the versioned SCM v1.2.3
- `/[ONLY_EXISTS_IN_DEFAULT]` only exists in default SCM pmUnit

As expected, ONLY_EXISTS_IN_DEFAULT does not exist. Nor is the symlink created
```
# ls /run/devmap/sensors/ONLY_EXISTS_IN_DEFAULT
ls: cannot access '/run/devmap/sensors/ONLY_EXISTS_IN_DEFAULT': No such file or directory
```
And DOES_NOT_EXIST_IN_DEFAULT device and symlink are created
```
ls /run/devmap/sensors/DOES_NOT_EXIST_IN_DEFAULT
curr1_input  curr1_max        device  ...
```
Without the changes in this PR, build/platform_manager crashes on `/[DOES_NOT_EXIST_IN_DEFAULT]`
```
FAILS BUILD
ConfigValidator.cpp:857] Invalid DeviceName DOES_NOT_EXIST_IN_DEFAULT at SlotPath /

FAILS PLATFORM MANAGER
ConfigValidator.cpp:857] Invalid DeviceName DOES_NOT_EXIST_IN_DEFAULT at SlotPath /
```
And if `/[DOES_NOT_EXIST_IN_DEFAULT]` is removed, we still get "unexpected errors" on `/[ONLY_EXISTS_IN_DEFAULT]` when loading default pmunit.
```
ExplorationSummary.cpp:47] Explored ... with 1 unexpected errors and 0 expected errors...
ExplorationSummary.cpp:54] =========== UNEXPECTED ERRORS ===========
ExplorationSummary.cpp:56] /[ONLY_EXISTS_IN_DEFAULT]: Failed to create symlink /run/devmap/sensors/ONLY_EXISTS_IN_DEFAULT for DevicePath /[ONLY_EXISTS_IN_DEFAULT]. Reason: Could not find SysfsPath for /[ONLY_EXISTS_IN_DEFAULT]
```


## How about loading default PmUnit? (Non-matching versioned PmUnit)
```
Resolved / to default PmUnitConfig of SCM. No versioned config matches version 4.5.6
...

# ls /run/devmap/sensors/ONLY_EXISTS_IN_DEFAULT
curr1_input  curr1_max        device ...

# ls /run/devmap/sensors/DOES_NOT_EXIST_IN_DEFAULT
ls: cannot access '/run/devmap/sensors/DOES_NOT_EXIST_IN_DEFAULT': No such file or directory
```

## Hw & Sw Tests

```
Passed:
xgs_psamp_mod_test weutil_crc16_ccitt_test platform_helpers_platform_fs_utils_test platform_helpers_platform_utils_test platform_helpers_platform_name_lib_test async_logger_test transceiver_properties_manager_test rackmon_test weutil_fboss_eeprom_interface_test weutil_parser_utils_test platform_manager_data_store_test platform_manager_utils_test platform_manager_i2c_explorer_test platform_manager_cpld_manager_test platform_manager_pci_explorer_test platform_manager_device_path_resolver_test platform_manager_presence_checker_test thrift_node_tests thrift_cow_visitor_tests fboss2_framework_test fboss2_cmd_config_test fboss2_cmd_test fsdb_cgo_wrapper_test platform_manager_config_validator_test cross_config_validator_test platform_config_lib_config_lib_test runtime_config_builder_test platform_data_corral_sw_test fan_service_sw_test pci_device_check_test mac_address_check_test sensor_service_utils_test xcvr_lib_test build_from_xcvr_lib_test sensor_service_sw_test platform_manager_platform_explorer_test platform_manager_handler_test
```


platform_manager_hw_test ran against default & versioned PmUnit 
```
platform_manager_hw_test
[       OK ] PlatformManagerHwTest.XcvrLedFiles (5306 ms)
[----------] 8 tests from PlatformManagerHwTest (39049 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (39049 ms total)
[  PASSED  ] 8 tests.
```

```
platform_hw_test
[       OK ] PlatformHwTest.PCIDevicesPresent (34 ms)
[----------] 2 tests from PlatformHwTest (512 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (512 ms total)
[  PASSED  ] 2 tests.
```

```
sensor_service_hw_test
[       OK ] SensorServiceHwTest.CheckAllSensors (93 ms)
[----------] 6 tests from SensorServiceHwTest (1728 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (1728 ms total)
[  PASSED  ] 6 tests.
```

```
data_corral_service_hw_test
[       OK ] DataCorralServiceHwTest.getUncachedFruid (450 ms)
[----------] 4 tests from DataCorralServiceHwTest (910 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (910 ms total)
[  PASSED  ] 4 tests.
```

```
weutil_hw_test
[       OK ] WeutilTest.getInfoJson (893 ms)
[----------] 4 tests from WeutilTest (1788 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1788 ms total)
[  PASSED  ] 4 tests.
```
