### PR TITLE
[Accton][minipack3bta] Add minipack3bta test configs with 16-RIF limit for TU1

### DIFF
--- a/fboss/oss/hw_test_configs/minipack3bta_14x400g_1x100g.agent.materialized_JSON
+++ b/fboss/oss/hw_test_configs/minipack3bta_14x400g_1x100g.agent.materialized_JSON
@@ -1,0 +1,1129 @@
+{
+  "defaultCommandLineArgs": {
+    "check_wb_handles": "true",
+    "counter_refresh_interval": "0",
+    "enable_acl_table_group": "false",
+    "log_variable_name": "true",
+    "sai_configure_six_tap": "true",
+    "skip_transceiver_programming": "true",
+    "minipack3bta_16rifs": "true",
+    "use_full_dlb_scale": "true"
+  },
+  "sw": {
+    "version": 0,
+    "ports": [
+
+    ],
+    "vlans": [
+
+    ],
+    "vlanPorts": [
+
+    ],
+    "defaultVlan": 0,
+    "interfaces": [
+
+    ],
+    "arpTimeoutSeconds": 60,
+    "arpRefreshSeconds": 20,
+    "arpAgerInterval": 5,
+    "proactiveArp": false,
+    "staticRoutesWithNhops": [
+
+    ],
+    "staticRoutesToNull": [
+
+    ],
+    "staticRoutesToCPU": [
+
+    ],
+    "acls": [
+
+    ],
+    "maxNeighborProbes": 300,
+    "staleEntryInterval": 10,
+    "aggregatePorts": [
+
+    ],
+    "clientIdToAdminDistance": {
+      "0": 20,
+      "1": 1,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "700": 255,
+      "786": 10
+    },
+    "sFlowCollectors": [
+
+    ],
+    "cpuQueues": [
+
+    ],
+    "loadBalancers": [
+
+    ],
+    "mirrors": [
+
+    ],
+    "trafficCounters": [
+
+    ],
+    "qosPolicies": [
+
+    ],
+    "defaultPortQueues": [
+
+    ],
+    "staticMplsRoutesWithNhops": [
+
+    ],
+    "staticMplsRoutesToNull": [
+
+    ],
+    "staticMplsRoutesToCPU": [
+
+    ],
+    "staticIp2MplsRoutes": [
+
+    ],
+    "portQueueConfigs": {
+
+    },
+    "switchSettings": {
+      "l2LearningMode": 0,
+      "qcmEnable": false,
+      "ptpTcEnable": false,
+      "l2AgeTimerSeconds": 300,
+      "maxRouteCounterIDs": 0,
+      "blockNeighbors": [
+
+      ],
+      "macAddrsToBlock": [
+
+      ],
+      "switchType": 0,
+      "exactMatchTableConfigs": [
+
+      ],
+      "switchIdToSwitchType_DEPRECATED": {
+
+      },
+      "switchDrainState": 0,
+      "switchIdToSwitchInfo": {
+        "0": {
+            "switchType": 0,
+            "asicType": 22,
+            "switchIndex": 0,
+            "portIdRange": {
+              "minimum": 0,
+              "maximum": 2047
+            },
+            "firmwareNameToFirmwareInfo": {
+
+            }
+        }
+      },
+      "vendorMacOuis": [
+
+      ],
+      "metaMacOuis": [
+
+      ],
+      "needL2EntryForNeighbor": true
+    },
+    "aclTableGroup": {
+      "name": "acl-table-group-ingress",
+      "aclTables": [
+        {
+          "name": "AclTable1",
+          "priority": 0,
+          "aclEntries": [
+
+          ],
+          "actionTypes": [
+
+          ],
+          "qualifiers": [
+
+          ],
+          "udfGroups": [
+
+          ]
+        }
+      ],
+      "stage": 0
+    },
+    "sdkVersion": {
+      "asicSdk": "sdk",
+      "saiSdk": "sai"
+    },
+    "dsfNodes": {
+
+    },
+    "defaultVoqConfig": [
+
+    ],
+    "aclTableGroups": [
+      {
+        "name": "acl-table-group-ingress",
+        "aclTables": [
+          {
+            "name": "AclTable1",
+            "priority": 0,
+            "aclEntries": [
+
+            ],
+            "actionTypes": [
+
+            ],
+            "qualifiers": [
+
+            ],
+            "udfGroups": [
+
+            ]
+          }
+        ],
+        "stage": 0
+      }
+    ],
+    "mirrorOnDropReports": [
+
+    ]
+  },
+  "platform": {
+    "chip": {
+      "asicConfig": {
+        "common": {
+          "yamlConfig": "
+---
+device:
+  0:
+    TM_LL_THD_CONFIG:
+      THRESHOLD_MODE: LOSSLESS
+      LLR: 1
+    TM_THD_CONFIG:
+      THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+    PC_PM_CORE:
+      ?
+        PC_PM_ID: 1
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x8C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFF
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 2
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x55
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 3
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x23016745
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x33
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x00
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 4
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x52701634
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAA
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 5
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x74305612
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21640357
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF7
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x59
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 6
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x03562147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x29
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 7
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x14567302
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 8
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x67315024
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217034
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x53
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 9
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x21403765
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20543176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x48
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 10
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x53062147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x69
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 11
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54067312
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 12
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65304721
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x56
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 13
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x21403765
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20543176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x48
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 14
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x53062147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x69
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 15
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54067312
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 16
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65304721
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x56
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 17
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65274130
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x87
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 18
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47306521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 19
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x02731456
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x99
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x07
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 20
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x30472165
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21543076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAD
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 21
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x45376120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 22
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x40376521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x3C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 23
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x02731456
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x99
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x07
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 24
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x30472165
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21543076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAD
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 25
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x45376120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 26
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x40376521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x3C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 27
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x03762514
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDE
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x03
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 28
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x67125403
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x12470356
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x63
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xB2
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 29
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107654
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x22
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 30
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107654
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xCC
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x00
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 31
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x05371426
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x65
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 32
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x56741032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23016745
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x9C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFF
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 33
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x46751032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32106754
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x55
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 34
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54721036
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x22
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 35
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x63410725
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x93
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 36
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107645
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x77
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 37
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x74260351
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x13064257
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xD8
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x21
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 38
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10573246
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x99
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 39
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47356120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 40
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54217630
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x58
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 41
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01736524
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20365174
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x96
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x52
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 42
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10573246
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xD9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 43
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47356120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 44
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54217630
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x58
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 45
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01746523
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20365174
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x86
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x52
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 46
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10576423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xD9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 47
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x46357102
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 48
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54216703
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x54
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 49
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 50
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 51
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x60
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 52
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01572346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21560347
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 53
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 54
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 55
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x60
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 56
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01572346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21560347
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 57
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 58
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 59
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x20
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 60
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x64207531
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23671045
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0B
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xBB
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 61
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x51740362
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB1
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 62
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x23016745
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x66
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 63
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x00
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 64
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23016745
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xD9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 65
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x3210
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x3210
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x00
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x0F
+        TX_POLARITY_FLIP_AUTO: 0
+...
+---
+device:
+    0:
+        FP_CONFIG:
+            FP_LL_ING_OPERMODE: GLOBAL_PIPE_AWARE
+        PC_PORT_PHYS_MAP:
+            ?
+                PORT_ID: 1
+            :
+                PC_PHYS_PORT_ID: 1
+            ?
+                PORT_ID: 3
+            :
+                PC_PHYS_PORT_ID: 5
+            ?
+                PORT_ID: 5
+            :
+                PC_PHYS_PORT_ID: 9
+            ?
+                PORT_ID: 7
+            :
+                PC_PHYS_PORT_ID: 13
+            ?
+                PORT_ID: 9
+            :
+                PC_PHYS_PORT_ID: 17
+            ?
+                PORT_ID: 11
+            :
+                PC_PHYS_PORT_ID: 21
+            ?
+                PORT_ID: 13
+            :
+                PC_PHYS_PORT_ID: 25
+            ?
+                PORT_ID: 15
+            :
+                PC_PHYS_PORT_ID: 29
+            ?
+                PORT_ID: 17
+            :
+                PC_PHYS_PORT_ID: 33
+            ?
+                PORT_ID: 19
+            :
+                PC_PHYS_PORT_ID: 37
+            ?
+                PORT_ID: 21
+            :
+                PC_PHYS_PORT_ID: 41
+            ?
+                PORT_ID: 23
+            :
+                PC_PHYS_PORT_ID: 45
+            ?
+                PORT_ID: 25
+            :
+                PC_PHYS_PORT_ID: 49
+            ?
+                PORT_ID: 27
+            :
+                PC_PHYS_PORT_ID: 53
+...
+---
+device:
+    0:
+        PC_PORT:
+            ?
+                PORT_ID: [[1, 1],
+                       [3, 3],
+                       [5, 5],
+                       [7, 7],
+                       [9, 9],
+                       [11, 11],
+                       [13, 13],
+                       [15, 15],
+                       [17, 17],
+                       [19, 19],
+                       [21, 21],
+                       [23, 23],
+                       [25, 25],
+                       [27, 27]]
+
+            :
+                ENABLE: 0
+                SPEED: 400000
+                NUM_LANES: 4
+                FEC_MODE: PC_FEC_RS544_2XN
+...
+---
+device:
+    0:
+        PC_PORT_PHYS_MAP:
+            ?
+                PORT_ID: 257
+            :
+                PC_PHYS_PORT_ID: 513
+...
+---
+device:
+    0:
+        PC_PORT:
+            ?
+                PORT_ID: 257
+            :
+                ENABLE: 0
+                SPEED: 100000
+                NUM_LANES: 4
+                FEC_MODE: PC_FEC_RS528
+...
+---
+bcm_device:
+    0:
+        global:
+            pktio_mode: 0
+            sai_l3_byte1_udf_disable: 0
+            sai_rdma_udf_disable: 1
+            sai_brcm_sonic_trap_group: 1
+            sai_acl_qset_optimization: 1
+            sai_field_group_auto_prioritize: 1
+            mmu_canned_config: 0
+            mmu_canned_config_stat: 0
+            pfc_deadlock_seq_control : 1
+            sai_vfp_smac_drop_filter_disable : 1
+...
+---
+device:
+    0:
+        DEVICE_CONFIG:
+            AUTOLOAD_BOARD_SETTINGS: 0
+...
+"
+        }
+      }
+    }
+  },
+  "thriftApiToRateLimitInQps": {
+
+  }
+}

