### PR TITLE
[Cisco][G200/G202x] MoD related fixes for Tajo

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiManagerTable.cpp
+++ b/fboss/agent/hw/sai/switch/SaiManagerTable.cpp
@@ -232,6 +232,17 @@ void SaiManagerTable::reset(bool skipSwitchManager) {
     }
   }
 #endif
+#if defined(TAJO_SAI_SDK)
+  // Tajo keeps a default switch-event TAM handle even without MoD reports.
+  // Always clear switch TAM binding first so TAM/TAM_EVENT/TAM_EVENT_THRESHOLD
+  // objects can be removed cleanly before switch teardown.
+  switchManager_->setTamObject({});
+  // If MoD reports were configured, clear per-port TAM bindings too.
+  auto modPortIds = tamManager_->getAllMirrorOnDropPortIds();
+  for (auto portId : modPortIds) {
+    portManager_->setTamObject(portId, {});
+  }
+#endif
   tamManager_.reset();
 
   // ports may be referenced in acls, reset ports after acls

--- a/fboss/agent/hw/sai/switch/npu/tajo/SaiTamManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/tajo/SaiTamManager.cpp
@@ -7,6 +7,7 @@ extern "C" {
 }
 
 #include <folly/logging/xlog.h>
+#include <limits>
 
 #include "fboss/agent/hw/sai/api/SwitchApi.h"
 #include "fboss/agent/hw/sai/store/SaiStore.h"
@@ -104,28 +105,41 @@ void rebuildAndRebindTam(
              << " port(s)";
 }
 
-// Build a TAM_EVENT_THRESHOLD object whose UNIT is packets and RATE is the
-// configured packet-per-second cap. Returns nullptr if no rate is configured
-// or the configured value is non-positive — SAI_TAM_EVENT_ATTR_THRESHOLD
-// will then be left unset on the TAM_EVENT, which is the most permissive
-// default (no rate limiting).
+// Build a TAM_EVENT_THRESHOLD object for PACKET_DROP events.
+// On this SDK path, SAI_TAM_EVENT_ATTR_THRESHOLD is mandatory for
+// SAI_TAM_EVENT_TYPE_PACKET_DROP, so we always create and attach a threshold
+// object. When dropPacketRateThreshold is configured with a positive value,
+// program UNIT=PACKETS and RATE=<value>; otherwise leave threshold fields
+// unset to keep the most permissive behavior (no explicit rate limiting).
 std::shared_ptr<SaiTamEventThreshold> createTamEventThreshold(
     SaiStore* saiStore,
     std::optional<int32_t> rateThreshold) {
-  if (!rateThreshold.has_value() || *rateThreshold <= 0) {
-    if (rateThreshold.has_value()) {
-      XLOG(WARN) << "MirrorOnDropReport dropPacketRateThreshold="
-                 << *rateThreshold
-                 << " is non-positive; ignoring (no rate limiting will apply)";
-    }
-    return nullptr;
-  }
   SaiTamEventThresholdTraits::CreateAttributes thresholdTraits;
-  std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Unit>>(
-      thresholdTraits) =
-      static_cast<sai_int32_t>(SAI_TAM_EVENT_THRESHOLD_UNIT_PACKETS);
-  std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Rate>>(
-      thresholdTraits) = static_cast<sai_uint32_t>(*rateThreshold);
+  if (rateThreshold.has_value() && *rateThreshold > 0) {
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Unit>>(
+        thresholdTraits) =
+        static_cast<sai_int32_t>(SAI_TAM_EVENT_THRESHOLD_UNIT_PACKETS);
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Rate>>(
+        thresholdTraits) = static_cast<sai_uint32_t>(*rateThreshold);
+  } else if (rateThreshold.has_value()) {
+    XLOG(WARN) << "MirrorOnDropReport dropPacketRateThreshold="
+               << *rateThreshold
+               << " is non-positive; using threshold object without explicit "
+               << "rate limit";
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Unit>>(
+        thresholdTraits) =
+        static_cast<sai_int32_t>(SAI_TAM_EVENT_THRESHOLD_UNIT_PACKETS);
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Rate>>(
+        thresholdTraits) = std::numeric_limits<sai_uint32_t>::max();
+  } else {
+    // MoD default behavior when no threshold is configured: keep reporting
+    // enabled by using a permissive packet-rate cap.
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Unit>>(
+        thresholdTraits) =
+        static_cast<sai_int32_t>(SAI_TAM_EVENT_THRESHOLD_UNIT_PACKETS);
+    std::get<std::optional<SaiTamEventThresholdTraits::Attributes::Rate>>(
+        thresholdTraits) = std::numeric_limits<sai_uint32_t>::max();
+  }
   auto& store = saiStore->get<SaiTamEventThresholdTraits>();
   return store.setObject(thresholdTraits, thresholdTraits);
 }
