### PR TITLE
[Accton][minipack3bta] Add --extra-gflags pass-through to run_test.py

### DIFF
--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -266,6 +266,15 @@ class TestRunner(abc.ABC):
         self._known_bad_test_regexes = None
         self._unsupported_test_regexes = None
 
+    def _get_common_gflags(self) -> list[str]:
+        """
+        Return pass-through gflags appended to every test binary invocation.
+        No parsing or validation - just forward whatever the user provides.
+        """
+        if hasattr(args, "extra_gflags") and args.extra_gflags:
+            return args.extra_gflags.split()
+        return []
+
     @abc.abstractmethod
     def _get_config_path(self):
         pass
@@ -342,6 +351,7 @@ class TestRunner(abc.ABC):
         if args.fruid_path is not None:
             run_cmd.append("--fruid_filepath=" + args.fruid_path)
         run_cmd += self._get_test_run_args(conf_file)
+        run_cmd += self._get_common_gflags()
 
         return run_cmd + flags if flags else run_cmd
 
@@ -2405,6 +2415,17 @@ if __name__ == "__main__":
             + "=/opt/fboss/share/fsdb_test_configs/meru800bia.materialized_JSON"
         ),
         default=None,
+    )
+    # --- Pass-through gflags for test binaries ---
+    ap.add_argument(
+        "--extra-gflags",
+        type=str,
+        default=None,
+        help=(
+            "Pass-through flags appended to every test binary invocation. "
+            "Use = to attach value (required when value starts with --). "
+            "Example: --extra-gflags='--asic_feature_support_overrides=73=false --v=2'"
+        ),
     )
     # Add subparsers for different test types
     subparsers = ap.add_subparsers()


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

Add --extra-gflags argument to run_test.py for forwarding arbitrary gflags to test binaries without modifying run_test.py itself. This enables passing runtime flags (e.g., --asic_feature_support_overrides) directly to binaries.

Use = to attach value when it starts with --:
  --extra-gflags="--asic_feature_support_overrides=73=false --v=2"

Changes:
- Add _get_common_gflags() method in TestRunner base class
- Inject common gflags into _get_test_run_cmd() for all test runners
- Add --extra-gflags argument to the argument parser

# Test Plan

- Run run_test.py sai without --extra-gflags: no behavioral change
- Run with --extra-gflags="--v=2": confirm flag appears in binary command
- Run with --extra-gflags="--asic_feature_support_overrides=73=false": confirm override flag forwarded correctly
- Verify --extra-gflags can be placed at any position in the command line
