### PR TITLE
[Nexthop] fix "asic_config_v2" output generation

### DIFF
--- a/fboss/lib/asic_config_v2/run-helper.sh
+++ b/fboss/lib/asic_config_v2/run-helper.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
-python3 fboss/lib/oss/run-helper.py --target fboss-asic-config-gen.GEN_PY_EXE "$@"
+python3 fboss/lib/oss/run-helper.py \
+  --target fboss-asic-config-gen.GEN_PY_EXE \
+  --extra-cmake-defines='{"RANGE_V3_TESTS": "OFF"}' \
+  "$@"

--- a/fboss/lib/asic_config_v2/run-helper.sh
+++ b/fboss/lib/asic_config_v2/run-helper.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 fboss/lib/oss/run-helper.py --target fboss-asic-config-gen "$@"
+python3 fboss/lib/oss/run-helper.py --target fboss-asic-config-gen.GEN_PY_EXE "$@"

--- a/fboss/lib/oss/run-helper.py
+++ b/fboss/lib/oss/run-helper.py
@@ -13,24 +13,36 @@ Sample invocation:
 """
 
 import argparse
+import json
 import os
 import subprocess
 import sys
 from pathlib import Path
 
 
-def get_command_line_args() -> tuple[str, list[str]]:
+def get_command_line_args() -> tuple[str, dict[str, str], list[str]]:
     parser = argparse.ArgumentParser(
         description="OSS FBOSS build and run helper script."
     )
     parser.add_argument("--target", type=str, required=True, help="Target to build")
+    parser.add_argument(
+        "--extra-cmake-defines",
+        type=str,
+        default="{}",
+        help=("JSON object of additional cmake defines"),
+    )
     args, unknown_args = parser.parse_known_args()
 
-    return args.target, unknown_args
+    extra_defines = json.loads(args.extra_cmake_defines)
+    if not isinstance(extra_defines, dict):
+        print("--extra-cmake-defines must be a JSON object", file=sys.stderr)
+        sys.exit(1)
+
+    return args.target, extra_defines, unknown_args
 
 
 def main() -> None:
-    target, command_line_args = get_command_line_args()
+    target, extra_cmake_defines, command_line_args = get_command_line_args()
 
     run_path = os.getcwd()
     parents = Path(__file__).parents
@@ -69,10 +81,14 @@ Current run path: {run_path}"""
     if is_facebook_machine:
         get_deps_path = f"{proxy_env_vars} {get_deps_path}"
 
+    cmake_defines = {"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20"}
+    cmake_defines.update(extra_cmake_defines)
+    cmake_defines_json = json.dumps(cmake_defines)
+
     print(f"Starting build for {target}")
     subprocess.run(
         f"""{get_deps_path} build """
-        + '--allow-system-packages --num-jobs 32 --extra-cmake-defines=\'{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20"}\' --cmake-target'
+        + f"--allow-system-packages --num-jobs 32 --extra-cmake-defines='{cmake_defines_json}' --cmake-target"
         + f" {target} fboss",
         check=False,
         shell=True,

--- a/fboss/lib/oss/run-helper.py
+++ b/fboss/lib/oss/run-helper.py
@@ -17,10 +17,9 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Tuple
 
 
-def get_command_line_args() -> Tuple[str, List[str]]:
+def get_command_line_args() -> tuple[str, list[str]]:
     parser = argparse.ArgumentParser(
         description="OSS FBOSS build and run helper script."
     )
@@ -40,14 +39,14 @@ def main() -> None:
             "Please run the script from the root of the FBOSS repository",
             file=sys.stderr,
         )
-        exit(1)
+        sys.exit(1)
     expected_path = parents[3].absolute().as_posix()
     if run_path != expected_path:
         error_string = f"""Please executed the script from the root of the FBOSS repository
 Expected run path: {expected_path}
 Current run path: {run_path}"""
         print(error_string, file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     get_deps_paths = [
         expected_path + "/opensource/fbcode_builder/getdeps.py",
@@ -60,7 +59,7 @@ Current run path: {run_path}"""
             get_deps_path = maybe_path
     if get_deps_path is None:
         print("Could not find getdeps.py", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
     else:
         print(get_deps_path)
 
@@ -75,6 +74,7 @@ Current run path: {run_path}"""
         f"""{get_deps_path} build """
         + '--allow-system-packages --num-jobs 32 --extra-cmake-defines=\'{"CMAKE_BUILD_TYPE": "MinSizeRel", "CMAKE_CXX_STANDARD": "20"}\' --cmake-target'
         + f" {target} fboss",
+        check=False,
         shell=True,
     )
 
@@ -82,6 +82,7 @@ Current run path: {run_path}"""
 
     show_build_dir_proc = subprocess.run(
         f"""{get_deps_path} show-build-dir fboss""",
+        check=False,
         shell=True,
         capture_output=True,
         text=True,
@@ -96,15 +97,16 @@ Current run path: {run_path}"""
 
     result = subprocess.run(
         fboss_oss_target,
+        check=False,
         shell=True,
     )
 
     if result.returncode != 0:
         print(f"Failed to run target {target}", file=sys.stderr)
-        exit(1)
+        sys.exit(1)
 
     print("Configs have been written to specified output directory")
-    exit(0)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/fboss/lib/oss/run-helper.py
+++ b/fboss/lib/oss/run-helper.py
@@ -88,12 +88,13 @@ Current run path: {run_path}"""
         text=True,
     )
 
-    fboss_oss_target = (
-        show_build_dir_proc.stdout.rstrip()
-        + f"/{target}"
-        + " "
-        + " ".join(command_line_args)
-    )
+    build_dir = show_build_dir_proc.stdout.rstrip()
+    target_basename = target.removesuffix(".GEN_PY_EXE")
+    output_path = f"{build_dir}/{target_basename}"
+
+    # Thrift python output is a directory; everything else is a native executable
+    python_prefix = "python3 " if os.path.isdir(output_path) else ""
+    fboss_oss_target = f"{python_prefix}{output_path} {' '.join(command_line_args)}"
 
     result = subprocess.run(
         fboss_oss_target,


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
The `asic_config_v2` can generate output files in `fboss/lib/asic_config_v2/generated_asic_configs` by running `fboss/lib/asic_config_v2/run-helper.sh` but this is broken in OSS FBOSS currently because of some recent changes related to thrift etc.

In this PR, `asic_config_v2` output generation is fixed. The following are the main changes:

- Fixed existing ruff linter issues
- Updated `fboss/lib/oss/run-helper.py`
  - to handle python thrift generated directory type output along with C++ generated single binary output
  - to accept `--extra-cmake-defines` and merge with the existing hardcoded values
- Updated `fboss/lib/asic_config_v2/run-helper.sh` to
  - pass the target as expected by the latest thrift changes
  - pass  `--extra-cmake-defines` to disable `range-v3` tests

<br/>

_Note: Please check individual commits for reviewing each small change separately._

<br/>

# Test Plan
Generated `asic_config_v2` output files in `fboss/lib/asic_config_v2/generated_asic_configs` by running `fboss/lib/asic_config_v2/run-helper.sh`.