@@ -220,13 +234,39 @@ std::shared_ptr<SaiTamTransport> SaiTamManager::createTamTransport(
     sai_int32_t transportType,
     std::optional<folly::MacAddress> dstMac) {
   auto& transportStore = saiStore_->get<SaiTamTransportTraits>();
+  std::optional<SaiTamTransportTraits::Attributes::SrcMacAddress> srcMacAttr =
+      std::nullopt;
+  if (SaiTamTransportTraits::Attributes::SrcMacAddress::
+          optionalExtensionAttributeId()
+              .has_value()) {
+    srcMacAttr = SaiTamTransportTraits::Attributes::SrcMacAddress(
+        folly::MacAddress(report->getSwitchMac()));
+  } else {
+    XLOG(INFO) << "Skipping TAM transport srcMac extension attribute "
+               << "(unsupported on this SAI implementation)";
+  }
+
+  std::optional<SaiTamTransportTraits::Attributes::DstMacAddress> dstMacAttr =
+      std::nullopt;
+  if (dstMac.has_value()) {
+    if (SaiTamTransportTraits::Attributes::DstMacAddress::
+            optionalExtensionAttributeId()
+                .has_value()) {
+      dstMacAttr =
+          SaiTamTransportTraits::Attributes::DstMacAddress(dstMac.value());
+    } else {
+      XLOG(INFO) << "Skipping TAM transport dstMac extension attribute "
+                 << "(unsupported on this SAI implementation)";
+    }
+  }
+
   auto transportTraits = SaiTamTransportTraits::AdapterHostKey{
       transportType,
       report->getLocalSrcPort(),
       report->getCollectorPort(),
       report->getMtu(),
-      folly::MacAddress(report->getSwitchMac()),
-      dstMac,
+      srcMacAttr,
+      dstMacAttr,
   };
   return transportStore.setObject(transportTraits, transportTraits);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
	
	1. On Tajo, `SAI_TAM_TRANSPORT_ATTR_SRC_MAC_ADDRESS` and `DST_MAC_ADDRESS` are unsupported (`optionalExtensionAttributeId() == nullopt`), but code attempted to instantiate extension attributes unconditionally, causing a hard check failure id.has_value() Fix is to build `SrcMacAddress` and `DstMacAddress` as optional extension attributes.
	2. SDK requires `SAI_TAM_EVENT_ATTR_THRESHOLD` for `SAI_TAM_EVENT_TYPE_PACKET_DROP`. If not set, we get - `Failed to create sai entity TamEvent...: MANDATORY ATTRIBUTE MISSING`. Fix is to always create a SaiTamEventThreshold object for the packet-drop event path. 
	3. Tajo tear down fixes. For `TAJO_SAI_SDK` teardown path, clear TAM bindings using empty lists: `switchManager_->setTamObject({})`, `portManager_->setTamObject(portId, {})`instead of reset helpers that set `SAI_NULL_OBJECT_ID` list entries.
	4. Tear down ordering fix to avoid "OBJECT IN USE" error 
	Before `tamManager_.reset()` in Tajo path, 1. clear switch TAM object list
	2. clear TAM object list on all MoD egress ports returned by `getAllMirrorOnDropPortIds()`then reset TAM manager.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Executed the following MoD tests to ensure that the setup and teardown is successful: 
• AgentMirrorOnDropStatelessTest.DefaultRouteDrop
• AgentMirrorOnDropStatelessTest.AclDrop
• AgentMirrorOnDropStatelessTest.MmuDrop
• AgentMirrorOnDropStatelessWarmbootTest.WarmbootEnableSampling
• AgentMirrorOnDropStatelessWarmbootTest.WarmbootDisableSampling

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
