### PR TITLE
[Celestica] Tahansb800bcm: Add tahansb800bcm platform support for Netlake2.0

### DIFF
--- a/fboss/platform/configs/tahansb800bcm/bsp_tests.json
+++ b/fboss/platform/configs/tahansb800bcm/bsp_tests.json
@@ -1,0 +1,684 @@
+{
+  "testData": {
+    "TAHANSB800BCM_MCB.SCM_CPLD": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x04",
+            "expected": "0xde"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x41",
+            "value": "0x03"
+          },
+          {
+            "reg": "0x42",
+            "value": "0x03"
+          },
+          {
+            "reg": "0x43",
+            "value": "0x03"
+          },
+          {
+            "reg": "0x44",
+            "value": "0x03"
+          }
+        ]
+      },
+      "ledTestData": {
+        "createsLeds": true
+      }
+    },
+    "TAHANSB800BCM_MCB.PMBUS_1": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x00",
+            "value": "0x00"
+          }
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.PMBUS_2": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x00",
+            "value": "0x00"
+          }
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.PB_INLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.48V_STBY_PWR_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_FAN_CPLD": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x32",
+            "value": "0x20"
+          },
+          {
+            "reg": "0x42",
+            "value": "0x20"
+          },
+          {
+            "reg": "0x52",
+            "value": "0x20"
+          },
+          {
+            "reg": "0x62",
+            "value": "0x20"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "fan1",
+          "fan2",
+          "fan3",
+          "fan4",
+          "fan5",
+          "fan6",
+          "fan7",
+          "fan8"
+        ]
+      },
+      "watchdogTestData": {
+        "numWatchdogs": 1
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_CPLD": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x04",
+            "expected": "0xde"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x04",
+            "value": "0xde"
+          },
+          {
+            "reg": "0x06",
+            "value": "0x0d"
+          }
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.LOAD_SWITCH_MONITOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_FAN1_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_FAN2_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_FAN3_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_FAN4_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "vin",
+          "vmon",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_COME_INLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.OSFP_PWR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.48V_HSC_MONITOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iout1",
+          "vin",
+          "vout1",
+          "pin"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_ADC1_MONITOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x0b",
+            "expected": "0x02"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x02"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "in0",
+          "in1",
+          "in2",
+          "in3",
+          "in4",
+          "in5",
+          "in6",
+          "in7"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_ADC2_MONITOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x0b",
+            "expected": "0x02"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x02"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "in0",
+          "in1",
+          "in2",
+          "in3",
+          "in4",
+          "in5",
+          "in6",
+          "in7"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_COME_OUTLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.PB_OUTLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "TAHANSB800BCM_MCB.MCB_ADC3_MONITOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x0b",
+            "expected": "0x02"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x02"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "in0",
+          "in1",
+          "in2",
+          "in3",
+          "in4",
+          "in5",
+          "in6",
+          "in7"
+        ]
+      }
+    },
+    "BMC.RUNBMC_THERMAL_SENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "NETLAKE.COME_INLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "NETLAKE.COME_OUTLET_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_0": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_1": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_TH6_SENSOR_TMP432_1": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x64"
+          },
+          {
+            "reg": "0x0d",
+            "value": "0x64"
+          },
+          {
+            "reg": "0x13",
+            "value": "0x00"
+          },
+          {
+            "reg": "0x15",
+            "value": "0x64"
+          },
+          {
+            "reg": "0x17",
+            "value": "0x00"
+          },
+          {
+            "reg": "0x27",
+            "value": "0x05"
+          },
+          {
+            "reg": "0x28",
+            "value": "0x05"
+          },
+          {
+            "reg": "0x3d",
+            "value": "0x00"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1",
+          "temp2",
+          "temp3"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_2": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_OUTLET_TH6_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_3": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_TH6_SENSOR_TMP432_2": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x64"
+          },
+          {
+            "reg": "0x0d",
+            "value": "0x64"
+          },
+          {
+            "reg": "0x13",
+            "value": "0x00"
+          },
+          {
+            "reg": "0x27",
+            "value": "0x05"
+          },
+          {
+            "reg": "0x28",
+            "value": "0x05"
+          },
+          {
+            "reg": "0x3d",
+            "value": "0x00"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1",
+          "temp2",
+          "temp3"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_4": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_5_1": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_5_2": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_6": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ASIC_VOLTAGE_7": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin1",
+          "iin2",
+          "iout1",
+          "iout2",
+          "vin1",
+          "vin2",
+          "vout1",
+          "vout2",
+          "pin1",
+          "pin2",
+          "pout1",
+          "pout2"
+        ]
+      }
+    },
+    "SMB.SMB_ADC1_SENSOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x0b",
+            "expected": "0x02"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x02"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "in0",
+          "in1",
+          "in2",
+          "in3",
+          "in4",
+          "in5",
+          "in6",
+          "in7"
+        ]
+      }
+    },
+    "SMB.SMB_CPLD": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x04",
+            "expected": "0xde"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x04",
+            "value": "0xde"
+          }
+        ]
+      }
+    },
+    "SMB.SMB_ADC2_SENSOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x0b",
+            "expected": "0x02"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x0b",
+            "value": "0x02"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "in0",
+          "in1",
+          "in2",
+          "in3",
+          "in4",
+          "in5",
+          "in6",
+          "in7"
+        ]
+      }
+    },
+    "SMB.SMB_INLET_TH6_TSENSOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1"
+        ]
+      }
+    },
+    "SMB.SMB_VDDCORE": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "iin",
+          "iout1",
+          "iout2",
+          "vin",
+          "vout1",
+          "vout2",
+          "pin",
+          "pout1",
+          "pout2"
+        ]
+      }
+    }
+  }
+}

