### PR TITLE
[Accton][minipack3n] Restore SCM_CPLD default write protect and OOB control

### DIFF
--- a/fboss/platform/configs/minipack3n/platform_manager.json
+++ b/fboss/platform/configs/minipack3n/platform_manager.json
@@ -642,15 +642,7 @@
           "busName": "INCOMING@2",
           "address": "0x35",
           "kernelDeviceName": "mp3n_scmcpld",
-          "pmUnitScopedName": "SCM_CPLD",
-          "initRegSettings": [
-            {
-              "regOffset": 177,
-              "ioBuf": [
-                2
-              ]
-            }
-          ]
+          "pmUnitScopedName": "SCM_CPLD"
         },
         {
           "busName": "SCM_MUX_A@0",


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

# Summary:
Remove the initRegSettings configuration for SCM_CPLD (register 0xB1) and rely on hardware default values instead.

Previously, we explicitly set register 0xB1 to 0x2 during CPLD initialization:
- Bit[0] = 0: Disable SCM EEPROM write protect (writable)
- Bit[1] = 1: Transfer OOB switch EEPROM control from 88E6321 to SCM

Using hardware default values provides better consistency and reduces the risk of misconfiguration during initialization. Write protection can be managed explicitly when needed rather than being disabled by default.

### Changes:
- Removed initRegSettings block from SCM_CPLD configuration
- Register 0xB1 will now use hardware default value (0x1):
  - Bit[0] = 1: Enable SCM EEPROM write protect (default protected)
  - Bit[1] = 0: OOB switch EEPROM controlled by 88E6321 (default)

# Test Plan:
1. Build and deploy the updated configuration to the target platform
2. Check platform manager logs for any CPLD-related errors
3. Verify register 0xB1 uses default value (0x1): 
#Read register 0xB1 (decimal 177) 
i2cget -f -y 4 0x35 0xB1 
#Expected output: 0x01
[[mp3n] platform_manager.txt](https://github.com/user-attachments/files/27750746/mp3n.platform_manager.txt)
[[mp3n] scm_write_protect_test.txt](https://github.com/user-attachments/files/27750748/mp3n.scm_write_protect_test.txt)
