### PR TITLE
[Accton][minipack3bta] Harden TU1 SAI capability handling in ACL and hostif paths

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
@@ -817,6 +817,13 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
         SaiAclEntryTraits::Attributes::FieldOutPort{AclEntryFieldSaiObjectIdT(
             std::make_pair(portHandle->port->adapterKey(), kMaskDontCare))};
   }
+  if (fieldOutPort.has_value() &&
+      !isQualifierSupported(aclTableName, cfg::AclTableQualifier::OUT_PORT)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier OUT_PORT for aclEntry: "
+        << addedAclEntry->getID();
+    fieldOutPort.reset();
+  }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldL4SrcPort> fieldL4SrcPort{
       std::nullopt};
@@ -893,6 +900,13 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
             std::make_pair(
                 addedAclEntry->getTcpFlagsBitMap().value(), kTcpFlagsMask))};
   }
+  if (fieldTcpFlags.has_value() &&
+      !isQualifierSupported(aclTableName, cfg::AclTableQualifier::TCP_FLAGS)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier TCP_FLAGS for aclEntry: "
+        << addedAclEntry->getID();
+    fieldTcpFlags.reset();
+  }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldIpFrag> fieldIpFrag{
       std::nullopt};
@@ -945,6 +959,38 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
           "proto or etherType not sepcified in ACL when matching icmp type/code");
     }
   }
+  if (fieldIcmpV4Type.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::ICMPV4_TYPE)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier ICMPV4_TYPE for aclEntry: "
+        << addedAclEntry->getID();
+    fieldIcmpV4Type.reset();
+  }
+  if (fieldIcmpV4Code.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::ICMPV4_CODE)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier ICMPV4_CODE for aclEntry: "
+        << addedAclEntry->getID();
+    fieldIcmpV4Code.reset();
+  }
+  if (fieldIcmpV6Type.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::ICMPV6_TYPE)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier ICMPV6_TYPE for aclEntry: "
+        << addedAclEntry->getID();
+    fieldIcmpV6Type.reset();
+  }
+  if (fieldIcmpV6Code.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::ICMPV6_CODE)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier ICMPV6_CODE for aclEntry: "
+        << addedAclEntry->getID();
+    fieldIcmpV6Code.reset();
+  }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldDscp> fieldDscp{
       std::nullopt};
@@ -975,6 +1021,12 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
             addedAclEntry->getTtl().value().getValue(),
             addedAclEntry->getTtl().value().getMask()))};
   }
+  if (fieldTtl.has_value() &&
+      !isQualifierSupported(aclTableName, cfg::AclTableQualifier::TTL)) {
+    XLOG(WARNING) << "Skipping unsupported ACL qualifier TTL for aclEntry: "
+                  << addedAclEntry->getID();
+    fieldTtl.reset();
+  }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldRouteDstUserMeta>
       fieldRouteDstUserMeta{std::nullopt};
@@ -984,6 +1036,14 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
             AclEntryFieldU32(cfgLookupClassToSaiRouteMetaDataAndMask(
                 addedAclEntry->getLookupClassRoute().value()))};
   }
+  if (fieldRouteDstUserMeta.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::LOOKUP_CLASS_ROUTE)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier LOOKUP_CLASS_ROUTE for aclEntry: "
+        << addedAclEntry->getID();
+    fieldRouteDstUserMeta.reset();
+  }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldNeighborDstUserMeta>
       fieldNeighborDstUserMeta{std::nullopt};
@@ -992,6 +1052,14 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
         SaiAclEntryTraits::Attributes::FieldNeighborDstUserMeta{
             AclEntryFieldU32(cfgLookupClassToSaiNeighborMetaDataAndMask(
                 addedAclEntry->getLookupClassNeighbor().value()))};
