### PR TITLE
[Meta][fboss][oss] Fix ruff isort config to match BLACK import sorting

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -43,6 +43,7 @@ ignore = [
 known-first-party = ["fboss"]
 force-single-line = false
 combine-as-imports = true
+order-by-type = false
 
 [lint.pylint]
 max-args = 8


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add order-by-type = false to ruff's isort config. Without this, ruff
sorts UPPER_CASE names before lowercase (ASCII order), which conflicts
with Meta's internal BLACK formatter that sorts case-insensitively.
This caused pre-commit failures on any file importing both constants
and functions from the same module.

# Test Plan

  Staged `run_test.py` with wrong import order (UPPER_CASE names hoisted to top)
  alongside the `ruff.toml` fix, and ran pre-commit:

  **1. Staged diff (wrong import order + ruff.toml fix):**

```
  $ git diff --staged

  diff --git a/fboss/oss/scripts/run_scripts/run_test.py b/fboss/oss/scripts/run_scripts/run_test.py
   from fboss_agent_utils import (
  +HW_AGENT_SERVICE_PROD,
  +SW_AGENT_SERVICE_PROD,
       agent_can_warm_boot_file_path,
       cleanup_hw_agent_service,
       cleanup_sw_agent_service,
       cold_boot_agents,
  - HW_AGENT_SERVICE_PROD,
  is_agent_running,
  setup_and_start_hw_agent_service,
  setup_and_start_sw_agent_service,
  - SW_AGENT_SERVICE_PROD,
   )

  diff --git a/ruff.toml b/ruff.toml
   known-first-party = ["fboss"]
   force-single-line = false
   combine-as-imports = true
  +order-by-type = false
```

  **2. Pre-commit auto-fixed the wrong order:**

```
  $ pre-commit run

  ruff check...............................................................Failed
  - hook id: ruff-check
  - files were modified by this hook

  Found 1 error (1 fixed, 0 remaining).
```

  **3. Ruff corrected imports back to BLACK's case-insensitive alphabetical order:**

```
  $ git diff

   from fboss_agent_utils import (
  -HW_AGENT_SERVICE_PROD,
  -SW_AGENT_SERVICE_PROD,
       agent_can_warm_boot_file_path,
       cleanup_hw_agent_service,
       cleanup_sw_agent_service,
       cold_boot_agents,
  - HW_AGENT_SERVICE_PROD,
  is_agent_running,
  setup_and_start_hw_agent_service,
  setup_and_start_sw_agent_service,
  - SW_AGENT_SERVICE_PROD,
   )
```

  With `order-by-type = false`, ruff's isort now enforces the same
  case-insensitive alphabetical order as Meta's internal BLACK formatter.

