### PR TITLE
[Nexthop][fboss2-dev] Fixing flaky integration tests

### DIFF
--- a/fboss/cli/fboss2/test/integration_test/ConfigConcurrentSessionsTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigConcurrentSessionsTest.cpp
@@ -9,10 +9,8 @@
  * in-process-CLI limitation where a single process can only track one active
  * session.
  *
- * The path to the fboss2-dev binary is taken from FBOSS2_DEV_PATH (falling
- * back to "fboss2-dev" in PATH). The test is skipped if no such binary is
- * runnable — when the suite is deployed alongside fboss2-dev on the DUT,
- * the caller sets FBOSS2_DEV_PATH explicitly.
+ * The path to the fboss2-dev binary is taken from FBOSS2_DEV_PATH, falling
+ * back to /opt/fboss/bin/fboss2-dev (the deployed location on the DUT).
  *
  * Verifies:
  *   1. User1 opens a session and commits successfully.
@@ -47,7 +45,12 @@ std::string toLower(std::string s) {
 std::string fboss2DevPath() {
   // NOLINTNEXTLINE(concurrency-mt-unsafe)
   const char* env = std::getenv("FBOSS2_DEV_PATH");
-  return env ? env : "fboss2-dev";
+  if (env) {
+    return env;
+  }
+  // folly::Subprocess does not search PATH, so a bare name like "fboss2-dev"
+  // would always fail to exec. Fall back to the deployed location on the DUT.
+  return "/opt/fboss/bin/fboss2-dev";
 }
 } // namespace
 
