### PR TITLE
[Cisco][G200]Srv6 Encap test fix for missing interface scoping for link local NH

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentSrv6EncapTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSrv6EncapTests.cpp
@@ -291,8 +291,9 @@ class AgentSrv6EncapTest : public AgentHwTest {
     for (auto i = 0; i < sidLists.size(); ++i) {
       auto nhop = ecmpHelper.nhop(i);
       CHECK(nhop.linkLocalNhopIp.has_value());
-      nhops.insert(UnresolvedNextHop(
+      nhops.insert(ResolvedNextHop(
           folly::IPAddress(*nhop.linkLocalNhopIp),
+          nhop.intf,
           ECMP_WEIGHT,
           std::nullopt,
           std::nullopt,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Verified all these tests manually with sha from May13: 
                •	AgentSrv6EncapTest/0.sendPacketToEncapRoute + warmboot
		•	AgentSrv6EncapTest/1.sendPacketToEncapRoute + warmboot
		•	AgentSrv6EncapTest/0.sendPacketToEncapRouteAfterLinkFlap + warmboot
		•	AgentSrv6EncapTest/1.sendPacketToEncapRouteAfterLinkFlap + warmboot
		•	AgentSrv6EncapTest/0.resolveNeighborsAfterRouteProgram + warmboot
		•	AgentSrv6EncapTest/1.resolveNeighborsAfterRouteProgram + warmboot
		•	AgentSrv6TrunkLoadBalancerTest.Srv6TrunkEcmpLoadBalance + warmboot
		•	AgentSrv6EncapTest/0.recursiveResolutionPreservesSidList + warmboot
		•	AgentSrv6EncapTest/1.recursiveResolutionPreservesSidList + warmboot
		•	AgentSrv6EncapTest/0.multipleSidListsSameNextHop + warmboot
		•	AgentSrv6EncapTest/1.multipleSidListsSameNextHop + warmboot
		•	AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking + warmboot
		•	AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking + warmboot
		•	AgentSrv6EncapTest/0.VerifyDscpQueueMapping + warmboot
		•	AgentSrv6EncapTest/1.VerifyDscpQueueMapping + warmboot

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
