### PR TITLE
[Celestica] Montblanc: Config: Add PSU temperature thresholds for Delta and Liteon(AC/DC)

### DIFF
--- a/fboss/platform/configs/montblanc/sensor_service.json
+++ b/fboss/platform/configs/montblanc/sensor_service.json
@@ -1657,24 +1657,148 @@
           "name": "PSU1_FAN_R_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/fan2_input",
           "type": 4
+        }
+      ],
+      "versionedSensors": [
+        {
+          "productName": "AC3K12V_M_D",
+          "sensors": [
+            {
+              "name": "PSU1_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 73,
+                "maxAlarmVal": 68
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 102,
+                "maxAlarmVal": 97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU1_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "DC3K12V_M_D",
+          "sensors": [
+            {
+              "name": "PSU1_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 65
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU1_TEMP2",
-          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "AC3K12V_M_L",
+          "sensors": [
+            {
+              "name": "PSU1_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 80,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 120,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 112,
+                "maxAlarmVal": 107
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU1_TEMP3",
-          "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "DC3K12V_M_L",
+          "sensors": [
+            {
+              "name": "PSU1_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 65,
+                "maxAlarmVal": 60
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU1_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_L_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 120,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000"
+            }
+          ]
         }
       ]
     },
@@ -1794,24 +1918,148 @@
           "name": "PSU2_FAN_R_RPM",
           "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/fan2_input",
           "type": 4
+        }
+      ],
+      "versionedSensors": [
+        {
+          "productName": "AC3K12V_M_D",
+          "sensors": [
+            {
+              "name": "PSU2_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 73,
+                "maxAlarmVal": 68
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 102,
+                "maxAlarmVal": 97
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU2_TEMP1",
-          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "DC3K12V_M_D",
+          "sensors": [
+            {
+              "name": "PSU2_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 70,
+                "maxAlarmVal": 65
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 125,
+                "maxAlarmVal": 120
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU2_TEMP2",
-          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "AC3K12V_M_L",
+          "sensors": [
+            {
+              "name": "PSU2_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 80,
+                "maxAlarmVal": 70
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 120,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 112,
+                "maxAlarmVal": 107
+              },
+              "compute": "@/1000"
+            }
+          ]
         },
         {
-          "name": "PSU2_TEMP3",
-          "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
-          "type": 3,
-          "compute": "@/1000"
+          "productName": "DC3K12V_M_L",
+          "sensors": [
+            {
+              "name": "PSU2_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 65,
+                "maxAlarmVal": 60
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 130,
+                "maxAlarmVal": 125
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "PSU2_TEMP3",
+              "sysfsPath": "/run/devmap/sensors/PDB_R_PMBUS/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 120,
+                "maxAlarmVal": 115
+              },
+              "compute": "@/1000"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
This PR adds PSU temperature thresholds for Delta and Liteon (AC/DC) based on product names to support monitoring and alerting.
<img width="599" height="353" alt="image" src="https://github.com/user-attachments/assets/df522344-b391-4a83-8be7-18196e6d25f9" />
# Test Plan
1. Platform Services build and config validation has passed.
2. Run platform_manager, sensor_service, and sensor_service_client on the different PSU testbeds and check the PSU temperature monitoring.
3. Liteon DC: [DC3K12V_M_L_logs.tar.gz](https://github.com/user-attachments/files/27698363/DC3K12V_M_L_logs.tar.gz)
   <img width="341" height="493" alt="image" src="https://github.com/user-attachments/assets/bdfd4dd0-1ed0-4c7f-811b-f39536663a4f" />
   <img width="1125" height="365" alt="image" src="https://github.com/user-attachments/assets/d23f9cc8-b029-4158-9437-023d51982d14" />
   <img width="1124" height="363" alt="image" src="https://github.com/user-attachments/assets/3a2a30dc-268c-4628-b3ea-a0e5e8bc5463" />
4. Liteon AC:  [AC3K12V_M_L_logs.tar.gz](https://github.com/user-attachments/files/27698431/AC3K12V_M_L_logs.tar.gz)
   <img width="336" height="488" alt="image" src="https://github.com/user-attachments/assets/ef8a7a84-f5fc-487d-8e08-493efd63b6ac" />
   <img width="1119" height="361" alt="image" src="https://github.com/user-attachments/assets/2c38fcb9-fa07-4acb-b6c3-a0f320d1c93d" />
   <img width="1128" height="360" alt="image" src="https://github.com/user-attachments/assets/ba6792da-9937-4b32-a5e9-99c342e243f4" />
5. Delta DC: [DC3K12V_M_D_logs.tar.gz](https://github.com/user-attachments/files/27698465/DC3K12V_M_D_logs.tar.gz)
   <img width="334" height="490" alt="image" src="https://github.com/user-attachments/assets/a663e0d7-7632-49f0-b569-bfbf8e1bc4c1" />
   <img width="1130" height="361" alt="image" src="https://github.com/user-attachments/assets/e84ffbbb-c297-445c-94c2-4b9fb9242381" />
    <img width="1118" height="359" alt="image" src="https://github.com/user-attachments/assets/33fcdc9b-c32c-4b6d-aec6-3cf5202dca83" />
6. Delta AC:  [AC3K12V_M_D_logs.tar.gz](https://github.com/user-attachments/files/27698529/AC3K12V_M_D_logs.tar.gz)
   <img width="337" height="488" alt="image" src="https://github.com/user-attachments/assets/f5b37de4-277e-4270-b71a-aa3b39de2fc4" />
   <img width="1133" height="363" alt="image" src="https://github.com/user-attachments/assets/a68c38d1-051b-4abb-b2d3-9fe9de98dc48" />
   <img width="1123" height="359" alt="image" src="https://github.com/user-attachments/assets/32d1175e-adbf-4e0d-9244-83eda8744032" />