@@ -108,14 +111,8 @@ class ConfigConcurrentSessionsTest : public Fboss2IntegrationTest {
 };
 
 TEST_F(ConfigConcurrentSessionsTest, ConflictAndRebase) {
-  // Quick sanity check — skip if fboss2-dev is not invokable.
-  {
-    auto probe = runAsUser(user1Home_, {"--help"});
-    if (probe.exitCode != 0) {
-      GTEST_SKIP() << "Cannot exec fboss2-dev (set FBOSS2_DEV_PATH). stderr="
-                   << probe.stderr;
-    }
-  }
+  auto probe = runAsUser(user1Home_, {"--help"});
+  ASSERT_EQ(probe.exitCode, 0) << probe.stderr;
 
   XLOG(INFO) << "[Step 1] Finding test interface...";
   Interface intf = findFirstEthInterface();

--- a/fboss/cli/fboss2/test/integration_test/ConfigPfcTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigPfcTest.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <fmt/format.h>
+#include <folly/String.h>
 #include <folly/json/dynamic.h>
 #include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
@@ -52,11 +53,36 @@ class ConfigPfcTest : public Fboss2IntegrationTest {
  protected:
   std::string bufferPoolName_ = kBufferPoolName;
   std::string policyName_ = kPolicyName;
+  static constexpr auto kSnapshot = "/tmp/cli_e2e_pfc_snapshot.conf";
 
   void SetUp() override {
     Fboss2IntegrationTest::SetUp();
+    auto r = runCmd({"/usr/bin/cp", "/etc/coop/cli/agent.conf", kSnapshot});
+    ASSERT_EQ(r.exitCode, 0) << "snapshot failed: " << r.stderr;
     XLOG(INFO) << "Using buffer-pool: " << bufferPoolName_;
     XLOG(INFO) << "Using pg-policy:  " << policyName_;
+  }
+
+  // Restore the pre-test agent.conf and bounce both agents so polluted PFC
+  // config does not crash the HW agent on a subsequent warm/cold boot via
+  // SaiPortManager::changePfcBuffers (Bug 1 in
+  // fboss2-integration-test-root-cause.md). File-level restore + systemctl
+  // restart bypasses fboss2's `config rollback`, which requires a live
+  // thrift connection that may not be available mid-warmboot.
+  void TearDown() override {
+    runCmd({"/usr/bin/cp", kSnapshot, "/etc/coop/cli/agent.conf"});
+    runCmd(
+        {"/usr/bin/systemctl",
+         "restart",
+         "fboss_hw_agent@0",
+         "fboss_sw_agent"});
+    try {
+      waitForAgentReady();
+    } catch (const std::exception& e) {
+      XLOG(WARN) << "Agent did not recover after restore: " << e.what();
+    }
+    runCmd({"/usr/bin/rm", "-f", kSnapshot});
+    Fboss2IntegrationTest::TearDown();
   }
 
   void configureBufferPool(int sharedBytes, int headroomBytes) {

--- a/fboss/cli/fboss2/test/integration_test/ConfigPortQueueConfigTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigPortQueueConfigTest.cpp
@@ -16,6 +16,7 @@
  * then assigns the policy to an interface and verifies the running config.
  */
 
+#include <folly/String.h>
 #include <folly/json/dynamic.h>
 #include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
@@ -45,11 +46,32 @@ class ConfigPortQueueConfigTest : public Fboss2IntegrationTest {
  protected:
   std::string bufferPoolName_ = kBufferPoolName;
   std::string policyName_ = kQueuingPolicyName;
+  static constexpr auto kSnapshot = "/tmp/cli_e2e_queue_snapshot.conf";
 
   void SetUp() override {
     Fboss2IntegrationTest::SetUp();
+    auto r = runCmd({"/usr/bin/cp", "/etc/coop/cli/agent.conf", kSnapshot});
+    ASSERT_EQ(r.exitCode, 0) << "snapshot failed: " << r.stderr;
     XLOG(INFO) << "Using buffer-pool: " << bufferPoolName_;
     XLOG(INFO) << "Using queuing-policy: " << policyName_;
+  }
+
+  // File-level restore + systemctl restart. See ConfigPfcTest for
+  // rationale.
+  void TearDown() override {
+    runCmd({"/usr/bin/cp", kSnapshot, "/etc/coop/cli/agent.conf"});
+    runCmd(
+        {"/usr/bin/systemctl",
+         "restart",
+         "fboss_hw_agent@0",
+         "fboss_sw_agent"});
+    try {
+      waitForAgentReady();
+    } catch (const std::exception& e) {
+      XLOG(WARN) << "Agent did not recover after restore: " << e.what();
+    }
+    runCmd({"/usr/bin/rm", "-f", kSnapshot});
+    Fboss2IntegrationTest::TearDown();
   }
 
   void configureBufferPool(int sharedBytes, int headroomBytes) {

--- a/fboss/cli/fboss2/test/integration_test/ConfigVlanSwitchportAccessTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigVlanSwitchportAccessTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/logging/xlog.h>
 #include <gtest/gtest.h>
 #include <optional>
+#include <set>
 #include <string>
 #include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
 
@@ -52,7 +53,40 @@ TEST_F(ConfigVlanSwitchportAccessTest, SetAndVerifyAccessVlan) {
   ASSERT_TRUE(originalOpt.has_value())
       << "Port " << intf.name << " has no ingressVlan in running config";
   int originalVlan = *originalOpt;
-  int testVlan = (originalVlan == 4094) ? originalVlan - 1 : originalVlan + 1;
+
+  // Pick a testVlan that is both a real VLAN (sw.vlans[].id) and has an
+  // L3 interface configured (sw.interfaces[].vlanID). Filtering on
+  // sw.interfaces alone is unsafe: non-VLAN-typed interfaces (e.g.
+  // system-port interfaces) appear there with vlanID=0, which the CLI
+  // rejects. Using `originalVlan ± 1` blindly is also unsafe: if that ID
+  // does not exist in sw.vlans / sw.interfaces, the agent's config
+  // validator (`VLAN <id> has no interface, even when corresp port is
+  // enabled`) SIGABRTs on the next warmboot.
+  auto config = getRunningConfig();
+  const auto& sw = config["sw"];
+  std::set<int> realVlans;
+  if (sw.count("vlans")) {
+    for (const auto& v : sw["vlans"]) {
+      if (v.count("id") && !v["id"].isNull()) {
+        realVlans.insert(static_cast<int>(v["id"].asInt()));
+      }
+    }
+  }
+  std::set<int> candidateVlans;
+  if (sw.count("interfaces")) {
+    for (const auto& i : sw["interfaces"]) {
+      if (i.count("vlanID") && !i["vlanID"].isNull()) {
+        int id = static_cast<int>(i["vlanID"].asInt());
+        if (realVlans.count(id)) {
+          candidateVlans.insert(id);
+        }
+      }
+    }
+  }
+  candidateVlans.erase(originalVlan);
+  ASSERT_FALSE(candidateVlans.empty())
+      << "Need at least 2 VLANs with L3 interfaces to test transition";
+  int testVlan = *candidateVlans.begin();
   XLOG(INFO) << "  Using " << intf.name << " (ingressVlan: " << originalVlan
              << " -> " << testVlan << ")";
 

--- a/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
@@ -104,8 +104,7 @@ Fboss2IntegrationTest::Result Fboss2IntegrationTest::executeCliCommand(
 
   // Build argv-style argument list
   // Prepend program name and --fmt json
-  std::vector<std::string> fullArgs = {
-      "fboss2_integration_test", "--fmt", "json"};
+  std::vector<std::string> fullArgs = {"fboss2", "--fmt", "json"};
   fullArgs.insert(fullArgs.end(), args.begin(), args.end());
 
   // Convert to argc/argv format


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Fix three fboss2_integration_test integration tests that don't clean up after themselves on fake-SAI, leading to cascading agent crashes later in the suite (and one outright incorrect test).

- ConfigPfcTest / ConfigPortQueueConfigTest — both tests commit PFC / buffer-pool config and never undo it. Once that lands in agent.conf, a subsequent warmboot in any later test trips a null-deref in SaiPortManager::changePfcBuffers (PG handle absent in fake SAI) and the HW agent SIGSEGVs, dragging the SW agent down with it. Added a SetUp snapshot of /etc/coop/cli/agent.conf and a TearDown that restores the file directly, then systemctl restart fboss_hw_agent@0 fboss_sw_agent and waitForAgentReady(). Tried config rollback <sha> first — unreliable mid-warmboot (Channel got EOF from the rollback's thrift reloadConfig), which left pollution behind.

- ConfigVlanSwitchportAccessTest — picked the new VLAN as originalVlan ± 1, which lands on a non-existent VLAN whenever the random port selection happens to pick the topmost configured port. The agent's config validator then SIGABRTs on the next init: VLAN <id> has no interface, even when corresp port is enabled. Replaced with a lookup that picks from the set of VLANs that actually have an L3 interface (sw.interfaces[].vlanID).
# Test Plan
Existing integration tests.

- Fboss2IntegrationTest -- executeCli was falsely calling fboss2_integration_test for show command check.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
