### PR TITLE
[Accton][minipack3bta] Add runtime asic feature support override via gflag

### DIFF
--- a/fboss/agent/hw/switch_asics/HwAsic.cpp
+++ b/fboss/agent/hw/switch_asics/HwAsic.cpp
@@ -8,7 +8,12 @@
  *
  */
 #include "fboss/agent/hw/switch_asics/HwAsic.h"
+#include <folly/logging/xlog.h>
 #include <thrift/lib/cpp/util/EnumUtils.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/hw/switch_asics/Agera3PhyAsic.h"
 #include "fboss/agent/hw/switch_asics/Chenab2Asic.h"
@@ -35,6 +40,10 @@
 
 DEFINE_int32(acl_gid, -1, "Content aware processor group ID for ACLs");
 DEFINE_int32(teFlow_gid, -1, "Exact Match group ID for TeFlows");
+DEFINE_string(
+    asic_feature_support_overrides,
+    "",
+    "Comma-separated feature overrides in the format FEATURE_ID=true|false");
 
 namespace {
 constexpr auto kDefaultACLGroupID = 128;
@@ -199,6 +208,82 @@ int HwAsic::getStationID(int intfID) const {
 
 int HwAsic::getDefaultDropEgressID() const {
   return kDefaultDropEgressID;
+}
+
+void HwAsic::logFeatureSupportOverrides() const {
+  if (FLAGS_asic_feature_support_overrides.empty()) {
+    return;
+  }
+  XLOG(WARNING) << "[FeatureOverride] Active overrides: "
+                << FLAGS_asic_feature_support_overrides;
+  XLOG(WARNING) << "[FeatureOverride] AsicType: " << getAsicTypeStr();
+
+  std::stringstream ss(FLAGS_asic_feature_support_overrides);
+  std::string token;
+  while (std::getline(ss, token, ',')) {
+    token.erase(
+        std::remove_if(
+            token.begin(),
+            token.end(),
+            [](unsigned char c) { return std::isspace(c); }),
+        token.end());
+    if (token.empty()) {
+      continue;
+    }
+    auto sep = token.find('=');
+    if (sep == std::string::npos) {
+      continue;
+    }
+    auto featureId = token.substr(0, sep);
+    auto value = token.substr(sep + 1);
+    XLOG(WARNING) << "[FeatureOverride]   Feature ID=" << featureId << " -> "
+                  << value;
+  }
+}
+
+std::optional<bool> HwAsic::getFeatureSupportOverride(Feature feature) const {
+  if (FLAGS_asic_feature_support_overrides.empty()) {
+    return std::nullopt;
+  }
+
+  std::stringstream ss(FLAGS_asic_feature_support_overrides);
+  std::string token;
+  while (std::getline(ss, token, ',')) {
+    token.erase(
+        std::remove_if(
+            token.begin(),
+            token.end(),
+            [](unsigned char c) { return std::isspace(c); }),
+        token.end());
+    if (token.empty()) {
+      continue;
+    }
+    auto sep = token.find('=');
+    if (sep == std::string::npos || sep == 0 || sep + 1 >= token.size()) {
+      continue;
+    }
+
+    auto featureName = token.substr(0, sep);
+    auto value = token.substr(sep + 1);
+    char* end = nullptr;
+    auto parsedFeatureId = std::strtol(featureName.c_str(), &end, 10);
+    if (end == nullptr || *end != '\0' ||
+        static_cast<Feature>(parsedFeatureId) != feature) {
+      continue;
+    }
+
+    std::transform(
+        value.begin(), value.end(), value.begin(), [](unsigned char c) {
+          return std::tolower(c);
+        });
+    if (value == "true" || value == "1") {
+      return true;
+    }
+    if (value == "false" || value == "0") {
+      return false;
+    }
+  }
+  return std::nullopt;
 }
 
 std::vector<cfg::AsicType> HwAsic::getAllHwAsicList() {

--- a/fboss/agent/hw/switch_asics/HwAsic.h
+++ b/fboss/agent/hw/switch_asics/HwAsic.h
@@ -573,6 +573,12 @@ class HwAsic {
       std::optional<HwAsic::FabricNodeRole> fabricNodeRole);
 
   virtual bool isSupported(Feature) const = 0;
+
+ protected:
+  std::optional<bool> getFeatureSupportOverride(Feature feature) const;
+  void logFeatureSupportOverrides() const;
+
+ public:
   virtual cfg::AsicType getAsicType() const = 0;
   std::string getAsicTypeStr() const;
   virtual AsicVendor getAsicVendor() const = 0;

--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -6,6 +6,15 @@
 namespace facebook::fboss {
 
 bool TomahawkUltra1Asic::isSupported(Feature feature) const {
+  static bool loggedOverrides = [this]() {
+    logFeatureSupportOverrides();
+    return true;
+  }();
+  (void)loggedOverrides;
+  if (auto featureOverride = getFeatureSupportOverride(feature);
+      featureOverride.has_value()) {
+    return *featureOverride;
+  }
   switch (feature) {
     case HwAsic::Feature::SPAN:
     case HwAsic::Feature::ERSPANv4:


### PR DESCRIPTION
**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

Add runtime feature support override mechanism via gflag --asic_feature_support_overrides for TomahawkUltra1 ASIC.

This allows overriding individual HwAsic::Feature support at runtime without code changes, enabling faster platform bring-up and SDK compatibility testing. The override is specified as comma-separated FEATURE_ID=true|false pairs.

Changes:
- Add getFeatureSupportOverride() protected method in HwAsic base class
- Add logFeatureSupportOverrides() to log active overrides at startup
- Integrate override check in TomahawkUltra1Asic::isSupported()


# Test Plan

- Build and run SAI agent with no flag: no behavioral change, no log output
- Run with --asic_feature_support_overrides 73=false: feature reported as unsupported and FeatureOverride log lines appear at startup
- Run with invalid/empty values: graceful handling, no crash
- Verify removing the flag restores original feature support behavior

[test_log.txt](https://github.com/user-attachments/files/27634398/test_log.txt)