--- a/fboss/platform/configs/tahansb800bcm/fan_service.json
+++ b/fboss/platform/configs/tahansb800bcm/fan_service.json
@@ -1,0 +1,208 @@
+{
+  "pwmBoostOnNumDeadFan": 3,
+  "pwmBoostOnNumDeadSensor": 0,
+  "pwmBoostOnNoQsfpAfterInSec": 0,
+  "pwmBoostValue": 100,
+  "pwmTransitionValue": 50,
+  "pwmLowerThreshold": 30,
+  "pwmUpperThreshold": 100,
+  "watchdog": {
+    "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
+    "value": 0
+  },
+  "controlInterval": {
+    "sensorReadInterval": 5,
+    "pwmUpdateInterval": 5
+  },
+  "sensors": [
+    {
+      "sensorName": "COME_U1_CPU_UNCORE_TEMP",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
+      "pidSetting": {
+        "kp": 2,
+        "ki": 0.6,
+        "kd": 0,
+        "setPoint": 90,
+        "posHysteresis": 3,
+        "negHysteresis": 3
+      }
+    },
+    {
+      "sensorName": "MCB_PS108_XP12R0V_PB1_TEMPARTURES",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
+      "pidSetting": {
+        "kp": 9,
+        "ki": 0.6,
+        "kd": 0,
+        "setPoint": 104,
+        "posHysteresis": 1,
+        "negHysteresis": 1
+      }
+    },
+    {
+      "sensorName": "MCB_PS109_XP12R0V_PB2_TEMPARTURES",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
+      "pidSetting": {
+        "kp": 8,
+        "ki": 0.6,
+        "kd": 0,
+        "setPoint": 104,
+        "posHysteresis": 1,
+        "negHysteresis": 1
+      }
+    },
+    {
+      "sensorName": "MCB_U62_PB_INLET_TSENSOR",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "23": 30,
+        "28": 35,
+        "33": 40,
+        "38": 45
+      },
+      "normalDownTable": {
+        "21": 30,
+        "26": 35,
+        "31": 40,
+        "36": 45
+      },
+      "failUpTable": {
+        "23": 50,
+        "28": 60,
+        "33": 70,
+        "38": 80
+      },
+      "failDownTable": {
+        "21": 50,
+        "26": 60,
+        "31": 70,
+        "36": 80
+      },
+      "twoRotorsFailUpTable": {
+        "23": 100,
+        "28": 100,
+        "33": 100,
+        "38": 100
+      },
+      "twoRotorsFailDownTable": {
+        "21": 100,
+        "26": 100,
+        "31": 100,
+        "36": 100
+      }
+    }
+  ],
+  "fans": [
+    {
+      "fanName": "FAN_1_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_1_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_2_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_2_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_3_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_3_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_4_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    },
+    {
+      "fanName": "FAN_4_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "rpmMin": 3105
+    }
+  ],
+  "zones": [
+    {
+      "zoneType": "ZONE_TYPE_MAX",
+      "zoneName": "zone1",
+      "sensorNames": [
+        "COME_U1_CPU_UNCORE_TEMP",
+        "MCB_PS108_XP12R0V_PB1_TEMPARTURES",
+        "MCB_PS109_XP12R0V_PB2_TEMPARTURES",
+        "MCB_U62_PB_INLET_TSENSOR"
+      ],
+      "fanNames": [
+        "FAN_1_F",
+        "FAN_1_R",
+        "FAN_2_F",
+        "FAN_2_R",
+        "FAN_3_F",
+        "FAN_3_R",
+        "FAN_4_F",
+        "FAN_4_R"
+      ],
+      "slope": 10
+    }
+  ]
+}

--- a/fboss/platform/configs/tahansb800bcm/fw_util.json
+++ b/fboss/platform/configs/tahansb800bcm/fw_util.json
@@ -1,0 +1,328 @@
+{
+  "fwConfigs": {
+    "bios": {
+      "preUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x15",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "internal"
+          }
+        }
+      ],
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal"
+        }
+      },
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal"
+        }
+      },
+      "postUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x16",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "version": {
+        "versionType": "sysfs",
+        "path": "/sys/devices/virtual/dmi/id/bios_version"
+      },
+      "priority": 1
+    },
+    "iob_fpga": {
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/MCB_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
+    "dom_fpga": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/MCB_DOM_INFO_ROM/fw_ver"
+      },
+      "priority": 3
+    },
+    "mcb_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/MCB_CPLD/fw_ver"
+      },
+      "priority": 4
+    },
+    "smb_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "7"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "7"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SMB_CPLD/fw_ver"
+      },
+      "priority": 5
+    },
+    "scm_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SCM_CPLD/fw_ver"
+      },
+      "priority": 6
+    }
+  }
+}

