### PR TITLE
[Accton][minipack3bta] Refine TU1 feature flags

### DIFF
--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -43,7 +43,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::CPU_QUEUES:
     case HwAsic::Feature::VRF:
     case HwAsic::Feature::SAI_HASH_FIELDS_CLEAR_BEFORE_SET:
-    case HwAsic::Feature::ROUTE_COUNTERS:
     case HwAsic::Feature::ROUTE_FLEX_COUNTERS:
     case HwAsic::Feature::BRIDGE_PORT_8021Q:
     case HwAsic::Feature::FEC_DIAG_COUNTERS:
@@ -63,7 +62,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ECMP_HASH_V6:
     case HwAsic::Feature::FEC_CORRECTED_BITS:
     case HwAsic::Feature::ECMP_MEMBER_WIDTH_INTROSPECTION:
-    case HwAsic::Feature::SAI_MPLS_QOS:
     case HwAsic::Feature::QOS_MAP_GLOBAL:
     case HwAsic::Feature::MACSEC:
     case HwAsic::Feature::SAI_PORT_GET_PMD_LANES:
@@ -71,7 +69,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ROUTE_METADATA:
     case HwAsic::Feature::NON_UNICAST_HASH:
     case HwAsic::Feature::WEIGHTED_NEXTHOPGROUP_MEMBER:
-    case HwAsic::Feature::ARS:
     case HwAsic::Feature::IN_PAUSE_INCREMENTS_DISCARDS:
     case HwAsic::Feature::IN_DISCARDS_EXCLUDES_PFC:
     case HwAsic::Feature::WARMBOOT:
@@ -81,7 +78,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SAI_UDF_HASH:
     case HwAsic::Feature::SEPARATE_BYTE_AND_PACKET_ACL_COUNTER:
     case HwAsic::Feature::ARS_PORT_ATTRIBUTES:
-    case HwAsic::Feature::ARS_ALTERNATE_MEMBERS:
     case HwAsic::Feature::SAI_EAPOL_TRAP:
     case HwAsic::Feature::SAI_USER_DEFINED_TRAP:
     case HwAsic::Feature::ACL_COUNTER_LABEL:
@@ -106,7 +102,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::RX_SERDES_PARAMETERS:
     case HwAsic::Feature::SAI_PORT_IN_CONGESTION_DISCARDS:
     case HwAsic::Feature::TEMPERATURE_MONITORING:
-    case HwAsic::Feature::ACL_SET_ECMP_HASH_ALGORITHM:
     case HwAsic::Feature::SET_NEXT_HOP_GROUP_HASH_ALGORITHM:
     case HwAsic::Feature::SAI_PORT_PG_DROP_STATUS:
     case HwAsic::Feature::SAI_PORT_ERR_STATUS:
@@ -115,6 +110,9 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::BULK_CREATE_ECMP_MEMBER:
     case HwAsic::Feature::ARS_FUTURE_PORT_LOAD:
     case HwAsic::Feature::ECN_PROBABILISTIC_MARKING:
+    case HwAsic::Feature::FEC:
+    case HwAsic::Feature::MEDIA_TYPE:
+    case HwAsic::Feature::ACL_TABLE_GROUP:
       return true;
     case HwAsic::Feature::MIRROR_PACKET_TRUNCATION:
     case HwAsic::Feature::SFLOW_SAMPLING:
@@ -229,14 +227,16 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SRV6_MYSID_RESOURCE_COUNTER:
     case HwAsic::Feature::DEVICE_WATERMARK_SUPPORT:
     // TU1 SDK 15.0/15.1 unsupported features (Accton/Broadcom CSPs)
-    case HwAsic::Feature::FEC:
-    case HwAsic::Feature::MEDIA_TYPE:
     case HwAsic::Feature::BUFFER_POOL:
     case HwAsic::Feature::SAI_PORT_SPEED_CHANGE:
     case HwAsic::Feature::L3_MTU_ERROR_TRAP:
     case HwAsic::Feature::L3_INTF_MTU:
     case HwAsic::Feature::MANAGEMENT_PORT_MULTICAST_QUEUE_ALPHA:
-    case HwAsic::Feature::ACL_TABLE_GROUP:
+    case HwAsic::Feature::ROUTE_COUNTERS:
+    case HwAsic::Feature::SAI_MPLS_QOS:
+    case HwAsic::Feature::ARS:
+    case HwAsic::Feature::ARS_ALTERNATE_MEMBERS:
+    case HwAsic::Feature::ACL_SET_ECMP_HASH_ALGORITHM:
       return false;
   }
   return false;


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

 - Reclassify TU1 feature flags: move ROUTE_COUNTERS, SAI_MPLS_QOS, ARS, ARS_ALTERNATE_MEMBERS, ACL_SET_ECMP_HASH_ALGORITHM to unsupported; move FEC, MEDIA_TYPE, ACL_TABLE_GROUP to supported.

# Test Plan

 - Build SAI agent targets, confirm no compile/link regressions.
 - Testing restricted to SAI_15.1.0.2_EA environment; will expand in future iterations.


