### PR TITLE
[Nexthop][NPI] "asic_config_v3" part 3 - Broadcom XGS generator and vendor data

### DIFF
--- a/cmake/AsicConfigV3ConfigCli.cmake
+++ b/cmake/AsicConfigV3ConfigCli.cmake
@@ -9,12 +9,31 @@ set(
     "fboss/lib/asic_config_v3/base_generator.py"
     "fboss/lib/asic_config_v3/gen.py"
     "fboss/lib/asic_config_v3/generators/__init__.py"
+    "fboss/lib/asic_config_v3/generators/broadcom_xgs_generator.py"
+    "fboss/lib/platform_mapping_v2/asic_vendor_config.py"
+    "fboss/lib/platform_mapping_v2/gen.py"
+    "fboss/lib/platform_mapping_v2/helpers.py"
+    "fboss/lib/platform_mapping_v2/integrated_transceiver_mapping.py"
+    "fboss/lib/platform_mapping_v2/platform_mapping_v2.py"
+    "fboss/lib/platform_mapping_v2/port_profile_mapping.py"
+    "fboss/lib/platform_mapping_v2/profile_settings.py"
+    "fboss/lib/platform_mapping_v2/read_files_utils.py"
+    "fboss/lib/platform_mapping_v2/si_settings.py"
+    "fboss/lib/platform_mapping_v2/static_mapping.py"
 )
 
 add_fb_thrift_python_executable(
     fboss-asic-config-v3-gen
     MAIN_MODULE fboss.lib.asic_config_v3.gen:generate_all_asic_configs
     SOURCES ${ASIC_CONFIG_V3_PY_SRCS}
+    DEPENDS
+        platform_config_python
+        switch_config_python
+        transceiver_python
+        phy_python
+        platform_mapping_config_python
+        fboss_common_python
+        python-pyyaml::python-pyyaml
 )
 
 install_fb_python_executable(fboss-asic-config-v3-gen)

--- a/fboss/lib/asic_config_v3/gen.py
+++ b/fboss/lib/asic_config_v3/gen.py
@@ -5,11 +5,17 @@ import os
 import sys
 
 from fboss.lib.asic_config_v3.base_generator import BaseAsicConfigGenerator, MODULE_DIR
+from fboss.lib.asic_config_v3.generators.broadcom_xgs_generator import (
+    BroadcomXgsGenerator,
+)
 
 OUTPUT_DIR: str = f"{MODULE_DIR}/generated_asic_configs"
 
 # Add a new (vendor, asic) entry when bringing up a new ASIC family.