--- a/fboss/oss/link_test_configs/minipack3bta_12x400g_1x100g.materialized_JSON
+++ b/fboss/oss/link_test_configs/minipack3bta_12x400g_1x100g.materialized_JSON
@@ -1,0 +1,2162 @@
+{
+  "defaultCommandLineArgs": {
+    "check_wb_handles": "true",
+    "counter_refresh_interval": "0",
+    "disable_neighbor_updates": "true",
+    "ecmp_width": "256",
+    "enable_replayer": "true",
+    "intf_nbr_tables": "true",
+    "log_variable_name": "true",
+    "sai_user_defined_trap": "false",
+    "minipack3bta_16rifs": "true",
+    "sai_configure_six_tap": "true"
+  },
+  "sw": {
+    "version": 0,
+    "ports": [
+      {
+        "logicalID": 5,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2001,
+        "speed": 400000,
+        "name": "eth1/1/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/1/5"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 7,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2002,
+        "speed": 400000,
+        "name": "eth1/1/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/1/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 1,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2003,
+        "speed": 400000,
+        "name": "eth1/2/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/2/5"
+        },
+        "lookupClasses": [
+
+    ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 3,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "routable": true,
+        "ingressVlan": 2004,
+        "speed": 400000,
+        "name": "eth1/2/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/2/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 9,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2005,
+        "speed": 400000,
+        "name": "eth1/3/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/3/5"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 11,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2006,
+        "speed": 400000,
+        "name": "eth1/3/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/3/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 13,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2007,
+        "speed": 400000,
+        "name": "eth1/4/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/4/5"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 15,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2008,
+        "speed": 400000,
+        "name": "eth1/4/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/4/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 17,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2009,
+        "speed": 400000,
+        "name": "eth1/5/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/5/5"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 19,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2010,
+        "speed": 400000,
+        "name": "eth1/5/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/5/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+
+
+      {
+        "logicalID": 21,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2011,
+        "speed": 400000,
+        "name": "eth1/6/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/6/5"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 23,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2012,
+        "speed": 400000,
+        "name": "eth1/6/5",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/6/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 38,
+        "portType": 0,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      },
+      {
+        "logicalID": 257,
+        "state": 2,
+        "minFrameSize": 64,
+        "maxFrameSize": 9412,
+        "parserType": 1,
+        "routable": true,
+        "ingressVlan": 2200,
+        "speed": 100000,
+        "name": "eth1/65/1",
+        "description": "",
+        "queues_DEPRECATED": [
+
+        ],
+        "pause": {
+          "tx": false,
+          "rx": false
+        },
+        "sFlowIngressRate": 0,
+        "sFlowEgressRate": 0,
+        "loopbackMode": 0,
+        "expectedLLDPValues": {
+          "2": "eth1/65/1"
+        },
+        "lookupClasses": [
+
+        ],
+        "profileID": 23,
+        "portType": 4,
+        "expectedNeighborReachability": [
+
+        ],
+        "drainState": 0,
+        "scope": 0,
+        "conditionalEntropyRehash": false
+      }
+    ],
+    "vlans": [
+      {
+        "name": "fbossLoopback0",
+        "id": 10,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "default",
+        "id": 4094,
+        "recordStats": true,
+        "routable": false,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2001",
+        "id": 2001,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2002",
+        "id": 2002,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2003",
+        "id": 2003,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2004",
+        "id": 2004,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2005",
+        "id": 2005,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2006",
+        "id": 2006,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2007",
+        "id": 2007,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2008",
+        "id": 2008,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2009",
+        "id": 2009,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2010",
+        "id": 2010,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2011",
+        "id": 2011,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2012",
+        "id": 2012,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      },
+      {
+        "name": "vlan2200",
+        "id": 2200,
+        "recordStats": true,
+        "routable": true,
+        "ipAddresses": [
+
+        ]
+      }
+    ],
+    "vlanPorts": [
+      {
+        "vlanID": 2001,
+        "logicalPort": 5,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2002,
+        "logicalPort": 7,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+
+      {
+        "vlanID": 2003,
+        "logicalPort": 1,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2004,
+        "logicalPort": 3,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2005,
+        "logicalPort": 9,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2006,
+        "logicalPort": 11,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2007,
+        "logicalPort": 13,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2008,
+        "logicalPort": 15,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2009,
+        "logicalPort": 17,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2010,
+        "logicalPort": 19,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2011,
+        "logicalPort": 21,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2012,
+        "logicalPort": 23,
+        "spanningTreeState": 2,
+        "emitTags": false
+      },
+      {
+        "vlanID": 2200,
+        "logicalPort": 257,
+        "spanningTreeState": 2,
+        "emitTags": false
+      }
+    ],
+    "defaultVlan": 4094,
+    "interfaces": [
+      {
+        "intfID": 2001,
+        "routerID": 0,
+        "vlanID": 2001,
+        "ipAddresses": [
+          "2400::/64",
+          "10.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2002,
+        "routerID": 0,
+        "vlanID": 2002,
+        "ipAddresses": [
+          "2401::/64",
+          "11.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2003,
+        "routerID": 0,
+        "vlanID": 2003,
+        "ipAddresses": [
+          "2402::/64",
+          "12.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2004,
+        "routerID": 0,
+        "vlanID": 2004,
+        "ipAddresses": [
+          "2403::/64",
+          "13.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2005,
+        "routerID": 0,
+        "vlanID": 2005,
+        "ipAddresses": [
+          "2404::/64",
+          "14.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2006,
+        "routerID": 0,
+        "vlanID": 2006,
+        "ipAddresses": [
+          "2405::/64",
+          "15.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2007,
+        "routerID": 0,
+        "vlanID": 2007,
+        "ipAddresses": [
+          "2406::/64",
+          "16.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2008,
+        "routerID": 0,
+        "vlanID": 2008,
+        "ipAddresses": [
+          "2407::/64",
+          "17.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2009,
+        "routerID": 0,
+        "vlanID": 2009,
+        "ipAddresses": [
+          "2408::/64",
+          "18.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2010,
+        "routerID": 0,
+        "vlanID": 2010,
+        "ipAddresses": [
+          "2409::/64",
+          "19.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2011,
+        "routerID": 0,
+        "vlanID": 2011,
+        "ipAddresses": [
+          "2410::/64",
+          "20.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2012,
+        "routerID": 0,
+        "vlanID": 2012,
+        "ipAddresses": [
+          "2411::/64",
+          "21.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": false,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 2200,
+        "routerID": 0,
+        "vlanID": 2200,
+        "ipAddresses": [
+          "2414::/64",
+          "24.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": true,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      },
+      {
+        "intfID": 10,
+        "routerID": 0,
+        "vlanID": 10,
+        "ipAddresses": [
+          "2527::/64",
+          "137.0.0.0/24"
+        ],
+        "mtu": 9000,
+        "isVirtual": true,
+        "isStateSyncDisabled": true,
+        "type": 1,
+        "scope": 0
+      }
+    ],
+    "arpTimeoutSeconds": 60,
+    "arpRefreshSeconds": 20,
+    "arpAgerInterval": 5,
+    "proactiveArp": false,
+    "staticRoutesWithNhops": [
+
+    ],
+    "staticRoutesToNull": [
+
+    ],
+    "staticRoutesToCPU": [
+
+    ],
+    "acls": [
+    ],
+    "maxNeighborProbes": 300,
+    "staleEntryInterval": 10,
+    "aggregatePorts": [
+
+    ],
+    "clientIdToAdminDistance": {
+      "0": 20,
+      "1": 1,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "700": 255,
+      "786": 10
+    },
+    "sFlowCollectors": [
+
+    ],
+    "cpuQueues": [
+      {
+        "id": 9,
+        "streamType": 1,
+        "scheduling": 1,
+        "name": "cpuQueue-high"
+      },
+      {
+        "id": 2,
+        "streamType": 1,
+        "scheduling": 1,
+        "name": "cpuQueue-mid"
+      },
+      {
+        "id": 1,
+        "streamType": 1,
+        "scheduling": 1,
+        "name": "cpuQueue-default",
+        "portQueueRate": {
+          "pktsPerSec": {
+            "minimum": 0,
+            "maximum": 1000
+          }
+        }
+      },
+      {
+        "id": 0,
+        "streamType": 1,
+        "scheduling": 1,
+        "name": "cpuQueue-low",
+        "portQueueRate": {
+          "pktsPerSec": {
+            "minimum": 0,
+            "maximum": 500
+          }
+        }
+      }
+    ],
+    "cpuTrafficPolicy": {
+      "trafficPolicy": {},
+      "rxReasonToQueueOrderedList": [
+        {
+          "rxReason": 8,
+          "queueId": 9
+        },
+        {
+          "rxReason": 1,
+          "queueId": 9
+        },
+        {
+          "rxReason": 10,
+          "queueId": 9
+        },
+        {
+          "rxReason": 11,
+          "queueId": 9
+        },
+        {
+          "rxReason": 12,
+          "queueId": 9
+        },
+        {
+          "rxReason": 13,
+          "queueId": 9
+        },
+        {
+          "rxReason": 9,
+          "queueId": 2
+        },
+        {
+          "rxReason": 7,
+          "queueId": 2
+        },
+        {
+          "rxReason": 2,
+          "queueId": 2
+        },
+        {
+          "rxReason": 17,
+          "queueId": 2
+        },
+        {
+          "rxReason": 6,
+          "queueId": 0
+        },
+        {
+          "rxReason": 0,
+          "queueId": 1
+        }
+      ]
+    },
+    "loadBalancers": [
+      {
+        "id": 1,
+        "fieldSelection": {
+          "ipv4Fields": [
+            1,
+            2
+          ],
+          "ipv6Fields": [
+            1,
+            2
+          ],
+          "transportFields": [
+            1,
+            2
+          ],
+          "mplsFields": [
+
+          ],
+          "udfGroups": [
+
+          ]
+        },
+        "algorithm": 1
+      },
+      {
+        "id": 2,
+        "fieldSelection": {
+          "ipv4Fields": [
+            1,
+            2
+          ],
+          "ipv6Fields": [
+            1,
+            2
+          ],
+          "transportFields": [
+
+    ],
+          "mplsFields": [
+
+          ],
+          "udfGroups": [
+
+          ]
+        },
+        "algorithm": 1
+      }
+    ],
+    "dataPlaneTrafficPolicy": {
+      "matchToAction": [
+        {
+          "matcher": "ttld-prod-private",
+          "action": {
+            "counter": "ttld-prod-private"
+          }
+        },
+        {
+          "matcher": "ttld-prod-public",
+          "action": {
+            "counter": "ttld-prod-public"
+          }
+        },
+        {
+          "matcher": "ttld-ip-per-task",
+          "action": {
+            "counter": "ttld-ip-per-task"
+          }
+        },
+        {
+          "matcher": "ttld-onavo-infra",
+          "action": {
+            "counter": "ttld-onavo-infra"
+          }
+        },
+        {
+          "matcher": "ttld-interconnect",
+          "action": {
+            "counter": "ttld-interconnect"
+          }
+        }
+      ]
+    },
+    "mirrors": [
+
+    ],
+    "trafficCounters": [
+      {
+        "name": "ttld-prod-private",
+        "types": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "ttld-prod-public",
+        "types": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "ttld-ip-per-task",
+        "types": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "ttld-onavo-infra",
+        "types": [
+          0,
+          1
+        ]
+      },
+      {
+        "name": "ttld-interconnect",
+        "types": [
+          0,
+          1
+        ]
+      }
+    ],
+    "qosPolicies": [
+
+    ],
+    "defaultPortQueues": [
+
+    ],
+    "staticMplsRoutesWithNhops": [
+
+    ],
+    "staticMplsRoutesToNull": [
+
+    ],
+    "staticMplsRoutesToCPU": [
+
+    ],
+    "staticIp2MplsRoutes": [
+
+    ],
+    "portQueueConfigs": {
+
+    },
+    "switchSettings": {
+      "l2LearningMode": 0,
+      "qcmEnable": false,
+      "ptpTcEnable": false,
+      "l2AgeTimerSeconds": 300,
+      "maxRouteCounterIDs": 0,
+      "blockNeighbors": [
+
+      ],
+      "macAddrsToBlock": [
+
+      ],
+      "switchType": 0,
+      "exactMatchTableConfigs": [
+
+      ],
+      "switchIdToSwitchType_DEPRECATED": {
+
+      },
+      "switchDrainState": 0,
+      "switchIdToSwitchInfo": {
+        "0": {
+            "switchType": 0,
+            "asicType": 22,
+            "switchIndex": 0,
+            "portIdRange": {
+              "minimum": 0,
+              "maximum": 2047
+            },
+            "firmwareNameToFirmwareInfo": {
+
+            }
+        }
+      },
+      "vendorMacOuis": [
+
+      ],
+      "metaMacOuis": [
+
+      ]
+    },
+    "sdkVersion": {
+      "asicSdk": "sdk",
+      "saiSdk": "sai"
+    },
+    "dsfNodes": {
+
+    },
+    "defaultVoqConfig": [
+
+    ],
+    "mirrorOnDropReports": [
+
+    ]
+  },
+  "platform": {
+    "chip": {
+      "asicConfig": {
+        "common": {
+          "yamlConfig": "
+---
+device:
+  0:
+    TM_LL_THD_CONFIG:
+      THRESHOLD_MODE: LOSSLESS
+      LLR: 1
+    TM_THD_CONFIG:
+      THRESHOLD_MODE: LOSSY_AND_LOSSLESS
+    PC_PM_CORE:
+      ?
+        PC_PM_ID: 1
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x8C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFF
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 2
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x55
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 3
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x23016745
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x33
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x00
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 4
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x52701634
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAA
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 5
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x74305612
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21640357
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF7
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x59
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 6
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x03562147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x29
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 7
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x14567302
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 8
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x67315024
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217034
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x53
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 9
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x21403765
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20543176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x48
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 10
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x53062147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x69
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 11
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54067312
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 12
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65304721
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x56
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 13
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x21403765
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20543176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x48
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 14
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x53062147
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30742165
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x48
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x69
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 15
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54067312
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56712430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xAF
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 16
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65304721
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56217430
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDD
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x56
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 17
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x65274130
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x87
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 18
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47306521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 19
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x02731456
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x99
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x07
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 20
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x30472165
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21543076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAD
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 21
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x45376120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 22
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x40376521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x3C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 23
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x02731456
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x99
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x07
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 24
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x30472165
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21543076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x6C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAD
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 25
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x45376120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56207431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA7
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 26
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x40376521
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x76305412
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x3C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x86
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 27
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x03762514
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21345076
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xDE
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x03
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 28
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x67125403
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x12470356
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x63
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xB2
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 29
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107654
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x22
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 30
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107654
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xCC
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x00
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 31
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x05371426
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x65
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 32
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x56741032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23016745
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x9C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xFF
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 33
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x46751032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32106754
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x55
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 34
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54721036
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x22
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 35
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x63410725
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x93
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 36
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32107645
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x77
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xCC
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 37
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x74260351
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x13064257
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xD8
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x21
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 38
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10573246
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x99
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 39
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47356120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 40
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54217630
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x58
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 41
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01736524
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20365174
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x96
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x52
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 42
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10573246
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xD9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 43
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x47356120
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 44
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54217630
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x58
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 45
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01746523
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20365174
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x86
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x52
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 46
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x10576423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x30762145
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC6
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xD9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 47
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x46357102
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x56702431
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x2D
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x8F
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 48
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75016423
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54216703
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xC9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x54
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 49
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 50
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 51
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x60
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 52
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01572346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21560347
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 53
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 54
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 55
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x60
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 56
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x01572346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x21560347
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0C
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xA9
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 57
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x57032146
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54702631
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xED
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 58
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x75102346
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x74305612
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xF3
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 59
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x32610754
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x20345176
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x95
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x20
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 60
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x64207531
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23671045
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x0B
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xBB
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 61
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x51740362
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xB1
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 62
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x23016745
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x54761032
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x66
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 63
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x32107654
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x00
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x66
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 64
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x54761032
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x23016745
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0xD9
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0xAA
+        TX_POLARITY_FLIP_AUTO: 0
+      ?
+        PC_PM_ID: 65
+        CORE_INDEX: 0
+      :
+        RX_LANE_MAP: 0x3210
+        RX_LANE_MAP_AUTO: 0
+        TX_LANE_MAP: 0x3210
+        TX_LANE_MAP_AUTO: 0
+        RX_POLARITY_FLIP: 0x00
+        RX_POLARITY_FLIP_AUTO: 0
+        TX_POLARITY_FLIP: 0x0F
+        TX_POLARITY_FLIP_AUTO: 0
+...
+---
+device:
+    0:
+        FP_CONFIG:
+            FP_LL_ING_OPERMODE: GLOBAL_PIPE_AWARE
+        PC_PORT_PHYS_MAP:
+            ?
+                PORT_ID: 1
+            :
+                PC_PHYS_PORT_ID: 1
+            ?
+                PORT_ID: 3
+            :
+                PC_PHYS_PORT_ID: 5
+            ?
+                PORT_ID: 5
+            :
+                PC_PHYS_PORT_ID: 9
+            ?
+                PORT_ID: 7
+            :
+                PC_PHYS_PORT_ID: 13
+            ?
+                PORT_ID: 9
+            :
+                PC_PHYS_PORT_ID: 17
+            ?
+                PORT_ID: 11
+            :
+                PC_PHYS_PORT_ID: 21
+            ?
+                PORT_ID: 13
+            :
+                PC_PHYS_PORT_ID: 25
+            ?
+                PORT_ID: 15
+            :
+                PC_PHYS_PORT_ID: 29
+            ?
+                PORT_ID: 17
+            :
+                PC_PHYS_PORT_ID: 33
+            ?
+                PORT_ID: 19
+            :
+                PC_PHYS_PORT_ID: 37
+            ?
+                PORT_ID: 21
+            :
+                PC_PHYS_PORT_ID: 41
+            ?
+                PORT_ID: 23
+            :
+                PC_PHYS_PORT_ID: 45
+            ?
+                PORT_ID: 25
+            :
+                PC_PHYS_PORT_ID: 49
+            ?
+                PORT_ID: 27
+            :
+                PC_PHYS_PORT_ID: 53
+...
+---
+device:
+    0:
+        PC_PORT:
+            ?
+                PORT_ID: [[1, 1],
+                       [3, 3],
+                       [5, 5],
+                       [7, 7],
+                       [9, 9],
+                       [11, 11],
+                       [13, 13],
+                       [15, 15],
+                       [17, 17],
+                       [19, 19],
+                       [21, 21],
+                       [23, 23],
+                       [25, 25],
+                       [27, 27]]
+
+            :
+                ENABLE: 0
+                SPEED: 400000
+                NUM_LANES: 4
+                FEC_MODE: PC_FEC_RS544_2XN
+...
+---
+device:
+    0:
+        PC_PORT_PHYS_MAP:
+            ?
+                PORT_ID: 257
+            :
+                PC_PHYS_PORT_ID: 513
+...
+---
+device:
+    0:
+        PC_PORT:
+            ?
+                PORT_ID: 257
+            :
+                ENABLE: 0
+                SPEED: 100000
+                NUM_LANES: 4
+                FEC_MODE: PC_FEC_RS528
+...
+---
+bcm_device:
+    0:
+        global:
+            pktio_mode: 0
+            sai_l3_byte1_udf_disable: 0
+            sai_rdma_udf_disable: 1
+            sai_brcm_sonic_trap_group: 1
+            sai_acl_qset_optimization: 1
+            sai_field_group_auto_prioritize: 1
+            mmu_canned_config: 0
+            mmu_canned_config_stat: 0
+            pfc_deadlock_seq_control : 1
+            sai_vfp_smac_drop_filter_disable : 1
+...
+---
+device:
+    0:
+        DEVICE_CONFIG:
+            AUTOLOAD_BOARD_SETTINGS: 0
+...
+"
+        }
+      }
+    }
+  },
+  "thriftApiToRateLimitInQps": {
+
+  }
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

Ad HW agent test and link test configs for minipack3bta platform, constrained to the 16-RIF hardware limit on TU1.
 - hw_test_configs/minipack3bta_14x400g_1x100g.agent.materialized_JSON: 14x400G + 1x100G agent test config.
 - link_test_configs/minipack3bta_12x400g_1x100g.materialized_JSON: 12x400G + 1x100G link test config.

# Test Plan

 - Deploy configs on minipack3bta with TU1 ASIC and confirm agent/link tests pass without RIF allocation failures.
 - Verify no more than 16 RIFs are programmed during test execution.
