### PR TITLE
[Nexthop][Distro] add gflags to package.py

### DIFF
--- a/fboss/oss/scripts/package.py
+++ b/fboss/oss/scripts/package.py
@@ -28,6 +28,7 @@ LIB_NAME_OVERRIDES = {
 # Global definitions describing what we package for each target.
 
 COMMON_LIBS = [
+    "gflags",
     "glog",
     "folly",
     "fmt-python",


### PR DESCRIPTION
# Summary
When the thrift-python migration forced shared lib bundling in https://github.com/facebook/fboss/pull/1107, COMMON_LIBS was added to package.py but gflags was missed.

# Test Plan
platform_manager will work instead of failing with:
`/opt/fboss/bin/platform_manager: error while loading shared libraries: libgflags.so.2.3: cannot open shared object file: No such file or directory`
