### PR TITLE
[Accton][minipack3bta] Gate L3_MTU_ERROR in BCM COPP test utils when trap not supported

### DIFF
--- a/fboss/agent/test/utils/CoppTestUtils.cpp
+++ b/fboss/agent/test/utils/CoppTestUtils.cpp
@@ -1286,11 +1286,14 @@ std::vector<cfg::PacketRxReasonToQueue> getCoppRxReasonToQueuesForBcm(
           std::pair(cfg::PacketRxReason::ARP, coppHighPriQueueId),
           std::pair(cfg::PacketRxReason::DHCP, coppMidPriQueueId),
           std::pair(cfg::PacketRxReason::BPDU, coppMidPriQueueId),
-          std::pair(cfg::PacketRxReason::L3_MTU_ERROR, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::L3_SLOW_PATH, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::L3_DEST_MISS, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::TTL_1, kCoppLowPriQueueId),
           std::pair(cfg::PacketRxReason::CPU_IS_NHOP, kCoppLowPriQueueId)};
+  if (hwAsic->isSupported(HwAsic::Feature::L3_MTU_ERROR_TRAP)) {
+    rxReasonToQueueMappings.push_back(
+        std::pair(cfg::PacketRxReason::L3_MTU_ERROR, kCoppLowPriQueueId));
+  }
   for (auto rxEntry : rxReasonToQueueMappings) {
     auto rxReasonToQueue = cfg::PacketRxReasonToQueue();
     rxReasonToQueue.rxReason() = rxEntry.first;


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

- Update `getCoppRxReasonToQueuesForBcm()` to conditionally include
  `L3_MTU_ERROR` mapping only when the ASIC supports
  `L3_MTU_ERROR_TRAP`.

# Test Plan

- Run COPP-related tests and confirm `L3_MTU_ERROR` mapping appears
  only when the capability is supported.
- Testing restricted to SAI_15.1.0.2_EA environment; will expand in
  future iterations.