+  }
+  if (fieldNeighborDstUserMeta.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::LOOKUP_CLASS_NEIGHBOR)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier LOOKUP_CLASS_NEIGHBOR for aclEntry: "
+        << addedAclEntry->getID();
+    fieldNeighborDstUserMeta.reset();
   }
 
   std::optional<SaiAclEntryTraits::Attributes::FieldEthertype> fieldEtherType{
@@ -1029,6 +1097,14 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
     fieldFdbDstUserMeta = SaiAclEntryTraits::Attributes::FieldFdbDstUserMeta{
         AclEntryFieldU32(cfgLookupClassToSaiFdbMetaDataAndMask(
             addedAclEntry->getLookupClassL2().value()))};
+  }
+  if (fieldFdbDstUserMeta.has_value() &&
+      !isQualifierSupported(
+          aclTableName, cfg::AclTableQualifier::LOOKUP_CLASS_L2)) {
+    XLOG(WARNING)
+        << "Skipping unsupported ACL qualifier LOOKUP_CLASS_L2 for aclEntry: "
+        << addedAclEntry->getID();
+    fieldFdbDstUserMeta.reset();
   }
 
 #if (                                                                  \
@@ -1183,6 +1259,25 @@ AclEntrySaiId SaiAclTableManager::addAclEntry(
         setCopyOrTrap(matchAction);
         aclActionSetTC = SaiAclEntryTraits::Attributes::ActionSetTC{
             AclEntryActionU8(tc.value())};
+      }
+    }
+    if (aclActionSetTC.has_value()) {
+      bool setTcActionSupported = true;
+      auto aclTableActionTypeList = std::get<
+          std::optional<SaiAclTableTraits::Attributes::ActionTypeList>>(
+          aclTableHandle->aclTable->attributes());
+      if (aclTableActionTypeList.has_value()) {
+        const auto& actionTypeList = aclTableActionTypeList->value();
+        setTcActionSupported =
+            std::find(
+                actionTypeList.begin(),
+                actionTypeList.end(),
+                SAI_ACL_ACTION_TYPE_SET_TC) != actionTypeList.end();
+      }
+      if (!setTcActionSupported) {
+        XLOG(WARNING) << "Skipping unsupported ACL action SET_TC for aclEntry: "
+                      << addedAclEntry->getID();
+        aclActionSetTC.reset();
       }
     }
 
