### PR TITLE
[Meta][OSS] Only trigger docs workflows on docs/ changes and drop fro…

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -9,8 +9,8 @@ on:
   push:
     branches:
       - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+    paths:
+      - 'docs/**'
 
 jobs:
   build:
@@ -24,10 +24,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: yarn
-          cache-dependency-path: docs/yarn.lock
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
       - name: Build website
         run: yarn build
 

--- a/.github/workflows/github-pages-test-deploy.yml
+++ b/.github/workflows/github-pages-test-deploy.yml
@@ -8,8 +8,8 @@ on:
   pull_request:
     branches:
       - main
-    # Review gh actions docs if you want to further define triggers, paths, etc
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
+    paths:
+      - 'docs/**'
 
 jobs:
   test-deploy:
@@ -22,9 +22,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: yarn
-          cache-dependency-path: docs/yarn.lock
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install
       - name: Test build website
         run: yarn build


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

  - Add paths: ['docs/**'] filter to both GitHub Actions workflows so they only trigger when docs content changes, avoiding unnecessary CI runs on code-only PRs
  - Replace yarn install --frozen-lockfile with yarn install since yarn.lock is no longer synced from the internal repo (it contains Meta-internal registry URLs that are not accessible from GitHub)
  - Remove yarn cache config (cache: yarn, cache-dependency-path) since there's no committed lockfile to cache against

 ## Context

  The internal yarn.lock is generated by Meta's bundled yarn which hardcodes an internal registry (registry.facebook.net). This caused 401 Unauthorized errors in CI. Rather than syncing an OSS-unsafe lockfile, we now let GitHub generate dependencies fresh from package.json at build time.

# Test Plan

  - Verify this PR does not trigger the docs workflows (since it only changes workflow files, not docs/ content)
  - Create a follow-up test PR touching a file in docs/ to verify the workflow triggers and builds successfully
