### PR TITLE
[Celestica] cmake: Integrate ConfigValidatorTest into sw test executable

### DIFF
--- a/cmake/PlatformDataCorralServiceTests.cmake
+++ b/cmake/PlatformDataCorralServiceTests.cmake
@@ -5,6 +5,7 @@
 
 
 add_executable(platform_data_corral_sw_test
+  fboss/platform/data_corral_service/tests/ConfigValidatorTest.cpp
   fboss/platform/data_corral_service/tests/FruPresenceExplorerTests.cpp
   fboss/platform/data_corral_service/tests/LedManagerTests.cpp
 )

--- a/cmake/PlatformFanService.cmake
+++ b/cmake/PlatformFanService.cmake
@@ -77,6 +77,7 @@ target_link_libraries(fan_service
 install(TARGETS fan_service)
 
 add_executable(fan_service_sw_test
+  fboss/platform/fan_service/tests/ConfigValidatorTest.cpp
   fboss/platform/fan_service/tests/BspTests.cpp
   fboss/platform/fan_service/tests/ControlLogicTests.cpp
   fboss/platform/fan_service/tests/OvertempTests.cpp

--- a/cmake/PlatformFwUtil.cmake
+++ b/cmake/PlatformFwUtil.cmake
@@ -43,6 +43,16 @@ target_link_libraries(fw_util
   fw_util_libs
 )
 
+add_executable(fw_util_sw_test
+  fboss/platform/fw_util/tests/ConfigValidatorTest.cpp
+)
+
+target_link_libraries(fw_util_sw_test
+  fw_util_libs
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+)
+
 add_executable(fw_util_hw_test
   fboss/platform/fw_util/hw_test/FwUtilHwTest.cpp
 )


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Following the [PR#1120](https://github.com/facebook/fboss/pull/1120), this PR integrates the corresponding ConfigValidatorTest.cpp into the respective executables (fan_service_sw_test, platform_data_corral_sw_test and fw_util_sw_test) within the CMake build system to ensure the UT ConfigValidatorTest cases can be executed.

Note: fw_util_sw_test is a newly built binary and need be included in the UT scope for the [External_Meta FBOSS Platform Test Requirement](https://docs.google.com/spreadsheets/d/1I3a_cAsi6SEGOOuNswU_tO9MNJO6KSkKbegHxYznJoE/edit?gid=1692294260#gid=1692294260).


# Test Plan
1. Platform Services build and config validation has passed..
2. Run the UT cases: fan_service_sw_test, platform_data_corral_sw_test and fw_util_sw_test.
    LD_LIBRARY_PATH=./lib/  ./bin/fan_service_sw_test >& fan_service_sw_test.log
    LD_LIBRARY_PATH=./lib/  ./bin/platform_data_corral_sw_test >& platform_data_corral_sw_test.log
    LD_LIBRARY_PATH=./lib/  ./bin/fw_util_sw_test >& fw_util_sw_test.log
3. Result: ConfigValidatorTest cases can be executed and all functional tests PASSED.
    [fan_service_sw_test.txt](https://github.com/user-attachments/files/27951118/fan_service_sw_test.txt)
    [data_corral_sw_test.txt](https://github.com/user-attachments/files/27951128/data_corral_sw_test.txt)
    [fw_util_sw_test.txt](https://github.com/user-attachments/files/27951132/fw_util_sw_test.txt)