### PR TITLE
[Celestica] rma-showtech: get GPIO line value of current direction in rma-showtech GPIO show

### DIFF
--- a/fboss/lib/GpiodLine.cpp
+++ b/fboss/lib/GpiodLine.cpp
@@ -74,4 +74,28 @@ void GpiodLine::setValue(int defaultVal, int targetVal) {
   }
 }
 
+int GpiodLine::getLineValue() {
+  struct gpiod_line_request_config config = {
+      .consumer = name_.c_str(),
+      .request_type = GPIOD_LINE_REQUEST_DIRECTION_AS_IS,
+      .flags = 0};
+
+  if (gpiod_line_request(line_, &config, 0) != 0) {
+    throw GpiodLineError(
+        fmt::format(
+            "GpiodLineTrace: gpiod_line_request() failed for {}", name_));
+  }
+
+  int val = gpiod_line_get_value(line_); // Read the line value
+
+  if (-1 == val) {
+    throw GpiodLineError(
+        fmt::format(
+            "GpiodLineTrace: gpiod_line_get_value() failed to get {} value, errno = {}",
+            name_,
+            folly::errnoStr(errno)));
+  }
+
+  return val;
+}
 } // namespace facebook::fboss

--- a/fboss/lib/GpiodLine.h
+++ b/fboss/lib/GpiodLine.h
@@ -26,6 +26,7 @@ class GpiodLine {
   ~GpiodLine();
   int getValue();
   void setValue(int defaultVal, int targetVal);
+  int getLineValue();
 
   // Forbidden copy constructor and assignment operator
   GpiodLine(GpiodLine const&) = delete;

--- a/fboss/platform/rma-showtech/Utils.cpp
+++ b/fboss/platform/rma-showtech/Utils.cpp
@@ -464,8 +464,9 @@ void Utils::printGpio(const Gpio& gpio) {
     std::cout << fmt::format(
         "line {:>3}:   {:<15} -> ", *line.lineIndex(), *line.name());
     try {
-      std::cout << GpiodLine(chip, *line.lineIndex(), *line.name()).getValue()
-                << std::endl;
+      std::cout
+          << GpiodLine(chip, *line.lineIndex(), *line.name()).getLineValue()
+          << std::endl;
     } catch (const std::exception& e) {
       std::cout << fmt::format("Error: failed to read gpio line: {}", e.what())
                 << std::endl;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="869" height="199" alt="image" src="https://github.com/user-attachments/assets/db3ce250-830a-4f40-9357-68b3f074932e" />

# Summary
This pull introduces a safe method for reading GPIO line values without altering the pin's current direction.

# Motivation
rma-showtech invokes GpiodLine::getValue() to display GPIO pin states. However, getValue() internally calls gpiod_line_request_input(), which forcibly changes the GPIO pin direction to input mode. This behavior can lead to a mismatch with the actual hardware state and may even disrupt ongoing services.
Therefore, introduce a function,GpiodLine::getLineValue(), which reads the GPIO state while respecting its currently direction and integrates it into rma-showtech. This ensures that the rma-showtech GPIO display is non-disruptive.


The modifications include:
- Implemented the new function GpiodLine::getLineValue() to read the value of a GPIO line based on its current direction.
- Updated the Utils::printGpio utility to use the new GpiodLine::getLineValue() function
<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
1. Catch the santa platform snapshot via rma-showtech succesfully.
2. Change several GPIO line to output direction via cmd gpioset, show GPIO information via rma-showtech GPIO show. The value of output direction of these GPIO Lines could be shown correctly.

Before gpioset:
<img width="965" height="232" alt="image" src="https://github.com/user-attachments/assets/28af8aef-3b78-4723-8917-45a5f1ab5b96" />

After gpioset:
<img width="946" height="222" alt="image" src="https://github.com/user-attachments/assets/aa2df676-20e3-4599-bf43-45f34556998f" />


<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