--- a/fboss/platform/configs/tahansb800bcm/led_manager.json
+++ b/fboss/platform/configs/tahansb800bcm/led_manager.json
@@ -1,0 +1,82 @@
+{
+  "systemLedConfig": {
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:amber:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:amber:status/brightness"
+    },
+    "PWR": {
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:amber:status/brightness"
+    },
+    "SMB": {
+      "presentLedSysfsPath": "/sys/class/leds/smb_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/smb_led:amber:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PWR",
+      "fruType": "PWR",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/hs_48v_pg",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "SMB",
+      "fruType": "SMB",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/smb_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}

--- a/fboss/platform/configs/tahansb800bcm/platform_manager.json
+++ b/fboss/platform/configs/tahansb800bcm/platform_manager.json
@@ -1,0 +1,985 @@
+{
+  "platformName": "TAHANSB800BCM",
+  "rootPmUnitName": "TAHANSB800BCM_MCB",
+  "rootSlotType": "MCB_SLOT",
+  "slotTypeConfigs": {
+    "MCB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "idpromConfig": {
+        "busName": "CPU_BUS@0",
+        "address": "0x53",
+        "kernelDeviceName": "24c02"
+      },
+      "pmUnitName": "TAHANSB800BCM_MCB"
+    },
+    "RUNBMC_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x51",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "BMC"
+    },
+    "COMESE_SLOT": {
+      "numOutgoingI2cBuses": 2,
+      "idpromConfig": {
+        "busName": "INCOMING@1",
+        "address": "0x56",
+        "kernelDeviceName": "24c128"
+      },
+      "pmUnitName": "NETLAKE20"
+    },
+    "SMB_SLOT": {
+      "numOutgoingI2cBuses": 5,
+      "idpromConfig": {
+        "busName": "INCOMING@2",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      },
+      "pmUnitName": "SMB"
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "CPU_BUS@0"
+  ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE20": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_HWMON1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_HWMON2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_HWMON3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_INLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 2
+      }
+    ]
+  },
+  "pmUnitConfigs": {
+    "TAHANSB800BCM_MCB": {
+      "pluggedInSlotType": "MCB_SLOT",
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/pci/drivers/k10temp/0000:00:18.3"
+        }
+      ],
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "MCB_IOB",
+          "vendorId": "0x1d9b",
+          "deviceId": "0x0011",
+          "subSystemVendorId": "0x10ee",
+          "subSystemDeviceId": "0x0007",
+          "i2cAdapterBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "MCB_IOB_I2C_MASTER",
+              "deviceName": "iob_i2c_master",
+              "csrOffsetCalc": "0x4000 + ({adapterIndex} - {startAdapterIndex})*0x100",
+              "startAdapterIndex": 1,
+              "numAdapters": 28
+            },
+            {
+              "pmUnitScopedNamePrefix": "MCB_DOM_I2C_MASTER",
+              "deviceName": "dom1_i2c_master",
+              "csrOffsetCalc": "0x42000 + ({adapterIndex} - {startAdapterIndex})*0x100",
+              "startAdapterIndex": 1,
+              "numAdapters": 8
+            }
+          ],
+          "gpioChipConfigs": [
+            {
+              "pmUnitScopedName": "MCB_GPIO_CHIP_1",
+              "deviceName": "gpiochip",
+              "csrOffset": "0x0400"
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_1",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10000",
+                "iobufOffset": "0x12000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_1_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_2",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10080",
+                "iobufOffset": "0x12400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_2_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_3",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10100",
+                "iobufOffset": "0x12800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_3_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_4",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10180",
+                "iobufOffset": "0x12c00"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_4_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_5",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10200",
+                "iobufOffset": "0x13000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_5_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_6",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10280",
+                "iobufOffset": "0x13400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_6_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_7",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10300",
+                "iobufOffset": "0x13800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_7_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "xcvrCtrlBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "MCB_DOM",
+              "deviceName": "xcvr_ctrl",
+              "csrOffsetCalc": "0x40200 + ({portNum} - {startPort})*0x4",
+              "numPorts": 8,
+              "startPort": 1
+            },
+            {
+              "pmUnitScopedNamePrefix": "IOB",
+              "deviceName": "xcvr_ctrl",
+              "csrOffsetCalc": "0x1030 + ({portNum} - {startPort})*0x0",
+              "numPorts": 1,
+              "startPort": 9
+            }
+          ],
+          "ledCtrlBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "MCB_LED",
+              "deviceName": "port_led",
+              "csrOffsetCalc": "0x404d0 + ({portNum} - {startPort})*0x8 + ({ledNum} - 1)*0x4",
+              "numPorts": 8,
+              "ledPerPort": 2,
+              "startPort": 1
+            },
+            {
+              "pmUnitScopedNamePrefix": "MCB_LED",
+              "deviceName": "port_led",
+              "csrOffsetCalc": "0x40510 + ({portNum} - {startPort})*0x8 + ({ledNum} - 1)*0x4",
+              "numPorts": 1,
+              "ledPerPort": 1,
+              "startPort": 9,
+              "lanesPerPort": 4
+            }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "MCB_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            },
+            {
+              "pmUnitScopedName": "MCB_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x40000"
+            }
+          ]
+        }
+      ],
+      "i2cDeviceConfigs": [
+        {
+          "busName": "MCB_IOB_I2C_MASTER_2",
+          "address": "0x70",
+          "kernelDeviceName": "pca9546",
+          "pmUnitScopedName": "MCB_MUX",
+          "numOutgoingChannels": 4
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_3",
+          "address": "0x35",
+          "kernelDeviceName": "tahansb_scmcpld",
+          "pmUnitScopedName": "SCM_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x60",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_1",
+          "initRegSettings": [
+            {
+              "__comment__": "Set the page to 0 to ensure the driver can read the correct registers. PR:573",
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x61",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_2",
+          "initRegSettings": [
+            {
+              "__comment__": "Set the page to 0 to ensure the driver can read the correct registers. PR:573",
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PB_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_9",
+          "address": "0x46",
+          "kernelDeviceName": "tps1689",
+          "pmUnitScopedName": "48V_STBY_PWR_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x33",
+          "kernelDeviceName": "tahansb_fancpld",
+          "pmUnitScopedName": "MCB_FAN_CPLD",
+          "isWatchdog": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x60",
+          "kernelDeviceName": "fbg_mcbcpld",
+          "pmUnitScopedName": "MCB_CPLD",
+          "initRegSettings": [
+            {
+              "regOffset": 6,
+              "ioBuf": [
+                13
+              ]
+            }
+          ],
+          "cpldSysfsAttrs": [
+            {
+              "name": "version_id",
+              "regAddr": "0x00",
+              "bitOffset": 4,
+              "numBits": 4,
+              "description": "Hardware version ID"
+            },
+            {
+              "name": "board_id",
+              "regAddr": "0x00",
+              "numBits": 4,
+              "description": "Board ID"
+            },
+            {
+              "name": "cpld_ver",
+              "regAddr": "0x01",
+              "numBits": 7,
+              "description": "CPLD major version"
+            },
+            {
+              "name": "cpld_minor_ver",
+              "regAddr": "0x02",
+              "numBits": 8,
+              "description": "CPLD minor version"
+            },
+            {
+              "name": "cpld_sub_ver",
+              "regAddr": "0x03",
+              "numBits": 8,
+              "description": "CPLD sub version"
+            },
+            {
+              "name": "oob_eeprom_wp",
+              "mode": "rw",
+              "regAddr": "0x06",
+              "bitOffset": 2,
+              "description": "OOB EEPROM write protect"
+            },
+            {
+              "name": "oob_eeprom_sel",
+              "mode": "rw",
+              "regAddr": "0x06",
+              "bitOffset": 3,
+              "description": "OOB EEPROM select"
+            },
+            {
+              "name": "smb_pg",
+              "regAddr": "0x0A",
+              "bitOffset": 1,
+              "description": "SMB power good"
+            },
+            {
+              "name": "hs_48v_pg",
+              "regAddr": "0x0A",
+              "bitOffset": 6,
+              "description": "Hot swap 48V power good (1 = present, 0 = absent)"
+            },
+            {
+              "name": "smb_present",
+              "regAddr": "0x10",
+              "bitOffset": 5,
+              "description": "SMB present (1 = present, 0 = absent)"
+            },
+            {
+              "name": "slot_present",
+              "regAddr": "0xA0",
+              "bitOffset": 3,
+              "description": "Slot present"
+            },
+            {
+              "name": "slot_id",
+              "regAddr": "0xA0",
+              "numBits": 3,
+              "description": "Slot ID"
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_15",
+          "address": "0x53",
+          "kernelDeviceName": "24c64",
+          "pmUnitScopedName": "CHASSIS_EEPROM",
+          "isEeprom": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "LOAD_SWITCH_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_17",
+          "address": "0x50",
+          "kernelDeviceName": "24c02",
+          "pmUnitScopedName": "OOB_88E6321_EEPROM"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_19",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "MCB_FAN1_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_19",
+          "address": "0x4d",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "MCB_FAN2_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_20",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "MCB_FAN3_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_20",
+          "address": "0x4d",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "MCB_FAN4_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_21",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_22",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "OSFP_PWR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_23",
+          "address": "0x11",
+          "kernelDeviceName": "ltc4287",
+          "pmUnitScopedName": "48V_HSC_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC1_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_24",
+          "address": "0x37",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC2_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_26",
+          "address": "0x4e",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_COME_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_27",
+          "address": "0x4c",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PB_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_27",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC3_MONITOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RUNBMC_SLOT@0": {
+          "slotType": "RUNBMC_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_1"
+          ]
+        },
+        "COMESE_SLOT@0": {
+          "slotType": "COMESE_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_MUX@1",
+            "MCB_IOB_I2C_MASTER_18"
+          ]
+        },
+        "SMB_SLOT@0": {
+          "slotType": "SMB_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_7",
+            "MCB_IOB_I2C_MASTER_8",
+            "MCB_IOB_I2C_MASTER_10",
+            "MCB_IOB_I2C_MASTER_11",
+            "MCB_IOB_I2C_MASTER_12"
+          ]
+        }
+      }
+    },
+    "BMC": {
+      "pluggedInSlotType": "RUNBMC_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4a",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RUNBMC_THERMAL_SENSOR"
+        }
+      ]
+    },
+    "NETLAKE20": {
+      "pluggedInSlotType": "COMESE_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x20",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "COME_HWMON1"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x21",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "COME_HWMON2"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x40",
+          "kernelDeviceName": "ina230",
+          "pmUnitScopedName": "COME_HWMON3"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x4a",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x50",
+          "kernelDeviceName": "spd5118",
+          "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x51",
+          "kernelDeviceName": "spd5118",
+          "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+        }
+      ]
+    },
+    "SMB": {
+      "pluggedInSlotType": "SMB_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x74",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "SMB_MUX",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "SMB_MUX@0",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_0"
+        },
+        {
+          "busName": "SMB_MUX@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_1"
+        },
+        {
+          "busName": "SMB_MUX@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_1",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temp(temp1) high limit setting for high byte. PR:1001",
+              "regOffset": 11,
+              "ioBuf": [
+                95
+              ]
+            },
+            {
+              "__comment__": "Remote temp1(temp2) high limit setting for high byte. PR:1001",
+              "regOffset": 13,
+              "ioBuf": [
+                95
+              ]
+            },
+            {
+              "__comment__": "Remote temp1(temp2) high limit setting for low byte. PR:594",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp2(temp3) high limit setting for high byte. PR:1001",
+              "regOffset": 21,
+              "ioBuf": [
+                95
+              ]
+            },
+            {
+              "__comment__": "Remote temp2(temp3) high limit setting for low byte. PR:594",
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1. PR:594",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2. PR:594",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "Local temp(temp1) high limit setting for low byte. PR:594",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_MUX@2",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_2"
+        },
+        {
+          "busName": "SMB_MUX@2",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_OUTLET_TH6_TSENSOR"
+        },
+        {
+          "busName": "SMB_MUX@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_3"
+        },
+        {
+          "busName": "SMB_MUX@3",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_TH6_SENSOR_TMP432_2",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temp(temp1) high limit setting for high byte. PR:1001",
+              "regOffset": 11,
+              "ioBuf": [
+                95
+              ]
+            },
+            {
+              "__comment__": "Remote temp1(temp2) high limit setting for high byte. PR:1001",
+              "regOffset": 13,
+              "ioBuf": [
+                95
+              ]
+            },
+            {
+              "__comment__": "Remote temp1(temp2) high limit setting for low byte. PR:594",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1. PR:594",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2. PR:594",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "Local temp(temp1) high limit setting for low byte. PR:594",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_MUX@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_4"
+        },
+        {
+          "busName": "SMB_MUX@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_1"
+        },
+        {
+          "busName": "SMB_MUX@5",
+          "address": "0x6a",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_5_2"
+        },
+        {
+          "busName": "SMB_MUX@6",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_6"
+        },
+        {
+          "busName": "SMB_MUX@7",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_ASIC_VOLTAGE_7"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x33",
+          "kernelDeviceName": "th6_smbcpld",
+          "pmUnitScopedName": "SMB_CPLD"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_INLET_TH6_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x76",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SMB_VDDCORE"
+        }
+      ]
+    }
+  },
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/eeproms/MCB_EEPROM": "/[IDPROM]",
+    "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_EEPROM]",
+    "/run/devmap/eeproms/RUNBMC_EEPROM": "/RUNBMC_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/COME_EEPROM": "/COMESE_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/SMB_EEPROM": "/SMB_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/PMBUS_1": "/[PMBUS_1]",
+    "/run/devmap/sensors/PMBUS_2": "/[PMBUS_2]",
+    "/run/devmap/sensors/MCB_COME_INLET_TSENSOR": "/[MCB_COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/PB_INLET_TSENSOR": "/[PB_INLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_COME_OUTLET_TSENSOR": "/[MCB_COME_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/48V_STBY_PWR_SENSOR": "/[48V_STBY_PWR_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN_CPLD": "/[MCB_FAN_CPLD]",
+    "/run/devmap/sensors/LOAD_SWITCH_MONITOR": "/[LOAD_SWITCH_MONITOR]",
+    "/run/devmap/sensors/OSFP_PWR": "/[OSFP_PWR]",
+    "/run/devmap/sensors/48V_HSC_MONITOR": "/[48V_HSC_MONITOR]",
+    "/run/devmap/sensors/MCB_FAN1_SENSOR": "/[MCB_FAN1_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN2_SENSOR": "/[MCB_FAN2_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN3_SENSOR": "/[MCB_FAN3_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN4_SENSOR": "/[MCB_FAN4_SENSOR]",
+    "/run/devmap/sensors/MCB_ADC1_MONITOR": "/[MCB_ADC1_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC2_MONITOR": "/[MCB_ADC2_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC3_MONITOR": "/[MCB_ADC3_MONITOR]",
+    "/run/devmap/sensors/PB_OUTLET_TSENSOR": "/[PB_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
+    "/run/devmap/cplds/SCM_CPLD": "/[SCM_CPLD]",
+    "/run/devmap/cplds/MCB_CPLD": "/[MCB_CPLD]",
+    "/run/devmap/cplds/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
+    "/run/devmap/fpgas/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/fpgas/MCB_DOM_INFO_ROM": "/[MCB_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/inforoms/MCB_DOM_INFO_ROM": "/[MCB_DOM_INFO_ROM]",
+    "/run/devmap/watchdogs/FAN_WATCHDOG": "/[MCB_FAN_CPLD]",
+    "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
+    "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
+    "/run/devmap/sensors/COME_HWMON3": "/COMESE_SLOT@0/[COME_HWMON3]",
+    "/run/devmap/sensors/COME_INLET_TSENSOR": "/COMESE_SLOT@0/[COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_OUTLET_TSENSOR": "/COMESE_SLOT@0/[COME_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/COME_DIMM1_TSENSOR": "/COMESE_SLOT@0/[COME_DIMM1_TSENSOR]",
+    "/run/devmap/sensors/COME_DIMM2_TSENSOR": "/COMESE_SLOT@0/[COME_DIMM2_TSENSOR]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_0]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_1]",
+    "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_1]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_2]",
+    "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_OUTLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_3]",
+    "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2": "/SMB_SLOT@0/[SMB_TH6_SENSOR_TMP432_2]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_4]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_5_1]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_5_2]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_6]",
+    "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7": "/SMB_SLOT@0/[SMB_ASIC_VOLTAGE_7]",
+    "/run/devmap/sensors/SMB_ADC1_SENSOR": "/SMB_SLOT@0/[SMB_ADC1_SENSOR]",
+    "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
+    "/run/devmap/sensors/SMB_INLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_VDDCORE": "/SMB_SLOT@0/[SMB_VDDCORE]",
+    "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1": "/[MCB_SPI_MASTER_3_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1": "/[MCB_SPI_MASTER_4_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1": "/[MCB_SPI_MASTER_5_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_6_DEVICE_1": "/[MCB_SPI_MASTER_6_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1": "/[MCB_SPI_MASTER_7_DEVICE_1]",
+    "/run/devmap/xcvrs/xcvr_io_1": "/[MCB_DOM_I2C_MASTER_1]",
+    "/run/devmap/xcvrs/xcvr_ctrl_1": "/[MCB_DOM_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_io_2": "/[MCB_DOM_I2C_MASTER_2]",
+    "/run/devmap/xcvrs/xcvr_ctrl_2": "/[MCB_DOM_XCVR_CTRL_PORT_2]",
+    "/run/devmap/xcvrs/xcvr_io_3": "/[MCB_DOM_I2C_MASTER_3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_3": "/[MCB_DOM_XCVR_CTRL_PORT_3]",
+    "/run/devmap/xcvrs/xcvr_io_4": "/[MCB_DOM_I2C_MASTER_4]",
+    "/run/devmap/xcvrs/xcvr_ctrl_4": "/[MCB_DOM_XCVR_CTRL_PORT_4]",
+    "/run/devmap/xcvrs/xcvr_io_5": "/[MCB_DOM_I2C_MASTER_5]",
+    "/run/devmap/xcvrs/xcvr_ctrl_5": "/[MCB_DOM_XCVR_CTRL_PORT_5]",
+    "/run/devmap/xcvrs/xcvr_io_6": "/[MCB_DOM_I2C_MASTER_6]",
+    "/run/devmap/xcvrs/xcvr_ctrl_6": "/[MCB_DOM_XCVR_CTRL_PORT_6]",
+    "/run/devmap/xcvrs/xcvr_io_7": "/[MCB_DOM_I2C_MASTER_7]",
+    "/run/devmap/xcvrs/xcvr_ctrl_7": "/[MCB_DOM_XCVR_CTRL_PORT_7]",
+    "/run/devmap/xcvrs/xcvr_io_8": "/[MCB_DOM_I2C_MASTER_8]",
+    "/run/devmap/xcvrs/xcvr_ctrl_8": "/[MCB_DOM_XCVR_CTRL_PORT_8]",
+    "/run/devmap/xcvrs/xcvr_io_9": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_9": "/[IOB_XCVR_CTRL_PORT_9]"
+  },
+  "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
+  "numXcvrs": 9,
+  "bspKmodsRpmName": "fboss_bsp_kmods",
+  "bspKmodsRpmVersion": "4.2.0-1",
+  "requiredKmodsToLoad": [
+    "i2c_i801",
+    "spidev",
+    "fboss_iob_pci",
+    "fboss_iob_i2c",
+    "fboss_iob_spi",
+    "ledtrig_timer"
+  ]
+}

