### PR TITLE
[Nexthop] [Distro] Add chrony to FBOSS distro image

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -144,6 +144,7 @@
         <package name="tcpdump"/>
         <package name="usbutils"/>
         <package name="ndisc6"/>
+        <package name="chrony"/>
     </packages>
 
     <packages type="bootstrap">


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Add `chrony` to the FBOSS Distro Image package list. The image currently ships with no NTP client, so any device with a dead RTC battery boots with an arbitrary wall clock and drifts unbounded thereafter. 

Installing chrony makes the NTP client available; enabling `chronyd` is intentionally left to image consumers.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Built the Distro Image and confirmed chrony is installed:

```bash
$ rpm -q chrony
chrony-4.6.1-1.el9.x86_64
```