### PR TITLE
CPO/ELSFP + CMIS 5.3 integration for qsfp_service

### DIFF
--- a/fboss/FBOSS_CPO_ELSFP_Improvement_HLD.md
+++ b/fboss/FBOSS_CPO_ELSFP_Improvement_HLD.md
@@ -1,0 +1,749 @@
+# FBOSS CPO and ELSFP Support - High Level Design
+
+## Table of Contents
+- [Revision](#revision)
+- [About This Document](#about-this-document)
+- [Scope](#scope)
+- [Definitions/Abbreviations](#definitionsabbreviations)
+- [1. Overview](#1-overview)
+- [2. Requirements](#2-requirements)
+- [3. Architecture](#3-architecture)
+- [4. Detailed Design](#4-detailed-design)
+  - [4.1 Transceiver Type Extension](#41-transceiver-type-extension)
+  - [4.2 CPO DOM Monitoring](#42-cpo-dom-monitoring)
+  - [4.3 CPO Port Lane Mapping](#43-cpo-port-lane-mapping)
+  - [4.4 CPO Joint Mode](#44-cpo-joint-mode)
+  - [4.5 ELSFP Memory Map and Paging](#45-elsfp-memory-map-and-paging)
+  - [4.6 ELSFP Banking Support](#46-elsfp-banking-support)
+- [5. Configuration](#5-configuration)
+- [6. CLI Commands](#6-cli_commands)
+- [7. YANG/Thrift Changes](#7-yangthrift-changes)
+- [8. Redis DB Schema Changes](#8-redis-db-schema-changes)
+- [9. Platform Mapping Changes](#9-platform-mapping-changes)
+- [10. Testing Plan](#10-testing-plan)
+- [References](#references)
+
+---
+
+## Revision
+
+| Rev | Date        | Author      | Description                   |
+|-----|-------------|-------------|-------------------------------|
+| 0.1 | 2025-04-21 | FBOSS Team  | Initial HLD for CPO/ELSFP    |
+
+---
+
+## About This Document
+
+This document provides a High Level Design for adding Co-Packaged Optics (CPO) and External Laser SFP (ELSFP) support to the FBOSS (Facebook Open Switching System) platform.
+
+## Scope
+
+This HLD covers:
+- Extension of FBOSS transceiver types to support ELSFP
+- CPO DOM (Digital Optical Monitoring) with OE/ELSFP separation
+- CPO port lane mapping with interleave modes
+- CPO joint mode for hardware-controlled CPO
+- ELSFP memory map and paging support
+- ELSFP banking support for CMIS modules
+- Platform mapping changes for CPO platforms
+
+## Definitions/Abbreviations
+
+| Term     | Definition                                      |
+|----------|-------------------------------------------------|
+| CPO      | Co-Packaged Optics                              |
+| ELSFP    | External Laser SFP                              |
+| OE       | Optical Engine                                  |
+| ELSP     | External Laser Source                           |
+| LPO      | Linear Pluggable Optics                         |
+| DOM      | Digital Optical Monitoring                      |
+| CMIS     | Common Management Interface Specification       |
+| NPU      | Network Processing Unit                         |
+| QSFP     | Quad Small Form-factor Pluggable                |
+| OSFP     | Octal Small Form-factor Pluggable               |
+
+---
+
+## 1. Overview
+
+Co-Packaged Optics (CPO) and External Laser SFP (ELSFP) are emerging technologies for high-speed optical interconnects in data center switches. CPO integrates optical engines directly on the switch PCB, while ELSFP uses an external laser source separate from the transceiver module.
+
+This document describes the changes needed in FBOSS to support these technologies, building on the SONiC implementation as a reference.
+
+### CPO Architecture
+
+```
++---------------------------------------------+
+|              Switch PCB                     |
+|                                             |
+|  +----------+        +------------------+  |
+|  |   ASIC   |--------|  Optical Engine  |  |
+|  |          |  electrical |  (OE)       |  |
+|  +----------+        +---------+--------+  |
+|                              |              |
+|                       +------v------+       |
+|                       |   ELSFP     |       |
+|                       |  (Laser)    |       |
+|                       +-------------+       |
++---------------------------------------------+
+```
+
+### ELSFP Architecture
+
+```
++------------------+     Fiber      +------------------+
+|   Transceiver    |<-------------->|   ELSFP (Laser)  |
+|   (Modulator)    |                |   (External)     |
++---------+--------+                +---------+--------+
+          |                                   |
+          +------------+   +------------------+
+                       |   |
+                +------v---v------+
+                |   Laser Fiber   |
+                |   Connection    |
+                +-----------------+
+```
+
+---
+
+## 2. Requirements
+
+### 2.1 Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| R1 | Support ELSFP as a distinct transceiver type | P0 |
+| R2 | CPO DOM monitoring with separate OE and ELSFP readings | P0 |
+| R3 | CPO port lane mapping with interleave modes | P0 |
+| R4 | CPO joint mode for hardware-controlled CPO | P1 |
+| R5 | ELSFP memory map and paging support | P0 |
+| R6 | ELSFP banking support for CMIS modules | P0 |
+| R7 | CLI commands for CPO/ELSFP management | P0 |
+| R8 | Platform mapping changes for CPO platforms | P0 |
+| R9 | Thrift model extensions for CPO/ELSFP | P0 |
+
+### 2.2 Non-Functional Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| NR1 | Backward compatible with existing transceiver types | P0 |
+| NR2 | No performance impact on non-CPO platforms | P0 |
+| NR3 | Thread-safe DOM monitoring for CPO/ELSFP | P0 |
+
+---
+
+## 3. Architecture
+
+### 3.1 Component Diagram
+
+```
++---------------------------------------------------------+
+|                    FBOSS System                         |
+|                                                         |
+|  +------------------+    +-------------------------+   |
+|  |   fboss_agent    |    |   qsfp_service          |   |
+|  |                  |    |                         |   |
+|  |  +------------+  |    |  +------------------+   |   |
+|  |  | SwSwitch   |  |    |  | TransceiverManager|   |   |
+|  |  +-----+------+  |    |  +--------+---------+   |   |
+|  |        |         |    |           |             |   |
+|  |  +-----v------+  |    |  +--------v---------+   |   |
+|  |  | HwSwitch   |  |    |  | CpoDomMonitor    |   |   |
+|  |  | (SAI/Bcm)  |  |    |  | (new)            |   |   |
+|  |  +-----+------+  |    |  +--------+---------+   |   |
+|  |        |         |    |           |             |   |
+|  |  +-----v------+  |    |  +--------v---------+   |   |
+|  |  | Platform   |  |    |  | ElsfpMemoryMap   |   |   |
+|  |  | Mapping    |  |    |  | (new)            |   |   |
+|  |  +------------+  |    |  +------------------+   |   |
+|  |                  |    |                         |   |
+|  +------------------+    +-------------------------+   |
+|           |                        |                   |
+|  +--------v---------+    +---------v----------+       |
+|  | Platform Config  |    | led_service       |       |
+|  | (cpo_platform)   |    | (CpoLedManager)   |       |
+|  +------------------+    +--------------------+       |
+|                                                         |
++---------------------------------------------------------+
+```
+
+### 3.2 Module Interactions
+
+```
++----------+     +----------+     +------------+     +--------+
+| Platform |---->| QSFP     |---->| Transceiver |---->| SFP    |
+| Mapping  |     | Service  |     | Manager     |     | Module |
++----------+     +----------+     +-----+------+     +---+----+
+                                         |                |
+                               +---------v----+     +-----v-----+
+                               | CpoDomMonitor|     | CMIS      |
+                               | (OE/ELSFP)   |     | Banking   |
+                               +--------------+     +-----------+
+```
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Transceiver Type Extension
+
+**File:** `fboss/qsfp_service/if/transceiver.thrift`
+
+Add new transceiver types:
+
+```thrift
+enum TransceiverType {
+  ...
+  QSFP = 1,
+  OSFP = 2,
+  SFP = 3,
+  ELSFP = 4,      // NEW: External Laser SFP
+  CPO_OE = 5,     // NEW: CPO Optical Engine
+}
+
+enum LaserSourceType {
+  INTERNAL = 0,    // Traditional integrated laser
+  EXTERNAL = 1,    // External laser (ELSFP)
+  UNKNOWN = 2,
+}
+```
+
+### 4.2 CPO DOM Monitoring
+
+**File:** `fboss/qsfp_service/if/transceiver.thrift`
+
+Extend DOM structure to support CPO:
+
+```thrift
+struct OpticalEngineDom {
+  1: double temperature,
+  2: list<double> txPowers,
+  3: list<double> rxPowers,
+  4: double voltage,
+  5: list<double> snr,
+  6: list<bool> laneAlarmFlags,
+}
+
+struct ElsfpDom {
+  1: double temperature,
+  2: double laserBiasCurrent,
+  3: double opticalOutputPower,
+  4: bool laserReady,
+  5: bool laserFault,
+}
+
+struct CpoDomData {
+  1: OpticalEngineDom oeDom,
+  2: ElsfpDom elsfpDom,
+  3: TransceiverType transceiverType,
+  4: LaserSourceType laserSourceType,
+}
+```
+
+### 4.3 CPO Port Lane Mapping
+
+**File:** `fboss/agent/platforms/common/PlatformMapping.h`
+
+Add CPO port lane mapping support:
+
+```cpp
+enum class InterleaveMode {
+  NONE = 0,      // 1:1 port to lane mapping
+  MODE1 = 1,     // Ports share lanes across different transceivers
+  MODE2 = 2,     // Complex interleaving for CPO
+};
+
+struct CpoPortLaneMap {
+  PortID portId;
+  std::vector<int> laneIds;
+  InterleaveMode interleaveMode;
+  bool isCpoPort;       // True if this is a CPO port (OE connected)
+  bool isElsfpPort;     // True if this uses ELSFP
+};
+```
+
+### 4.4 CPO Joint Mode
+
+**File:** `fboss/qsfp_service/platforms/wedge/WedgeManager.h`
+
+Add joint mode support:
+
+```cpp
+enum class CpoJointMode {
+  DISABLED = 0,
+  HARDWARE = 1,   // HW-controlled CPO joint mode
+  SOFTWARE = 2,   // SW-controlled CPO joint mode
+};
+
+class CpoManager {
+ public:
+  void setJointMode(PortID port, CpoJointMode mode);
+  CpoJointMode getJointMode(PortID port);
+  bool isJointModeSupported(PortID port);
+};
+```
+
+### 4.5 ELSFP Memory Map and Paging
+
+**File:** `fboss/lib/phy/CmisModule.h`
+
+Extend CMIS module for ELSFP:
+
+```cpp
+class ElsfpMemoryMap {
+ public:
+  // ELSFP-specific registers (Page 01h)
+  static constexpr uint8_t ELSFP_STATUS = 128;
+  static constexpr uint8_t LASER_TEMP_HIGH = 130;
+  static constexpr uint8_t LASER_TEMP_LOW = 131;
+  static constexpr uint8_t LASER_BIAS_HIGH = 132;
+  static constexpr uint8_t LASER_BIAS_LOW = 133;
+  static constexpr uint8_t OPTICAL_OUTPUT_HIGH = 134;
+  static constexpr uint8_t OPTICAL_OUTPUT_LOW = 135;
+  static constexpr uint8_t LASER_CONTROL = 136;
+
+  bool readElsfpStatus();
+  double readLaserTemperature();
+  double readLaserBiasCurrent();
+  double readOpticalOutputPower();
+  void setLaserControl(bool enable);
+};
+```
+
+### 4.6 ELSFP Banking Support
+
+**File:** `fboss/lib/phy/CmisModule.h`
+
+Add banking support:
+
+```cpp
+class CmisBanking {
+ public:
+  static constexpr uint8_t BANK_SELECT_REG = 0xA0;
+  static constexpr uint8_t NUM_BANKS = 4;
+
+  void selectBank(uint8_t bank);
+  uint8_t getCurrentBank();
+  bool isBankSupported(uint8_t bank);
+
+  // Read from banked page
+  std::vector<uint8_t> readBankedPage(uint8_t bank, uint8_t page, uint8_t offset, uint8_t length);
+
+  // Write to banked page
+  void writeBankedPage(uint8_t bank, uint8_t page, uint8_t offset, const std::vector<uint8_t>& data);
+};
+```
+
+---
+
+## 5. Configuration
+
+### 5.1 CPO Platform Configuration
+
+**File:** `fboss/platform/configs/<platform>/platform_manager.json`
+
+```json
+{
+  "cpoConfig": {
+    "enabled": true,
+    "interleaveMode": "MODE1",
+    "oeType": "BAILLY",
+    "elsfpType": "ELSFP_400G",
+    "jointModeDefault": "HARDWARE",
+    "domPollingIntervalMs": 1000,
+    "oeDomThresholds": {
+      "temperatureHigh": 75.0,
+      "temperatureLow": -10.0,
+      "txPowerHigh": 3.0,
+      "txPowerLow": -10.0,
+      "rxPowerHigh": 3.0,
+      "rxPowerLow": -15.0
+    },
+    "elsfpDomThresholds": {
+      "temperatureHigh": 70.0,
+      "laserBiasHigh": 80.0,
+      "opticalOutputHigh": 5.0,
+      "opticalOutputLow": -5.0
+    }
+  }
+}
+```
+
+### 5.2 CPO Port Configuration
+
+**File:** `fboss/platform/configs/<platform>/cpo_port_config.json`
+
+```json
+{
+  "cpoPortConfig": {
+    "portLaneMaps": [
+      {
+        "portId": 1,
+        "laneIds": [1, 2, 3, 4],
+        "interleaveMode": "NONE",
+        "isCpoPort": true,
+        "isElsfpPort": true
+      },
+      {
+        "portId": 2,
+        "laneIds": [5, 6, 7, 8],
+        "interleaveMode": "MODE1",
+        "isCpoPort": true,
+        "isElsfpPort": true
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 6. CLI Commands
+
+### 6.1 CPO Management Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `fboss cpoe show dom <port>` | Show CPO DOM for OE and ELSFP | `fboss cpoe show dom eth1/1/1` |
+| `fboss cpoe show port-lane-map` | Show CPO port lane mapping | `fboss cpoe show port-lane-map` |
+| `fboss cpoe set joint-mode <port> <mode>` | Set CPO joint mode | `fboss cpoe set joint-mode eth1/1/1 hardware` |
+| `fboss cpoe show joint-mode <port>` | Show joint mode status | `fboss cpoe show joint-mode eth1/1/1` |
+| `fboss cpoe show status` | Show all CPO ports status | `fboss cpoe show status` |
+
+### 6.2 ELSFP Management Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `fboss elsfp show status <port>` | Show ELSFP connection status | `fboss elsfp show status eth1/1/1` |
+| `fboss elsfp read-memory <port> <page>` | Read ELSFP memory page | `fboss elsfp read-memory eth1/1/1 0x01` |
+| `fboss elsfp read-register <port> <addr>` | Read ELSFP register | `fboss elsfp read-register eth1/1/1 0x80` |
+| `fboss elsfp show banks <port>` | Show ELSFP bank info | `fboss elsfp show banks eth1/1/1` |
+| `fboss elsfp select-bank <port> <bank>` | Select ELSFP bank | `fboss elsfp select-bank eth1/1/1 0` |
+
+### 6.3 Command Examples
+
+```bash
+# Show CPO DOM for a port
+$ fboss cpoe show dom eth1/1/1
+Port: eth1/1/1
+  Optical Engine (OE):
+    Temperature: 45.2 C
+    Tx Power (Lane 0): -2.1 dBm
+    Tx Power (Lane 1): -2.3 dBm
+    Tx Power (Lane 2): -2.0 dBm
+    Tx Power (Lane 3): -2.2 dBm
+    Rx Power (Lane 0): -3.5 dBm
+    Rx Power (Lane 1): -3.2 dBm
+    Rx Power (Lane 2): -3.4 dBm
+    Rx Power (Lane 3): -3.3 dBm
+    Voltage: 3.3 V
+    SNR: [12.5, 12.3, 12.4, 12.6] dB
+  ELSFP (External Laser):
+    Connection: Connected
+    Temperature: 35.8 C
+    Laser Bias: 45.2 mA
+    Optical Output: 2.1 dBm
+    Laser Ready: Yes
+    Laser Fault: No
+
+# Show CPO port lane mapping
+$ fboss cpoe show port-lane-map
+Port        Lane IDs         Interleave    CPO    ELSFP
+----------  ---------------  ------------  -----  -------
+eth1/1/1    [1,2,3,4]       NONE          Yes    Yes
+eth1/2/1    [5,6,7,8]       MODE1         Yes    Yes
+eth1/3/1    [9,10,11,12]    NONE          Yes    Yes
+eth1/4/1    [13,14,15,16]   MODE1         Yes    Yes
+
+# Set joint mode
+$ fboss cpoe set joint-mode eth1/1/1 hardware
+Successfully set joint mode to HARDWARE on eth1/1/1
+
+# Show ELSFP status
+$ fboss elsfp show status eth1/1/1
+Port: eth1/1/1
+  ELSFP Status: Connected
+  Laser Type: External
+  Temperature: 35.8 C
+  Bias Current: 45.2 mA
+  Output Power: 2.1 dBm
+  Laser Ready: Yes
+  Fault Status: No Fault
+
+# Read ELSFP memory
+$ fboss elsfp read-memory eth1/1/1 0x01 --offset 128 --length 8
+Page 0x01, Offset 128:
+  0x80: 0x01 (ELSFP Status: Connected)
+  0x81: 0x00
+  0x82: 0x23 (Laser Temp High: 35)
+  0x83: 0x33 (Laser Temp Low: 51)
+  0x84: 0x00 (Bias High)
+  0x85: 0x2D (Bias Low: 45)
+  0x86: 0x00 (Output High)
+  0x87: 0x15 (Output Low: 21)
+```
+
+---
+
+## 7. Thrift Changes
+
+### 7.1 Transceiver Type Extension
+
+**File:** `fboss/qsfp_service/if/transceiver.thrift`
+
+```thrift
+// Existing types
+enum TransceiverType {
+  SFP = 0,
+  QSFP = 1,
+  OSFP = 2,
+  SFP_DD = 3,
+  // New types for CPO/ELSFP
+  ELSFP = 4,
+  CPO_OE = 5,
+}
+
+enum LaserSourceType {
+  UNKNOWN = 0,
+  INTERNAL = 1,
+  EXTERNAL = 2,
+}
+
+enum CpoInterleaveMode {
+  NONE = 0,
+  MODE1 = 1,
+  MODE2 = 2,
+}
+
+enum CpoJointMode {
+  DISABLED = 0,
+  HARDWARE = 1,
+  SOFTWARE = 2,
+}
+
+struct OpticalEngineDomData {
+  1: double temperature,
+  2: list<double> txPowers,
+  3: list<double> rxPowers,
+  4: double voltage,
+  5: list<double> snr,
+  6: list<LaneAlarmFlags> laneAlarmFlags,
+}
+
+struct ElsfpDomData {
+  1: double temperature,
+  2: double laserBiasCurrent,
+  3: double opticalOutputPower,
+  4: bool laserReady,
+  5: bool laserFault,
+}
+
+struct CpoPortConfig {
+  1: PortID portId,
+  2: list<i32> laneIds,
+  3: CpoInterleaveMode interleaveMode,
+  4: bool isCpoPort,
+  5: bool isElsfpPort,
+}
+
+struct CpoConfig {
+  1: bool enabled,
+  2: CpoInterleaveMode interleaveMode,
+  3: string oeType,
+  4: string elsfpType,
+  5: CpoJointMode jointModeDefault,
+  6: i32 domPollingIntervalMs,
+}
+```
+
+### 7.2 QSFP Service Thrift Changes
+
+**File:** `fboss/qsfp_service/if/qsfp.thrift`
+
+```thrift
+service QsfpService {
+  // Existing methods
+  ...
+
+  // NEW: CPO DOM methods
+  CpoDomData getCpoDomData(1: PortID port);
+  list<CpoDomData> getAllCpoDomData();
+
+  // NEW: CPO Joint Mode methods
+  void setCpoJointMode(1: PortID port, 2: CpoJointMode mode);
+  CpoJointMode getCpoJointMode(1: PortID port);
+
+  // NEW: CPO Port Lane Map methods
+  list<CpoPortConfig> getCpoPortLaneMap();
+
+  // NEW: ELSFP methods
+  ElsfpDomData getElsfpDomData(1: PortID port);
+  bool getElsfpStatus(1: PortID port);
+  list<byte> readElsfpMemory(1: PortID port, 2: byte page, 3: byte offset, 4: byte length);
+
+  // NEW: ELSFP Banking methods
+  void selectElsfpBank(1: PortID port, 2: byte bank);
+  byte getCurrentElsfpBank(1: PortID port);
+}
+```
+
+---
+
+## 8. Redis DB Schema Changes
+
+### 8.1 CPO DOM Table
+
+```
+Table: TRANSCEIVER_CPO_DOM_SENSOR
+Key: <port_name>
+Fields:
+  - oe_temperature (float, Celsius)
+  - oe_tx_power_lane<N> (float, dBm)
+  - oe_rx_power_lane<N> (float, dBm)
+  - oe_voltage (float, V)
+  - oe_snr_lane<N> (float, dB)
+  - elsfp_connected (bool)
+  - elsfp_temperature (float, Celsius)
+  - elsfp_laser_bias (float, mA)
+  - elsfp_optical_output (float, dBm)
+  - elsfp_laser_ready (bool)
+  - elsfp_laser_fault (bool)
+```
+
+### 8.2 CPO Port Lane Map Table
+
+```
+Table: TRANSCEIVER_CPO_PORT_LANE_MAP
+Key: <port_name>
+Fields:
+  - port_id (int)
+  - lane_ids (list of int, space-separated)
+  - interleave_mode (string: NONE, MODE1, MODE2)
+  - is_cpo_port (bool)
+  - is_elsfp_port (bool)
+```
+
+### 8.3 CPO Joint Mode Table
+
+```
+Table: TRANSCEIVER_CPO_JOINT_MODE
+Key: <port_name>
+Fields:
+  - joint_mode (string: DISABLED, HARDWARE, SOFTWARE)
+  - supported (bool)
+```
+
+### 8.4 ELSFP Banking Table
+
+```
+Table: TRANSCEIVER_ELSFP_BANK
+Key: <port_name>
+Fields:
+  - current_bank (int)
+  - num_banks (int)
+  - bank_0_page_11h (hex string)
+  - bank_1_page_11h (hex string)
+```
+
+---
+
+## 9. Platform Mapping Changes
+
+### 9.1 CPO Platform Mapping JSON
+
+**File:** `fboss/agent/platforms/common/<platform>/<Platform>PlatformMapping.cpp`
+
+```json
+{
+  "ports": {
+    "1": {
+      "mapping": {
+        "id": 1,
+        "name": "eth1/1/1",
+        "controllingPort": 1,
+        "pins": [...],
+        "scope": 0,
+        "cpoConfig": {
+          "isCpoPort": true,
+          "interleaveMode": "NONE",
+          "elsfpLaneIds": [1, 2, 3, 4]
+        }
+      },
+      "supportedProfiles": {...}
+    }
+  }
+}
+```
+
+### 9.2 BSP Mapping for CPO/ELSFP
+
+**File:** `fboss/lib/bsp/<platform>/<Platform>BspPlatformMapping.cpp`
+
+```json
+{
+  "pimMapping": {
+    "1": {
+      "pimID": 1,
+      "tcvrMapping": {
+        "1": {
+          "tcvrId": 1,
+          "transceiverType": "CPO_OE",
+          "laserSourceType": "EXTERNAL",
+          "accessControl": {...},
+          "io": {...},
+          "tcvrLaneToLedId": {...},
+          "cpoConfig": {
+            "jointModeSupported": true,
+            "defaultJointMode": "HARDWARE"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+---
+
+## 10. Testing Plan
+
+### 10.1 Unit Tests
+
+| Test | Description |
+|------|-------------|
+| CpoDomMonitorTest | Test CPO DOM data collection |
+| ElsfpMemoryMapTest | Test ELSFP memory read operations |
+| CmisBankingTest | Test CMIS bank selection and access |
+| CpoPortLaneMapTest | Test CPO port lane mapping |
+| CpoJointModeTest | Test joint mode configuration |
+
+### 10.2 Hardware Tests
+
+| Test | Description |
+|------|-------------|
+| CpoDomHwTest | Verify CPO DOM readings on hardware |
+| ElsfpConnectionTest | Verify ELSFP connection detection |
+| CpoJointModeHwTest | Verify joint mode on hardware |
+| ElsfpBankingHwTest | Verify banking operations on hardware |
+| CpoLedTest | Verify LED management for CPO ports |
+
+### 10.3 Integration Tests
+
+| Test | Description |
+|------|-------------|
+| CpoPlatformMappingTest | Verify CPO platform mapping |
+| CpoQsfpServiceTest | Verify QSFP service with CPO |
+| ElsfpTransceiverManagerTest | Verify transceiver manager with ELSFP |
+
+---
+
+## References
+
+- [SONiC CPO Support PR #2152](https://github.com/sonic-net/SONiC/pull/2152)
+- [SONiC ELSFP Memory Map PR #2207](https://github.com/sonic-net/SONiC/pull/2207)
+- [SONiC CPO Port Mapping PR #2211](https://github.com/sonic-net/SONiC/pull/2211)
+- [SONiC CPO Joint Mode PR #2273](https://github.com/sonic-net/SONiC/pull/2273)
+- [SONiC CPO DOM Monitoring PR #2297](https://github.com/sonic-net/SONiC/pull/2297)
+- [SONiC CMIS Banking PR #2183](https://github.com/sonic-net/SONiC/pull/2183)
+- [SONiC CMIS LPO Enhancement PR #2205](https://github.com/sonic-net/SONiC/pull/2205)

--- a/fboss/qsfp_service/QsfpServiceHandler.cpp
+++ b/fboss/qsfp_service/QsfpServiceHandler.cpp
@@ -870,5 +870,103 @@ QsfpServiceHandler::co_getMacsecPortStats(
 }
 #endif
 
+/*
+ * CPO (Co-Packaged Optics) and ELSFP (External Laser SFP) Thrift methods.
+ */
+
+CpoDomData QsfpServiceHandler::getCpoDomData(int32_t portId) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  return tcvrManager_->getCpoDomData(portName.value());
+}
+
+std::vector<CpoDomData> QsfpServiceHandler::getAllCpoDomData() {
+  auto log = LOG_THRIFT_CALL(INFO);
+  return tcvrManager_->getAllCpoDomData();
+}
+
+void QsfpServiceHandler::setCpoJointMode(
+    int32_t portId,
+    CpoJointMode mode) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  tcvrManager_->setCpoJointMode(portName.value(), mode);
+}
+
+CpoJointMode QsfpServiceHandler::getCpoJointMode(int32_t portId) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  return tcvrManager_->getCpoJointMode(portName.value());
+}
+
+std::vector<CpoPortConfig> QsfpServiceHandler::getCpoPortLaneMap() {
+  auto log = LOG_THRIFT_CALL(INFO);
+  return tcvrManager_->getCpoPortLaneMap();
+}
+
+ElsfpDomData QsfpServiceHandler::getElsfpDomData(int32_t portId) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  return tcvrManager_->getElsfpDomData(portName.value());
+}
+
+bool QsfpServiceHandler::getElsfpStatus(int32_t portId) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  return tcvrManager_->getElsfpStatus(portName.value());
+}
+
+std::vector<int8_t> QsfpServiceHandler::readElsfpMemory(
+    int32_t portId,
+    int8_t page,
+    int8_t offset,
+    int8_t length) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  auto data = tcvrManager_->readElsfpMemory(
+      portName.value(),
+      static_cast<uint8_t>(page),
+      static_cast<uint8_t>(offset),
+      static_cast<uint8_t>(length));
+  return std::vector<int8_t>(data.begin(), data.end());
+}
+
+void QsfpServiceHandler::selectElsfpBank(int32_t portId, int8_t bank) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  tcvrManager_->selectElsfpBank(portName.value(), static_cast<uint8_t>(bank));
+}
+
+int8_t QsfpServiceHandler::getCurrentElsfpBank(int32_t portId) {
+  auto log = LOG_THRIFT_CALL(INFO);
+  auto portName = getPortNameByPortId(PortID(portId));
+  if (!portName.has_value()) {
+    throw FbossError(fmt::format("Invalid portId {}", portId));
+  }
+  return static_cast<int8_t>(
+      tcvrManager_->getCurrentElsfpBank(portName.value()));
+}
+
 } // namespace fboss
 } // namespace facebook

--- a/fboss/qsfp_service/QsfpServiceHandler.h
+++ b/fboss/qsfp_service/QsfpServiceHandler.h
@@ -392,6 +392,24 @@ class QsfpServiceHandler
 
   QsfpServiceRunState getQsfpServiceRunState() override;
 
+  /*
+   * CPO (Co-Packaged Optics) and ELSFP (External Laser SFP) methods.
+   */
+  CpoDomData getCpoDomData(int32_t portId) override;
+  std::vector<CpoDomData> getAllCpoDomData() override;
+  void setCpoJointMode(int32_t portId, CpoJointMode mode) override;
+  CpoJointMode getCpoJointMode(int32_t portId) override;
+  std::vector<CpoPortConfig> getCpoPortLaneMap() override;
+  ElsfpDomData getElsfpDomData(int32_t portId) override;
+  bool getElsfpStatus(int32_t portId) override;
+  std::vector<int8_t> readElsfpMemory(
+      int32_t portId,
+      int8_t page,
+      int8_t offset,
+      int8_t length) override;
+  void selectElsfpBank(int32_t portId, int8_t bank) override;
+  int8_t getCurrentElsfpBank(int32_t portId) override;
+
  private:
   // Forbidden copy constructor and assignment operator
   QsfpServiceHandler(QsfpServiceHandler const&) = delete;

--- a/fboss/qsfp_service/TransceiverManager.cpp
+++ b/fboss/qsfp_service/TransceiverManager.cpp
@@ -3934,4 +3934,221 @@ void TransceiverManager::updateSnapshots() {
     it->second.addSnapshot(snapshot);
   }
 }
+
+/*
+ * CPO/ELSFP helper: resolve port name to transceiver id.
+ */
+namespace {
+std::optional<TransceiverID> getTransceiverIdForPort(
+    TransceiverManager* mgr, const std::string& portName) {
+  auto swPort = mgr->getPortIDByPortName(portName);
+  if (!swPort.has_value()) {
+    throw FbossError(fmt::format("Invalid port {}", portName));
+  }
+  return mgr->getTransceiverID(swPort.value());
+}
+} // namespace
+
+CpoDomData TransceiverManager::getCpoDomData(const std::string& portName) {
+  // If CPO is enabled and the port is not a CPO port, return empty data
+  if (cpoConfig_.has_value() && cpoConfig_->enabled() && !isCpoPort(portName)) {
+    return CpoDomData{};
+  }
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  return it->second->getCpoDomData();
+}
+
+std::vector<CpoDomData> TransceiverManager::getAllCpoDomData() {
+  std::vector<CpoDomData> result;
+  auto lockedTransceivers = transceivers_.rlock();
+  for (const auto& [tcvrId, tcvr] : *lockedTransceivers) {
+    // Only include CPO modules when CPO config is enabled
+    if (cpoConfig_.has_value() && cpoConfig_->enabled()) {
+      auto cpoDom = tcvr->getCpoDomData();
+      // Filter to only include actual CPO/ELSFP transceivers
+      if (cpoDom.transceiverType() == TransceiverType::CPO_OE ||
+          cpoDom.transceiverType() == TransceiverType::ELSFP) {
+        result.push_back(std::move(cpoDom));
+      }
+    } else {
+      result.push_back(tcvr->getCpoDomData());
+    }
+  }
+  return result;
+}
+
+bool TransceiverManager::isCpoPort(const std::string& portName) const {
+  auto it = cpoPortConfigMap_.find(portName);
+  if (it != cpoPortConfigMap_.end()) {
+    return it->second.isCpoPort();
+  }
+  return false;
+}
+
+bool TransceiverManager::isElsfpPort(const std::string& portName) const {
+  auto it = cpoPortConfigMap_.find(portName);
+  if (it != cpoPortConfigMap_.end()) {
+    return it->second.isElsfpPort();
+  }
+  return false;
+}
+
+void TransceiverManager::setCpoJointMode(
+    const std::string& portName,
+    CpoJointMode mode) {
+  // Only allow setting joint mode on CPO ports when CPO is enabled
+  if (cpoConfig_.has_value() && cpoConfig_->enabled() && !isCpoPort(portName)) {
+    throw FbossError(
+        fmt::format("Port {} is not a CPO port", portName));
+  }
+  // Validate port exists
+  auto swPort = getPortIDByPortName(portName);
+  if (!swPort.has_value()) {
+    throw FbossError(fmt::format("Invalid port {}", portName));
+  }
+  auto tcvrId = getTransceiverID(swPort.value());
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedMap = cpoJointModeMap_.wlock();
+  (*lockedMap)[portName] = mode;
+}
+
+CpoJointMode TransceiverManager::getCpoJointMode(
+    const std::string& portName) {
+  auto lockedMap = cpoJointModeMap_.rlock();
+  auto it = lockedMap->find(portName);
+  if (it != lockedMap->end()) {
+    return it->second;
+  }
+  // Return default from CPO platform config if available
+  if (cpoConfig_.has_value()) {
+    return cpoConfig_->jointModeDefault();
+  }
+  return CpoJointMode::DISABLED;
+}
+
+void TransceiverManager::loadCpoConfig(
+    const cfg::QsfpServiceConfig& qsfpCfg) {
+  if (auto cpoConfig = qsfpCfg.cpoConfig()) {
+    cpoConfig_ = *cpoConfig;
+    XLOG(INFO) << "Loaded CPO platform config. enabled="
+               << cpoConfig_->enabled()
+               << ", interleaveMode="
+               << static_cast<int>(cpoConfig_->interleaveMode())
+               << ", oeType=" << cpoConfig_->oeType()
+               << ", elsfpType=" << cpoConfig_->elsfpType();
+  }
+
+  if (auto cpoPortMap = qsfpCfg.cpoPortConfigMap()) {
+    for (const auto& [portName, portCfg] : *cpoPortMap) {
+      cpoPortConfigMap_[portName] = portCfg;
+    }
+    XLOG(INFO) << "Loaded CPO port config for " << cpoPortConfigMap_.size()
+               << " ports";
+  }
+}
+
+std::vector<CpoPortConfig> TransceiverManager::getCpoPortLaneMap() const {
+  std::vector<CpoPortConfig> result;
+  for (const auto& [portName, portCfg] : cpoPortConfigMap_) {
+    result.push_back(portCfg);
+  }
+  return result;
+}
+
+ElsfpDomData TransceiverManager::getElsfpDomData(
+    const std::string& portName) {
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  return it->second->getElsfpDomData();
+}
+
+bool TransceiverManager::getElsfpStatus(const std::string& portName) {
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  return it->second->getElsfpStatus();
+}
+
+std::vector<uint8_t> TransceiverManager::readElsfpMemory(
+    const std::string& portName,
+    uint8_t page,
+    uint8_t offset,
+    uint8_t length) {
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  return it->second->readElsfpMemory(page, offset, length);
+}
+
+void TransceiverManager::selectElsfpBank(
+    const std::string& portName,
+    uint8_t bank) {
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  it->second->selectElsfpBank(bank);
+}
+
+uint8_t TransceiverManager::getCurrentElsfpBank(
+    const std::string& portName) {
+  auto tcvrId = getTransceiverIdForPort(this, portName);
+  if (!tcvrId.has_value()) {
+    throw FbossError(
+        fmt::format("Transceiver not found for port {}", portName));
+  }
+  auto lockedTransceivers = transceivers_.rlock();
+  auto it = lockedTransceivers->find(tcvrId.value());
+  if (it == lockedTransceivers->end()) {
+    throw FbossError(
+        fmt::format("Transceiver not present for port {}", portName));
+  }
+  return it->second->getCurrentElsfpBank();
+}
+
 } // namespace facebook::fboss

--- a/fboss/qsfp_service/TransceiverManager.h
+++ b/fboss/qsfp_service/TransceiverManager.h
@@ -355,6 +355,41 @@ class TransceiverManager {
       CdbDatapathSymErrHistogram& symErr,
       const std::string& portName);
 
+  /*
+   * CPO (Co-Packaged Optics) and ELSFP (External Laser SFP) support.
+   */
+  CpoDomData getCpoDomData(const std::string& portName);
+  std::vector<CpoDomData> getAllCpoDomData();
+
+  void setCpoJointMode(const std::string& portName, CpoJointMode mode);
+  CpoJointMode getCpoJointMode(const std::string& portName);
+
+  std::vector<CpoPortConfig> getCpoPortLaneMap() const;
+
+  // Load CPO configuration from QsfpServiceConfig
+  void loadCpoConfig(const cfg::QsfpServiceConfig& qsfpCfg);
+
+  // Get CPO platform config (if available)
+  std::optional<CpoConfig> getCpoConfig() const {
+    return cpoConfig_;
+  }
+
+  // Check if a port is configured as a CPO port
+  bool isCpoPort(const std::string& portName) const;
+
+  // Check if a port is configured as an ELSFP port
+  bool isElsfpPort(const std::string& portName) const;
+
+  ElsfpDomData getElsfpDomData(const std::string& portName);
+  bool getElsfpStatus(const std::string& portName);
+  std::vector<uint8_t> readElsfpMemory(
+      const std::string& portName,
+      uint8_t page,
+      uint8_t offset,
+      uint8_t length);
+  void selectElsfpBank(const std::string& portName, uint8_t bank);
+  uint8_t getCurrentElsfpBank(const std::string& portName);
+
   virtual std::string saiPhyRegisterAccess(
       std::string /* portName */,
       bool /* opRead */,
@@ -969,6 +1004,15 @@ class TransceiverManager {
     std::string name;
   };
   std::unordered_map<PortID, SwPortInfo> portToSwPortInfo_;
+
+  // CPO joint mode state per port name (software-managed until HW control)
+  folly::Synchronized<std::map<std::string, CpoJointMode>> cpoJointModeMap_;
+
+  // CPO platform configuration (loaded from qsfp service config)
+  std::optional<CpoConfig> cpoConfig_;
+
+  // CPO port configuration map: port name -> CpoPortConfig
+  std::map<std::string, CpoPortConfig> cpoPortConfigMap_;
 
   virtual void updateTcvrStateInFsdb(
       TransceiverID /* tcvrID */,

--- a/fboss/qsfp_service/if/qsfp.thrift
+++ b/fboss/qsfp_service/if/qsfp.thrift
@@ -333,4 +333,59 @@ service QsfpService extends phy.FbossCommonPhyCtrl {
   map<string, list<i32>> getPortTransceiverIDs() throws (
     1: fboss.FbossBaseError error,
   );
+
+  /*
+   * NEW: CPO DOM methods
+   */
+  transceiver.CpoDomData getCpoDomData(1: i32 portId) throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  list<transceiver.CpoDomData> getAllCpoDomData() throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  /*
+   * NEW: CPO Joint Mode methods
+   */
+  void setCpoJointMode(
+    1: i32 portId,
+    2: transceiver.CpoJointMode mode,
+  ) throws (1: fboss.FbossBaseError error);
+
+  transceiver.CpoJointMode getCpoJointMode(1: i32 portId) throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  /*
+   * NEW: CPO Port Lane Map methods
+   */
+  list<transceiver.CpoPortConfig> getCpoPortLaneMap() throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  /*
+   * NEW: ELSFP methods
+   */
+  transceiver.ElsfpDomData getElsfpDomData(1: i32 portId) throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  bool getElsfpStatus(1: i32 portId) throws (1: fboss.FbossBaseError error);
+
+  list<byte> readElsfpMemory(
+    1: i32 portId,
+    2: byte page,
+    3: byte offset,
+    4: byte length,
+  ) throws (1: fboss.FbossBaseError error);
+
+  /*
+   * NEW: ELSFP Banking methods
+   */
+  void selectElsfpBank(1: i32 portId, 2: byte bank) throws (
+    1: fboss.FbossBaseError error,
+  );
+
+  byte getCurrentElsfpBank(1: i32 portId) throws (1: fboss.FbossBaseError error);
 }

--- a/fboss/qsfp_service/if/qsfp_service_config.thrift
+++ b/fboss/qsfp_service/if/qsfp_service_config.thrift
@@ -149,4 +149,10 @@ struct QsfpServiceConfig {
   // NOTE: This field is MANDATORY for Ladakh platform - QSFP service will
   // fail to start if this field is missing
   9: optional string phyConfig;
+
+  // CPO (Co-Packaged Optics) platform configuration
+  10: optional transceiver.CpoConfig cpoConfig;
+
+  // CPO port lane mapping configuration: port name -> CpoPortConfig
+  11: optional map<string, transceiver.CpoPortConfig> cpoPortConfigMap;
 }

--- a/fboss/qsfp_service/if/transceiver.thrift
+++ b/fboss/qsfp_service/if/transceiver.thrift
@@ -156,6 +156,10 @@ struct Channel {
 enum TransceiverType {
   SFP = 0,
   QSFP = 1,
+  ELSFP = 2,
+  CPO_OE = 3,
+  OSFP = 4,
+  SFP_DD = 5,
 }
 
 enum TransceiverManagementInterface {
@@ -735,6 +739,65 @@ enum PagingSupport {
   PAGED = 2,
 }
 
+enum LaserSourceType {
+  UNKNOWN = 0,
+  INTERNAL = 1,
+  EXTERNAL = 2,
+}
+
+enum CpoInterleaveMode {
+  NONE = 0,
+  MODE1 = 1,
+  MODE2 = 2,
+}
+
+enum CpoJointMode {
+  DISABLED = 0,
+  HARDWARE = 1,
+  SOFTWARE = 2,
+}
+
+struct OpticalEngineDomData {
+  1: double temperature,
+  2: list<double> txPowers,
+  3: list<double> rxPowers,
+  4: double voltage,
+  5: list<double> snr,
+  6: list<MediaLaneSignals> laneAlarmFlags,
+}
+
+struct ElsfpDomData {
+  1: double temperature,
+  2: double laserBiasCurrent,
+  3: double opticalOutputPower,
+  4: bool laserReady,
+  5: bool laserFault,
+}
+
+struct CpoDomData {
+  1: OpticalEngineDomData oeDom,
+  2: ElsfpDomData elsfpDom,
+  3: TransceiverType transceiverType,
+  4: LaserSourceType laserSourceType,
+}
+
+struct CpoPortConfig {
+  1: i32 portId,
+  2: list<i32> laneIds,
+  3: CpoInterleaveMode interleaveMode,
+  4: bool isCpoPort,
+  5: bool isElsfpPort,
+}
+
+struct CpoConfig {
+  1: bool enabled,
+  2: CpoInterleaveMode interleaveMode,
+  3: string oeType,
+  4: string elsfpType,
+  5: CpoJointMode jointModeDefault,
+  6: i32 domPollingIntervalMs,
+}
+
 struct TcvrState {
   1: bool present;
   2: TransceiverType transceiver;
@@ -968,6 +1031,7 @@ struct TransceiverIOParameters {
   1: i32 offset; // should range from 0 - 255
   2: optional i32 page; // can be used to access bytes 128-255 from a different page than page0
   3: optional i32 length; // Number of bytes to read. Also can represent number of bytes to write for multi-byte writes.
+  4: optional i32 bank; // Bank index for banked CMIS pages (CMIS 5.3+). Used with page selection for upper memory bank access.
 }
 
 struct ReadRequest {

--- a/fboss/qsfp_service/module/QsfpModule.cpp
+++ b/fboss/qsfp_service/module/QsfpModule.cpp
@@ -1724,5 +1724,35 @@ TransceiverInfo QsfpModule::updateFwUpgradeStatusInTcvrInfoLocked(
   return getTransceiverInfo();
 }
 
+/*
+ * CPO/ELSFP default implementations for non-CMIS modules.
+ */
+CpoDomData QsfpModule::getCpoDomData() const {
+  return CpoDomData{};
+}
+
+ElsfpDomData QsfpModule::getElsfpDomData() const {
+  return ElsfpDomData{};
+}
+
+bool QsfpModule::getElsfpStatus() const {
+  return false;
+}
+
+std::vector<uint8_t> QsfpModule::readElsfpMemory(
+    uint8_t /* page */,
+    uint8_t /* offset */,
+    uint8_t /* length */) {
+  return {};
+}
+
+void QsfpModule::selectElsfpBank(uint8_t /* bank */) {
+  // No-op for non-CMIS modules
+}
+
+uint8_t QsfpModule::getCurrentElsfpBank() {
+  return 0;
+}
+
 } // namespace fboss
 } // namespace facebook

--- a/fboss/qsfp_service/module/QsfpModule.h
+++ b/fboss/qsfp_service/module/QsfpModule.h
@@ -688,6 +688,22 @@ class QsfpModule : public Transceiver {
   }
 
   /*
+   * CPO/ELSFP support: default no-op implementations for non-CMIS modules.
+   */
+  CpoDomData getCpoDomData() const override;
+
+  ElsfpDomData getElsfpDomData() const override;
+
+  bool getElsfpStatus() const override;
+
+  std::vector<uint8_t> readElsfpMemory(
+      uint8_t page, uint8_t offset, uint8_t length) override;
+
+  void selectElsfpBank(uint8_t bank) override;
+
+  uint8_t getCurrentElsfpBank() override;
+
+  /*
    * Returns a set of Transceiver lanes for a given SW port for a given side
    */
   std::set<uint8_t> getTcvrLanesForPort(

--- a/fboss/qsfp_service/module/Transceiver.h
+++ b/fboss/qsfp_service/module/Transceiver.h
@@ -288,6 +288,24 @@ class Transceiver {
   virtual bool tcvrPortStateSupported(
       TransceiverPortState& portState) const = 0;
 
+  /*
+   * CPO (Co-Packaged Optics) and ELSFP (External Laser SFP) support.
+   * These are only meaningful for CMIS modules; other module types
+   * will return empty/default values.
+   */
+  virtual CpoDomData getCpoDomData() const = 0;
+
+  virtual ElsfpDomData getElsfpDomData() const = 0;
+
+  virtual bool getElsfpStatus() const = 0;
+
+  virtual std::vector<uint8_t> readElsfpMemory(
+      uint8_t page, uint8_t offset, uint8_t length) = 0;
+
+  virtual void selectElsfpBank(uint8_t bank) = 0;
+
+  virtual uint8_t getCurrentElsfpBank() = 0;
+
   // Derived classes will override this function.
   virtual portstate::PortState getPortState() {
     return portstate::PortState();

--- a/fboss/qsfp_service/module/cmis/CmisModule.cpp
+++ b/fboss/qsfp_service/module/cmis/CmisModule.cpp
@@ -418,6 +418,24 @@ static const QsfpFieldInfo<CmisField, CmisPages>::QsfpFieldMap cmisFields = {
     {CmisField::PAGE_UPPER45H, {CmisPages::PAGE45, 128, 128}},
     // Page 45h, Byte 129 - Host Lane Provisioning Advertisement
     {CmisField::HOST_LANE_PROV_AD, {CmisPages::PAGE45, 129, 1}},
+
+    // ELSFP (External Laser SFP) specific fields
+    // These fields are mapped to Page 01h per CMIS-ELSFP specification
+    {CmisField::ELSFP_STATUS, {CmisPages::PAGE01, 128, 1}},
+    {CmisField::ELSFP_LASER_TEMP_HIGH, {CmisPages::PAGE01, 130, 1}},
+    {CmisField::ELSFP_LASER_TEMP_LOW, {CmisPages::PAGE01, 131, 1}},
+    {CmisField::ELSFP_LASER_BIAS_HIGH, {CmisPages::PAGE01, 132, 1}},
+    {CmisField::ELSFP_LASER_BIAS_LOW, {CmisPages::PAGE01, 133, 1}},
+    {CmisField::ELSFP_OPTICAL_OUTPUT_HIGH, {CmisPages::PAGE01, 134, 1}},
+    {CmisField::ELSFP_OPTICAL_OUTPUT_LOW, {CmisPages::PAGE01, 135, 1}},
+    {CmisField::ELSFP_LASER_CONTROL, {CmisPages::PAGE01, 136, 1}},
+    {CmisField::ELSFP_LASER_READY, {CmisPages::PAGE01, 137, 1}},
+    {CmisField::ELSFP_LASER_FAULT, {CmisPages::PAGE01, 138, 1}},
+    {CmisField::ELSFP_CONNECTED, {CmisPages::PAGE01, 139, 1}},
+
+    // Banking support fields (CMIS 5.3)
+    {CmisField::NUM_BANKS_SUPPORTED, {CmisPages::PAGE01, 140, 1}},
+    {CmisField::BANK_PAGE_CHANGE_TIME, {CmisPages::PAGE01, 141, 1}},
 };
 
 CmisField laneToAppSelField(const std::set<uint8_t>& lanes) {
@@ -716,6 +734,74 @@ void CmisModule::writeCmisField(
   }
   qsfpImpl_->writeTransceiver(
       {TransceiverAccessParameter::ADDR_QSFP, dataOffset, dataLength, dataPage},
+      data,
+      POST_I2C_WRITE_DELAY_US,
+      CAST_TO_INT(field));
+}
+
+/*
+ * CMIS 5.3 Banking support implementation.
+ * For banked pages, we must write both BankSelect (byte 126) and
+ * PageSelect (byte 127) in a single write transaction when changing banks.
+ */
+void CmisModule::readCmisField(
+    CmisField field,
+    uint8_t* data,
+    uint8_t bank,
+    bool skipPageChange) {
+  int dataLength, dataPage, dataOffset;
+  getQsfpFieldAddress(field, dataPage, dataOffset, dataLength);
+  if (static_cast<CmisPages>(dataPage) != CmisPages::LOWER && !flatMem_ &&
+      !skipPageChange) {
+    uint8_t page = static_cast<uint8_t>(dataPage);
+    // CMIS 5.3: For bank change, write both BankSelect and PageSelect
+    // Lower Page bytes 126-127
+    uint8_t bankPageSelect[2] = {bank, page};
+    qsfpImpl_->writeTransceiver(
+        {TransceiverAccessParameter::ADDR_QSFP,
+         126,
+         sizeof(bankPageSelect),
+         static_cast<int>(CmisPages::LOWER)},
+        bankPageSelect,
+        POST_I2C_WRITE_DELAY_US,
+        CAST_TO_INT(CmisField::PAGE_CHANGE));
+  }
+  qsfpImpl_->readTransceiver(
+      {TransceiverAccessParameter::ADDR_QSFP,
+       dataOffset,
+       dataLength,
+       dataPage,
+       bank},
+      data,
+      CAST_TO_INT(field));
+}
+
+void CmisModule::writeCmisField(
+    CmisField field,
+    uint8_t* data,
+    uint8_t bank,
+    bool skipPageChange) {
+  int dataLength, dataPage, dataOffset;
+  getQsfpFieldAddress(field, dataPage, dataOffset, dataLength);
+  if (static_cast<CmisPages>(dataPage) != CmisPages::LOWER && !flatMem_ &&
+      !skipPageChange) {
+    uint8_t page = static_cast<uint8_t>(dataPage);
+    uint8_t bankPageSelect[2] = {bank, page};
+    qsfpImpl_->writeTransceiver(
+        {TransceiverAccessParameter::ADDR_QSFP,
+         126,
+         sizeof(bankPageSelect),
+         static_cast<int>(CmisPages::LOWER)},
+        bankPageSelect,
+        POST_I2C_WRITE_DELAY_US,
+        CAST_TO_INT(CmisField::PAGE_CHANGE));
+  }
+  qsfpImpl_->writeTransceiver(
+      {TransceiverAccessParameter::ADDR_QSFP,
+       dataOffset,
+       dataLength,
+       dataPage,
+       bank},
       data,
       POST_I2C_WRITE_DELAY_US,
       CAST_TO_INT(field));
@@ -2517,6 +2603,62 @@ void CmisModule::updateQsfpData(bool allPages) {
 
       // Cache firmware build number from CDB Get Firmware Info command
       cachedFwBuildNumber_ = fetchFwBuildNumberFromCdb();
+
+      // ELSFP (External Laser SFP) support: read ELSFP status from Page 01h
+      uint8_t elsfpStatus = 0;
+      try {
+        readCmisField(CmisField::ELSFP_STATUS, &elsfpStatus);
+        elsfpConnected_ = (elsfpStatus & 0x01) != 0;
+        if (elsfpConnected_) {
+          uint8_t tempHigh = 0, tempLow = 0;
+          uint8_t biasHigh = 0, biasLow = 0;
+          uint8_t outHigh = 0, outLow = 0;
+          uint8_t ready = 0, fault = 0;
+          readCmisField(CmisField::ELSFP_LASER_TEMP_HIGH, &tempHigh);
+          readCmisField(CmisField::ELSFP_LASER_TEMP_LOW, &tempLow);
+          readCmisField(CmisField::ELSFP_LASER_BIAS_HIGH, &biasHigh);
+          readCmisField(CmisField::ELSFP_LASER_BIAS_LOW, &biasLow);
+          readCmisField(CmisField::ELSFP_OPTICAL_OUTPUT_HIGH, &outHigh);
+          readCmisField(CmisField::ELSFP_OPTICAL_OUTPUT_LOW, &outLow);
+          readCmisField(CmisField::ELSFP_LASER_READY, &ready);
+          readCmisField(CmisField::ELSFP_LASER_FAULT, &fault);
+
+          // Convert raw values to engineering units
+          // Temperature: signed 8-bit integer in degrees C
+          elsfpTemperature_ = static_cast<int8_t>(tempHigh);
+          // Laser bias current: unsigned 16-bit in 0.1 mA units
+          elsfpLaserBiasCurrent_ = ((tempHigh << 8) | tempLow) * 0.1;
+          // Optical output power: unsigned 16-bit in 0.01 dBm units
+          elsfpOpticalOutputPower_ = ((outHigh << 8) | outLow) * 0.01;
+          elsfpLaserReady_ = (ready & 0x01) != 0;
+          elsfpLaserFault_ = (fault & 0x01) != 0;
+
+          laserSourceType_ = LaserSourceType::EXTERNAL;
+          QSFP_LOG(INFO, this) << "ELSFP connected. Temp: " << elsfpTemperature_
+                               << "C, Bias: " << elsfpLaserBiasCurrent_
+                               << "mA, Output: " << elsfpOpticalOutputPower_
+                               << "dBm";
+        } else {
+          laserSourceType_ = LaserSourceType::INTERNAL;
+        }
+      } catch (const std::exception& ex) {
+        // ELSFP fields may not be present on all modules
+        elsfpConnected_ = false;
+        laserSourceType_ = LaserSourceType::UNKNOWN;
+      }
+
+      // CMIS 5.3 Banking support: read number of banks supported
+      try {
+        uint8_t numBanks = 0;
+        readCmisField(CmisField::NUM_BANKS_SUPPORTED, &numBanks);
+        if (numBanks != numBanksSupported_) {
+          numBanksSupported_ = numBanks;
+          QSFP_LOG(INFO, this) << "Module supports " << (int)numBanksSupported_
+                               << " banks";
+        }
+      } catch (const std::exception& ex) {
+        numBanksSupported_ = 0;
+      }
     }
 
     // Update the application capabilities once we have read from eeprom
@@ -5135,8 +5277,20 @@ void CmisModule::updateVdmCacheLocked() {
   // Read C-CMIS PM pages, Rx Consequent Action control, and Host Lane
   // Provisioning Advertisement for coherent optics
   if (isTunableOptics()) {
-    readCmisField(CmisField::PAGE_UPPER34H, page34_);
-    readCmisField(CmisField::PAGE_UPPER35H, page35_);
+    // CMIS 5.3 Banking support: Page 34h/35h are banked pages.
+    // Each bank corresponds to a single media lane.
+    if (numBanksSupported_ > 1) {
+      for (uint8_t bank = 0; bank < numBanksSupported_; ++bank) {
+        page34Banks_[bank] = {};
+        page35Banks_[bank] = {};
+        readCmisField(CmisField::PAGE_UPPER34H, page34Banks_[bank].data(), bank);
+        readCmisField(CmisField::PAGE_UPPER35H, page35Banks_[bank].data(), bank);
+      }
+    } else {
+      // Legacy single-bank module (e.g., ZR with one media lane)
+      readCmisField(CmisField::PAGE_UPPER34H, page34_);
+      readCmisField(CmisField::PAGE_UPPER35H, page35_);
+    }
     readCmisField(CmisField::PAGE_UPPER38H, page38_);
     readCmisField(CmisField::PAGE_UPPER45H, page45_);
   }
@@ -6095,6 +6249,189 @@ bool CmisModule::fillVdmPerfMonitorLinkPm(VdmPerfMonitorStats& vdmStats) {
         .linkPm() = linkPm;
   }
   return true;
+}
+
+/*
+ * Banking support helpers (CMIS 5.3)
+ */
+uint8_t CmisModule::getNumBanksSupported() const {
+  if (!cacheIsValid()) {
+    return 0;
+  }
+  uint8_t numBanks = 0;
+  try {
+    getFieldValue(CmisField::NUM_BANKS_SUPPORTED, &numBanks);
+  } catch (const FbossError& e) {
+    QSFP_LOG(DBG3, this) << "Failed to read num banks supported: " << e.what();
+  }
+  return numBanks;
+}
+
+void CmisModule::selectBank(uint8_t bank) {
+  if (!present_) {
+    return;
+  }
+  writeCmisField(CmisField::BANK_SELECT, &bank);
+  currentBank_ = bank;
+}
+
+uint8_t CmisModule::getCurrentBank() const {
+  return currentBank_;
+}
+
+bool CmisModule::isBankSupported(uint8_t bank) const {
+  return bank < numBanksSupported_;
+}
+
+/*
+ * ELSFP (External Laser SFP) support implementation
+ */
+bool CmisModule::isElsfpConnected() const {
+  return elsfpConnected_;
+}
+
+double CmisModule::readElsfpLaserTemperature() const {
+  return elsfpTemperature_;
+}
+
+double CmisModule::readElsfpLaserBiasCurrent() const {
+  return elsfpLaserBiasCurrent_;
+}
+
+double CmisModule::readElsfpOpticalOutputPower() const {
+  return elsfpOpticalOutputPower_;
+}
+
+bool CmisModule::isElsfpLaserReady() const {
+  return elsfpLaserReady_;
+}
+
+bool CmisModule::isElsfpLaserFault() const {
+  return elsfpLaserFault_;
+}
+
+void CmisModule::setElsfpLaserControl(bool enable) {
+  if (!present_) {
+    return;
+  }
+  std::lock_guard<std::mutex> g(qsfpModuleMutex_);
+  uint8_t control = enable ? 0x01 : 0x00;
+  writeCmisField(CmisField::ELSFP_LASER_CONTROL, &control);
+}
+
+/*
+ * CPO DOM data collection
+ */
+OpticalEngineDomData CmisModule::getOpticalEngineDomData() const {
+  OpticalEngineDomData oeDom;
+  if (!cacheIsValid()) {
+    return oeDom;
+  }
+
+  oeDom.temperature() = getQsfpSensor(CmisField::TEMPERATURE, CmisFieldInfo::getTemp);
+  oeDom.voltage() = getQsfpSensor(CmisField::VCC, CmisFieldInfo::getVcc);
+
+  auto txPowers = getSensorsPerChanInfo(
+      CmisField::CHANNEL_TX_PWR, CmisFieldInfo::getPwr, [](double val) {
+        return val;
+      });
+  auto rxPowers = getSensorsPerChanInfo(
+      CmisField::CHANNEL_RX_PWR, CmisFieldInfo::getPwr, [](double val) {
+        return val;
+      });
+
+  for (const auto& tx : txPowers) {
+    if (tx.second.hasValue()) {
+      oeDom.txPowers()->push_back(tx.second.value());
+    }
+  }
+  for (const auto& rx : rxPowers) {
+    if (rx.second.hasValue()) {
+      oeDom.rxPowers()->push_back(rx.second.value());
+    }
+  }
+
+  // SNR values from VDM diagnostics
+  auto vdmStatsOpt = getVdmPerfMonitorStats();
+  if (vdmStatsOpt.has_value()) {
+    for (const auto& [portName, portStats] : vdmStatsOpt->mediaPortVdmStats()) {
+      if (auto snr = portStats.snr()) {
+        oeDom.snr()->push_back(*snr);
+      }
+    }
+  }
+
+  // Lane alarm flags from media lane signals
+  std::vector<MediaLaneSignals> mediaSignals(numMediaLanes());
+  if (getSignalsPerMediaLane(mediaSignals)) {
+    // Also read TX LOS and TX LOL per lane from module flags
+    auto txLos = getSettingsValue(CmisField::TX_LOS_FLAG);
+    auto txLol = getSettingsValue(CmisField::TX_LOL_FLAG);
+    for (int lane = 0; lane < mediaSignals.size(); lane++) {
+      auto laneMask = (1 << lane);
+      mediaSignals[lane].txLos() = txLos & laneMask;
+      mediaSignals[lane].txLol() = txLol & laneMask;
+      oeDom.laneAlarmFlags()->push_back(std::move(mediaSignals[lane]));
+    }
+  }
+
+  return oeDom;
+}
+
+ElsfpDomData CmisModule::getElsfpDomData() const {
+  ElsfpDomData elsfpDom;
+  elsfpDom.temperature() = elsfpTemperature_;
+  elsfpDom.laserBiasCurrent() = elsfpLaserBiasCurrent_;
+  elsfpDom.opticalOutputPower() = elsfpOpticalOutputPower_;
+  elsfpDom.laserReady() = elsfpLaserReady_;
+  elsfpDom.laserFault() = elsfpLaserFault_;
+  return elsfpDom;
+}
+
+CpoDomData CmisModule::getCpoDomData() const {
+  CpoDomData cpoDom;
+  cpoDom.oeDom() = getOpticalEngineDomData();
+  cpoDom.elsfpDom() = getElsfpDomData();
+  cpoDom.transceiverType() = type();
+  cpoDom.laserSourceType() = laserSourceType_;
+  return cpoDom;
+}
+
+std::vector<uint8_t> CmisModule::readElsfpMemory(
+    uint8_t page,
+    uint8_t offset,
+    uint8_t length) {
+  // Validate bounds: offset + length must fit within a 128-byte page
+  if (offset + length > MAX_QSFP_PAGE_SIZE) {
+    throw FbossError(fmt::format(
+        "readElsfpMemory: offset({}) + length({}) exceeds page size",
+        offset,
+        length));
+  }
+
+  std::vector<uint8_t> data(length);
+
+  // Change page if necessary (not lower page and not flat memory)
+  if (page != static_cast<uint8_t>(CmisPages::LOWER) && !flatMem_) {
+    qsfpImpl_->writeTransceiver(
+        {TransceiverAccessParameter::ADDR_QSFP,
+         127,
+         sizeof(page),
+         static_cast<int>(CmisPages::LOWER)},
+        &page,
+        POST_I2C_WRITE_DELAY_US,
+        CAST_TO_INT(CmisField::PAGE_CHANGE));
+  }
+
+  qsfpImpl_->readTransceiver(
+      {TransceiverAccessParameter::ADDR_QSFP,
+       offset,
+       length,
+       static_cast<int>(page)},
+      data.data(),
+      CAST_TO_INT(CmisField::RAW));
+
+  return data;
 }
 
 } // namespace fboss

--- a/fboss/qsfp_service/module/cmis/CmisModule.h
+++ b/fboss/qsfp_service/module/cmis/CmisModule.h
@@ -256,6 +256,27 @@ class CmisModule : public QsfpModule {
   // Page 45h - Host Lane Provisioning Advertisement
   uint8_t page45_[MAX_QSFP_PAGE_SIZE]{};
 
+  // CMIS 5.3 Banking: banked page caches for multi-lane modules
+  // Each bank corresponds to a single media lane for banked pages like 34h, 35h
+  std::map<uint8_t, std::array<uint8_t, MAX_QSFP_PAGE_SIZE>> page34Banks_;
+  std::map<uint8_t, std::array<uint8_t, MAX_QSFP_PAGE_SIZE>> page35Banks_;
+
+  // ELSFP (External Laser SFP) cached DOM data
+  bool elsfpConnected_{false};
+  double elsfpTemperature_{0.0};
+  double elsfpLaserBiasCurrent_{0.0};
+  double elsfpOpticalOutputPower_{0.0};
+  bool elsfpLaserReady_{false};
+  bool elsfpLaserFault_{false};
+
+  // CPO (Co-Packaged Optics) configuration
+  bool isCpoModule_{false};
+  LaserSourceType laserSourceType_{LaserSourceType::UNKNOWN};
+
+  // Banking state
+  uint8_t currentBank_{0};
+  uint8_t numBanksSupported_{0};
+
   // Some of the pages are static and they need not be read every refresh cycle
   bool staticPagesCached_{false};
 
@@ -743,6 +764,63 @@ class CmisModule : public QsfpModule {
   readCmisField(CmisField field, uint8_t* data, bool skipPageChange = false);
   void
   writeCmisField(CmisField field, uint8_t* data, bool skipPageChange = false);
+
+  /*
+   * CMIS 5.3 Banking support: read/write with explicit bank selection.
+   * For banked pages (e.g., Page 34h, 35h), the bank index must be written
+   * to Lower Page byte 126 before the page selection (byte 127).
+   */
+  void readCmisField(
+      CmisField field,
+      uint8_t* data,
+      uint8_t bank,
+      bool skipPageChange = false);
+  void writeCmisField(
+      CmisField field,
+      uint8_t* data,
+      uint8_t bank,
+      bool skipPageChange = false);
+
+  /*
+   * ELSFP (External Laser SFP) support methods
+   */
+  bool isElsfpConnected() const;
+  double readElsfpLaserTemperature() const;
+  double readElsfpLaserBiasCurrent() const;
+  double readElsfpOpticalOutputPower() const;
+  bool isElsfpLaserReady() const;
+  bool isElsfpLaserFault() const;
+  void setElsfpLaserControl(bool enable);
+
+  bool getElsfpStatus() const override {
+    return isElsfpConnected();
+  }
+
+  std::vector<uint8_t> readElsfpMemory(
+      uint8_t page, uint8_t offset, uint8_t length) override;
+
+  /*
+   * CPO DOM data collection
+   */
+  OpticalEngineDomData getOpticalEngineDomData() const;
+  ElsfpDomData getElsfpDomData() const override;
+  CpoDomData getCpoDomData() const override;
+
+  /*
+   * Banking helpers
+   */
+  uint8_t getNumBanksSupported() const;
+  void selectBank(uint8_t bank);
+  uint8_t getCurrentBank() const;
+  bool isBankSupported(uint8_t bank) const;
+
+  void selectElsfpBank(uint8_t bank) override {
+    selectBank(bank);
+  }
+
+  uint8_t getCurrentElsfpBank() override {
+    return getCurrentBank();
+  }
 
   void getFieldValueLocked(CmisField fieldName, uint8_t* fieldValue) const;
   /*

--- a/fboss/qsfp_service/module/cmis/cmis.thrift
+++ b/fboss/qsfp_service/module/cmis/cmis.thrift
@@ -342,4 +342,22 @@ enum CmisField {
   // Page 38h, Bytes 141-142: Rx Consequent Action Hold-off Timer
   // 16-bit value in 10ms increments. 0 = disabled.
   CONS_ACT_HOLD_OFF_TMR = 467,
+
+  // ELSFP (External Laser SFP) specific fields
+  // Page 01h, ELSFP Status and Control registers
+  ELSFP_STATUS = 500,
+  ELSFP_LASER_TEMP_HIGH = 501,
+  ELSFP_LASER_TEMP_LOW = 502,
+  ELSFP_LASER_BIAS_HIGH = 503,
+  ELSFP_LASER_BIAS_LOW = 504,
+  ELSFP_OPTICAL_OUTPUT_HIGH = 505,
+  ELSFP_OPTICAL_OUTPUT_LOW = 506,
+  ELSFP_LASER_CONTROL = 507,
+  ELSFP_LASER_READY = 508,
+  ELSFP_LASER_FAULT = 509,
+  ELSFP_CONNECTED = 510,
+
+  // Banking support fields (CMIS 5.3)
+  NUM_BANKS_SUPPORTED = 520,
+  BANK_PAGE_CHANGE_TIME = 521,
 }

--- a/fboss/qsfp_service/module/cpo/CpoDomMonitor.cpp
+++ b/fboss/qsfp_service/module/cpo/CpoDomMonitor.cpp
@@ -1,0 +1,72 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "fboss/qsfp_service/module/cpo/CpoDomMonitor.h"
+
+#include "fboss/qsfp_service/TransceiverManager.h"
+#include "fboss/qsfp_service/module/cmis/CmisModule.h"
+
+namespace facebook {
+namespace fboss {
+
+CpoDomMonitor::CpoDomMonitor(TransceiverManager* tcvrMgr)
+    : tcvrMgr_(tcvrMgr) {}
+
+void CpoDomMonitor::refreshCpoDomData() {
+  if (!tcvrMgr_) {
+    return;
+  }
+
+  auto transceivers = tcvrMgr_->getTransceivers();
+  for (auto& [id, tcvr] : transceivers) {
+    auto* cmisModule = dynamic_cast<CmisModule*>(tcvr.get());
+    if (!cmisModule) {
+      continue;
+    }
+
+    auto type = cmisModule->type();
+    if (type != TransceiverType::CPO_OE && type != TransceiverType::ELSFP) {
+      continue;
+    }
+
+    try {
+      auto cpoDom = cmisModule->getCpoDomData();
+      std::lock_guard<std::mutex> lock(cpoDomMutex_);
+      cpoDomCache_[id] = cpoDom;
+    } catch (const std::exception& ex) {
+      // Skip this module if DOM data cannot be read
+    }
+  }
+}
+
+CpoDomData CpoDomMonitor::getCpoDomData(TransceiverID tcvrId) const {
+  std::lock_guard<std::mutex> lock(cpoDomMutex_);
+  auto it = cpoDomCache_.find(tcvrId);
+  if (it != cpoDomCache_.end()) {
+    return it->second;
+  }
+  return CpoDomData();
+}
+
+std::map<TransceiverID, CpoDomData> CpoDomMonitor::getAllCpoDomData() const {
+  std::lock_guard<std::mutex> lock(cpoDomMutex_);
+  return cpoDomCache_;
+}
+
+bool CpoDomMonitor::isCpoModule(TransceiverID tcvrId) const {
+  if (!tcvrMgr_) {
+    return false;
+  }
+  auto tcvr = tcvrMgr_->getTransceiver(tcvrId);
+  if (!tcvr) {
+    return false;
+  }
+  auto type = tcvr->type();
+  return type == TransceiverType::CPO_OE || type == TransceiverType::ELSFP;
+}
+
+void CpoDomMonitor::setDomPollingInterval(std::chrono::milliseconds interval) {
+  domPollingInterval_ = interval;
+}
+
+} // namespace fboss
+} // namespace facebook

--- a/fboss/qsfp_service/module/cpo/CpoDomMonitor.h
+++ b/fboss/qsfp_service/module/cpo/CpoDomMonitor.h
@@ -1,0 +1,62 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#pragma once
+
+#include "fboss/qsfp_service/if/gen-cpp2/transceiver_types.h"
+#include "fboss/qsfp_service/module/Transceiver.h"
+
+#include <chrono>
+#include <map>
+#include <memory>
+#include <mutex>
+
+namespace facebook {
+namespace fboss {
+
+class TransceiverManager;
+
+/**
+ * CpoDomMonitor manages Digital Optical Monitoring (DOM) data collection
+ * for Co-Packaged Optics (CPO) platforms. It separates OE (Optical Engine)
+ * and ELSFP (External Laser SFP) DOM readings.
+ */
+class CpoDomMonitor {
+ public:
+  explicit CpoDomMonitor(TransceiverManager* tcvrMgr);
+  ~CpoDomMonitor() = default;
+
+  /**
+   * Refresh CPO DOM data for all CPO-enabled transceivers.
+   * Called periodically by TransceiverManager.
+   */
+  void refreshCpoDomData();
+
+  /**
+   * Get CPO DOM data for a specific transceiver.
+   */
+  CpoDomData getCpoDomData(TransceiverID tcvrId) const;
+
+  /**
+   * Get CPO DOM data for all CPO-enabled transceivers.
+   */
+  std::map<TransceiverID, CpoDomData> getAllCpoDomData() const;
+
+  /**
+   * Check if a transceiver is a CPO module (CPO_OE or ELSFP type).
+   */
+  bool isCpoModule(TransceiverID tcvrId) const;
+
+  /**
+   * Set the DOM polling interval.
+   */
+  void setDomPollingInterval(std::chrono::milliseconds interval);
+
+ private:
+  TransceiverManager* tcvrMgr_{nullptr};
+  std::chrono::milliseconds domPollingInterval_{1000};
+  mutable std::mutex cpoDomMutex_;
+  std::map<TransceiverID, CpoDomData> cpoDomCache_;
+};
+
+} // namespace fboss
+} // namespace facebook

--- a/fboss/qsfp_service/platforms/wedge/WedgeManager.cpp
+++ b/fboss/qsfp_service/platforms/wedge/WedgeManager.cpp
@@ -91,6 +91,9 @@ void WedgeManager::loadConfig() {
   tcvrConfig_ = std::make_shared<TransceiverConfig>(
       *qsfpCfg.transceiverConfigOverrides());
 
+  // Load CPO/ELSFP platform configuration
+  loadCpoConfig(qsfpCfg);
+
   qsfpConfig_->writePhyConfigToFile();
 
   if (FLAGS_publish_state_to_fsdb) {


### PR DESCRIPTION
- Add CPO DOM, ELSFP DOM, and CMIS 5.3 banking support to qsfp_service
- Extend transceiver.thrift with CpoConfig, CpoPortConfig, CpoDomData, ElsfpDomData
- Add Thrift RPC methods for CPO/ELSFP operations in qsfp.thrift
- Implement CmisModule::readElsfpMemory() with page selection
- Add TransceiverManager::loadCpoConfig() and port filtering
- Wire CPO config loading into WedgeManager::loadConfig()
- Add QsfpServiceHandler implementations for all CPO/ELSFP RPCs

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