-_GENERATOR_REGISTRY: dict[tuple[str, str], type[BaseAsicConfigGenerator]] = {}
+_GENERATOR_REGISTRY: dict[tuple[str, str], type[BaseAsicConfigGenerator]] = {
+    ("broadcom", "tomahawk5"): BroadcomXgsGenerator,
+    ("broadcom", "tomahawk6"): BroadcomXgsGenerator,
+}
 
 
 def get_generator(

--- a/fboss/lib/asic_config_v3/generators/broadcom_xgs_generator.py
+++ b/fboss/lib/asic_config_v3/generators/broadcom_xgs_generator.py
@@ -1,0 +1,505 @@
+# pyre-strict
+
+import json
+import os
+from typing import Any
+
+import yaml
+
+from fboss.lib.asic_config_v3.base_generator import (
+    BaseAsicConfigGenerator,
+    MODULE_DIR,
+)
+from fboss.lib.platform_mapping_v2.gen import read_all_vendor_data
+from fboss.lib.platform_mapping_v2.platform_mapping_v2 import PlatformMappingParser
+
+
+class BroadcomXgsGenerator(BaseAsicConfigGenerator):
+    """Data-driven ASIC config generator for the Broadcom XGS family.
+
+    Produces multi-document YAML output with typed tables.
+    """
+
+    ASIC_FAMILY: str = "xgs"
+
+    def __init__(
+        self,
+        platform_name: str,
+        variant: str,
+        platform_config: dict[str, Any],
+    ) -> None:
+        super().__init__(platform_name, variant, platform_config)
+
+        self.values: dict[str, Any] = {}
+        self.asic_config: dict[str, Any] = {}
+
+        self._load_vendor_configs()
+        self._init_tables()
+
+        self.parser = PlatformMappingParser(read_all_vendor_data(), self.platform_name)
+
+        self.num_ports_per_core: int = self.platform_config.get("num_ports_per_core", 2)
+        self.mmu_size: int = self.asic_config.get("mmu_size", 9416)
+
+        # Compute lanes_per_port from ASIC port_architecture and platform num_ports_per_core
+        port_arch = self.asic_config.get("port_architecture", {})
+        num_lanes_per_core = port_arch.get("num_lanes_per_core", 8)
+        self.lanes_per_port: int = num_lanes_per_core // self.num_ports_per_core
+
+    @property
+    def output_extension(self) -> str:
+        return ".yml"
+
+    def _load_vendor_configs(self) -> None:
+        """Load the family-wide OCP, SDK, SAI common blocks and the per-ASIC config."""
+        vendor = self.asic_vendor
+        asic = self.asic_name
+
+        ocp_sai_common_path = os.path.join(MODULE_DIR, "common", "ocp_sai_common.json")
+        if os.path.exists(ocp_sai_common_path):
+            with open(ocp_sai_common_path) as f:
+                self.ocp_sai_common = json.load(f)
+        else:
+            self.ocp_sai_common = {"global": {}}
+
+        vendor_sdk_common_path = os.path.join(
+            MODULE_DIR, "vendors", vendor, self.ASIC_FAMILY, "sdk_common.json"
+        )
+        with open(vendor_sdk_common_path) as f:
+            self.vendor_sdk_common = json.load(f)
+
+        vendor_sai_common_path = os.path.join(
+            MODULE_DIR, "vendors", vendor, self.ASIC_FAMILY, "sai_common.json"
+        )
+        with open(vendor_sai_common_path) as f:
+            self.vendor_sai_common = json.load(f)
+
+        asic_config_path = os.path.join(
+            MODULE_DIR, "vendors", vendor, self.ASIC_FAMILY, "asics", f"{asic}.json"
+        )
+        with open(asic_config_path) as f:
+            self.asic_config = json.load(f)
+
+        self.asic_name = self.asic_config.get("asic", asic)
+
+    def _init_tables(self) -> None:
+        """Initialize empty dictionaries for each table."""
+        table_names = self.asic_config.get("table_names", [])
+        for table_name in table_names:
+            self.values[table_name] = {}
+
+    def _read_preamble(self, file_name: str) -> str:
+        """Read preamble file contents."""
+        preamble_path = os.path.join(MODULE_DIR, file_name)
+        with open(preamble_path, encoding="utf-8") as f:
+            return f.read()
+
+    def get_lane_map_str(self, lane_map: list[int]) -> str:
+        """Convert a lane map list to its little-endian hex string form.
+
+        For example, [3, 2, 1, 0, 7, 6, 5, 4] becomes "0x45670123".
+        """
+        lane_map_str = "".join(str(lane) for lane in reversed(lane_map))
+        return f"0x{lane_map_str}"
+
+    def get_polarity_map_str(self, pn_map: list[int]) -> str:
+        """Convert a polarity map (per-lane binary flags) to a hex byte string.
+
+        The polarity bits are read little-endian and packed into a single byte
+        rendered as "0x" plus two uppercase hex digits.
+        """
+        pn_map_str = "".join(str(pn) for pn in reversed(pn_map))
+        return f"0x{int(pn_map_str, 2):02X}"
+
+    def _apply_pass_through_settings(self) -> None:
+        """Copy each pass-through source block to its target output table.
+
+        A variant may declare a top-level dict at the same source key to
+        replace the ASIC default for that pass-through entirely. This lets a
+        platform emit a subset or different values than the chip-wide defaults.
+        """
+        for pt in self.asic_config.get("pass_through_settings", []):
+            source_key = pt["source"]
+            target_table = pt["target_table"]
+            data = self.variant_config.get(
+                source_key, self.asic_config.get(source_key, {})
+            )
+            self.values[target_table].update(data)
+
+    def _compute_skip_from_sai_common(self) -> list[str]:
+        """Collect skip_from_sai_common fields from all active conditional settings."""
+        skip_fields: list[str] = []
+        for cs in self.asic_config.get("conditional_settings", []):
+            condition = cs.get("condition", {})
+            source = condition.get("source", "asic_config_params")
+            if source == "asic_config_params":
+                param_value = self.asic_config_params.get(condition["param"])
+            elif source == "features":
+                param_value = self.variant_config.get("features", {}).get(
+                    condition["param"]
+                )
+            else:
+                continue
+            if param_value == condition.get("equals"):
+                skip_fields.extend(cs.get("skip_from_sai_common", []))
+        return skip_fields
+
+    def _apply_conditional_settings(self) -> None:
+        """Evaluate and apply conditional settings.
+
+        ASIC-level entries from ``asic_config.conditional_settings`` are
+        evaluated first, then platform-level entries from
+        ``variant_config.conditional_settings``. Within each list, matching
+        entries are applied in array order. Platform entries are applied after
+        ASIC entries so platform settings can override chip-level ones.
+        """
+        asic_entries = self.asic_config.get("conditional_settings", [])
+        platform_entries = self.variant_config.get("conditional_settings", [])
+        for cs in list(asic_entries) + list(platform_entries):
+            condition = cs.get("condition", {})
+            source = condition.get("source", "asic_config_params")
+            if source == "asic_config_params":
+                param_value = self.asic_config_params.get(condition["param"])
+            elif source == "features":
+                param_value = self.variant_config.get("features", {}).get(
+                    condition["param"]
+                )
+            else:
+                continue
+            if param_value != condition.get("equals"):
+                continue
+
+            for table_name, entries in cs.get("apply", {}).items():
+                self.values.setdefault(table_name, {}).update(entries)
+
+            apply_from = cs.get("apply_from")
+            if apply_from:
+                source_key = apply_from["source"]
+                target_table = apply_from["target_table"]
+                self.values[target_table].update(self.asic_config.get(source_key, {}))
+
+    def _apply_layered_global_settings(self) -> None:
+        """Apply layered settings to the ``global`` table. Higher-numbered steps override lower."""
+        # OCP SAI common (vendor-agnostic SAI standard defaults)
+        self.values["global"].update(self.ocp_sai_common.get("global", {}))
+
+        # ASIC global defaults (chip-specific base settings)
+        self.values["global"].update(self.asic_config.get("global_defaults", {}))
+
+        # Vendor SDK common (shared BCM settings)
+        self.values["global"].update(self.vendor_sdk_common.get("global", {}))
+
+        # Vendor SAI common (with skip_from_sai_common filtering)
+        skip_fields = self._compute_skip_from_sai_common()
+        for key, value in self.vendor_sai_common.get("global", {}).items():
+            if key in skip_fields:
+                continue
+            self.values["global"][key] = value
+
+        # ASIC SAI overrides (chip-specific SAI overrides)
+        self.values["global"].update(self.asic_config.get("sai_overrides", {}))
+
+        # Platform-level SAI overrides from the variant config, layered
+        # on top of the chip-level SAI overrides so platform tuning wins.
+        self.values["global"].update(
+            self.variant_config.get("platform_sai_overrides", {})
+        )
+
+    def _get_core_range(self) -> list[int]:
+        """Return the list of core indices to include in the port mapping.
+
+        Honors the ``core_range`` override (a comma-separated list of inclusive
+        ranges such as ``"0-15,48-63"``) when present, otherwise falls back to
+        the ASIC's full core count.
+        """
+        port_mapping_overrides = self.variant_config.get("port_mapping_overrides", {})
+        core_range_str = port_mapping_overrides.get("core_range", None)
+
+        if core_range_str:
+            cores = []
+            for part in core_range_str.split(","):
+                if "-" in part:
+                    start, end = part.split("-")
+                    cores.extend(range(int(start), int(end) + 1))
+                else:
+                    cores.append(int(part))
+            return cores
+        port_arch = self.asic_config.get("port_architecture", {})
+        num_cores = port_arch.get("num_cores", 64)
+        return list(range(num_cores))
+
+    def _get_logical_port_to_physical_port_mapping(self) -> list[list[int]]:
+        """Compute the logical-to-physical port mapping for this variant.
+
+        The mapping formula is driven by the ASIC's ``port_architecture`` and
+        may be tuned per variant via ``port_mapping_overrides``:
+
+          * ``num_logical_ports_per_datapath``: override the ASIC-level value.
+          * ``num_lp_ports_on_even_core``: override the ASIC-level default.
+          * ``lp_start_step_offset``: offset added to the logical-ports-per-
+            datapath value when computing the per-datapath logical-port start.
+            Defaults to 1.
+          * ``lp_offset_simple``: when true, compute the per-port logical-port
+            offset as ``i * lanes_per_port`` on all cores rather than using
+            the default even / odd conditional.
+        """
+        port_arch = self.asic_config.get("port_architecture", {})
+        port_mapping_overrides = self.variant_config.get("port_mapping_overrides", {})
+
+        lp_per_dp = port_mapping_overrides.get(
+            "num_logical_ports_per_datapath",
+            port_arch.get("num_logical_ports_per_datapath", 10),
+        )
+        pp_per_dp = port_arch.get("num_physical_ports_per_datapath", 16)
+        lp_on_even_core = port_mapping_overrides.get(
+            "num_lp_ports_on_even_core",
+            port_arch.get("num_lp_ports_on_even_core_default", 8),
+        )
+        lanes_per_core = port_arch.get("num_lanes_per_core", 8)
+        lp_start_step_offset = port_mapping_overrides.get("lp_start_step_offset", 1)
+        lp_offset_simple = port_mapping_overrides.get("lp_offset_simple", False)
+
+        logical_to_physical_port_mapping = []
+        cores = self._get_core_range()
+
+        for core_num in cores:
+            core_offset = 1 if core_num <= 1 else 0
+            lp_start_offset = 0 if core_num % 2 == 0 else lp_on_even_core
+            lp_start = (
+                (core_num // 2) * (lp_per_dp + lp_start_step_offset)
+                + lp_start_offset
+                + core_offset
+            )
+            pp_start_offset = 0 if core_num % 2 == 0 else lanes_per_core
+            pp_start = ((core_num // 2) * pp_per_dp) + 1 + pp_start_offset
+
+            for i in range(self.num_ports_per_core):
+                if lp_offset_simple:
+                    lp_offset = i * self.lanes_per_port
+                else:
+                    lp_offset = i * (self.lanes_per_port if core_num % 2 == 0 else 1)
+                pp_offset = i * self.lanes_per_port
+                lp_id = lp_start + lp_offset
+                pp_id = pp_start + pp_offset
+                logical_to_physical_port_mapping.append([lp_id, pp_id])
+
+        return logical_to_physical_port_mapping
+
+    def _generate_logical_port_to_physical_port_mapping(
+        self, mgmt_port: bool = False
+    ) -> None:
+        """Generate PC_PORT_PHYS_MAP entries."""
+        lp_mapping = self._get_logical_port_to_physical_port_mapping()
+
+        # Reserve the CPU port row for logical 0 to physical 0 mapping.
+        lp_mapping.append([0, 0])
+
+        for lp_map in lp_mapping:
+            pm_key = (f"PORT_ID: {lp_map[0]}",)
+            pm_value = (f"PC_PHYS_PORT_ID: {lp_map[1]}",)
+            self.values["PC_PORT_PHYS_MAP"][pm_key] = pm_value
+
+        if mgmt_port:
+            mgmt_defaults = self.asic_config.get("mgmt_port_defaults", {})
+            mgmt_overrides = self.variant_config.get("mgmt_port_overrides", {})
+            logical_id = mgmt_overrides.get(
+                "logical_id", mgmt_defaults.get("logical_id", 76)
+            )
+            physical_id = mgmt_overrides.get(
+                "physical_id", mgmt_defaults.get("physical_id", 513)
+            )
+            pm_key = (f"PORT_ID: {logical_id}",)
+            pm_value = (f"PC_PHYS_PORT_ID: {physical_id}",)
+            self.values["PC_PORT_PHYS_MAP"][pm_key] = pm_value
+
+    def _generate_lane_map(self) -> None:
+        """Generate lane map entries in PC_PM_CORE."""
+        static_mapping = self.parser.get_static_mapping().get_static_mapping()
+        lane_maps = static_mapping.phy_lane_map
+
+        for core_id, lane_info in lane_maps.items():
+            tx_lane_info, rx_lane_info = lane_info.tx_lane_info, lane_info.rx_lane_info
+            pm_key = (f"PC_PM_ID: {core_id + 1}", "CORE_INDEX: 0")
+            pm_value = (
+                f"RX_LANE_MAP: {self.get_lane_map_str(list(rx_lane_info))}",
+                "RX_LANE_MAP_AUTO: 0",
+                f"TX_LANE_MAP: {self.get_lane_map_str(list(tx_lane_info))}",
+                "TX_LANE_MAP_AUTO: 0",
+            )
+            pm_value = self.values["PC_PM_CORE"].get(pm_key, ()) + pm_value
+            self.values["PC_PM_CORE"][pm_key] = pm_value
+
+    def _generate_polarity_map(self) -> None:
+        """Generate polarity map entries in PC_PM_CORE."""
+        static_mapping = self.parser.get_static_mapping().get_static_mapping()
+        pn_swap_maps = static_mapping.polarity_swap_map
+
+        for core_id, swap_map in pn_swap_maps.items():
+            tx_swap_map, rx_swap_map = swap_map.tx_lane_info, swap_map.rx_lane_info
+            pm_key = (f"PC_PM_ID: {core_id + 1}", "CORE_INDEX: 0")
+            pm_value = (
+                f"RX_POLARITY_FLIP: {self.get_polarity_map_str(list(rx_swap_map))}",
+                "RX_POLARITY_FLIP_AUTO: 0",
+                f"TX_POLARITY_FLIP: {self.get_polarity_map_str(list(tx_swap_map))}",
+                "TX_POLARITY_FLIP_AUTO: 0",
+            )
+            pm_value = self.values["PC_PM_CORE"].get(pm_key, ()) + pm_value
+            self.values["PC_PM_CORE"][pm_key] = pm_value
+
+    def _generate_port_config(self, mgmt_port: bool = False) -> None:
+        """Generate PC_PORT and PORT entries."""
+        port_config = self.variant_config.get("port_config", {})
+        cpu_port_config = self.variant_config.get("cpu_port", {})
+        mgmt_port_config = self.variant_config.get("mgmt_port", {})
+        mgmt_defaults = self.asic_config.get("mgmt_port_defaults", {})
+        mgmt_overrides = self.variant_config.get("mgmt_port_overrides", {})
+
+        default_speed = port_config.get("default_speed", 400000)
+        speed_to_fec = port_config.get("speed_to_fec", {})
+
+        cpu_speed = cpu_port_config.get("speed", 10000)
+        cpu_num_lanes = cpu_port_config.get("num_lanes", 1)
+        self.values["PC_PORT"][(f"PORT_ID: {0}",)] = (
+            "ENABLE: 1",
+            f"SPEED: {cpu_speed}",
+            f"NUM_LANES: {cpu_num_lanes}",
+        )
+
+        fec = speed_to_fec.get(str(default_speed), "PC_FEC_RS544_2XN")
+        fp_enable = port_config.get("enable", 0)
+        port_ranges = [
+            f"[{lp_map[0]}, {lp_map[0]}]"
+            for lp_map in self._get_logical_port_to_physical_port_mapping()
+        ]
+        port_ranges_str = ", ".join(port_ranges)
+        pc_key = (f"PORT_ID: [{port_ranges_str}]",)
+        pc_value = (
+            f"ENABLE: {fp_enable}",
+            f"SPEED: {default_speed}",
+            f"NUM_LANES: {self.lanes_per_port}",
+            f"FEC_MODE: {fec}",
+            f"MAX_FRAME_SIZE: {self.mmu_size}",
+        )
+        self.values["PC_PORT"][pc_key] = pc_value
+
+        if mgmt_port and mgmt_port_config.get("enabled", False):
+            logical_id = mgmt_overrides.get(
+                "logical_id", mgmt_defaults.get("logical_id", 76)
+            )
+            mgmt_speed = mgmt_overrides.get("speed", mgmt_defaults.get("speed", 100000))
+            mgmt_num_lanes = mgmt_overrides.get(
+                "num_lanes", mgmt_defaults.get("num_lanes", 4)
+            )
+            mgmt_fec = mgmt_overrides.get(
+                "fec", mgmt_defaults.get("fec", "PC_FEC_RS528")
+            )
+            mgmt_enable = mgmt_port_config.get("enable", 0)
+
+            mgmt_port_key = (f"PORT_ID: {logical_id}",)
+            mgmt_port_value = (
+                f"ENABLE: {mgmt_enable}",
+                f"SPEED: {mgmt_speed}",
+                f"NUM_LANES: {mgmt_num_lanes}",
+                f"FEC_MODE: {mgmt_fec}",
+                f"MAX_FRAME_SIZE: {self.mmu_size}",
+            )
+            self.values["PC_PORT"][mgmt_port_key] = mgmt_port_value
+
+            # Optionally include the mgmt port in the PORT (MTU) range alongside FP.
+            if mgmt_port_config.get("in_port_block", False):
+                port_ranges.append(f"[{logical_id}, {logical_id}]")
+                port_ranges_str = ", ".join(port_ranges)
+                pc_key = (f"PORT_ID: [{port_ranges_str}]",)
+
+        self.values["PORT"][pc_key] = (
+            f"MTU: {self.mmu_size}",
+            "MTU_CHECK: 1",
+        )
+
+    def _generate_device_config_overrides(self) -> None:
+        """Apply device config overrides from variant config."""
+        self.values["DEVICE_CONFIG"].update(
+            self.variant_config.get("device_config_overrides", {})
+        )
+
+    def generate(self) -> str:
+        """Build the full ASIC config and return it as a YAML string.
+
+        The XGS layering defines a nine-step priority order. Later steps
+        override earlier steps when a key appears in more than one source:
+
+          1. Pass-through settings (named data blocks routed to output tables).
+          2. OCP SAI common.
+          3. ASIC global defaults.
+          4. Vendor SDK common.
+          5. Vendor SAI common (with skip_from_sai_common filtering).
+          6. ASIC SAI overrides, then platform-level SAI overrides.
+          7. Conditional settings (feature toggles).
+          8. Device config overrides (per-variant DEVICE_CONFIG entries).
+          9. Lane and polarity maps from platform_mapping_v2 (into PC_PM_CORE).
+
+        The numbering describes *priority*, not execution order. The layered
+        global settings (steps 2-6) are applied before pass-through settings
+        so keys that both contribute to the ``global`` dict appear in a
+        deterministic positional order. Pass-through-only tables (PORT_CONFIG,
+        FP_CONFIG, TM_THD_CONFIG, CTR_EFLEX_CONFIG) are disjoint from the
+        global layering and unaffected by this choice.
+
+        Port mapping and port-config generation target disjoint tables
+        (PC_PORT_PHYS_MAP, PC_PORT, PORT) and stand outside the nine-step
+        priority order.
+        """
+        self._apply_layered_global_settings()
+        self._apply_pass_through_settings()
+        self._apply_conditional_settings()
+        self._generate_device_config_overrides()
+        self._generate_logical_port_to_physical_port_mapping(mgmt_port=True)
+        self._generate_port_config(mgmt_port=True)
+        self._generate_lane_map()
+        self._generate_polarity_map()
+
+        return self._generate_yaml_string()
+
+    def _generate_yaml_string(self) -> str:
+        """Render the populated tables as a multi-document YAML string."""
+        table_names = self.asic_config.get("table_names", [])
+        unit = 0
+        tables = []
+
+        for table_name in table_names:
+            if table_name.startswith(
+                (
+                    "PC_",
+                    "PORT_CONFIG",
+                    "TM_THD_CONFIG",
+                    "PORT",
+                    "DEVICE_CONFIG",
+                    "FP_CONFIG",
+                    "CTR_EFLEX_CONFIG",
+                    "DLB_ECMP_CONFIG",
+                )
+            ):
+                device = "device"
+            else:
+                device = "bcm_device"
+
+            if table_value := self.values.get(table_name):
+                tables.append({device: {unit: {table_name: table_value}}})
+
+        yaml_str = yaml.dump_all(
+            tables, sort_keys=False, explicit_start=True, explicit_end=True
+        )
+
+        # Strip tuple tags and bullet-style indentation introduced by yaml.dump
+        # so the output matches the legacy format produced by asic_config_v2.
+        yaml_str = yaml_str.replace(" !!python/tuple", "")
+        yaml_str = yaml_str.replace("- ", "  ")
+        yaml_str = yaml_str.replace("'", "")
+
+        preamble_str = ""
+        if self.asic_config.get("preamble_support", False):
+            preamble_file = self.variant_config.get("preamble_file")
+            if preamble_file:
+                preamble_str = self._read_preamble(preamble_file)
+
+        return preamble_str + yaml_str

--- a/fboss/lib/asic_config_v3/vendors/broadcom/xgs/asics/tomahawk5.json
+++ b/fboss/lib/asic_config_v3/vendors/broadcom/xgs/asics/tomahawk5.json
@@ -1,0 +1,141 @@
+{
+  "vendor": "broadcom",
+  "asic": "tomahawk5",
+
+  "port_architecture": {
+    "num_cores": 64,
+    "num_lanes_per_core": 8,
+    "num_logical_ports_per_datapath": 10,
+    "num_physical_ports_per_datapath": 16,
+    "num_lp_ports_on_even_core_default": 8
+  },
+
+  "mmu_size": 9416,
+  "table_names": [
+    "PC_PM_CORE",
+    "PC_PORT_PHYS_MAP",
+    "PC_PORT",
+    "PORT_CONFIG",
+    "global",
+    "port",
+    "TM_THD_CONFIG",
+    "PORT",
+    "DEVICE_CONFIG",
+    "FP_CONFIG",
+    "CTR_EFLEX_CONFIG",
+    "PC_PMD_FIRMWARE",
+    "DLB_ECMP_CONFIG"
+  ],
+  "mgmt_port_defaults": {
+    "logical_id": 76,
+    "physical_id": 513,
+    "speed": 100000,
+    "num_lanes": 4,
+    "fec": "PC_FEC_RS528"
+  },
+  "preamble_support": true,
+
+  "global_defaults": {
+    "l3_alpm_template": 1,
+    "l3_alpm_hit_mode": 1,
+    "ipv6_lpm_128b_enable": 1,
+    "pktio_driver_type": 1,
+    "qos_map_multi_get_mode": 1,
+    "rx_cosq_mapping_management_mode": 0,
+    "l3_iif_reservation_skip": 0
+  },
+  "sai_overrides": {
+    "sai_field_group_auto_prioritize": 1,
+    "bcm_tunnel_term_compatible_mode": 1,
+    "sai_l2_cpu_fdb_event_suppress": 1,
+    "sai_port_phy_time_sync_en": 1,
+    "sai_stats_support_mask": "0x802",
+    "sai_disable_internal_port_serdes": 1,
+    "stat_custom_receive0_management_mode": 1,
+    "sai_stats_disable_mask": "0x800"
+  },
+  "flex_counter_settings": {
+    "global_flexctr_ing_action_num_reserved": 20,
+    "global_flexctr_ing_pool_num_reserved": 8,
+    "global_flexctr_ing_op_profile_num_reserved": 20,
+    "global_flexctr_ing_group_num_reserved": 2,
+    "global_flexctr_egr_action_num_reserved": 8,
+    "global_flexctr_egr_pool_num_reserved": 5,
+    "global_flexctr_egr_op_profile_num_reserved": 10,
+    "global_flexctr_egr_group_num_reserved": 1
+  },
+  "ctr_eflex_config": {
+    "CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE": 1,
+    "CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE": 1,
+    "CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE": 1,
+    "CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE": 1
+  },
+  "dlb_defaults": {
+    "ecmp_dlb_port_speeds": 1,
+    "l3_ecmp_member_secondary_mem_size": 4096
+  },
+  "dlb_ecmp_config_defaults": {
+    "PATH_QUALITY_PROFILE_MODE": "WIDE"
+  },
+
+  "port_config_defaults": {"PORT_SYSTEM_PROFILE_OPERMODE_PIPEUNIQUE": 1},
+  "fp_config_defaults": {"FP_ING_OPERMODE": "GLOBAL_PIPE_AWARE"},
+  "tm_thd_config_defaults": {"THRESHOLD_MODE": "LOSSY"},
+
+  "pass_through_settings": [
+    {"source": "port_config_defaults", "target_table": "PORT_CONFIG"},
+    {"source": "fp_config_defaults", "target_table": "FP_CONFIG"},
+    {"source": "tm_thd_config_defaults", "target_table": "TM_THD_CONFIG"},
+    {"source": "flex_counter_settings", "target_table": "global"},
+    {"source": "ctr_eflex_config", "target_table": "CTR_EFLEX_CONFIG"}
+  ],
+
+  "conditional_settings": [
+    {
+      "name": "mmu_lossless",
+      "description": "Enables MMU lossless mode for PFC and RDMA workloads.",
+      "condition": {"source": "asic_config_params", "param": "mmu_lossless", "equals": true},
+      "apply": {
+        "global": {
+          "sai_mmu_custom_config": 1,
+          "sai_rdma_udf_disable": 1,
+          "sai_l3_byte1_udf_disable": 1,
+          "clm_enable": 1
+        },
+        "TM_THD_CONFIG": {
+          "THRESHOLD_MODE": "LOSSY_AND_LOSSLESS",
+          "SKIP_BUFFER_RESERVATION": 1
+        }
+      },
+      "skip_from_sai_common": ["sai_mmu_qgroups_default", "sai_optimized_mmu"]
+    },
+    {
+      "name": "exact_match",
+      "description": "Enables exact-match forwarding table entries.",
+      "condition": {"source": "asic_config_params", "param": "exact_match", "equals": true},
+      "apply": {
+        "global": {"fpem_mem_entries_width": 1, "fpem_mem_entries": 65536}
+      }
+    },
+    {
+      "name": "dlb_config",
+      "description": "Enables Dynamic Load Balancing settings for ECMP groups.",
+      "condition": {"source": "features", "param": "generate_dlb_config", "equals": true},
+      "apply_from": {"source": "dlb_defaults", "target_table": "global"}
+    },
+    {
+      "name": "dlb_ecmp_config",
+      "description": "Emits the DLB_ECMP_CONFIG path-quality profile settings.",
+      "condition": {"source": "features", "param": "generate_dlb_ecmp_config", "equals": true},
+      "apply_from": {"source": "dlb_ecmp_config_defaults", "target_table": "DLB_ECMP_CONFIG"}
+    },
+    {
+      "name": "autoload_board_settings",
+      "description": "Disables board auto-loading by setting AUTOLOAD_BOARD_SETTINGS to 0.",
+      "condition": {"source": "features", "param": "generate_autoload_board_settings", "equals": true},
+      "apply": {
+        "DEVICE_CONFIG": {"AUTOLOAD_BOARD_SETTINGS": 0}
+      }
+    }
+  ]
+}

--- a/fboss/lib/asic_config_v3/vendors/broadcom/xgs/asics/tomahawk6.json
+++ b/fboss/lib/asic_config_v3/vendors/broadcom/xgs/asics/tomahawk6.json
@@ -1,0 +1,131 @@
+{
+  "vendor": "broadcom",
+  "asic": "tomahawk6",
+
+  "port_architecture": {
+    "num_cores": 64,
+    "num_lanes_per_core": 8,
+    "num_logical_ports_per_datapath": 10,
+    "num_physical_ports_per_datapath": 16,
+    "num_lp_ports_on_even_core_default": 8
+  },
+
+  "mmu_size": 9416,
+  "table_names": [
+    "PC_PM_CORE",
+    "PC_PORT_PHYS_MAP",
+    "PC_PORT",
+    "PORT_CONFIG",
+    "global",
+    "port",
+    "TM_THD_CONFIG",
+    "PORT",
+    "DEVICE_CONFIG",
+    "FP_CONFIG",
+    "CTR_EFLEX_CONFIG",
+    "DLB_ECMP_CONFIG"
+  ],
+  "mgmt_port_defaults": {
+    "logical_id": 76,
+    "physical_id": 513,
+    "speed": 100000,
+    "num_lanes": 4,
+    "fec": "PC_FEC_RS528"
+  },
+  "preamble_support": false,
+
+  "global_defaults": {
+    "l3_alpm_template": 1,
+    "l3_alpm_hit_mode": 1,
+    "ipv6_lpm_128b_enable": 1,
+    "pktio_driver_type": 1,
+    "qos_map_multi_get_mode": 1,
+    "rx_cosq_mapping_management_mode": 0,
+    "l3_iif_reservation_skip": 0
+  },
+  "sai_overrides": {
+    "sai_field_group_auto_prioritize": 1,
+    "bcm_tunnel_term_compatible_mode": 1,
+    "sai_l2_cpu_fdb_event_suppress": 1,
+    "sai_port_phy_time_sync_en": 1,
+    "sai_stats_support_mask": "0x2",
+    "sai_disable_internal_port_serdes": 1
+  },
+  "flex_counter_settings": {
+    "global_flexctr_ing_action_num_reserved": 20,
+    "global_flexctr_ing_pool_num_reserved": 8,
+    "global_flexctr_ing_op_profile_num_reserved": 20,
+    "global_flexctr_ing_group_num_reserved": 2,
+    "global_flexctr_egr_action_num_reserved": 8,
+    "global_flexctr_egr_pool_num_reserved": 5,
+    "global_flexctr_egr_op_profile_num_reserved": 10,
+    "global_flexctr_egr_group_num_reserved": 1
+  },
+  "ctr_eflex_config": {
+    "CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE": 1,
+    "CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE": 1,
+    "CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE": 1,
+    "CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE": 1
+  },
+  "dlb_defaults": {
+    "ecmp_dlb_port_speeds": 1,
+    "l3_ecmp_member_secondary_mem_size": 4096
+  },
+  "dlb_ecmp_config_defaults": {
+    "PATH_QUALITY_PROFILE_MODE": "WIDE"
+  },
+
+  "port_config_defaults": {"PORT_SYSTEM_PROFILE_OPERMODE_PIPEUNIQUE": 1},
+  "fp_config_defaults": {"FP_ING_OPERMODE": "GLOBAL_PIPE_AWARE"},
+  "tm_thd_config_defaults": {"THRESHOLD_MODE": "LOSSY"},
+
+  "pass_through_settings": [
+    {"source": "port_config_defaults", "target_table": "PORT_CONFIG"},
+    {"source": "fp_config_defaults", "target_table": "FP_CONFIG"},
+    {"source": "tm_thd_config_defaults", "target_table": "TM_THD_CONFIG"},
+    {"source": "flex_counter_settings", "target_table": "global"},
+    {"source": "ctr_eflex_config", "target_table": "CTR_EFLEX_CONFIG"}
+  ],
+
+  "conditional_settings": [
+    {
+      "name": "mmu_lossless",
+      "description": "Enables MMU lossless mode for PFC and RDMA workloads.",
+      "condition": {"source": "asic_config_params", "param": "mmu_lossless", "equals": true},
+      "apply": {
+        "TM_THD_CONFIG": {
+          "THRESHOLD_MODE": "LOSSY_AND_LOSSLESS",
+          "SKIP_BUFFER_RESERVATION": 1
+        }
+      }
+    },
+    {
+      "name": "exact_match",
+      "description": "Enables exact-match forwarding table entries.",
+      "condition": {"source": "asic_config_params", "param": "exact_match", "equals": true},
+      "apply": {
+        "global": {"fpem_mem_entries_width": 1, "fpem_mem_entries": 65536}
+      }
+    },
+    {
+      "name": "dlb_config",
+      "description": "Enables Dynamic Load Balancing settings for ECMP groups.",
+      "condition": {"source": "features", "param": "generate_dlb_config", "equals": true},
+      "apply_from": {"source": "dlb_defaults", "target_table": "global"}
+    },
+    {
+      "name": "dlb_ecmp_config",
+      "description": "Emits the DLB_ECMP_CONFIG path-quality profile settings.",
+      "condition": {"source": "features", "param": "generate_dlb_ecmp_config", "equals": true},
+      "apply_from": {"source": "dlb_ecmp_config_defaults", "target_table": "DLB_ECMP_CONFIG"}
+    },
+    {
+      "name": "autoload_board_settings",
+      "description": "Disables board auto-loading by setting AUTOLOAD_BOARD_SETTINGS to 0.",
+      "condition": {"source": "features", "param": "generate_autoload_board_settings", "equals": true},
+      "apply": {
+        "DEVICE_CONFIG": {"AUTOLOAD_BOARD_SETTINGS": 0}
+      }
+    }
+  ]
+}

--- a/fboss/lib/asic_config_v3/vendors/broadcom/xgs/sai_common.json
+++ b/fboss/lib/asic_config_v3/vendors/broadcom/xgs/sai_common.json
@@ -1,0 +1,20 @@
+{
+  "global": {
+    "sai_common_hash_crc": "0x1",
+    "sai_disable_srcmacqedstmac_ctrl": "0x1",
+    "sai_acl_qset_optimization": "0x1",
+    "sai_optimized_mmu": "0x1",
+    "sai_pkt_rx_custom_cfg": "1",
+    "sai_pkt_rx_pkt_size": "16512",
+    "sai_pkt_rx_cfg_ppc": "16",
+    "sai_async_fdb_nbr_enable": "0x1",
+    "sai_pfc_defaults_disable": "0x1",
+    "sai_ifp_enable_on_cpu_tx": "0x1",
+    "sai_vfp_smac_drop_filter_disable": "1",
+    "sai_macro_flow_based_hash": "1",
+    "sai_mmu_qgroups_default": "1",
+    "sai_dis_ctr_incr_on_port_ln_dn": "0",
+    "custom_feature_mesh_topology_sync_mode": "1",
+    "sai_ecmp_group_members_increment": "1"
+  }
+}

--- a/fboss/lib/asic_config_v3/vendors/broadcom/xgs/sdk_common.json
+++ b/fboss/lib/asic_config_v3/vendors/broadcom/xgs/sdk_common.json
@@ -1,0 +1,8 @@
+{
+  "global": {
+    "pcie_host_intf_timeout_purge_enable": "0",
+    "qos_map_multi_get_mode": "1",
+    "macro_flow_hash_shuffle_random_seed": "34345645",
+    "bcm_linkscan_interval": "25000"
+  }
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Implements `asic_config_v3` design.

In this PR, introduce the `asic_config_v3` Broadcom XGS generator class along with the shared XGS SDK and SAI common JSONs, and per-ASIC JSONs for Tomahawk 5 and Tomahawk 6. Registered both ASICs in gen.py's `_GENERATOR_REGISTRY` and extend the CMake target SOURCES with the new generator file.

After this commit the `asic_config_v3` package can generate XGS configs for any platform whose `asic_config.json` references `tomahawk5` or `tomahawk6`.

No platforms are registered yet but will be added in the following PRs.


# Test Plan

Running `fboss/lib/asic_config_v3/run-helper.sh` is no-op as there are no platforms added yet. The platforms will be added in the following PRs.

Schema validation passes for all files.
```
$ python3 ./fboss/lib/asic_config_v3/validation/validate_asic_configs.py
Vendor common configs (vendor_common.schema.json):
  vendors/broadcom/xgs/sai_common.json: PASSED
  vendors/broadcom/xgs/sdk_common.json: PASSED

Broadcom XGS ASIC configs (broadcom_xgs_asic_config.schema.json):
  vendors/broadcom/xgs/asics/tomahawk5.json: PASSED
  vendors/broadcom/xgs/asics/tomahawk6.json: PASSED

Platform configs (platform_config.schema.json):
  No files found.
4 passed, 0 failed
```

----


**This PR is created on top of**
- https://github.com/facebook/fboss/pull/1131
- https://github.com/facebook/fboss/pull/1149 
- https://github.com/facebook/fboss/pull/1198 
- https://github.com/facebook/fboss/pull/1199

**so it contains diff from these PRs. When these PRs will merge, this PR will have a shorter diff.**