### PR TITLE
[Celestica] Icecube: Config: Add TRVDD sensor support for SMB v3.1.10 (PVT Bring-up)

### DIFF
--- a/fboss/platform/configs/icecube/sensor_service.json
+++ b/fboss/platform/configs/icecube/sensor_service.json
@@ -2182,6 +2182,61 @@
           "productProductionState": 2,
           "productVersion": 3,
           "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_XP0R72V_PB_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 3,
+          "productVersion": 1,
+          "productSubVersion": 10
         }
       ]
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="998" height="362" alt="icecube_sensor" src="https://github.com/user-attachments/assets/5edb913f-f2fe-48e5-b42c-393984eb409b" />



# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

As part of the Icecube PVT bring-up process, new **SMB** (System Main Board) units have been manufactured with version combination **3.1.10** (Production State: 3, Version: 1, Sub-version: 10). 

This PR adds the necessary sensor configuration block in `sensor_service.json` to support these new units. Without this change, the `sensor_service` would fail to correctly associate and monitor the voltage rails for this specific hardware revision.

The update specifically includes **VOUT monitoring** for the four SMB TRVDD rails (Phase 0-3), mapped to `in4_input` on their respective voltage monitor chips:
- `SMB_XP0R72V_PB_TRVDD_0_VOUT` -> `SMB_ASIC_VOLTAGE_0`
- `SMB_XP0R72V_PB_TRVDD_1_VOUT` -> `SMB_ASIC_VOLTAGE_6`
- `SMB_XP0R72V_PB_TRVDD_2_VOUT` -> `SMB_ASIC_VOLTAGE_3`
- `SMB_XP0R72V_PB_TRVDD_3_VOUT` -> `SMB_ASIC_VOLTAGE_7`

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

1. **Syntax Validation**: Validated JSON syntax.
2. **Formatting**: Pretty-printed configurations using the `jq` command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Service Verification**: Confirmed that the following services start and run without errors:
    - `platform_manager`
    - `sensor_service`/`sensor_service_client`/`sensor_service_sw_test`/`sensor_service_hw_test`

5. **Hardware Identification**: Verified the SMB version (**3.1.10**) is correctly identified via FRU/EEPROM utility during initial bring-up.
6. **Voltage Audit**: Confirmed TRVDD voltage readings are within the nominal **0.72V** range (verified via `sensor_service_client`).

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

**Attachments**:


[icecube_platform_manager_2026_04_29_log.txt](https://github.com/user-attachments/files/27946470/icecube_platform_manager_2026_04_29_log.txt)
[icecube_sensor_service_2026_04_29_log.txt](https://github.com/user-attachments/files/27946476/icecube_sensor_service_2026_04_29_log.txt)
[icecube_sensor_service_client_2026_04_29_log.txt](https://github.com/user-attachments/files/27946478/icecube_sensor_service_client_2026_04_29_log.txt)
[icecube_sensor_service_hw_test_2026_04_29_log.txt](https://github.com/user-attachments/files/27946489/icecube_sensor_service_hw_test_2026_04_29_log.txt)
[icecube_sensor_service_sw_test_2026_04_29_log.txt](https://github.com/user-attachments/files/27946518/icecube_sensor_service_sw_test_2026_04_29_log.txt)



