### PR TITLE
[Accton] minipack3ba: sensor_service: Add sensor thresholds across COME/PSU/SMB

### DIFF
--- a/fboss/platform/configs/minipack3ba/sensor_service.json
+++ b/fboss/platform/configs/minipack3ba/sensor_service.json
@@ -915,7 +915,7 @@
           "compute": "@/1000000"
         },
         {
-          "name": "COME_PU41_TDA38640_P1V05_STBY_POUT",
+          "name": "COME_PU41_TDA38640_PVDDQ_ABC_CPU_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR3/power2_input",
           "type": 0,
           "thresholds": {
@@ -979,7 +979,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU42_TDA38640_P1V05_STBY_POUT",
+          "name": "COME_PU42_TDA38640_PVCCANCPU_POUT",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR4/power2_input",
           "type": 0,
           "thresholds": {
@@ -1433,12 +1433,24 @@
         {
           "name": "PSU1_FAN_F_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/fan1_input",
-          "type": 4
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 33000,
+            "maxAlarmVal": 29500,
+            "minAlarmVal": 4000,
+            "lowerCriticalVal": 3600
+          }
         },
         {
           "name": "PSU1_FAN_R_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/fan2_input",
-          "type": 4
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 32670,
+            "maxAlarmVal": 28350,
+            "minAlarmVal": 4000,
+            "lowerCriticalVal": 3600
+          }
         },
         {
           "name": "PSU1_TEMP1",
@@ -1597,12 +1609,24 @@
         {
           "name": "PSU2_FAN_F_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/fan1_input",
-          "type": 4
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 33000,
+            "maxAlarmVal": 29500,
+            "minAlarmVal": 4000,
+            "lowerCriticalVal": 3600
+          }
         },
         {
           "name": "PSU2_FAN_R_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/fan2_input",
-          "type": 4
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 32670,
+            "maxAlarmVal": 28350,
+            "minAlarmVal": 4000,
+            "lowerCriticalVal": 3600
+          }
         },
         {
           "name": "PSU2_TEMP1",
@@ -2088,6 +2112,10 @@
           "name": "SMB_VDDC_VRM_PIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM1/power1_input",
           "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 660,
+            "maxAlarmVal": 580
+          },
           "compute": "@/1000000"
         },
         {
@@ -2127,6 +2155,10 @@
           "name": "SMB_0V75_0V9_R_VRM1_PIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM2/power1_input",
           "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 99,
+            "maxAlarmVal": 91.7
+          },
           "compute": "@/1000000"
         },
         {
@@ -2145,6 +2177,10 @@
           "name": "SMB_0V75_0V9_R_VRM1_IIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM2/curr1_input",
           "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 8.3,
+            "maxAlarmVal": 7.6
+          },
           "compute": "@/1000"
         },
         {
@@ -2163,6 +2199,10 @@
           "name": "SMB_0V75_0V9_L_VRM0_PIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/power1_input",
           "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 99,
+            "maxAlarmVal": 91.7
+          },
           "compute": "@/1000000"
         },
         {
@@ -2181,6 +2221,10 @@
           "name": "SMB_0V75_0V9_L_VRM0_IIN",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/curr1_input",
           "type": 2,
+          "thresholds": {
+            "upperCriticalVal": 8.3,
+            "maxAlarmVal": 7.6
+          },
           "compute": "@/1000"
         },
         {


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary:
Add threshold definitions including upperCriticalVal,maxAlarmVal, and where applicable, lower limits (minAlarmVal,lowerCriticalVal) for voltage, current, power, and temperature monitoring across all subsystems.

### Changes:
sensor_service.json

- Power/Voltage Sensors: 
Added upperCriticalVal and maxAlarmVal thresholds for voltage, current,
and power monitoring across COME, PSU, and SMB subsystems.
- Sensor Naming:
  Corrected COME_PU41/PU42 sensor names.

# Test Plan:
  - sensor_service starts normally and all sensors are correctly discovered.
[mp3ba_sensor_service.txt](https://github.com/user-attachments/files/27428371/mp3ba_sensor_service.txt)
  - sensor_service_client: all test cases passed.
[mp3ba_sensor_service_client.txt](https://github.com/user-attachments/files/27428372/mp3ba_sensor_service_client.txt)
  - sensor_service_hw_test: all test cases passed.
[mp3ba_sensor_service_hw_test.txt](https://github.com/user-attachments/files/27428373/mp3ba_sensor_service_hw_test.txt)