### PR TITLE
[Arista] Add ability to set smbus bus_speed through platform_manager

### DIFF
--- a/fboss/platform/platform_manager/PciExplorer.cpp
+++ b/fboss/platform/platform_manager/PciExplorer.cpp
@@ -246,6 +246,9 @@ std::vector<uint16_t> PciExplorer::createI2cAdapter(
     uint32_t instanceId) {
   auto auxData = getAuxData(*i2cAdapterConfig.fpgaIpBlockConfig(), instanceId);
   auxData.i2c_data.num_channels = *i2cAdapterConfig.numberOfAdapters();
+  if (i2cAdapterConfig.busFreqHz().has_value()) {
+    auxData.i2c_data.bus_freq_hz = *i2cAdapterConfig.busFreqHz();
+  }
   create(pciDevice, *i2cAdapterConfig.fpgaIpBlockConfig(), auxData);
   return getI2cAdapterBusNums(pciDevice, i2cAdapterConfig, instanceId);
 }

--- a/fboss/platform/platform_manager/Utils.cpp
+++ b/fboss/platform/platform_manager/Utils.cpp
@@ -287,6 +287,10 @@ std::vector<I2cAdapterConfig> Utils::createI2cAdapterConfigs(
       i2cAdapterConfig.numberOfAdapters() =
           *i2cAdapterBlockConfig.numBusesPerAdapter();
 
+      if (i2cAdapterBlockConfig.busFreqHz().has_value()) {
+        i2cAdapterConfig.busFreqHz() = *i2cAdapterBlockConfig.busFreqHz();
+      }
+
       i2cAdapterConfigs.push_back(i2cAdapterConfig);
     }
   }

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -320,9 +320,12 @@ struct FpgaIpBlockConfig {
 // `fpgaIpBlockConfig`: See FgpaIpBlockConfig above
 //
 // `numberOfAdapters`: Number of I2C Adapters created by this block.
+//
+// `busFreqHz`: I2C bus clock frequency in Hz. Applies to all buses in this block.
 struct I2cAdapterConfig {
   1: FpgaIpBlockConfig fpgaIpBlockConfig;
   2: i32 numberOfAdapters;
+  3: optional i32 busFreqHz;
 }
 
 // Defines generic I2C Adapter block in FPGAs.
@@ -366,6 +369,8 @@ struct I2cAdapterConfig {
 //  adapterIndex=2, startAdapterIndex=1:
 //    iobufOffsetCalc: "0x2000 + 1*0x100"
 //    iobufOffsetCalc: "0x2100"
+//
+// `busFreqHz`: I2C bus clock frequency in Hz. Applies to all buses in this block.
 struct I2cAdapterBlockConfig {
   1: string pmUnitScopedNamePrefix;
   2: string deviceName;
@@ -374,6 +379,7 @@ struct I2cAdapterBlockConfig {
   5: i32 numAdapters;
   6: i32 numBusesPerAdapter = 1;
   7: string iobufOffsetCalc;
+  8: optional i32 busFreqHz;
 }
 
 // Defines a Spi Device in FPGAs.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Add ability to optionally specify i2c bus speed in platform_manager config.

Changes:
  - Add optional busFreqHz to I2cAdapterConfig and I2cAdapterBlockConfig thrift structs
  - Thread busFreqHz through PciExplorer and Utils to ioctl bus_freq_hz
  - Missing piece: scd-smbus driver needs to be implemented to handle bus_freq_hz and
    create buses at the specified speed

# Test Plan

At Arista we have tested setting icecube800bawn platform_manager config to set OSFP buses to 100khz/400khz
and with scd-smbus driver changes buses are created successfully at the correct speed

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