--- a/fboss/platform/configs/tahansb800bcm/rma_showtech.json
+++ b/fboss/platform/configs/tahansb800bcm/rma_showtech.json
@@ -1,0 +1,3 @@
+{
+  "i2cBusIgnore": []
+}

--- a/fboss/platform/configs/tahansb800bcm/sensor_service.json
+++ b/fboss/platform/configs/tahansb800bcm/sensor_service.json
@@ -1,0 +1,3256 @@
+{
+  "platformName": "TAHANSB800BCM",
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "TAHANSB800BCM_MCB",
+      "sensors": [
+        {
+          "name": "MCB_U17_FAN_1_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 41800,
+            "minAlarmVal": 3420,
+            "upperCriticalVal": 43700,
+            "lowerCriticalVal": 3230
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_1_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 38060,
+            "minAlarmVal": 3105,
+            "upperCriticalVal": 39790,
+            "lowerCriticalVal": 2932
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_2_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 41800,
+            "minAlarmVal": 3420,
+            "upperCriticalVal": 43700,
+            "lowerCriticalVal": 3230
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_2_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 38060,
+            "minAlarmVal": 3105,
+            "upperCriticalVal": 39790,
+            "lowerCriticalVal": 2932
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_3_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 41800,
+            "minAlarmVal": 3420,
+            "upperCriticalVal": 43700,
+            "lowerCriticalVal": 3230
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_3_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 38060,
+            "minAlarmVal": 3105,
+            "upperCriticalVal": 39790,
+            "lowerCriticalVal": 2932
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_4_F_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 41800,
+            "minAlarmVal": 3420,
+            "upperCriticalVal": 43700,
+            "lowerCriticalVal": 3230
+          }
+        },
+        {
+          "name": "MCB_U17_FAN_4_R_RPM",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+          "type": 4,
+          "thresholds": {
+            "maxAlarmVal": 38060,
+            "minAlarmVal": 3105,
+            "upperCriticalVal": 39790,
+            "lowerCriticalVal": 2932
+          }
+        },
+        {
+          "name": "MCB_U34_XP3R3V_LDO_PCIE",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP5R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP5R0V_USB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP12R0V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13,
+            "minAlarmVal": 11,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "11*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP3R3V_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP3R3V_STBY_BMC",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.57,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP12R0V_STBY_BMC",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13,
+            "minAlarmVal": 11,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "11*@/1000.0"
+        },
+        {
+          "name": "MCB_U34_XP3R3V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP3R3V_STBY",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP1R0V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.95,
+            "upperCriticalVal": 1.1,
+            "lowerCriticalVal": 0.9
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP1R2V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.23,
+            "minAlarmVal": 1.17,
+            "upperCriticalVal": 1.32,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP1R8V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP3R3V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP3R3V_I210",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP1R0V_IOB_MGTAVCC",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.03,
+            "minAlarmVal": 0.97,
+            "upperCriticalVal": 1.1033,
+            "lowerCriticalVal": 0.9027
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U35_XP5R0V_STBY",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5187,
+            "lowerCriticalVal": 4.5153
+          },
+          "compute": "5.7*@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP1R1V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP1R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP2R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP3R3V_DOM_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP2R5V_DOM_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.7566,
+            "lowerCriticalVal": 2.2554
+          },
+          "compute": "2*@/1000.0"
+        },
+        {
+          "name": "MCB_U1_XP1R1V_DOM_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U1_ORV3_PWR_NTC_P2",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in6_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "59.968*(@/1000.0)^3-326.66*(@/1000.0)^2+650.33*(@/1000.0)-420.1"
+        },
+        {
+          "name": "MCB_U1_ORV3_GND_NTC_P2",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC3_MONITOR/in7_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "59.968*(@/1000.0)^3-326.66*(@/1000.0)^2+650.33*(@/1000.0)-420.1"
+        },
+        {
+          "name": "MCB_U61_MCB_COME_INLET_TSENSOR",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U60_MCB_COME_OUTLET_TSENSOR",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_OUTLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U62_PB_INLET_TSENSOR",
+          "sysfsPath": "/run/devmap/sensors/PB_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U63_PB_OUTLET_TSENSOR",
+          "sysfsPath": "/run/devmap/sensors/PB_OUTLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 80,
+            "upperCriticalVal": 85
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU101_XP48R0V_STBY_VIN",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 53,
+            "minAlarmVal": 45,
+            "upperCriticalVal": 57,
+            "lowerCriticalVal": 41
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU101_XP48R0V_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 53,
+            "minAlarmVal": 45,
+            "upperCriticalVal": 57,
+            "lowerCriticalVal": 41
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU101_XP48R0V_STBY_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU101_XP48R0V_STBY_IIN",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU101_XP48R0V_STBY_PIN",
+          "sysfsPath": "/run/devmap/sensors/48V_STBY_PWR_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_PU1066_XP48R0V_HOTSWAP_VIN",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 53,
+            "minAlarmVal": 45,
+            "upperCriticalVal": 57,
+            "lowerCriticalVal": 41
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1066_XP48R0V_HOTSWAP_VOUT",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 53,
+            "minAlarmVal": 45,
+            "upperCriticalVal": 57,
+            "lowerCriticalVal": 41
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1066_XP48R0V_HOTSWAP_IOUT",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "upperCriticalVal": 70
+          },
+          "compute": "1.8*@/1000.0"
+        },
+        {
+          "name": "MCB_PU1066_XP48R0V_HOTSWAP_TEMP",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1066_XP48R0V_HOTSWAP_PIN",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 3000,
+            "upperCriticalVal": 3200
+          },
+          "compute": "0.0018*@/1000.0"
+        },
+        {
+          "name": "MCB_PU426_XP12R0V_FAN1_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU426_XP12R0V_FAN1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU426_XP12R0V_FAN1_IIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "MCB_PU426_XP12R0V_FAN1_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU595_XP12R0V_FAN2_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU595_XP12R0V_FAN2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU595_XP12R0V_FAN2_IIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "MCB_PU595_XP12R0V_FAN2_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU691_XP12R0V_FAN3_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU691_XP12R0V_FAN3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU691_XP12R0V_FAN3_IIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "MCB_PU691_XP12R0V_FAN3_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU810_XP12R0V_FAN4_VIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU810_XP12R0V_FAN4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU810_XP12R0V_FAN4_IIN",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "MCB_PU810_XP12R0V_FAN4_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS108_XP12R0V_PB1_VIN",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS108_XP12R0V_PB1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS108_XP12R0V_PB1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 160,
+            "upperCriticalVal": 167
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS108_XP12R0V_PB1_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS109_XP12R0V_PB2_VIN",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS109_XP12R0V_PB2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS109_XP12R0V_PB2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 160,
+            "upperCriticalVal": 167
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PS109_XP12R0V_PB2_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU925_XP12R0V_COME_VIN",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU925_XP12R0V_COME_VOUT",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU925_XP12R0V_COME_TEMPARTURES",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU925_XP12R0V_COME_IIN",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_VIN",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_IIN",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -2.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_VOUT",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.5,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_IOUT",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 110,
+            "minAlarmVal": -2.5,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_TEMP",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 170,
+            "upperCriticalVal": 175
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_PIN",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_PU1497_XP3R3V_OSFP_POUT",
+          "sysfsPath": "/run/devmap/sensors/OSFP_PWR/power3_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 280,
+            "minAlarmVal": 0,
+            "upperCriticalVal": 300
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "COME_U1_CPU_UNCORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U1_CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U1_CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/RUNBMC_SLOT@0",
+      "pmUnitName": "BMC",
+      "sensors": [
+        {
+          "name": "BMC_U9_LM75B_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
+          },
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/COMESE_SLOT@0",
+      "pmUnitName": "NETLAKE20",
+      "sensors": [
+        {
+          "name": "COME_U28_INLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 46.3,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U29_OUTLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 65.4,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_JCN1_DIMM_CHA_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_DIMM1_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 79,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_JCN2_DIMM_CHB_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_DIMM2_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 79,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_U6_INA230_P12V_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 117.46
+          },
+          "compute": "10*@/1000000"
+        },
+        {
+          "name": "COME_U6_INA230_P12V_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.22,
+            "minAlarmVal": 10.82,
+            "upperCriticalVal": 13.35,
+            "lowerCriticalVal": 10.71
+          },
+          "compute": "@/1000"
+        },
+        {
+          "name": "COME_U6_INA230_P12V_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.87,
+            "upperCriticalVal": 10.97
+          },
+          "compute": "10*@/1000"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_POUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "upperCriticalVal": 13.2,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_VOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_IOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "upperCriticalVal": 13.2,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 3,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_POUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "upperCriticalVal": 13.2,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_VOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_IOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 12.6,
+                "minAlarmVal": 11.4,
+                "upperCriticalVal": 13.2,
+                "lowerCriticalVal": 10.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 3,
+          "productSubVersion": 2
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0",
+      "pmUnitName": "SMB",
+      "sensors": [
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -16
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 1300,
+            "minAlarmVal": -16
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2978_XP0R8V_TH6_VDDC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_VDDCORE/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U8_LM75B_TH6_INLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_INLET_TH6_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R8V_PT_VDDC_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R75V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1502_XP0R8V_PT_VDDC_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U29_LEFT_TMP432_1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_1/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2056_XP0R8V_PT_VDDC_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_U7_LM75B_TH6_OUTLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_OUTLET_TH6_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R8V_PT_VDDC_7_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_U30_RIGHT_TMP432_2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U30_RIGHT_TMP432_2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_TH6_SENSOR_TMP432_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP0R8V_PT_VDDC_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22,
+            "minAlarmVal": -0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1342_XP1R5V_TH6_RVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_4/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP0R8V_PT_VDDC_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22,
+            "minAlarmVal": -0.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU2052_XP1R5V_TH6_RVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R75V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "minAlarmVal": -1,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1937_XP0R8V_PT_VDDC_5_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_5_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120,
+            "minAlarmVal": -2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R9V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120,
+            "minAlarmVal": -2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R9V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "minAlarmVal": -1.5
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_U21_XP3R3V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP1R8V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP0R75V_TH6_PT_RESCAL",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP0R8V_TH6_VDDA",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.824,
+            "minAlarmVal": 0.776,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP1R8V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.854,
+            "minAlarmVal": 1.746,
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP1R5V_TH6_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP1R2V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.236,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U21_XP0R9V_TH6_PVDD_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC1_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP1R8V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP1R2V_TH6_VDDHTX",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.3,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP3R3V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP0R9V_TH6_PVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP0R9V_TH6_PVDD_3",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP0R9V_TH6_PVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP1R8V_SMB",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2,
+            "minAlarmVal": 1.81,
+            "upperCriticalVal": 2.1,
+            "lowerCriticalVal": 1.71
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U22_XP1R5V_TH6_PVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_ADC2_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.56,
+            "minAlarmVal": 1.44,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 1,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_PU1746_XP0R72V_PB_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 6,
+          "productSubVersion": 10
+        }
+      ]
+    }
+  ],
+  "powerConfig": {
+    "perSlotPowerConfigs": [
+      {
+        "__comment__": "Hot-swap VRM chip ltc4287 monitors the main power consumption of the system",
+        "name": "HSC1",
+        "powerSensorName": "MCB_PU1066_XP48R0V_HOTSWAP_PIN"
+      }
+    ],
+    "__comment__": "TPS16890 chip monitors the standby power consumption of the system",
+    "otherPowerSensorNames": [
+      "MCB_PU101_XP48R0V_STBY_PIN"
+    ],
+    "inputVoltageSensors": [
+      "MCB_PU1066_XP48R0V_HOTSWAP_VIN",
+      "MCB_PU101_XP48R0V_STBY_VIN"
+    ]
+  },
+  "temperatureConfigs": [
+    {
+      "name": "ASIC",
+      "temperatureSensorNames": [
+        "SMB_U29_LEFT_TMP432_1_TEMP2",
+        "SMB_U29_LEFT_TMP432_1_TEMP3",
+        "SMB_U30_RIGHT_TMP432_2_TEMP2"
+      ]
+    }
+  ]
+}

