### PR TITLE
[Celestica] Tahansb800bcm: Add QSFP and LED service support for tahansb800bcm

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -192,7 +192,9 @@ void PlatformProductInfo::initMode() {
     } else if (
         modelName.find("JANGA800BIC") == 0 || modelName.find("JANGA") == 0) {
       type_ = PlatformType::PLATFORM_JANGA800BIC;
-    } else if (modelName.find("TAHANSB800BC") == 0) {
+    } else if (
+        modelName.find("TAHANSB800BC") == 0 ||
+        modelName.find("TAHANSB800BCM") == 0) {
       type_ = PlatformType::PLATFORM_TAHANSB800BC;
     } else if (
         modelName.find("TAHAN") == 0 || modelName.find("TAHAN800BC") == 0 ||
@@ -281,7 +283,7 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_MINIPACK3N;
     } else if (FLAGS_mode == "wedge800bact") {
       type_ = PlatformType::PLATFORM_WEDGE800BACT;
-    } else if (FLAGS_mode == "tahansb800bc") {
+    } else if (FLAGS_mode == "tahansb800bc" || FLAGS_mode == "tahansb800bcm") {
       type_ = PlatformType::PLATFORM_TAHANSB800BC;
     } else if (FLAGS_mode == "wedge800cact") {
       type_ = PlatformType::PLATFORM_WEDGE800CACT;


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Following the tahansb800bcm platform support for Netlake2.0 ([[PR#1186](https://github.com/facebook/fboss/pull/1186)]), this update registers the platform in PlatformProductInfo.cpp. This enablement allows the platform to leverage existing qsfp_service and led_service logic. By ensuring correct PlatformType identification, it also enables the successful execution of qsfp_hw_test and led_service_hw_test without necessitating redundant hardware-specific code.

# Test Plan

- **qsfp_hw_test:**
1. Run T0 QSFP tests with the "mode": "tahansb800bcm" in qsfp.conf.
2. Run T0 QSFP tests with the "Product Name": "TAHANSB800BCM" in fruid.json.
3. Result: Platform identified successfully; all functional tests PASSED.
4. Execution Command:
    ./bin/run_test.py qsfp --qsfp-config ./qsfp.conf  --filter_file=./share/hw_sanity_tests/t0_qsfp_hw_tests.conf  >& t0_qsfp_hw_tests.log &
- **led_service_hw_test:**
1. Run led_service_hw_test with the "mode": "tahansb800bcm" in led.conf.
2. Run led_service_hw_test with the "Product Name": "TAHANSB800BCM" in fruid.json.
3. Result: Platform identified successfully; all functional tests PASSED.
4. Execution Commands:
./bin/led_service_hw_test --logging=DBG --gtest_filter=LedServiceTest.checkLedColorChange --led-config ./led.conf --visual_delay_sec 1 >& checkLedColorChange.log &
 ./bin/led_service_hw_test --logging=DBG --gtest_filter=LedServiceTest.checkLedBlinking  --led-config ./led.conf --visual_delay_sec 1 >& checkLedBlinking.log &

- **Detailed logs:**
 Please see the detailed logs: [Netlake2.0_tahansb800bcm_oss_qsfp_led_service_hw_test_logs](https://drive.google.com/drive/folders/1-hGl4w04WBSS7Eux6amBuosBc38I-D2r)