### PR TITLE
[Celestica] Ladakh800bcls: Bsp: Add mdio bsp tests

### DIFF
--- a/cmake/PlatformBspTests.cmake
+++ b/cmake/PlatformBspTests.cmake
@@ -80,6 +80,7 @@ add_executable(bsp_tests
   fboss/platform/bsp_tests/WatchdogTests.cpp
   fboss/platform/bsp_tests/XcvrTests.cpp
   fboss/platform/bsp_tests/HwmonTests.cpp
+  fboss/platform/bsp_tests/MdioTests.cpp
 )
 
 target_link_libraries(bsp_tests
@@ -89,6 +90,7 @@ target_link_libraries(bsp_tests
   bsp_test_utils
   platform_manager_i2c_explorer
   platform_manager_config_cpp2
+  device_mdio
   Folly::folly
   ${GFLAGS}
 )

--- a/fboss/platform/bsp_tests/BspTest.h
+++ b/fboss/platform/bsp_tests/BspTest.h
@@ -117,6 +117,15 @@ class BspTest : public ::testing::Test {
     return std::nullopt;
   }
 
+  const std::optional<DeviceTestData> getDeviceTestData(
+      const std::string& pmName) const {
+    RuntimeConfig conf = GetRuntimeConfig();
+    if (conf.testData()->contains(pmName)) {
+      return conf.testData()->at(pmName);
+    }
+    return std::nullopt;
+  }
+
   const std::optional<std::string> getExpectedErrorReason(
       const std::string& pmName,
       ExpectedErrorType type) const {

--- a/fboss/platform/bsp_tests/MdioTests.cpp
+++ b/fboss/platform/bsp_tests/MdioTests.cpp
@@ -1,0 +1,219 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+
+#include "fboss/mdio/BspDeviceMdio.h"
+#include "fboss/platform/bsp_tests/BspTest.h"
+#include "fboss/platform/bsp_tests/utils/CdevUtils.h"
+
+namespace facebook::fboss::platform::bsp_tests {
+
+constexpr auto kMdioBusCtrlPathPrefix = "/sys/class/mdio_bus/mdio_controller.";
+constexpr auto kMdioBusDevPathPrefix = "/dev/fb-mdio-";
+
+class MdioTest : public BspTest {
+ protected:
+  std::optional<MdioTestData> getMdioTestData(const std::string& pmName) {
+    auto testDataOpt = getDeviceTestData(pmName);
+    if (testDataOpt.has_value() && testDataOpt->mdioTestData().has_value()) {
+      return testDataOpt->mdioTestData().value();
+    }
+    return std::nullopt;
+  }
+};
+
+class MdioAuxDevice {
+ public:
+  MdioAuxDevice(
+      const PciDeviceInfo& pciInfo,
+      const fbiob::AuxData& auxDevice,
+      int32_t id)
+      : pciInfo_(pciInfo), auxDevice_(auxDevice), id_(id) {
+    CdevUtils::createNewDevice(pciInfo_, auxDevice_, id_);
+  }
+
+  ~MdioAuxDevice() {
+    try {
+      CdevUtils::deleteDevice(pciInfo_, auxDevice_, id_);
+    } catch (const std::exception& e) {
+      // Destructors should not throw. Just log the error.
+      XLOG(ERR) << "Failed to delete MDIO_BUS device in destructor: "
+                << e.what();
+    }
+  }
+
+  // Prevent copying
+  MdioAuxDevice(const MdioAuxDevice&) = delete;
+  MdioAuxDevice& operator=(const MdioAuxDevice&) = delete;
+
+ private:
+  const PciDeviceInfo& pciInfo_;
+  const fbiob::AuxData& auxDevice_;
+  int32_t id_;
+};
+
+// Test create MDIO bus
+TEST_F(MdioTest, CreateMdioBus) {
+  const auto& devices = *GetRuntimeConfig().devices();
+  if (devices.empty()) {
+    GTEST_SKIP() << "No devices found in runtime config";
+    return;
+  }
+
+  for (const auto& device : devices) {
+    // Skip devices without aux devices
+    if (device.auxDevices()->empty()) {
+      continue;
+    }
+
+    int32_t id = 0;
+    for (const auto& auxDevice : *device.auxDevices()) {
+      // Skip non-MDIO devices
+      if (*auxDevice.type() != fbiob::AuxDeviceType::MDIO_BUS) {
+        continue;
+      }
+
+      id++;
+
+      try {
+        std::string mdioDevPath =
+            fmt::format("{}{}", kMdioBusDevPathPrefix, id);
+        {
+          MdioAuxDevice mdioAuxDevice(*device.pciInfo(), auxDevice, id);
+
+          XLOG(DBG4) << "Created MDIO_BUS device for PM: " << *auxDevice.name();
+
+          // Check that the dev files exist
+          ASSERT_TRUE(std::filesystem::exists(mdioDevPath))
+              << "MDIO_BUS device file does not exist: " << mdioDevPath;
+
+          // Expected sysfs files in MDIO_BUS Ctrl directory
+          std::vector<std::string> expectedFiles = {"reset_bus"};
+          // Check that the expected sysfs files exist
+          std::vector<std::string> missingFiles;
+          for (const auto& file : expectedFiles) {
+            if (!std::filesystem::exists(
+                    fmt::format("{}{}/{}", kMdioBusCtrlPathPrefix, id, file))) {
+              missingFiles.push_back(file);
+            }
+          }
+
+          ASSERT_TRUE(missingFiles.empty())
+              << "Expected sysfs files do not exist: "
+              << folly::join(", ", missingFiles);
+        }
+
+        ASSERT_FALSE(std::filesystem::exists(mdioDevPath))
+            << "MDIO_BUS device file was not deleted: " << mdioDevPath;
+
+      } catch (const std::exception& e) {
+        FAIL() << "Exception during MDIO_BUS device creation: " << e.what();
+      }
+    }
+  }
+}
+
+// Test MDIO_BUS read and write
+TEST_F(MdioTest, MdioBusReadAndWrite) {
+  const auto& devices = *GetRuntimeConfig().devices();
+  if (devices.empty()) {
+    GTEST_SKIP() << "No devices found in runtime config";
+    return;
+  }
+
+  for (const auto& device : devices) {
+    // Skip devices without aux devices
+    if (device.auxDevices()->empty()) {
+      continue;
+    }
+
+    int32_t id = 0;
+    for (const auto& auxDevice : *device.auxDevices()) {
+      // Skip non-MDIO devices
+      if (*auxDevice.type() != fbiob::AuxDeviceType::MDIO_BUS) {
+        continue;
+      }
+
+      id++;
+
+      try {
+        std::string mdioDevPath =
+            fmt::format("{}{}", kMdioBusDevPathPrefix, id);
+        {
+          MdioAuxDevice mdioAuxDevice(*device.pciInfo(), auxDevice, id);
+
+          XLOG(DBG4) << "Created MDIO_BUS device for PM: " << *auxDevice.name();
+
+          // Create MdioController instance,
+
+          MdioController<BspDeviceMdio> mdioController(id, 1, id, mdioDevPath);
+          mdioController.init();
+
+          auto mdioTestDataOpt = getMdioTestData(*auxDevice.name());
+          if (mdioTestDataOpt) {
+            const auto& mdioTestData = *mdioTestDataOpt;
+
+            auto devAddr = 1;
+
+            for (const auto& test : *mdioTestData.mdioWriteData()) {
+              auto phyAddr = static_cast<uint8_t>(test.phyAddress().value());
+              auto regAddr = static_cast<uint16_t>(test.regAddress().value());
+              auto setValue = static_cast<uint16_t>(test.setValue().value());
+              // Read and write to the specified register
+
+              XLOG(DBG4) << fmt::format(
+                  "Writing to MDIO_BUS device, PM: {}, phyAddr: 0x{:x}, devAddr: 0x{:x}, regAddr: 0x{:x}, setValue: 0x{:x}",
+                  *auxDevice.name(),
+                  phyAddr,
+                  devAddr,
+                  regAddr,
+                  setValue);
+
+              mdioController.writeCl45(phyAddr, devAddr, regAddr, setValue);
+              auto readValue =
+                  mdioController.readCl45(phyAddr, devAddr, regAddr);
+              EXPECT_EQ(readValue, setValue) << fmt::format(
+                  "MDIO_BUS write/read value mismatch for phyAddr: 0x{:x}, regAddr: 0x{:x}",
+                  phyAddr,
+                  regAddr);
+            }
+
+            for (const auto& test : *mdioTestData.mdioReadData()) {
+              // Read from the specified register
+              auto phyAddr = static_cast<uint8_t>(test.phyAddress().value());
+              auto regAddr = static_cast<uint16_t>(test.regAddress().value());
+              auto expectedValue =
+                  static_cast<uint16_t>(test.expected().value());
+
+              XLOG(DBG4) << fmt::format(
+                  "Reading from MDIO_BUS device, PM: {}, phyAddr: 0x{:x}, devAddr: 0x{:x}, regAddr: 0x{:x}",
+                  *auxDevice.name(),
+                  phyAddr,
+                  devAddr,
+                  regAddr);
+
+              auto readValue =
+                  mdioController.readCl45(phyAddr, devAddr, regAddr);
+              EXPECT_EQ(readValue, expectedValue) << fmt::format(
+                  "MDIO_BUS read value mismatch for phyAddr: 0x{:x}, regAddr: 0x{:x}",
+                  phyAddr,
+                  regAddr);
+            }
+          }
+        }
+
+        ASSERT_FALSE(std::filesystem::exists(mdioDevPath))
+            << "MDIO_BUS device file was not deleted: " << mdioDevPath;
+      } catch (const std::exception& e) {
+        FAIL() << "Exception during MDIO_BUS read test: " << e.what();
+      }
+    }
+  }
+}
+
+} // namespace facebook::fboss::platform::bsp_tests

--- a/fboss/platform/bsp_tests/RuntimeConfigBuilder.cpp
+++ b/fboss/platform/bsp_tests/RuntimeConfigBuilder.cpp
@@ -102,6 +102,12 @@ fbiob::AuxData RuntimeConfigBuilder::createSpiAuxData(
   return auxData;
 }
 
+fbiob::AuxData RuntimeConfigBuilder::createMdioAuxData(
+    const FpgaIpBlockConfig& mdioBus) {
+  auto auxData = createBaseAuxData(mdioBus, fbiob::AuxDeviceType::MDIO_BUS);
+  return auxData;
+}
+
 facebook::fboss::platform::bsp_tests::I2CAdapter*
 RuntimeConfigBuilder::findAdapter(
     std::map<std::string, facebook::fboss::platform::bsp_tests::I2CAdapter>&
@@ -284,6 +290,9 @@ RuntimeConfig RuntimeConfigBuilder::buildRuntimeConfig(
       }
       for (const auto& spiMaster : *dev.spiMasterConfigs()) {
         pciDevice.auxDevices()->push_back(createSpiAuxData(spiMaster));
+      }
+      for (const auto& mdioBusConfig : Utils::createMdioBusConfigs(dev)) {
+        pciDevice.auxDevices()->push_back(createMdioAuxData(mdioBusConfig));
       }
       devices.push_back(pciDevice);
     }

--- a/fboss/platform/bsp_tests/RuntimeConfigBuilder.h
+++ b/fboss/platform/bsp_tests/RuntimeConfigBuilder.h
@@ -49,6 +49,7 @@ class RuntimeConfigBuilder {
   fbiob::AuxData createFanAuxData(const FanPwmCtrlConfig& fanCtrl);
   fbiob::AuxData createSpiAuxData(const SpiMasterConfig& spiMaster);
   fbiob::AuxData createIdpromAuxData(const IdpromConfig& idpromConfig);
+  fbiob::AuxData createMdioAuxData(const FpgaIpBlockConfig& mdioBus);
   facebook::fboss::platform::bsp_tests::I2CAdapter* findAdapter(
       std::map<std::string, facebook::fboss::platform::bsp_tests::I2CAdapter>&
           adapters,

--- a/fboss/platform/bsp_tests/bsp_tests_config.thrift
+++ b/fboss/platform/bsp_tests/bsp_tests_config.thrift
@@ -34,6 +34,7 @@ struct DeviceTestData {
   3: optional GpioTestData gpioTestData;
   4: optional WatchdogTestData watchdogTestData;
   5: optional LedTestData ledTestData;
+  6: optional MdioTestData mdioTestData;
 }
 
 struct I2CTestData {
@@ -80,4 +81,21 @@ struct WatchdogTestData {
 
 struct LedTestData {
   1: bool createsLeds;
+}
+
+struct MdioTestData {
+  1: list<MdioWriteData> mdioWriteData;
+  2: list<MdioReadData> mdioReadData;
+}
+
+struct MdioWriteData {
+  1: i32 phyAddress;
+  2: i32 regAddress;
+  3: i32 setValue;
+}
+
+struct MdioReadData {
+  1: i32 phyAddress;
+  2: i32 regAddress;
+  3: i32 expected;
 }

--- a/fboss/platform/bsp_tests/fbiob_device_config.thrift
+++ b/fboss/platform/bsp_tests/fbiob_device_config.thrift
@@ -37,6 +37,7 @@ enum AuxDeviceType {
   XCVR = 4,
   GPIO = 5,
   SYSLED = 6,
+  MDIO_BUS = 7,
 }
 
 struct I2cData {

--- a/fboss/platform/bsp_tests/utils/CdevUtils.cpp
+++ b/fboss/platform/bsp_tests/utils/CdevUtils.cpp
@@ -105,6 +105,9 @@ struct fbiob_aux_data getFbiobAuxData(const AuxData& auxDevice, int32_t id) {
     case AuxDeviceType::SYSLED:
       // Do nothing
       break;
+    case AuxDeviceType::MDIO_BUS:
+      // Do nothing
+      break;
   }
 
   return auxData;

--- a/fboss/platform/configs/ladakh800bcls/bsp_tests.json
+++ b/fboss/platform/configs/ladakh800bcls/bsp_tests.json
@@ -68,6 +68,745 @@
           "iout1"
         ]
       }
+    },
+    "RTM_L_MDIO_BUS_1": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "__comment__": "0x8000 is the retimer initialization register. ",
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "__comment__": "0x8B00 is the retimer chip ID register low word. ",
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "__comment__": "0x8B01 is the retimer chip ID register high word. ",
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_2": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_3": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_4": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_5": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_6": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_7": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_8": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_9": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_10": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_11": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_12": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_13": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_14": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_15": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_L_MDIO_BUS_16": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_1": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_2": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_3": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_4": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_5": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_6": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_7": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_8": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_9": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_10": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_11": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_12": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_13": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_14": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_15": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
+    },
+    "RTM_R_MDIO_BUS_16": {
+      "mdioTestData": {
+        "mdioWriteData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 32768,
+            "setValue": 0
+          }
+        ],
+        "mdioReadData": [
+          {
+            "phyAddress": 0,
+            "regAddress": 35584,
+            "expected": 13153
+          },
+          {
+            "phyAddress": 0,
+            "regAddress": 35585,
+            "expected": 32928
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

To verify the MDIO function of BSP, need add related tests.

1. `MdioTest.CreateMdioBus`: Verifies the ability to add and delete an MDIO bus.
2. `MdioTest.MdioBusReadAndWrite`: Verifies read and write operations. The test MDIO bus and related registers are configured via `bsp_tests.json`.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
[root@localhost fboss]# LD_LIBRARY_PATH=./lib/ ./bin/bsp_tests  --bsp_tests_config_file ./config/bsp_tests.json --gtest_filter=MdioTest.* 2>&1 | tee -a "logs/bsp_tests.log" &
[1] 151024
[root@localhost fboss]# Note: Google Test filter = MdioTest.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
I0509 17:29:29.720261 151023 PlatformNameLib.cpp:84] Platform name read from cache: LADAKH800BCLS
I0509 17:29:29.720365 151023 BspTestEnvironment.cpp:32] Platform: LADAKH800BCLS
I0509 17:29:29.720799 151023 PlatformNameLib.cpp:84] Platform name read from cache: LADAKH800BCLS
[----------] 2 tests from MdioTest
[ RUN      ] MdioTest.CreateMdioBus
[       OK ] MdioTest.CreateMdioBus (2487 ms)
[ RUN      ] MdioTest.MdioBusReadAndWrite
[       OK ] MdioTest.MdioBusReadAndWrite (5714 ms)
[----------] 2 tests from MdioTest (8202 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (18072 ms total)
[  PASSED  ] 2 tests.
```

When adding `--logging=DBG4`, details can be found in the log below.
[bsp_tests.log](https://github.com/user-attachments/files/27681497/bsp_tests.log)