### PR TITLE
[Accton][wedge800cact] CMakeLists.txt : fix TAJO experimental header lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,46 @@ elseif(SAI_BRCM_PAI_IMPL)
   )
   include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR})
   message(STATUS "Found SAI Experimental dir: ${SAI_EXPERIMENTAL_INCLUDE_DIR}")
+elseif(SAI_TAJO_IMPL)
+  # Support run-getdeps include-based staging layouts:
+  # 1) <prefix>/*
+  # 2) <prefix>/experimental/*
+  # Use only Cisco-specific headers (sai_attr_ext.h) as NAMES.
+  # Do NOT use saiswitchextensions.h: it is a standard SAI header that also
+  # exists in the getdeps-installed libsai package, which would cause
+  # find_path to return the libsai prefix instead of the staging dir.
+  find_path(
+    SAI_EXPERIMENTAL_INCLUDE_DIR
+    NAMES
+    sai_attr_ext.h
+    experimental/sai_attr_ext.h
+  )
+  if(SAI_EXPERIMENTAL_INCLUDE_DIR)
+    # If only include/ exists, create experimental -> include so includes
+    # written as <experimental/...> stay valid.
+    if(
+      EXISTS "${SAI_EXPERIMENTAL_INCLUDE_DIR}/include/sai_attr_ext.h"
+      AND NOT EXISTS "${SAI_EXPERIMENTAL_INCLUDE_DIR}/experimental"
+    )
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E create_symlink
+        "${SAI_EXPERIMENTAL_INCLUDE_DIR}/include"
+        "${SAI_EXPERIMENTAL_INCLUDE_DIR}/experimental"
+      )
+    endif()
+
+    # Root path supports includes like <experimental/sai_attr_ext.h>.
+    # /include supports bare includes like <sai_attr_ext.h>.
+    include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR})
+    include_directories(${SAI_EXPERIMENTAL_INCLUDE_DIR}/include)
+    message(STATUS "Found SAI Experimental dir: ${SAI_EXPERIMENTAL_INCLUDE_DIR}")
+  else()
+    message(
+      FATAL_ERROR
+      "Could not find SAI experimental header for TAJO. Expected one of: "
+      "include/sai_attr_ext.h, include/experimental/sai_attr_ext.h"
+    )
+  endif()
 else()
   find_path(SAI_EXPERIMENTAL_INCLUDE_DIR
     NAMES


### PR DESCRIPTION

Add a dedicated SAI_TAJO_IMPL branch to locate Cisco-specific experimental headers from the run-getdeps staging layout. Use sai_attr_ext.h as the lookup key instead of saiswitchextensions.h to avoid accidentally matching the standard libsai install path. Headers included as <experimental/sai_attr_ext.h> and bare include forms can both resolve correctly.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`
$ pre-commit run --files CMakeLists.txt
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
Add a dedicated SAI_TAJO_IMPL branch to locate Cisco-specific experimental headers from the run-getdeps staging layout.

**Cisco's file structure**:
   built-cisco-sai/
  ├── experimental
  │ ├── sai_attr_ext.h    
  │ └── sai_extensions.h
 └── libsai_impl.a

The corresponding path for **run-getdeps.py** is like:
  ./fboss/oss/scripts/run-getdeps.py \
  --npu-sai-impl SAI_TAJO_IMPL \
  --npu-sai-sdk-version $TAJO_SDK_VERSION \
  --npu-libsai-impl-path ${BUILD_FBOSS_WORK_DIR}/**built-cisco-sai/libsai_impl.a** \
  --npu-experiments-path ${BUILD_FBOSS_WORK_DIR}/**built-cisco-sai**/ \
  build  \

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
After patching this, building wedge800cact is ok for FBOSS commit (5/2, 501f093f)

commit 501f093f117635b6825ce6fdba789bad2329a15f (HEAD)
Author: generatedunixname1450902979524814 <noreply+1450902979524814@fb.com>
Date:   Sat May 2 19:21:29 2026 -0700
   Update Stable Commits

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
