### PR TITLE
[Nexthop][fboss2-dev] Fix clang warning

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropDnxTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropDnxTests.cpp
@@ -2,7 +2,6 @@
 
 #include <folly/MacAddress.h>
 #include <gtest/gtest.h>
-#include <algorithm>
 #include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/TxPacket.h"
 #include "fboss/agent/Utils.h"
@@ -21,7 +20,6 @@
 #include "fboss/agent/test/utils/PacketSnooper.h"
 #include "fboss/agent/test/utils/PfcTestUtils.h"
 #include "fboss/agent/test/utils/PortTestUtils.h"
-#include "fboss/agent/test/utils/QosTestUtils.h"
 #include "fboss/agent/test/utils/TrapPacketUtils.h"
 #include "fboss/agent/test/utils/VoqTestUtils.h"
 #include "fboss/lib/CommonUtils.h"
@@ -513,7 +511,7 @@ TEST_F(AgentMirrorOnDropMtuTest, MtuTrapStillWorks) {
     // We expect all MTU traps to still work.
     WITH_RETRIES_N(5, {
       int pkts = 0;
-      for (const auto switchId : getSw()->getHwAsicTable()->getSwitchIDs()) {
+      for (const auto& switchId : getSw()->getHwAsicTable()->getSwitchIDs()) {
         // MTU trap goes to kCoppLowPriQueueId
         pkts += utility::getCpuQueueInPackets(
             getSw(), switchId, utility::kCoppLowPriQueueId);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The build was failing with -Werror on clang due to a range-loop copying a SwitchID value instead of taking it by reference:

AgentMirrorOnDropDnxTests.cpp:514: error: loop variable 'switchId' creates a copy
note: use reference type 'const value_type &' (aka 'const facebook::fboss::SwitchID &') to prevent copying
HwAsicTable::getSwitchIDs() returns a container of SwitchID (a non-trivial wrapper type), so clang flags the implicit per-iteration copy. The fix changes const auto to const auto& in the WITH_RETRIES_N loop in MtuTrapStillWorks, matching the convention used elsewhere in the file.

# Test Plan

CI build and existing tests passing.