### PR TITLE
platform: add reboot cause service with persistent history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1086,6 +1086,7 @@ add_dependencies(fboss_platform_services
   fw_util
   weutil
   data_corral_service
+  reboot_cause_service
   # Utilities
   sensor_service_client
   fixmyfboss

--- a/cmake/PlatformConfigLib.cmake
+++ b/cmake/PlatformConfigLib.cmake
@@ -62,6 +62,8 @@ target_link_libraries(platform_config_lib_config_generator
   platform_manager_config_validator
   platform_manager_config_cpp2
   platform_manager_presence_cpp2
+  reboot_cause_config_cpp2
+  reboot_cause_service_config_validator
   sensor_service_config_validator
   data_corral_service_config_validator
   sensor_config_cpp2

--- a/cmake/PlatformRebootCauseService.cmake
+++ b/cmake/PlatformRebootCauseService.cmake
@@ -30,3 +30,33 @@ target_link_libraries(reboot_cause_service_config_validator
   reboot_cause_config_cpp2
   Folly::folly
 )
+
+add_library(reboot_cause_service_lib
+  fboss/platform/reboot_cause_service/Flags.cpp
+  fboss/platform/reboot_cause_service/RebootCauseServiceImpl.cpp
+  fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.cpp
+)
+
+target_link_libraries(reboot_cause_service_lib
+  log_thrift_call
+  platform_config_lib
+  platform_name_lib
+  platform_utils
+  structured_logger
+  reboot_cause_service_cpp2
+  reboot_cause_config_cpp2
+  reboot_cause_service_config_validator
+  Folly::folly
+  FBThrift::thriftcpp2
+)
+
+add_executable(reboot_cause_service
+  fboss/platform/reboot_cause_service/Main.cpp
+)
+
+target_link_libraries(reboot_cause_service
+  reboot_cause_service_lib
+  fb303::fb303
+)
+
+install(TARGETS reboot_cause_service)

--- a/cmake/PlatformRebootCauseService.cmake
+++ b/cmake/PlatformRebootCauseService.cmake
@@ -1,0 +1,32 @@
+# Make to build libraries and binaries in fboss/platform/reboot_cause_service
+
+add_fbthrift_cpp_library(
+  reboot_cause_config_cpp2
+  fboss/platform/reboot_cause_service/if/reboot_cause_config.thrift
+  OPTIONS
+    json
+    reflection
+)
+
+add_fbthrift_cpp_library(
+  reboot_cause_service_cpp2
+  fboss/platform/reboot_cause_service/if/reboot_cause_service.thrift
+  SERVICES
+    RebootCauseService
+  OPTIONS
+    json
+    reflection
+  DEPENDS
+    fboss_cpp2
+    reboot_cause_config_cpp2
+)
+
+add_library(reboot_cause_service_config_validator
+  fboss/platform/reboot_cause_service/ConfigValidator.cpp
+)
+
+target_link_libraries(reboot_cause_service_config_validator
+  fmt::fmt
+  reboot_cause_config_cpp2
+  Folly::folly
+)

--- a/fboss/platform/config_lib/ConfigGenerator.cpp
+++ b/fboss/platform/config_lib/ConfigGenerator.cpp
@@ -18,6 +18,8 @@
 #include "fboss/platform/fw_util/if/gen-cpp2/fw_util_config_types.h"
 #include "fboss/platform/platform_manager/ConfigValidator.h"
 #include "fboss/platform/platform_manager/gen-cpp2/platform_manager_config_types.h"
+#include "fboss/platform/reboot_cause_service/ConfigValidator.h"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_config_types.h"
 #include "fboss/platform/rma-showtech/gen-cpp2/showtech_config_types.h"
 #include "fboss/platform/sensor_service/ConfigValidator.h"
 #include "fboss/platform/sensor_service/if/gen-cpp2/sensor_config_types.h"
@@ -40,6 +42,7 @@ using namespace facebook::fboss::platform::weutil_config;
 using namespace facebook::fboss::platform::fw_util_config;
 using namespace facebook::fboss::platform::bsp_tests;
 using namespace facebook::fboss::platform::showtech_config;
+using namespace facebook::fboss::platform::reboot_cause_config;
 using namespace apache::thrift;
 
 namespace {
@@ -64,6 +67,9 @@ std::any deserialize(
       return SimpleJSONSerializer::deserialize<BspTestsConfig>(jsonConfigStr);
     } else if (serviceName == "rma_showtech") {
       return SimpleJSONSerializer::deserialize<ShowtechConfig>(jsonConfigStr);
+    } else if (serviceName == "reboot_cause_service") {
+      return SimpleJSONSerializer::deserialize<RebootCauseConfig>(
+          jsonConfigStr);
     }
     LOG(FATAL) << fmt::format("Unsupported service {}", serviceName);
   } catch (std::exception& ex) {
@@ -83,7 +89,8 @@ const auto kX86Services = std::set<std::string>{
     "fw_util",
     "led_manager",
     "bsp_tests",
-    "rma_showtech"};
+    "rma_showtech",
+    "reboot_cause_service"};
 constexpr auto kHdrName = "GeneratedConfig.h";
 constexpr auto kHdrBegin = R"(#pragma once
 
@@ -179,6 +186,13 @@ std::map<std::string, std::map<std::string, std::string>> getConfigs() {
           deserializedConfigs.at("led_manager"));
       if (!data_corral_service::ConfigValidator().isValid(config)) {
         throw std::runtime_error("Invalid led_manager configuration");
+      }
+    }
+    if (deserializedConfigs.contains("reboot_cause_service")) {
+      auto config = std::any_cast<RebootCauseConfig>(
+          deserializedConfigs.at("reboot_cause_service"));
+      if (!reboot_cause_service::ConfigValidator().isValid(config)) {
+        throw std::runtime_error("Invalid reboot_cause_service configuration");
       }
     }
     if (deserializedConfigs.contains("weutil")) {

--- a/fboss/platform/config_lib/ConfigLib.cpp
+++ b/fboss/platform/config_lib/ConfigLib.cpp
@@ -143,4 +143,18 @@ std::string ConfigLib::getShowtechConfig(
   return configs::rma_showtech.at(getPlatformName(platformName));
 }
 
+std::string ConfigLib::getRebootCauseServiceConfig(
+    const std::optional<std::string>& platformName) const {
+  if (auto configJson = getConfigFromFile()) {
+    return *configJson;
+  }
+  try {
+    return configs::reboot_cause_service.at(getPlatformName(platformName));
+  } catch (const std::out_of_range&) {
+    throw std::runtime_error(
+        "reboot_cause_service configuration not found for platform: " +
+        getPlatformName(platformName));
+  }
+}
+
 } // namespace facebook::fboss::platform

--- a/fboss/platform/config_lib/ConfigLib.h
+++ b/fboss/platform/config_lib/ConfigLib.h
@@ -38,6 +38,9 @@ class ConfigLib {
   virtual std::string getShowtechConfig(
       const std::optional<std::string>& platformName = std::nullopt) const;
 
+  virtual std::string getRebootCauseServiceConfig(
+      const std::optional<std::string>& platformName = std::nullopt) const;
+
  protected:
   std::string configFilePath_;
   std::optional<std::string> getConfigFromFile() const;

--- a/fboss/platform/config_lib/ConfigLibTest.cpp
+++ b/fboss/platform/config_lib/ConfigLibTest.cpp
@@ -86,4 +86,11 @@ TEST(ConfigLibTest, Basic) {
   EXPECT_NO_THROW(ConfigLib().getShowtechConfig(kSample));
   EXPECT_THROW(
       ConfigLib().getShowtechConfig(kNonExistentPlatform), std::out_of_range);
+
+  // RebootCauseService Configs
+  EXPECT_NO_THROW(ConfigLib().getRebootCauseServiceConfig(kMeru800bfa));
+  EXPECT_NO_THROW(ConfigLib().getRebootCauseServiceConfig(kMeru800bia));
+  EXPECT_THROW(
+      ConfigLib().getRebootCauseServiceConfig(kNonExistentPlatform),
+      std::runtime_error);
 }

--- a/fboss/platform/config_lib/MockConfigLib.h
+++ b/fboss/platform/config_lib/MockConfigLib.h
@@ -34,6 +34,12 @@ class MockConfigLib : public ConfigLib {
       (const std::optional<std::string>&),
       (const));
 
+  MOCK_METHOD(
+      std::string,
+      getRebootCauseServiceConfig,
+      (const std::optional<std::string>&),
+      (const));
+
  private:
 };
 

--- a/fboss/platform/configs/meru800bfa/reboot_cause_service.json
+++ b/fboss/platform/configs/meru800bfa/reboot_cause_service.json
@@ -1,0 +1,16 @@
+{
+  "rebootCauseProviderConfigs": {
+    "SMB_UCD90320": {
+      "type": 0,
+      "priority": 1,
+      "sysfsReadPath": "/run/devmap/sensors/SMB_UCD90320/reboot_causes",
+      "sysfsClearPath": "/run/devmap/sensors/SMB_UCD90320/clear_reboot_causes"
+    },
+    "MERU_SCM_CPLD": {
+      "type": 0,
+      "priority": 2,
+      "sysfsReadPath": "/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes",
+      "sysfsClearPath": "/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes"
+    }
+  }
+}

--- a/fboss/platform/configs/meru800bia/reboot_cause_service.json
+++ b/fboss/platform/configs/meru800bia/reboot_cause_service.json
@@ -1,0 +1,16 @@
+{
+  "rebootCauseProviderConfigs": {
+    "MERU800BIA_SMB_CPLD": {
+      "type": 0,
+      "priority": 1,
+      "sysfsReadPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes",
+      "sysfsClearPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes"
+    },
+    "MERU_SCM_CPLD": {
+      "type": 0,
+      "priority": 2,
+      "sysfsReadPath": "/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes",
+      "sysfsClearPath": "/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes"
+    }
+  }
+}

--- a/fboss/platform/reboot_cause_service/ConfigValidator.cpp
+++ b/fboss/platform/reboot_cause_service/ConfigValidator.cpp
@@ -1,0 +1,53 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/platform/reboot_cause_service/ConfigValidator.h"
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+
+#include <unordered_set>
+
+namespace facebook::fboss::platform::reboot_cause_service {
+using namespace reboot_cause_config;
+
+bool ConfigValidator::isValid(const RebootCauseConfig& config) {
+  XLOG(INFO) << "Validating reboot_cause_service config";
+
+  std::unordered_set<std::string> seenNames;
+  std::unordered_set<int16_t> seenPriorities;
+
+  for (const auto& [name, providerConfig] :
+       *config.rebootCauseProviderConfigs()) {
+    if (name.empty()) {
+      XLOG(ERR) << "RebootCauseProviderConfig name must be non-empty";
+      return false;
+    }
+    if (seenNames.contains(name)) {
+      XLOG(ERR) << fmt::format("Provider name '{}' is a duplicate", name);
+      return false;
+    }
+    seenNames.insert(name);
+
+    auto priority = *providerConfig.priority();
+    if (seenPriorities.contains(priority)) {
+      XLOG(ERR) << fmt::format("Provider priority {} is a duplicate", priority);
+      return false;
+    }
+    seenPriorities.insert(priority);
+
+    if (providerConfig.sysfsReadPath()->empty()) {
+      XLOG(ERR) << fmt::format(
+          "Provider '{}' sysfsReadPath must be non-empty", name);
+      return false;
+    }
+    if (providerConfig.sysfsClearPath()->empty()) {
+      XLOG(ERR) << fmt::format(
+          "Provider '{}' sysfsClearPath must be non-empty", name);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/ConfigValidator.h
+++ b/fboss/platform/reboot_cause_service/ConfigValidator.h
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_config_types.h"
+
+namespace facebook::fboss::platform::reboot_cause_service {
+
+class ConfigValidator {
+ public:
+  bool isValid(const reboot_cause_config::RebootCauseConfig& config);
+};
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/Flags.cpp
+++ b/fboss/platform/reboot_cause_service/Flags.cpp
@@ -1,0 +1,13 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/platform/reboot_cause_service/Flags.h"
+
+DEFINE_int32(thrift_port, 5974, "Port for the thrift service");
+DEFINE_bool(
+    determine_reboot_cause,
+    false,
+    "Read reboot causes from all providers and determine the reboot cause");
+DEFINE_bool(
+    clear_reboot_causes,
+    false,
+    "Clear reboot causes from all providers after reading");

--- a/fboss/platform/reboot_cause_service/Flags.h
+++ b/fboss/platform/reboot_cause_service/Flags.h
@@ -1,0 +1,9 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <gflags/gflags.h>
+
+DECLARE_int32(thrift_port);
+DECLARE_bool(determine_reboot_cause);
+DECLARE_bool(clear_reboot_causes);

--- a/fboss/platform/reboot_cause_service/Main.cpp
+++ b/fboss/platform/reboot_cause_service/Main.cpp
@@ -1,0 +1,50 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <fb303/FollyLoggingHandler.h>
+#include <folly/logging/xlog.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+
+#include "fboss/platform/config_lib/ConfigLib.h"
+#include "fboss/platform/helpers/Init.h"
+#include "fboss/platform/helpers/StructuredLogger.h"
+#include "fboss/platform/reboot_cause_service/ConfigValidator.h"
+#include "fboss/platform/reboot_cause_service/Flags.h"
+#include "fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h"
+
+using namespace facebook;
+using namespace facebook::fboss::platform;
+using namespace facebook::fboss::platform::reboot_cause_service;
+using facebook::fboss::platform::helpers::StructuredLogger;
+
+int main(int argc, char** argv) {
+  fb303::registerFollyLoggingOptionHandlers();
+
+  helpers::init(&argc, &argv);
+
+  try {
+    auto config = apache::thrift::SimpleJSONSerializer::deserialize<
+        reboot_cause_config::RebootCauseConfig>(
+        ConfigLib().getRebootCauseServiceConfig());
+    if (!ConfigValidator().isValid(config)) {
+      throw std::runtime_error("Invalid reboot_cause_service config");
+    }
+    auto serviceImpl = std::make_shared<RebootCauseServiceImpl>(config);
+
+    if (FLAGS_determine_reboot_cause) {
+      serviceImpl->determineRebootCause();
+    }
+
+    auto server = std::make_shared<apache::thrift::ThriftServer>();
+    auto handler =
+        std::make_shared<RebootCauseServiceThriftHandler>(serviceImpl);
+
+    helpers::runThriftService(
+        server, handler, "RebootCauseService", FLAGS_thrift_port);
+  } catch (const std::exception& ex) {
+    StructuredLogger structuredLogger("reboot_cause_service");
+    structuredLogger.logAlert("unexpected_crash", ex.what());
+    throw;
+  }
+
+  return 0;
+}

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.cpp
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.cpp
@@ -3,6 +3,7 @@
 #include "fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h"
 
 #include <chrono>
+#include <filesystem>
 #include <iomanip>
 #include <sstream>
 
@@ -11,11 +12,15 @@
 #include <folly/dynamic.h>
 #include <folly/json.h>
 #include <folly/logging/xlog.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
 
 #include "fboss/platform/helpers/StructuredLogger.h"
 #include "fboss/platform/reboot_cause_service/Flags.h"
 
 namespace facebook::fboss::platform::reboot_cause_service {
+
+constexpr auto kHistoryDir = "/var/facebook/fboss/reboot_cause_service/history";
+constexpr int16_t kLogFileVersion = 1;
 
 namespace {
 
@@ -24,6 +29,14 @@ std::string nowAsString() {
   auto t = std::chrono::system_clock::to_time_t(now);
   std::ostringstream oss;
   oss << std::put_time(std::localtime(&t), "%m-%d-%Y %H:%M:%S");
+  return oss.str();
+}
+
+std::string nowAsFilename() {
+  auto now = std::chrono::system_clock::now();
+  auto t = std::chrono::system_clock::to_time_t(now);
+  std::ostringstream oss;
+  oss << std::put_time(std::localtime(&t), "%Y-%m-%d-%H-%M-%S");
   return oss.str();
 }
 
@@ -111,7 +124,7 @@ reboot_cause_service::RebootCauseResult RebootCauseServiceImpl::investigate(
 
     // Follow externalProvider pointer if set.
     if (determinedCause.externalProvider().has_value()) {
-      const auto& extName = *determinedCause.externalProvider();
+      const auto extName = *determinedCause.externalProvider();
       bool found = false;
       for (const auto& extProvider : providers) {
         if (*extProvider.name() == extName && !extProvider.causes()->empty()) {
@@ -158,6 +171,9 @@ void RebootCauseServiceImpl::determineRebootCause() {
 
   std::sort(providers.begin(), providers.end(), byPriority);
 
+  auto result = investigate(providers);
+  persistResult(result);
+
   if (FLAGS_clear_reboot_causes) {
     for (const auto& [name, providerConfig] :
          *config_.rebootCauseProviderConfigs()) {
@@ -165,22 +181,121 @@ void RebootCauseServiceImpl::determineRebootCause() {
       clearProvider(providerConfig);
     }
   }
-
-  lastResult_ = investigate(providers);
   XLOG(INFO) << fmt::format(
       "Determined reboot cause: '{}' [Provider: {}]",
-      *lastResult_->determinedCause()->description(),
-      *lastResult_->determinedCauseProvider());
+      *result.determinedCause()->description(),
+      *result.determinedCauseProvider());
 }
+
+void RebootCauseServiceImpl::persistResult(
+    reboot_cause_service::RebootCauseResult& result) {
+  std::error_code ec;
+  std::filesystem::create_directories(kHistoryDir, ec);
+  if (ec) {
+    XLOG(ERR) << fmt::format(
+        "Failed to create history dir '{}': {}", kHistoryDir, ec.message());
+    return;
+  }
+
+  auto filePath =
+      fmt::format("{}/reboot-cause-{}.json", kHistoryDir, nowAsFilename());
+
+  reboot_cause_service::RebootCauseResultLogFile logFile;
+  logFile.filePath() = filePath;
+  logFile.fileVersion() = kLogFileVersion;
+  result.logFile() = logFile;
+
+  // Inject a top-level "version" key so readers can check the schema version
+  // before deserializing the rest of the file.
+  auto obj = folly::parseJson(
+      apache::thrift::SimpleJSONSerializer::serialize<std::string>(result));
+  obj["version"] = static_cast<int64_t>(kLogFileVersion);
+
+  if (!folly::writeFile(folly::toJson(obj), filePath.c_str())) {
+    XLOG(ERR) << fmt::format("Failed to write history file '{}'", filePath);
+  }
+}
+
+namespace {
+
+// Deserialize a RebootCauseResult from a versioned history file.
+// The file has a top-level "version" key alongside the result fields.
+// SimpleJSONSerializer ignores the unknown "version" key when deserializing.
+reboot_cause_service::RebootCauseResult deserializeHistoryFile(
+    const std::string& path,
+    const std::string& contents) {
+  auto obj = folly::parseJson(contents);
+  if (obj.count("version") && obj["version"].asInt() != kLogFileVersion) {
+    XLOG(WARN) << fmt::format(
+        "Unexpected file version {} in '{}', expected {}",
+        obj["version"].asInt(),
+        path,
+        kLogFileVersion);
+  }
+  return apache::thrift::SimpleJSONSerializer::deserialize<
+      reboot_cause_service::RebootCauseResult>(contents);
+}
+
+std::vector<std::filesystem::path> listHistoryFiles() {
+  std::error_code ec;
+  std::vector<std::filesystem::path> files;
+  for (const auto& entry :
+       std::filesystem::directory_iterator(kHistoryDir, ec)) {
+    if (entry.path().extension() == ".json") {
+      files.push_back(entry.path());
+    }
+  }
+  if (ec) {
+    XLOG(ERR) << fmt::format(
+        "Failed to list history dir '{}': {}", kHistoryDir, ec.message());
+    return files;
+  }
+  std::sort(files.begin(), files.end(), std::greater<>());
+  return files;
+}
+
+} // namespace
 
 reboot_cause_service::RebootCauseResult
 RebootCauseServiceImpl::getLastRebootCause() const {
-  if (!lastResult_.has_value()) {
-    throw std::runtime_error(
-        "No reboot cause result available. "
-        "Run with --determine_reboot_cause first.");
+  auto files = listHistoryFiles();
+  if (files.empty()) {
+    throw std::runtime_error("No reboot cause history found.");
   }
-  return *lastResult_;
+
+  std::string contents;
+  if (!folly::readFile(files.front().string().c_str(), contents)) {
+    throw std::runtime_error(
+        fmt::format("Failed to read '{}'", files.front().string()));
+  }
+
+  return deserializeHistoryFile(files.front().string(), contents);
+}
+
+std::vector<reboot_cause_service::RebootCauseResult>
+RebootCauseServiceImpl::getRebootCauseHistory() const {
+  auto files = listHistoryFiles();
+  if (files.empty()) {
+    return {};
+  }
+
+  std::vector<reboot_cause_service::RebootCauseResult> history;
+  for (const auto& file : files) {
+    std::string contents;
+    if (!folly::readFile(file.string().c_str(), contents)) {
+      XLOG(ERR) << fmt::format(
+          "Failed to read history file '{}'", file.string());
+      continue;
+    }
+    try {
+      history.push_back(deserializeHistoryFile(file.string(), contents));
+    } catch (const std::exception& ex) {
+      XLOG(ERR) << fmt::format(
+          "Failed to parse history file '{}': {}", file.string(), ex.what());
+    }
+  }
+
+  return history;
 }
 
 } // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.cpp
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.cpp
@@ -1,0 +1,186 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h"
+
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+
+#include <fmt/format.h>
+#include <folly/FileUtil.h>
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <folly/logging/xlog.h>
+
+#include "fboss/platform/helpers/StructuredLogger.h"
+#include "fboss/platform/reboot_cause_service/Flags.h"
+
+namespace facebook::fboss::platform::reboot_cause_service {
+
+namespace {
+
+std::string nowAsString() {
+  auto now = std::chrono::system_clock::now();
+  auto t = std::chrono::system_clock::to_time_t(now);
+  std::ostringstream oss;
+  oss << std::put_time(std::localtime(&t), "%m-%d-%Y %H:%M:%S");
+  return oss.str();
+}
+
+// Sort providers by priority ascending (lower value = higher priority).
+// Generic providers (priority 0) always sort first.
+bool byPriority(
+    const reboot_cause_service::RebootCauseProvider& a,
+    const reboot_cause_service::RebootCauseProvider& b) {
+  return *a.config()->priority() < *b.config()->priority();
+}
+
+} // namespace
+
+RebootCauseServiceImpl::RebootCauseServiceImpl(
+    const reboot_cause_config::RebootCauseConfig& config)
+    : config_(config) {}
+
+reboot_cause_service::RebootCauseProvider RebootCauseServiceImpl::readProvider(
+    const std::string& name,
+    const reboot_cause_config::RebootCauseProviderConfig& providerConfig) {
+  reboot_cause_service::RebootCauseProvider provider;
+  provider.name() = name;
+  provider.config() = providerConfig;
+  provider.causes() = {};
+
+  std::string contents;
+  if (!folly::readFile(providerConfig.sysfsReadPath()->c_str(), contents)) {
+    helpers::StructuredLogger("reboot_cause_service")
+        .logAlert(
+            "provider_read_error",
+            fmt::format(
+                "Failed to read reboot causes from provider '{}' at path '{}'",
+                name,
+                *providerConfig.sysfsReadPath()));
+    return provider;
+  }
+
+  try {
+    auto json = folly::parseJson(contents);
+    for (const auto& causeJson : json["causes"]) {
+      reboot_cause_service::RebootCauseData cause;
+      cause.description() = causeJson["description"].asString();
+      cause.date() = causeJson["date"].asString();
+      if (causeJson.count("externalProvider")) {
+        cause.externalProvider() = causeJson["externalProvider"].asString();
+      }
+      provider.causes()->push_back(std::move(cause));
+    }
+  } catch (const std::exception& ex) {
+    helpers::StructuredLogger("reboot_cause_service")
+        .logAlert(
+            "provider_parse_error",
+            fmt::format(
+                "Failed to parse reboot causes from provider '{}': {}",
+                name,
+                ex.what()));
+  }
+
+  return provider;
+}
+
+void RebootCauseServiceImpl::clearProvider(
+    const reboot_cause_config::RebootCauseProviderConfig& providerConfig) {
+  if (!folly::writeFile(
+          std::string("1"), providerConfig.sysfsClearPath()->c_str())) {
+    XLOG(ERR) << fmt::format(
+        "Failed to clear reboot causes at '{}'",
+        *providerConfig.sysfsClearPath());
+  }
+}
+
+reboot_cause_service::RebootCauseResult RebootCauseServiceImpl::investigate(
+    const std::vector<reboot_cause_service::RebootCauseProvider>& providers) {
+  reboot_cause_service::RebootCauseResult result;
+  result.date() = nowAsString();
+  result.providers() = providers;
+
+  for (const auto& provider : providers) {
+    if (provider.causes()->empty()) {
+      continue;
+    }
+
+    // Chronologically first cause from this provider is the determined cause.
+    auto determinedCause = provider.causes()->front();
+
+    // Follow externalProvider pointer if set.
+    if (determinedCause.externalProvider().has_value()) {
+      const auto& extName = *determinedCause.externalProvider();
+      bool found = false;
+      for (const auto& extProvider : providers) {
+        if (*extProvider.name() == extName && !extProvider.causes()->empty()) {
+          determinedCause = extProvider.causes()->front();
+          result.determinedCauseProvider() = extName;
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        XLOG(WARN) << fmt::format(
+            "externalProvider '{}' not found or has no causes, "
+            "falling back to provider '{}'",
+            extName,
+            *provider.name());
+        result.determinedCauseProvider() = *provider.name();
+      }
+    } else {
+      result.determinedCauseProvider() = *provider.name();
+    }
+
+    result.determinedCause() = determinedCause;
+    return result;
+  }
+
+  // No cause found — report unknown.
+  reboot_cause_service::RebootCauseData unknown;
+  unknown.description() = "Unknown";
+  unknown.date() = nowAsString();
+  result.determinedCause() = unknown;
+  result.determinedCauseProvider() = "None";
+  return result;
+}
+
+void RebootCauseServiceImpl::determineRebootCause() {
+  XLOG(INFO) << "Reading reboot causes from all providers";
+
+  std::vector<reboot_cause_service::RebootCauseProvider> providers;
+  for (const auto& [name, providerConfig] :
+       *config_.rebootCauseProviderConfigs()) {
+    XLOG(INFO) << fmt::format("Reading provider '{}'", name);
+    providers.push_back(readProvider(name, providerConfig));
+  }
+
+  std::sort(providers.begin(), providers.end(), byPriority);
+
+  if (FLAGS_clear_reboot_causes) {
+    for (const auto& [name, providerConfig] :
+         *config_.rebootCauseProviderConfigs()) {
+      XLOG(INFO) << fmt::format("Clearing provider '{}'", name);
+      clearProvider(providerConfig);
+    }
+  }
+
+  lastResult_ = investigate(providers);
+  XLOG(INFO) << fmt::format(
+      "Determined reboot cause: '{}' [Provider: {}]",
+      *lastResult_->determinedCause()->description(),
+      *lastResult_->determinedCauseProvider());
+}
+
+reboot_cause_service::RebootCauseResult
+RebootCauseServiceImpl::getLastRebootCause() const {
+  if (!lastResult_.has_value()) {
+    throw std::runtime_error(
+        "No reboot cause result available. "
+        "Run with --determine_reboot_cause first.");
+  }
+  return *lastResult_;
+}
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h
@@ -1,0 +1,39 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <optional>
+
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_config_types.h"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_service_types.h"
+
+namespace facebook::fboss::platform::reboot_cause_service {
+
+class RebootCauseServiceImpl {
+ public:
+  explicit RebootCauseServiceImpl(
+      const reboot_cause_config::RebootCauseConfig& config);
+
+  // Read all providers, run investigation, optionally clear providers.
+  // Called at startup when --determine_reboot_cause is set.
+  void determineRebootCause();
+
+  // Return the result of the last investigation.
+  reboot_cause_service::RebootCauseResult getLastRebootCause() const;
+
+ private:
+  reboot_cause_config::RebootCauseConfig config_;
+  std::optional<reboot_cause_service::RebootCauseResult> lastResult_;
+
+  reboot_cause_service::RebootCauseProvider readProvider(
+      const std::string& name,
+      const reboot_cause_config::RebootCauseProviderConfig& config);
+
+  void clearProvider(
+      const reboot_cause_config::RebootCauseProviderConfig& config);
+
+  reboot_cause_service::RebootCauseResult investigate(
+      const std::vector<reboot_cause_service::RebootCauseProvider>& providers);
+};
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h
@@ -18,12 +18,15 @@ class RebootCauseServiceImpl {
   // Called at startup when --determine_reboot_cause is set.
   void determineRebootCause();
 
-  // Return the result of the last investigation.
+  // Return the result of the last reboot cause investigation.
   reboot_cause_service::RebootCauseResult getLastRebootCause() const;
 
+  // Return all persisted reboot cause results, most recent first.
+  std::vector<reboot_cause_service::RebootCauseResult> getRebootCauseHistory()
+      const;
+
  private:
-  reboot_cause_config::RebootCauseConfig config_;
-  std::optional<reboot_cause_service::RebootCauseResult> lastResult_;
+  const reboot_cause_config::RebootCauseConfig config_;
 
   reboot_cause_service::RebootCauseProvider readProvider(
       const std::string& name,
@@ -34,6 +37,9 @@ class RebootCauseServiceImpl {
 
   reboot_cause_service::RebootCauseResult investigate(
       const std::vector<reboot_cause_service::RebootCauseProvider>& providers);
+
+  // Persist result to history dir and set logFile field.
+  void persistResult(reboot_cause_service::RebootCauseResult& result);
 };
 
 } // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.cpp
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.cpp
@@ -1,0 +1,15 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h"
+
+#include "fboss/lib/LogThriftCall.h"
+
+namespace facebook::fboss::platform::reboot_cause_service {
+
+void RebootCauseServiceThriftHandler::getLastRebootCause(
+    reboot_cause_service::RebootCauseResult& result) {
+  auto log = LOG_THRIFT_CALL(DBG1);
+  result = serviceImpl_->getLastRebootCause();
+}
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.cpp
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.cpp
@@ -12,4 +12,10 @@ void RebootCauseServiceThriftHandler::getLastRebootCause(
   result = serviceImpl_->getLastRebootCause();
 }
 
+void RebootCauseServiceThriftHandler::getRebootCauseHistory(
+    std::vector<reboot_cause_service::RebootCauseResult>& result) {
+  auto log = LOG_THRIFT_CALL(DBG1);
+  result = serviceImpl_->getRebootCauseHistory();
+}
+
 } // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h
@@ -18,6 +18,9 @@ class RebootCauseServiceThriftHandler : public RebootCauseServiceSvIf {
   void getLastRebootCause(
       reboot_cause_service::RebootCauseResult& result) override;
 
+  void getRebootCauseHistory(
+      std::vector<reboot_cause_service::RebootCauseResult>& result) override;
+
  private:
   std::shared_ptr<RebootCauseServiceImpl> serviceImpl_;
 };

--- a/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h
+++ b/fboss/platform/reboot_cause_service/RebootCauseServiceThriftHandler.h
@@ -1,0 +1,25 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <memory>
+
+#include "fboss/platform/reboot_cause_service/RebootCauseServiceImpl.h"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/RebootCauseService.h"
+
+namespace facebook::fboss::platform::reboot_cause_service {
+
+class RebootCauseServiceThriftHandler : public RebootCauseServiceSvIf {
+ public:
+  explicit RebootCauseServiceThriftHandler(
+      std::shared_ptr<RebootCauseServiceImpl> serviceImpl)
+      : serviceImpl_(std::move(serviceImpl)) {}
+
+  void getLastRebootCause(
+      reboot_cause_service::RebootCauseResult& result) override;
+
+ private:
+  std::shared_ptr<RebootCauseServiceImpl> serviceImpl_;
+};
+
+} // namespace facebook::fboss::platform::reboot_cause_service

--- a/fboss/platform/reboot_cause_service/if/reboot_cause_config.thrift
+++ b/fboss/platform/reboot_cause_service/if/reboot_cause_config.thrift
@@ -1,0 +1,33 @@
+namespace cpp2 facebook.fboss.platform.reboot_cause_config
+namespace go neteng.fboss.platform.reboot_cause_config
+namespace php NetengFbossPlatformRebootCauseConfig
+namespace py neteng.fboss.platform.reboot_cause_config
+namespace py3 neteng.fboss.platform.reboot_cause_config
+namespace py.asyncio neteng.fboss.platform.asyncio.reboot_cause_config
+
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
+
+enum RebootCauseProviderType {
+  KERNEL_DRIVER_JSON = 0,
+}
+
+// RebootCauseProviderConfig defines a hardware provider of a reboot cause
+// type: the format of the reboot causes returned by sysfsReadPath
+// priority: the importance of the provider in the system (lower is more important)
+// sysfsReadPath: the sysfs path from which to read reboot causes
+// sysfsClearPath: the sysfs path to write to clear reboot causes
+struct RebootCauseProviderConfig {
+  1: RebootCauseProviderType type;
+  2: i16 priority;
+  3: string sysfsReadPath;
+  4: string sysfsClearPath;
+}
+
+// RebootCauseConfig defines the reboot_cause_service configuration for the platform
+// rebootCauseProviderConfigs: platform-specific providers of reboot causes
+struct RebootCauseConfig {
+  1: map<string, RebootCauseProviderConfig> rebootCauseProviderConfigs;
+}

--- a/fboss/platform/reboot_cause_service/if/reboot_cause_service.thrift
+++ b/fboss/platform/reboot_cause_service/if/reboot_cause_service.thrift
@@ -32,21 +32,34 @@ struct RebootCauseProvider {
   3: list<RebootCauseData> causes;
 }
 
+// RebootCauseResultLogFile models the log file for a reboot cause result
+// filePath: the path to the log file on disk
+// fileVersion: the version of the log file format
+struct RebootCauseResultLogFile {
+  1: string filePath;
+  2: i16 fileVersion;
+}
+
 // RebootCauseResult models the result of a reboot cause investigation
 // date: the human-readable date string of when investigation ran
 // determinedCause: cause determined to be responsible for reboot
 // determinedCauseProvider: the name of the provider of the determined reboot cause
 // providers: all providers that reported causes for this investigation
+// logFile: the log file for this result
 struct RebootCauseResult {
   1: string date;
   2: RebootCauseData determinedCause;
   3: string determinedCauseProvider;
   4: list<RebootCauseProvider> providers;
+  5: RebootCauseResultLogFile logFile;
 }
 
 // RebootCauseService is the service API
 // getLastRebootCause: returns the result of the last reboot cause investigation
+// getRebootCauseHistory: returns the history of reboot cause investigations
 service RebootCauseService {
   RebootCauseResult getLastRebootCause()
+    throws (1: fboss.FbossBaseError error);
+  list<RebootCauseResult> getRebootCauseHistory()
     throws (1: fboss.FbossBaseError error);
 }

--- a/fboss/platform/reboot_cause_service/if/reboot_cause_service.thrift
+++ b/fboss/platform/reboot_cause_service/if/reboot_cause_service.thrift
@@ -1,0 +1,52 @@
+namespace cpp2 facebook.fboss.platform.reboot_cause_service
+namespace go neteng.fboss.platform.reboot_cause_service
+namespace php NetengFbossPlatformRebootCauseService
+namespace py neteng.fboss.platform.reboot_cause_service
+namespace py3 neteng.fboss.platform.reboot_cause_service
+namespace py.asyncio neteng.fboss.platform.asyncio.reboot_cause_service
+
+include "fboss/agent/if/fboss.thrift"
+include "fboss/platform/reboot_cause_service/if/reboot_cause_config.thrift"
+include "thrift/annotation/thrift.thrift"
+
+@thrift.AllowLegacyMissingUris
+package;
+
+// RebootCauseData models a reboot cause
+// description: a human-readable description of the cause
+// date: a human-readable date string of when cause occurred
+// externalProvider: the name of an external provider that is responsible for this cause
+struct RebootCauseData {
+  1: string description;
+  2: string date;
+  3: optional string externalProvider;
+}
+
+// RebootCauseProvider models a reboot cause provider and its read causes
+// name: the name of the provider
+// config: the configuration of the provider
+// causes: any reboot causes read from the provider
+struct RebootCauseProvider {
+  1: string name;
+  2: reboot_cause_config.RebootCauseProviderConfig config;
+  3: list<RebootCauseData> causes;
+}
+
+// RebootCauseResult models the result of a reboot cause investigation
+// date: the human-readable date string of when investigation ran
+// determinedCause: cause determined to be responsible for reboot
+// determinedCauseProvider: the name of the provider of the determined reboot cause
+// providers: all providers that reported causes for this investigation
+struct RebootCauseResult {
+  1: string date;
+  2: RebootCauseData determinedCause;
+  3: string determinedCauseProvider;
+  4: list<RebootCauseProvider> providers;
+}
+
+// RebootCauseService is the service API
+// getLastRebootCause: returns the result of the last reboot cause investigation
+service RebootCauseService {
+  RebootCauseResult getLastRebootCause()
+    throws (1: fboss.FbossBaseError error);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

  - Adds the reboot cause service that reads reboot causes from kernel drivers and determines the root cause through a priority ordered provider lookup
  - Implements Thrift IDL, config validation, platform configs for meru800bia/meru800bfa, and CMake build wiring
  - Persists reboot cause investigations to disk and exposes `getLastRebootCause` and `getRebootCauseHistory` RPCs on port 5974
- This PR is organized as a series of self-contained commits, each with its own description

**Dependency**: facebookexternal/fboss.bsp.arista#189 — exposes reload causes via sysfs; required for the service to read provider data on Arista platforms

# Test Plan
Used an internal thrift test utility to validate getLastRebootCause and getRebootCauseHistory RPC responses on port 5974:
```
[root@vpr428 ~]# thriftctl request --host localhost --port 5974 --json getLastRebootCause
{
  "date": "04-29-2026 06:22:12",
  "determinedCause": {
    "description": "PSU AC Loss",
    "date": "04-29-2026 06:16:55.000",
    "externalProvider": null
  },
  "determinedCauseProvider": "MERU800BIA_SMB_CPLD",
  "providers": [
    {
      "name": "MERU800BIA_SMB_CPLD",
      "config": {
        "type": 0,
        "priority": 1,
        "sysfsReadPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes",
        "sysfsClearPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes"
      },
      "causes": [
        {
          "description": "PSU AC Loss",
          "date": "04-29-2026 06:16:55.000",
          "externalProvider": null
        }
      ]
    },
    {
      "name": "MERU_SCM_CPLD",
      "config": {
        "type": 0,
        "priority": 2,
        "sysfsReadPath": "/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes",
        "sysfsClearPath": "/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes"
      },
      "causes": [
        {
          "description": "12V input voltage fault",
          "date": "04-29-2026 06:16:55.000",
          "externalProvider": null
        }
      ]
    }
  ],
  "logFile": {
    "filePath": "/var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-22-12.json",
    "fileVersion": 1
  }
}
[root@vpr428 ~]# thriftctl request --host localhost --port 5974 --json getRebootCauseHistory
[
  {
    "date": "04-29-2026 06:22:12",
    "determinedCause": {
      "description": "PSU AC Loss",
      "date": "04-29-2026 06:16:55.000",
      "externalProvider": null
    },
    "determinedCauseProvider": "MERU800BIA_SMB_CPLD",
    "providers": [
      {
        "name": "MERU800BIA_SMB_CPLD",
        "config": {
          "type": 0,
          "priority": 1,
          "sysfsReadPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes",
          "sysfsClearPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes"
        },
        "causes": [
          {
            "description": "PSU AC Loss",
            "date": "04-29-2026 06:16:55.000",
            "externalProvider": null
          }
        ]
      },
      {
        "name": "MERU_SCM_CPLD",
        "config": {
          "type": 0,
          "priority": 2,
          "sysfsReadPath": "/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes",
          "sysfsClearPath": "/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes"
        },
        "causes": [
          {
            "description": "12V input voltage fault",
            "date": "04-29-2026 06:16:55.000",
            "externalProvider": null
          }
        ]
      }
    ],
    "logFile": {
      "filePath": "/var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-22-12.json",
      "fileVersion": 1
    }
  },
  {
    "date": "04-29-2026 06:15:08",
    "determinedCause": {
      "description": "PSU AC Loss",
      "date": "04-29-2026 06:06:03.000",
      "externalProvider": null
    },
    "determinedCauseProvider": "MERU800BIA_SMB_CPLD",
    "providers": [
      {
        "name": "MERU800BIA_SMB_CPLD",
        "config": {
          "type": 0,
          "priority": 1,
          "sysfsReadPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes",
          "sysfsClearPath": "/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes"
        },
        "causes": [
          {
            "description": "PSU AC Loss",
            "date": "04-29-2026 06:06:03.000",
            "externalProvider": null
          }
        ]
      },
      {
        "name": "MERU_SCM_CPLD",
        "config": {
          "type": 0,
          "priority": 2,
          "sysfsReadPath": "/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes",
          "sysfsClearPath": "/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes"
        },
        "causes": [
          {
            "description": "12V input voltage fault",
            "date": "04-29-2026 06:06:03.000",
            "externalProvider": null
          }
        ]
      }
    ],
    "logFile": {
      "filePath": "/var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-15-08.json",
      "fileVersion": 1
    }
  }
]
```
Verified reboot cause detection and inspected history file contents at `/var/facebook/fboss/reboot_cause_service/history/`:
```
[root@vpr428 ~]# ls -lrt /var/facebook/fboss/reboot_cause_service/history/
total 8
-rw-r--r-- 1 root root 877 Apr 29 06:15 reboot-cause-2026-04-29-06-15-08.json
-rw-r--r-- 1 root root 877 Apr 29 06:22 reboot-cause-2026-04-29-06-22-12.json
[root@vpr428 ~]# cat /var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-15-08.json
{"version":1,"logFile":{"fileVersion":1,"filePath":"/var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-15-08.json"},"providers":[{"causes":[{"date":"04-29-2026 06:06:03.000","description":"PSU AC Loss"}],"config":{"sysfsClearPath":"/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes","sysfsReadPath":"/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes","priority":1,"type":0},"name":"MERU800BIA_SMB_CPLD"},{"causes":[{"date":"04-29-2026 06:06:03.000","description":"12V input voltage fault"}],"config":{"sysfsClearPath":"/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes","sysfsReadPath":"/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes","priority":2,"type":0},"name":"MERU_SCM_CPLD"}],"determinedCauseProvider":"MERU800BIA_SMB_CPLD","determinedCause":{"date":"04-29-2026 06:06:03.000","description":"PSU AC Loss"},"date":"04-29-2026 06:15:08"}[root@vpr428 ~]#
[root@vpr428 ~]# cat /var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-22-12.json
{"version":1,"logFile":{"fileVersion":1,"filePath":"/var/facebook/fboss/reboot_cause_service/history/reboot-cause-2026-04-29-06-22-12.json"},"providers":[{"causes":[{"date":"04-29-2026 06:16:55.000","description":"PSU AC Loss"}],"config":{"sysfsClearPath":"/run/devmap/cplds/MERU800BIA_SMB_CPLD/clear_reboot_causes","sysfsReadPath":"/run/devmap/cplds/MERU800BIA_SMB_CPLD/reboot_causes","priority":1,"type":0},"name":"MERU800BIA_SMB_CPLD"},{"causes":[{"date":"04-29-2026 06:16:55.000","description":"12V input voltage fault"}],"config":{"sysfsClearPath":"/run/devmap/fpgas/MERU_SCM_CPLD/clear_reboot_causes","sysfsReadPath":"/run/devmap/fpgas/MERU_SCM_CPLD/reboot_causes","priority":2,"type":0},"name":"MERU_SCM_CPLD"}],"determinedCauseProvider":"MERU800BIA_SMB_CPLD","determinedCause":{"date":"04-29-2026 06:16:55.000","description":"PSU AC Loss"},"date":"04-29-2026 06:22:12"}[root@vpr428 ~]#
```
