### PR TITLE
[Celestica] Icecube: Config: Implement Software Overtemp Protection (OTP) for TH6 ASIC

### DIFF
--- a/fboss/platform/configs/icecube/fan_service.json
+++ b/fboss/platform/configs/icecube/fan_service.json
@@ -6,6 +6,7 @@
   "pwmTransitionValue": 35,
   "pwmLowerThreshold": 20,
   "pwmUpperThreshold": 100,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD/th6_pwr_en",
   "watchdog": {
     "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
@@ -68,6 +69,16 @@
       }
     }
   ],
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 1,
+    "conditions": [
+      {
+        "sensorName": "TH6_TEMP",
+        "overtempThreshold": 101.0,
+        "slidingWindowSize": 1
+      }
+    ]
+  },
   "fans": [
     {
       "fanName": "FAN_1_F",

--- a/fboss/platform/configs/icecube/platform_manager.json
+++ b/fboss/platform/configs/icecube/platform_manager.json
@@ -1341,6 +1341,7 @@
     "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_INLET_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TSENSOR]",
     "/run/devmap/sensors/SMB_VDDCORE": "/SMB_SLOT@0/[SMB_VDDCORE]",
+    "/run/devmap/sensors/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
     "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
     "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
     "/run/devmap/sensors/COME_HWMON3": "/COMESE_SLOT@0/[COME_HWMON3]",

--- a/fboss/platform/configs/icecube/sensor_service.json
+++ b/fboss/platform/configs/icecube/sensor_service.json
@@ -1795,6 +1795,16 @@
             "maxAlarmVal": 61
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "TH6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 97,
+            "upperCriticalVal": 101
+          },
+          "compute": "@/1000.0"
         }
       ],
       "versionedSensors": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="972" height="304" alt="icecube_fan_otp" src="https://github.com/user-attachments/assets/5cd0dc8a-93b9-448d-b4fa-250c8823852d" />


# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR introduces a comprehensive software-based Overtemp Protection (OTP) mechanism for the Icecube platform. By integrating sensor monitoring with the `fan-service` shutdown logic, we ensure the hardware is protected during thermal anomalies before reaching catastrophic physical limits.

Currently, the Icecube platform lacks a software-driven emergency power-off sequence for the TH6 ASIC. Relying solely on hardware-level protection can be risky if the thermal ramp is too steep. This change establishes a "Soft OTP" layer to trigger an orderly shutdown when the TH6 temperature hits the critical threshold.

### Key Changes

- **platform_manager.json**: Exported the `SMB_CPLD` sysfs path to ensure `sensor_service` has consistent access to temperature registers.

- **sensor_service.json**: Defined the `TH6_TEMP` sensor (mapped to `SMB_CPLD`) with a critical threshold (`upperCriticalVal`) of `101.0°C`.

- **fan_service.json**: 
    - Implemented `shutdownCondition` triggered by `TH6_TEMP`.
    - Defined `shutdownCmd` to explicitly disable TH6 power via `SMB_CPLD` (`echo 0 > /run/devmap/cplds/SMB_CPLD/th6_pwr_en`).



# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

1. **Syntax Validation**: Validated JSON syntax.
2. **Formatting**: Pretty-printed configurations using the jq command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Service Verification**: Confirmed that the following services start and run without errors:
    - platform_manager/platform_hw_test/platform_manager_hw_test
    - sensor_service/sensor_service_client/sensor_service_sw_test/sensor_service_hw_test
    - fan_service/fan_service_sw_test/fan_service_hw_test

5. **End-to-End Thermal Protection Verification (Soft OTP)**
To verify the effectiveness of the software shutdown logic, we performed a controlled thermal stress test:

- **Methodology**:
    - **Hardware Guardrail Adjustment**: Temporarily increased the hardware initialization threshold of the TMP432 sensor to **110°C** via `platform_manager`. This ensures the hardware-level protection is bypassed during the test window, allowing the software logic to be the primary defender.
    - **Controlled Thermal Ramp**: Adjusted the CDU (Cooling Distribution Unit) to allow the TH6 ASIC temperature to rise naturally.
    - **Observation**: Monitored the `fan_service` polling cycle and system logs to capture the exact trigger point.

- **Test Result**:
    - **Trigger Point**: Once `TH6_TEMP` hit the software-defined threshold of **101°C**, the `fan_service` successfully identified the `shutdownCondition`.
    - **Action Executed**: The `shutdownCmd` was immediately triggered, executing:  
      `echo 0 > /run/devmap/cplds/SMB_CPLD/th6_pwr_en`
    - **Conclusion**: Confirmed that the TH6 power rail was successfully disabled by the software trigger, preventing the temperature from reaching the 110°C hardware limit.
    - **Audit Logs**: The attached `.zip` contains specific evidence:
        - `temp_shutdown_monitor`: Captures the thermal ramp and the `fan_service` trigger event at `101.604°C`.
        - `pcie_shutdown_monitor`: Verifies the physical removal of TH6 from the PCIe bus post-shutdown, confirming successful power-off.

<img width="1906" height="562" alt="image" src="https://github.com/user-attachments/assets/da2fc3a2-844c-495f-a40b-8f987aee84f1" />

**Attachment**:
[icecube_sw_OTP_test_2026_04_24_log.zip](https://github.com/user-attachments/files/27988072/icecube_sw_OTP_test_2026_04_24_log.zip)


