### PR TITLE
[Accton][minipack3nm] Set PlatformType for minipack3nm to support QSFP/LED HW tests

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -282,7 +282,7 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_YANGRA;
     } else if (FLAGS_mode == "minipack3bta") {
       type_ = PlatformType::PLATFORM_MINIPACK3BTA;
-    } else if (FLAGS_mode == "minipack3n") {
+    } else if (FLAGS_mode == "minipack3n" || FLAGS_mode == "minipack3nm") {
       type_ = PlatformType::PLATFORM_MINIPACK3N;
     } else if (FLAGS_mode == "wedge800bact") {
       type_ = PlatformType::PLATFORM_WEDGE800BACT;

--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -328,7 +328,7 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_YANGRA;
     } else if (FLAGS_mode == "minipack3bta") {
       type_ = PlatformType::PLATFORM_MINIPACK3BTA;
-    } else if (FLAGS_mode == "minipack3n") {
+    } else if (FLAGS_mode == "minipack3n" || FLAGS_mode == "minipack3nm") {
       type_ = PlatformType::PLATFORM_MINIPACK3N;
     } else if (FLAGS_mode == "wedge800bact") {
       type_ = PlatformType::PLATFORM_WEDGE800BACT;


### PR DESCRIPTION
**Pre-submission checklist**

- [ ]  I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running
pip install -r requirements-dev.txt && pre-commit install
- [ ] pre-commit run
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary
Since the Minipack3n platform has migrated its COMe from the previous module to Netlake2 (AMD), the existing platform_manager.json is no longer compatible with the new CPU configuration. 
To support this transition while maintaining system identity, a new platform name, minipack3nm, has been introduced.

Given that the underlying hardware layout remains identical to the previous version, this update adds minipack3nm to PlatformProductInfo.cpp within the Minipack3n framework. 
This allows the new platform to leverage existing `qsfp_service `and `led_service `logic, 
as well as pass `qsfp_hw_test` and `led_service_hw_test` through proper `PlatformType `identification without requiring redundant hardware-specific implementations.

# Test Plan
- qsfp_hw_test
step1. Copy [minipack3n.materialized_JSON](https://github.com/facebook/fboss/blob/main/fboss/oss/qsfp_test_configs/minipack3n.materialized_JSON) to `minipack3nm.materialized_JSON` in qsfp-config.
step2. Modify the `mode` in the new JSON from `minipack3n `to `minipack3nm`.
step3. Goal: Confirm that the FBOSS framework can successfully recognize the `minipack3nm `platform identifier.
```
1. qsfp-hw-test command:
/opt/fboss/bin/run_test.py qsfp --filter_file=/opt/fboss/share/hw_sanity_tests/t0_qsfp_hw_tests.conf --qsfp-config /opt/fboss/share/qsfp_test_configs/minipack3nm.materialized_JSON
```
- led_service_hw_test
Generate led.conf with the mode field set to minipack3nm
```
/tmp/led.conf
{
  "defaultCommandLineArgs": {
    "mode": "minipack3nm"
  },
  "ledControlledThroughService": false
}

2-1. LED color change test command:
/opt/fboss/bin/led_service_hw_test --gtest_filter=LedServiceTest.checkLedBlinking --led-config /tmp/led.conf --visual_delay_sec 0

2-2. LED blinking test command:
/opt/fboss/bin/led_service_hw_test --gtest_filter=LedServiceTest.checkForceLed  --led-config /tmp/led.conf --visual_delay_sec 0
```
# Test Result:
1. **qsfp_hw_test t0 result:** 
[minipact3nm_t0_qsfp_hw_test.log.zip](https://github.com/user-attachments/files/28140779/minipact3nm_t0_qsfp_hw_test.log.zip)

```
Running all tests took 0:09:35.051965 between 2026-05-22 14:16:21.650426 and 2026-05-22 14:25:56.702391
[       OK ] cold_boot.EmptyHwTest.CheckInit (48377 ms)
[       OK ] warm_boot.EmptyHwTest.CheckInit (26383 ms)
[       OK ] cold_boot.HwTest.i2cStressRead (47942 ms)
[       OK ] warm_boot.HwTest.i2cStressRead (28433 ms)
[       OK ] cold_boot.HwTest.i2cStressWrite (51967 ms)
[       OK ] warm_boot.HwTest.i2cStressWrite (29584 ms)
[       OK ] cold_boot.HwTest.cmisPageChange (59035 ms)
[       OK ] warm_boot.HwTest.cmisPageChange (38583 ms)
[       OK ] cold_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (94671 ms)
[       OK ] warm_boot.HwTransceiverResetTest.resetTranscieverAndDetectPresence (79749 ms)
[       OK ] cold_boot.HwStateMachineTest.CheckPortsProgrammed (45413 ms)
[       OK ] warm_boot.HwStateMachineTest.CheckPortsProgrammed (24724 ms)
Summary:
   OK : 12
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
2-1. **led_service_hw_test led color change test** result: 
[minipact3nm_led_color_change.log](https://github.com/user-attachments/files/28140785/minipact3nm_led_color_change.log)

```
[       OK ] LedServiceTest.checkLedColorChange (1623 ms)
[----------] 1 test from LedServiceTest (1623 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1623 ms total)
[  PASSED  ] 1 test.
```
2-2. **led_service_hw_test led blinking test** result:
[minipact3nm_led_blinking_test.log](https://github.com/user-attachments/files/28140789/minipact3nm_led_blinking_test.log)

```
[       OK ] LedServiceTest.checkLedBlinking (6212 ms)
[----------] 1 test from LedServiceTest (6212 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (6212 ms total)
[  PASSED  ] 1 test.
```