### PR TITLE
[Minipack3n] platform: Add NETLAKE versioned support for 4.1.2/4.2.1/4.2.2

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -119,6 +119,48 @@
   "i2cAdaptersFromCpu": [
     "CPU_BUS@0"
   ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x11",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x22",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x45",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x66",
+              "kernelDeviceName": "tda38640",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR4"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x76",
+              "kernelDeviceName": "xdpe15284",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR5"
+            }
+          ]
+        },
+        "productSubVersion": 1
+      }
+    ]
+  },
   "pmUnitConfigs": {
     "MINIPACK3N_MCB": {
       "pluggedInSlotType": "MCB_SLOT",

--- a/fboss/platform/configs/minipack3n/sensor_service.json
+++ b/fboss/platform/configs/minipack3n/sensor_service.json
@@ -915,7 +915,7 @@
           "compute": "@/1000000"
         },
         {
-          "name": "COME_PU41_P1V05_STBY_POUT",
+          "name": "COME_PU41_PVDDQ_ABC_CPU_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
           "type": 0,
           "thresholds": {
@@ -979,7 +979,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU42_P1V05_STBY_POUT",
+          "name": "COME_PU42_PVCCANCPU_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
           "type": 0,
           "thresholds": {
@@ -1019,28 +1019,6 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU13_PVCCIN_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 2.2,
-            "maxAlarmVal": 2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "COME_PU13_P1V8_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 2.2,
-            "maxAlarmVal": 2,
-            "lowerCriticalVal": 1.4
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU13_PVCCIN_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/temp1_input",
           "type": 3,
@@ -1070,24 +1048,6 @@
           "compute": "@/1000000"
         },
         {
-          "name": "COME_PU13_PVCCIN_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 1024
-          },
-          "compute": "@/1000000"
-        },
-        {
-          "name": "COME_PU13_P1V8_POUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
-          "type": 0,
-          "thresholds": {
-            "maxAlarmVal": 125
-          },
-          "compute": "@/1000000"
-        },
-        {
           "name": "COME_PU13_PVCCIN_IIN",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr1_input",
           "type": 2,
@@ -1096,26 +1056,209 @@
             "maxAlarmVal": 12
           },
           "compute": "@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power4_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 2,
+          "productSubVersion": 1
         },
         {
-          "name": "COME_PU13_PVCCIN_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 130,
-            "maxAlarmVal": 94
-          },
-          "compute": "@/1000"
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 1,
+          "productSubVersion": 2
         },
         {
-          "name": "COME_PU13_P1V8_IOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
-          "type": 2,
-          "thresholds": {
-            "upperCriticalVal": 6,
-            "maxAlarmVal": 3
-          },
-          "compute": "@/1000"
+          "sensors": [
+            {
+              "name": "COME_PU13_PVCCIN_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 2.2,
+                "maxAlarmVal": 2,
+                "lowerCriticalVal": 1.4
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power2_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 1024
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_P1V8_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/power3_input",
+              "type": 0,
+              "thresholds": {
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU13_PVCCIN_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 94
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU13_P1V8_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR5/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 6,
+                "maxAlarmVal": 3
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 4,
+          "productVersion": 2,
+          "productSubVersion": 2
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary:
Introduce configuration support for alternative (2nd source) chips with interchangeable compatibility, ensuring proper functionality across different hardware variants.

### Changes:
Updated configuration for platform_manager and sensor_service to support NETLAKE 2nd source components on the minipack3n platform.

platform_manager:
  Added NETLAKE VersionedPmUnit Config entries for productSubVersion 1.
sensor_service:
  Introduced versionedSensors to distinguish between NETLAKE versions: 4.1.2, 4.2.1, and 4.2.2.

# Test Plan:
Hardware Verification: Verified on minipack3n devices equipped with each NETLAKE v4.1.2, v4.2.1 and v4.2.2
 - platform_manager started and initialized correctly.
 [mp3n_platform_manager_4.1.2.txt](https://github.com/user-attachments/files/27405207/mp3n_platform_manager_4.1.2.txt)
[mp3n_platform_manager_4.2.1.txt](https://github.com/user-attachments/files/27405208/mp3n_platform_manager_4.2.1.txt)
[mp3n_platform_manager_4.2.2.txt](https://github.com/user-attachments/files/27405210/mp3n_platform_manager_4.2.2.txt)
 - sensor_service correctly identified and resolved versioned configs: 
 Resolved to versionedPmSensors (v4.1.2/v4.2.1/ v4.2.2) for NETLAKE at /SCM_SLOT@0/COMESE_SLOT@0
 [mp3n_sensor_service_4.1.2.txt](https://github.com/user-attachments/files/27405212/mp3n_sensor_service_4.1.2.txt)
[mp3n_sensor_service_4.2.1.txt](https://github.com/user-attachments/files/27405213/mp3n_sensor_service_4.2.1.txt)
[mp3n_sensor_service_4.2.2.txt](https://github.com/user-attachments/files/27405214/mp3n_sensor_service_4.2.2.txt)
 - Executed sensor_service_hw_test; all test cases passed.
 [mp3n_sensor_service_hw_test_4.1.2.txt](https://github.com/user-attachments/files/27405220/mp3n_sensor_service_hw_test_4.1.2.txt)
[mp3n_sensor_service_hw_test_4.2.1.txt](https://github.com/user-attachments/files/27405221/mp3n_sensor_service_hw_test_4.2.1.txt)
[mp3n_sensor_service_hw_test_4.2.2.txt](https://github.com/user-attachments/files/27405222/mp3n_sensor_service_hw_test_4.2.2.txt)
 - sensor_service_client test cases passed
[mp3n_sensor_service_client_4.1.2.txt](https://github.com/user-attachments/files/27405216/mp3n_sensor_service_client_4.1.2.txt)
[mp3n_sensor_service_client_4.2.1.txt](https://github.com/user-attachments/files/27405217/mp3n_sensor_service_client_4.2.1.txt)
[mp3n_sensor_service_client_4.2.2.txt](https://github.com/user-attachments/files/27405219/mp3n_sensor_service_client_4.2.2.txt)