@@ -1729,6 +1824,8 @@ std::set<cfg::AclTableQualifier> SaiAclTableManager::getSupportedQualifierSet(
       platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_TOMAHAWK5;
   bool isTomahawk6 =
       platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_TOMAHAWK6;
+  bool isTomahawkUltra1 = platform_->getAsic()->getAsicType() ==
+      cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1;
   bool isChenab = platform_->getAsic()->getAsicVendor() ==
       HwAsic::AsicVendor::ASIC_VENDOR_CHENAB;
 
@@ -1880,6 +1977,18 @@ std::set<cfg::AclTableQualifier> SaiAclTableManager::getSupportedQualifierSet(
     // ETHER_TYPE required for Aifm controller packets using 0x88B6
     if (isTomahawk6) {
       bcmQualifiers.insert(cfg::AclTableQualifier::ETHER_TYPE);
+    }
+    if (isTomahawkUltra1) {
+      bcmQualifiers.erase(cfg::AclTableQualifier::TCP_FLAGS);
+      bcmQualifiers.erase(cfg::AclTableQualifier::OUT_PORT);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV4_TYPE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV4_CODE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV6_TYPE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV6_CODE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_L2);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_NEIGHBOR);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_ROUTE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::TTL);
     }
     if (isFake) {
       bcmQualifiers.insert(cfg::AclTableQualifier::L4_DST_PORT_RANGE);

--- a/fboss/agent/hw/sai/switch/SaiHostifManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiHostifManager.cpp
@@ -10,6 +10,7 @@
 
 #include "fboss/agent/hw/sai/switch/SaiHostifManager.h"
 #include "fboss/agent/VoqUtils.h"
+#include "fboss/agent/hw/sai/api/SaiApiError.h"
 #include "fboss/agent/hw/sai/store/SaiStore.h"
 #include "fboss/agent/hw/sai/switch/ConcurrentIndices.h"
 #include "fboss/agent/hw/sai/switch/SaiManagerTable.h"
@@ -373,16 +374,25 @@ void SaiHostifManager::processRxReasonToQueueDelta(
    */
   for (auto index = 0; index < newRxReasonToQueue->size(); index++) {
     const auto& newRxReasonEntry = newRxReasonToQueue->cref(index);
+    auto newRxReason =
+        newRxReasonEntry->cref<switch_config_tags::rxReason>()->cref();
     // We'll need to skip for unmatched reason because
     // (1) we're not programming hostif trap for that, and
     // (2) If newly added rx reason entries are above the unmatched reason,
     // we'll try to call changeHostifTrap() for the unmatched reason.
     // TODO(zecheng): Fix the below logic of comparing index (instead we should
     // compare priority)
-    if (newRxReasonEntry->cref<switch_config_tags::rxReason>()->toThrift() ==
-        cfg::PacketRxReason::UNMATCHED) {
+    if (newRxReason == cfg::PacketRxReason::UNMATCHED) {
       // what is the trap for unmatched?
       XLOG(WARN) << "ignoring UNMATCHED packet rx reason";
+      continue;
+    }
+    if (newRxReason == cfg::PacketRxReason::L3_MTU_ERROR &&
+        !platform_->getAsic()->isSupported(
+            HwAsic::Feature::L3_MTU_ERROR_TRAP)) {
+      XLOG(WARN) << "Skipping " << apache::thrift::util::enumName(newRxReason)
+                 << " packet reason since corresponding trap feature is not "
+                    "supported on this ASIC";
       continue;
     }
     auto oldRxReasonEntryIter = std::find_if(
@@ -435,10 +445,19 @@ void SaiHostifManager::processRxReasonToQueueDelta(
 
   for (auto index = 0; index < oldRxReasonToQueue->size(); index++) {
     const auto& oldRxReasonEntry = oldRxReasonToQueue->cref(index);
-    if (oldRxReasonEntry->cref<switch_config_tags::rxReason>()->toThrift() ==
-        cfg::PacketRxReason::UNMATCHED) {
+    auto oldRxReason =
+        oldRxReasonEntry->cref<switch_config_tags::rxReason>()->cref();
+    if (oldRxReason == cfg::PacketRxReason::UNMATCHED) {
       // UNMATCHED was never added in the first place, so ignoring here
       XLOG(WARN) << "ignoring UNMATCHED packet rx reason";
+      continue;
+    }
+    if (oldRxReason == cfg::PacketRxReason::L3_MTU_ERROR &&
+        !platform_->getAsic()->isSupported(
+            HwAsic::Feature::L3_MTU_ERROR_TRAP)) {
+      XLOG(WARN) << "Skipping " << apache::thrift::util::enumName(oldRxReason)
+                 << " packet reason since corresponding trap feature is not "
+                    "supported on this ASIC";
       continue;
     }
     auto newRxReasonEntry = std::find_if(

--- a/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "fboss/agent/hw/sai/switch/SaiAclTableManager.h"
+#include <algorithm>
 #include "fboss/agent/hw/sai/store/SaiStore.h"
 #include "fboss/agent/hw/sai/switch/SaiManagerTable.h"
 #include "fboss/agent/hw/sai/switch/SaiPortManager.h"
@@ -102,6 +103,8 @@ std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
         cfg::AsicType::ASIC_TYPE_JERICHO4;
     bool isChenab = platform_->getAsic()->getAsicVendor() ==
         HwAsic::AsicVendor::ASIC_VENDOR_CHENAB;
+    bool isTomahawkUltra1 = platform_->getAsic()->getAsicType() ==
+        cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1;
 
     std::vector<sai_int32_t> actionTypeList{
         SAI_ACL_ACTION_TYPE_PACKET_ACTION,
@@ -109,6 +112,15 @@ std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
         SAI_ACL_ACTION_TYPE_SET_TC,
         SAI_ACL_ACTION_TYPE_SET_DSCP,
         SAI_ACL_ACTION_TYPE_MIRROR_INGRESS};
+
+    if (isTomahawkUltra1) {
+      actionTypeList.erase(
+          std::remove(
+              actionTypeList.begin(),
+              actionTypeList.end(),
+              SAI_ACL_ACTION_TYPE_SET_TC),
+          actionTypeList.end());
+    }
 
     if (!(isTajo || isJericho2 || isJericho3 || isJericho4 || isChenab)) {
       // Chenab supports egress mirror action in egress table

--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -43,7 +43,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::CPU_QUEUES:
     case HwAsic::Feature::VRF:
     case HwAsic::Feature::SAI_HASH_FIELDS_CLEAR_BEFORE_SET:
-    case HwAsic::Feature::ROUTE_COUNTERS:
     case HwAsic::Feature::ROUTE_FLEX_COUNTERS:
     case HwAsic::Feature::BRIDGE_PORT_8021Q:
     case HwAsic::Feature::FEC_DIAG_COUNTERS:
@@ -63,7 +62,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ECMP_HASH_V6:
     case HwAsic::Feature::FEC_CORRECTED_BITS:
     case HwAsic::Feature::ECMP_MEMBER_WIDTH_INTROSPECTION:
-    case HwAsic::Feature::SAI_MPLS_QOS:
     case HwAsic::Feature::QOS_MAP_GLOBAL:
     case HwAsic::Feature::MACSEC:
     case HwAsic::Feature::SAI_PORT_GET_PMD_LANES:
@@ -71,7 +69,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ROUTE_METADATA:
     case HwAsic::Feature::NON_UNICAST_HASH:
     case HwAsic::Feature::WEIGHTED_NEXTHOPGROUP_MEMBER:
-    case HwAsic::Feature::ARS:
     case HwAsic::Feature::IN_PAUSE_INCREMENTS_DISCARDS:
     case HwAsic::Feature::IN_DISCARDS_EXCLUDES_PFC:
     case HwAsic::Feature::WARMBOOT:
@@ -81,7 +78,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SAI_UDF_HASH:
     case HwAsic::Feature::SEPARATE_BYTE_AND_PACKET_ACL_COUNTER:
     case HwAsic::Feature::ARS_PORT_ATTRIBUTES:
-    case HwAsic::Feature::ARS_ALTERNATE_MEMBERS:
     case HwAsic::Feature::SAI_EAPOL_TRAP:
     case HwAsic::Feature::SAI_USER_DEFINED_TRAP:
     case HwAsic::Feature::ACL_COUNTER_LABEL:
@@ -106,7 +102,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::RX_SERDES_PARAMETERS:
     case HwAsic::Feature::SAI_PORT_IN_CONGESTION_DISCARDS:
     case HwAsic::Feature::TEMPERATURE_MONITORING:
-    case HwAsic::Feature::ACL_SET_ECMP_HASH_ALGORITHM:
     case HwAsic::Feature::SET_NEXT_HOP_GROUP_HASH_ALGORITHM:
     case HwAsic::Feature::SAI_PORT_PG_DROP_STATUS:
     case HwAsic::Feature::SAI_PORT_ERR_STATUS:
@@ -115,6 +110,9 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::BULK_CREATE_ECMP_MEMBER:
     case HwAsic::Feature::ARS_FUTURE_PORT_LOAD:
     case HwAsic::Feature::ECN_PROBABILISTIC_MARKING:
+    case HwAsic::Feature::FEC:
+    case HwAsic::Feature::MEDIA_TYPE:
+    case HwAsic::Feature::ACL_TABLE_GROUP:
       return true;
     case HwAsic::Feature::MIRROR_PACKET_TRUNCATION:
     case HwAsic::Feature::SFLOW_SAMPLING:
@@ -229,14 +227,16 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SRV6_MYSID_RESOURCE_COUNTER:
     case HwAsic::Feature::DEVICE_WATERMARK_SUPPORT:
     // TU1 SDK 15.0/15.1 unsupported features (Accton/Broadcom CSPs)
-    case HwAsic::Feature::FEC:
-    case HwAsic::Feature::MEDIA_TYPE:
     case HwAsic::Feature::BUFFER_POOL:
     case HwAsic::Feature::SAI_PORT_SPEED_CHANGE:
     case HwAsic::Feature::L3_MTU_ERROR_TRAP:
     case HwAsic::Feature::L3_INTF_MTU:
     case HwAsic::Feature::MANAGEMENT_PORT_MULTICAST_QUEUE_ALPHA:
-    case HwAsic::Feature::ACL_TABLE_GROUP:
+    case HwAsic::Feature::ROUTE_COUNTERS:
+    case HwAsic::Feature::SAI_MPLS_QOS:
+    case HwAsic::Feature::ARS:
+    case HwAsic::Feature::ARS_ALTERNATE_MEMBERS:
+    case HwAsic::Feature::ACL_SET_ECMP_HASH_ALGORITHM:
       return false;
   }
   return false;

--- a/fboss/agent/test/utils/CoppTestUtils.cpp
+++ b/fboss/agent/test/utils/CoppTestUtils.cpp
@@ -1336,11 +1336,15 @@ std::vector<cfg::PacketRxReasonToQueue> getCoppRxReasonToQueuesForBcm(
           std::pair(cfg::PacketRxReason::ARP, coppHighPriQueueId),
           std::pair(cfg::PacketRxReason::DHCP, coppMidPriQueueId),
           std::pair(cfg::PacketRxReason::BPDU, coppMidPriQueueId),
-          std::pair(cfg::PacketRxReason::L3_MTU_ERROR, kCoppLowPriQueueId),
+          // std::pair(cfg::PacketRxReason::L3_MTU_ERROR, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::L3_SLOW_PATH, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::L3_DEST_MISS, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::TTL_1, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::CPU_IS_NHOP, kCoppLowPriQueueId)};
+  if (hwAsic->isSupported(HwAsic::Feature::L3_MTU_ERROR_TRAP)) {
+    rxReasonToQueueMappings.push_back(
+        std::pair(cfg::PacketRxReason::L3_MTU_ERROR, kCoppLowPriQueueId));
+  }
   for (auto rxEntry : rxReasonToQueueMappings) {
     auto rxReasonToQueue = cfg::PacketRxReasonToQueue();
     rxReasonToQueue.rxReason() = rxEntry.first;


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary
 - Add defensive capability gating in SAI ACL entry programming so unsupported qualifiers/actions are skipped with explicit warning logs instead of causing programming failures.
 - Refine TU1-specific ACL capability behavior, including removing unsupported SET_TC action exposure and filtering unsupported qualifiers from the supported set.
 - Update hostif RX-reason processing to skip L3_MTU_ERROR programming when L3_MTU_ERROR_TRAP is not supported on the target ASIC.
 - Align COPP RX-reason mapping utilities with ASIC capability checks, so L3_MTU_ERROR is only configured when the hardware feature is available.

# Why
 - Prevent runtime failures caused by attempting to program unsupported SAI capabilities on TU1.
 - Make ASIC-specific behavior explicit and consistent across ACL, hostif trap handling, and test utility mapping.
 - Reduce operational risk during platform bring-up and mixed-SDK deployments.

# Test Plan
 - Build and run relevant SAI agent targets to confirm no compile/link regressions.
 - Validate ACL programming on TU1 and confirm unsupported qualifiers/actions are skipped with warning logs.
 - Verify hostif RX-reason updates do not program L3_MTU_ERROR on ASICs without L3_MTU_ERROR_TRAP.
 - Run COPP-related tests/utilities and confirm L3_MTU_ERROR mapping appears only when the capability is supported.
 
 Current limitation:
Testing is currently restricted to SAI_15.1.0.2_EA environment and will be expanded in future iterations
 
[20260505.zip](https://github.com/user-attachments/files/27392883/20260505.zip)
