### PR TITLE
fboss2: add show reboot-cause and show reboot-cause history commands

### DIFF
--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -152,6 +152,13 @@ add_fbthrift_cpp_library(
 )
 
 add_fbthrift_cpp_library(
+  show_reboot_cause_model
+  fboss/cli/fboss2/commands/show/reboot_cause/model.thrift
+  OPTIONS
+    json
+)
+
+add_fbthrift_cpp_library(
   show_aggregateport_model
   fboss/cli/fboss2/commands/show/aggregateport/model.thrift
   OPTIONS
@@ -502,6 +509,10 @@ add_library(fboss2_lib
   fboss/cli/fboss2/commands/show/product/CmdShowProduct.cpp
   fboss/cli/fboss2/commands/show/product/CmdShowProductDetails.h
   fboss/cli/fboss2/commands/show/product/CmdShowProductDetails.cpp
+  fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.h
+  fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.cpp
+  fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.h
+  fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.cpp
   fboss/cli/fboss2/commands/show/route/utils.cpp
   fboss/cli/fboss2/commands/show/route/CmdShowRouteDetails.h
   fboss/cli/fboss2/commands/show/route/CmdShowRouteDetails.cpp
@@ -643,6 +654,8 @@ target_link_libraries(fboss2_lib
   show_ndp_model
   show_port_model
   show_product_model
+  show_reboot_cause_model
+  reboot_cause_service_cpp2
   show_transceiver_model
   show_interface_model
   show_interface_flaps

--- a/fboss/cli/fboss2/CmdGlobalOptions.h
+++ b/fboss/cli/fboss2/CmdGlobalOptions.h
@@ -455,6 +455,10 @@ class CmdGlobalOptions {
     return dataCorralServiceThriftPort_;
   }
 
+  int getRebootCauseServiceThriftPort() const {
+    return rebootCauseServiceThriftPort_;
+  }
+
   int getBmcHttpPort() const {
     return bmcHttpPort_;
   }
@@ -557,6 +561,7 @@ class CmdGlobalOptions {
   int fanServiceThriftPort_{5972};
   int teAgentThriftPort_{2022};
   int dataCorralServiceThriftPort_{5971};
+  int rebootCauseServiceThriftPort_{5974};
   int vipInjectorThriftPort_{3333};
   std::string color_{"yes"};
   std::string filter_;

--- a/fboss/cli/fboss2/CmdList.cpp
+++ b/fboss/cli/fboss2/CmdList.cpp
@@ -84,6 +84,8 @@
 #include "fboss/cli/fboss2/commands/show/port/CmdShowPortQueue.h"
 #include "fboss/cli/fboss2/commands/show/product/CmdShowProduct.h"
 #include "fboss/cli/fboss2/commands/show/product/CmdShowProductDetails.h"
+#include "fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.h"
+#include "fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.h"
 #include "fboss/cli/fboss2/commands/show/rif/CmdShowRif.h"
 #include "fboss/cli/fboss2/commands/show/route/CmdShowRoute.h"
 #include "fboss/cli/fboss2/commands/show/route/CmdShowRouteDetails.h"
@@ -580,6 +582,16 @@ const CommandTree& kCommandTree() {
          "Show Product Detail Information",
          commandHandler<CmdShowProductDetails>,
          argTypeHandler<CmdShowProductDetailsTraits>}}},
+
+      {"show",
+       "reboot-cause",
+       "Show reboot cause information",
+       commandHandler<CmdShowRebootCause>,
+       argTypeHandler<CmdShowRebootCauseTraits>,
+       {{"history",
+         "Show reboot cause history",
+         commandHandler<CmdShowRebootCauseHistory>,
+         argTypeHandler<CmdShowRebootCauseHistoryTraits>}}},
 
       {"stream",
        "fsdb",

--- a/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.cpp
+++ b/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.cpp
@@ -1,0 +1,40 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.h"
+#include "fboss/cli/fboss2/CmdGlobalOptions.h"
+#include "fboss/cli/fboss2/CmdHandler.cpp"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/RebootCauseService.h"
+
+namespace facebook::fboss {
+
+CmdShowRebootCause::RetType CmdShowRebootCause::queryClient(
+    const HostInfo& hostInfo) {
+  auto port =
+      CmdGlobalOptions::getInstance()->getRebootCauseServiceThriftPort();
+  auto client = utils::createPlaintextClient<apache::thrift::Client<
+      platform::reboot_cause_service::RebootCauseService>>(hostInfo, port);
+  platform::reboot_cause_service::RebootCauseResult result;
+  client->sync_getLastRebootCause(result);
+  return createModel(result);
+}
+
+CmdShowRebootCause::RetType CmdShowRebootCause::createModel(
+    const platform::reboot_cause_service::RebootCauseResult& result) {
+  RetType model;
+  model.investigationDate() = result.date().value();
+  model.causeDescription() = result.determinedCause()->description().value();
+  model.causeDate() = result.determinedCause()->date().value();
+  model.causeProvider() = result.determinedCauseProvider().value();
+  return model;
+}
+
+void CmdShowRebootCause::printOutput(const RetType& model, std::ostream& out) {
+  out << model.causeDescription().value()
+      << " [Provider: " << model.causeProvider().value()
+      << ", Time: " << model.causeDate().value() << "]" << std::endl;
+}
+
+// Explicit template instantiation
+template void CmdHandler<CmdShowRebootCause, CmdShowRebootCauseTraits>::run();
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.h
+++ b/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCause.h
@@ -1,0 +1,32 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "fboss/cli/fboss2/CmdHandler.h"
+#include "fboss/cli/fboss2/commands/show/reboot_cause/gen-cpp2/model_types.h"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/CmdUtils.h"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_service_types.h"
+
+namespace facebook::fboss {
+
+struct CmdShowRebootCauseTraits : public ReadCommandTraits {
+  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
+      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
+  using ObjectArgType = std::monostate;
+  using RetType = cli::ShowRebootCauseModel;
+};
+
+class CmdShowRebootCause
+    : public CmdHandler<CmdShowRebootCause, CmdShowRebootCauseTraits> {
+ public:
+  using ObjectArgType = CmdShowRebootCauseTraits::ObjectArgType;
+  using RetType = CmdShowRebootCauseTraits::RetType;
+
+  RetType queryClient(const HostInfo& hostInfo);
+  RetType createModel(
+      const platform::reboot_cause_service::RebootCauseResult& result);
+  void printOutput(const RetType& model, std::ostream& out = std::cout);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.cpp
+++ b/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.cpp
@@ -1,0 +1,70 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.h"
+#include "fboss/cli/fboss2/CmdGlobalOptions.h"
+#include "fboss/cli/fboss2/CmdHandler.cpp"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/RebootCauseService.h"
+
+#include <fmt/format.h>
+
+namespace facebook::fboss {
+
+CmdShowRebootCauseHistory::RetType CmdShowRebootCauseHistory::queryClient(
+    const HostInfo& hostInfo) {
+  auto port =
+      CmdGlobalOptions::getInstance()->getRebootCauseServiceThriftPort();
+  auto client = utils::createPlaintextClient<apache::thrift::Client<
+      platform::reboot_cause_service::RebootCauseService>>(hostInfo, port);
+  std::vector<platform::reboot_cause_service::RebootCauseResult> results;
+  client->sync_getRebootCauseHistory(results);
+  return createModel(results);
+}
+
+CmdShowRebootCauseHistory::RetType CmdShowRebootCauseHistory::createModel(
+    const std::vector<platform::reboot_cause_service::RebootCauseResult>&
+        results) {
+  RetType model;
+  for (const auto& result : results) {
+    cli::ShowRebootCauseModel entry;
+    entry.investigationDate() = result.date().value();
+    entry.causeDescription() = result.determinedCause()->description().value();
+    entry.causeDate() = result.determinedCause()->date().value();
+    entry.causeProvider() = result.determinedCauseProvider().value();
+    model.entries()->push_back(entry);
+  }
+  return model;
+}
+
+void CmdShowRebootCauseHistory::printOutput(
+    const RetType& model,
+    std::ostream& out) {
+  const auto& entries = model.entries().value();
+  if (entries.empty()) {
+    out << "No reboot cause history found." << std::endl;
+    return;
+  }
+  auto truncate = [](const std::string& s, size_t maxLen) -> std::string {
+    if (s.size() <= maxLen) {
+      return s;
+    }
+    return s.substr(0, maxLen - 3) + "...";
+  };
+  constexpr auto fmtString = "{:<24}{:<32}{:<24}{}\n";
+  out << fmt::format(
+      fmtString, "Collection Time", "Description", "Provider", "Cause Time");
+  out << std::string(88, '-') << std::endl;
+  for (const auto& entry : entries) {
+    out << fmt::format(
+        fmtString,
+        entry.investigationDate().value(),
+        truncate(entry.causeDescription().value(), 32),
+        entry.causeProvider().value(),
+        entry.causeDate().value());
+  }
+}
+
+// Explicit template instantiation
+template void
+CmdHandler<CmdShowRebootCauseHistory, CmdShowRebootCauseHistoryTraits>::run();
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.h
+++ b/fboss/cli/fboss2/commands/show/reboot_cause/CmdShowRebootCauseHistory.h
@@ -1,0 +1,34 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "fboss/cli/fboss2/CmdHandler.h"
+#include "fboss/cli/fboss2/commands/show/reboot_cause/gen-cpp2/model_types.h"
+#include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
+#include "fboss/cli/fboss2/utils/CmdUtils.h"
+#include "fboss/platform/reboot_cause_service/if/gen-cpp2/reboot_cause_service_types.h"
+
+namespace facebook::fboss {
+
+struct CmdShowRebootCauseHistoryTraits : public ReadCommandTraits {
+  static constexpr utils::ObjectArgTypeId ObjectArgTypeId =
+      utils::ObjectArgTypeId::OBJECT_ARG_TYPE_ID_NONE;
+  using ObjectArgType = std::monostate;
+  using RetType = cli::ShowRebootCauseHistoryModel;
+};
+
+class CmdShowRebootCauseHistory : public CmdHandler<
+                                      CmdShowRebootCauseHistory,
+                                      CmdShowRebootCauseHistoryTraits> {
+ public:
+  using ObjectArgType = CmdShowRebootCauseHistoryTraits::ObjectArgType;
+  using RetType = CmdShowRebootCauseHistoryTraits::RetType;
+
+  RetType queryClient(const HostInfo& hostInfo);
+  RetType createModel(
+      const std::vector<platform::reboot_cause_service::RebootCauseResult>&
+          results);
+  void printOutput(const RetType& model, std::ostream& out = std::cout);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/show/reboot_cause/model.thrift
+++ b/fboss/cli/fboss2/commands/show/reboot_cause/model.thrift
@@ -1,0 +1,16 @@
+package "facebook.com/fboss/cli"
+
+namespace cpp2 facebook.fboss.cli
+
+// A single reboot cause investigation result for display.
+struct ShowRebootCauseModel {
+  1: string investigationDate;   // when the service ran the investigation
+  2: string causeDescription;    // human-readable cause (e.g. "PSU AC Loss")
+  3: string causeDate;           // when the hardware event occurred
+  4: string causeProvider;       // which provider reported the cause
+}
+
+// History: a list of results, most recent first.
+struct ShowRebootCauseHistoryModel {
+  1: list<ShowRebootCauseModel> entries;
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
 - Adds fboss2 CLI commands to query the reboot_cause_service (port 5974):
    - show reboot-cause: displays the last reboot cause investigation result
    - show reboot-cause history: displays all persisted reboot cause results
  - Includes model.thrift for display types, command handlers, CmdList registration, and CliFboss2.cmake build wiring

**Dependency**: facebook/fboss#1141 — platform: add reboot cause service with persistent history; required for the CLI commands to function

# Test Plan
Verified `fboss2 show reboot-cause` and `fboss2 show reboot-cause history` outputs:
```
[root@vpr428 ~]# fboss2 show reboot-cause
PSU AC Loss [Provider: MERU800BIA_SMB_CPLD, Time: 04-29-2026 06:16:55.000]
[root@vpr428 ~]#
[root@vpr428 ~]# fboss2 show reboot-cause history
Collection Time         Description                     Provider                Cause Time
----------------------------------------------------------------------------------------
04-29-2026 06:22:12     PSU AC Loss                     MERU800BIA_SMB_CPLD     04-29-2026 06:16:55.000
04-29-2026 06:15:08     PSU AC Loss                     MERU800BIA_SMB_CPLD     04-29-2026 06:06:03.000
```
