### PR TITLE
[Meta] Upgrade GitHub Actions to Node.js 24 compatible versions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/distro_image_build.yml
+++ b/.github/workflows/distro_image_build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: 32-core-ubuntu
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Run fboss-image build
         run: ./fboss-image/distro_cli/fboss-image build fboss-image/from_source.json

--- a/.github/workflows/fboss2-cli.yml
+++ b/.github/workflows/fboss2-cli.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Clean workspace
         run: sudo rm -rf ${{ github.workspace }}/*
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run Docker-based build for fboss2 CLI
         run: >
           sudo
@@ -68,7 +68,7 @@ jobs:
       - name: Save Docker image
         run: sudo docker save fboss_image:latest | zstd -o ${{ github.workspace }}/build-output/fboss_docker_image.tar.zst
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fboss2-cli
           path: |
@@ -82,9 +82,9 @@ jobs:
     needs: fboss2-CLI-Build
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Download artifact with test binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: fboss2-cli
       - run: ls ${{ github.workspace }}

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -30,7 +30,7 @@ jobs:
         run: yarn build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
- Upgrade outdated GitHub Actions to latest versions (Node.js 24 compatible)
- Add `.github/dependabot.yml` for automatic future upgrade PRs

## Motivation
GitHub is deprecating Node.js 20 actions starting June 2, 2026. Several workflows were using older action versions that trigger deprecation warnings.

https://github.com/facebook/fboss/actions/runs/26126542327

## Changes
| File | Action | Before | After |
|---|---|---|---|
| fboss2-cli.yml | actions/checkout | v4 | v6 |
| fboss2-cli.yml | actions/upload-artifact | v4 | v6 |
| fboss2-cli.yml | actions/download-artifact | v4 | v7 |
| distro_image_build.yml | actions/checkout | v5 | v6 |
| github-pages-deploy.yml | actions/upload-pages-artifact | v3 | v4 |

# Test Plan

This will trigger the three github action flows and will monitor there's no more warning about outdated versions