--- a/fboss/platform/platform_manager/platform_manager_validators.thrift
+++ b/fboss/platform/platform_manager/platform_manager_validators.thrift
@@ -20,6 +20,7 @@ const list<string> ALLOWED_PMUNIT_NAMES = [
   "JUMPER",
   "MCB",
   "NETLAKE",
+  "NETLAKE20",
   "PDB",
   "PDB_L",
   "PDB_R",
@@ -60,6 +61,7 @@ const list<string> ALLOWED_PMUNIT_NAMES = [
   "MINIPACK3BAM_MCB",
   "MINIPACK3N_MCB",
   "TAHANSB800BC_MCB",
+  "TAHANSB800BCM_MCB",
   // The whole board is a PmUnit for these
   "TAHAN",
   "JANGA",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
This PR implements the tahansb800bcm platform for Netlake 2.0 by leveraging and extending the configurations from the existing tahansb800bc platform.

### Key Changes
- **Platform Manager:**
  1. Standardize CPU bus naming using the virtual bus "CPU_BUS".
  2. Implement the pmUnitConfig and versionedPmUnitConfigs for "NETLAKE20" hardware identification.
  3. Update symbolicLinkToDevicePath and "CPU_CORE_TEMP" sysfs paths to align with
      "NETLAKE20" I2C topology.
  4. Support "NETLAKE20" and "TAHANSB800BCM_MCB" in the ALLOWED_PMUNIT_NAMES list.
- **Sensor Service:**
  1. Add the "NETLAKE20" sensor definitions, thresholds and sysfs paths to support the new hardware layout.
  2. Please refer to the [Netlake2.0_Sensor_Thresholds_v1.0](https://docs.google.com/spreadsheets/d/1mRfn6fskTg-4qB-fvlgGNc29mRV4pYfpR75qHatDYYE/edit?gid=0#gid=0)
- **Firmware Utility:**
  1. Update the fw_util config for BIOS upgrade to support the "NETLAKE20" specific flash sequences.
  2. Note: the flashrom tool needs to suppport AMD bios upgrade, the patch will be updated in BSP repo.
- **Bsp tests:**
      Update the bsp_tests config for "tahansb800bcm" support.
- **No Change configs:**
      fan_service.json, led_manager.json and rma_showtech.json.
# Test Plan
1. Platform Services build and config validation has passed.
2. The verification covered the following scopes with all results returning PASS:
    (1) Platform Layers: Services, Utilities, and Unit Tests.
    (2) Hardware Interface: HW and BSP validation.
    (3) Component Coverage:  Both Infineon (Main) and MPS (Secondary) sources.
    (4) The test tracker and detailed logs can be found here:
        [Netlake2.0_tahansb800bcm_fboss_test_tracker](https://docs.google.com/spreadsheets/d/1VgirZn-2mgolo8euTFOWZ0jZHFT7FL8i9afukyLwIjg/edit?gid=0#gid=0)
       [Netlake2.0_tahansb800bcm_fboss_test_logs](https://drive.google.com/drive/folders/1SAm-Dex0YLd8UjBjlwv1OzCas5mOBYJR)