### PR TITLE
[Nexthop] Fix fbthrift-python setup.py bdist_wheel build: sccache + parallel

### DIFF
--- a/build/fbcode_builder/manifests/fbthrift-python
+++ b/build/fbcode_builder/manifests/fbthrift-python
@@ -16,6 +16,7 @@ fbthrift = thrift/lib/rust
 [build]
 builder = cmake
 job_weight_mib = 2048
+patchfile = fbthrift-python-sccache-launcher.patch
 
 [build.not(os=linux)]
 builder = nop

--- a/build/fbcode_builder/patches/fbthrift-python-sccache-launcher.patch
+++ b/build/fbcode_builder/patches/fbthrift-python-sccache-launcher.patch
@@ -1,0 +1,61 @@
+diff --git a/thrift/lib/python/CMakeLists.txt b/thrift/lib/python/CMakeLists.txt
+index f3b8192fa38..b215f7db99a 100644
+--- a/thrift/lib/python/CMakeLists.txt
++++ b/thrift/lib/python/CMakeLists.txt
+@@ -418,12 +418,23 @@ set(CYTHON_GENERATED_API_HEADERS
+ log_debug(
+   "At API header generation: cython_include_path='${cython_include_path}'")
+
++if(CMAKE_C_COMPILER_LAUNCHER)
++  set(_setup_py_cc "${CMAKE_C_COMPILER_LAUNCHER} ${CMAKE_C_COMPILER}")
++else()
++  set(_setup_py_cc "${CMAKE_C_COMPILER}")
++endif()
++if(CMAKE_CXX_COMPILER_LAUNCHER)
++  set(_setup_py_cxx "${CMAKE_CXX_COMPILER_LAUNCHER} ${CMAKE_CXX_COMPILER}")
++else()
++  set(_setup_py_cxx "${CMAKE_CXX_COMPILER}")
++endif()
+ add_custom_command(
+   OUTPUT ${CYTHON_GENERATED_API_HEADERS}
+   COMMAND ${CMAKE_COMMAND} -E env
+     "CFLAGS=${CMAKE_C_FLAGS}"
+     "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+-    "CXX=${CMAKE_CXX_COMPILER}"
++    "CC=${_setup_py_cc}"
++    "CXX=${_setup_py_cxx}"
+     "CYTHON_INCLUDE_PATH=${cython_include_path}"
+     ${Python3_EXECUTABLE} ${_lib_dir}/setup.py -v --api-only
+   DEPENDS
+@@ -675,16 +686,30 @@ add_custom_command(TARGET thrift_python_and_py3_bindings
+     "${_cybld}/folly"
+   COMMENT "Copying folly Python bindings into wheel build directory"
+ )
++set(_setup_py_parallel_jobs 1)
++if(DEFINED CMAKE_JOB_POOLS)
++  string(REGEX MATCH "compile=([0-9]+)" _m "${CMAKE_JOB_POOLS}")
++  if(CMAKE_MATCH_1)
++    set(_setup_py_parallel_jobs "${CMAKE_MATCH_1}")
++  endif()
++elseif(DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL})
++  set(_setup_py_parallel_jobs "$ENV{CMAKE_BUILD_PARALLEL_LEVEL}")
++else()
++  cmake_host_system_information(
++    RESULT _setup_py_parallel_jobs QUERY NUMBER_OF_LOGICAL_CORES)
++endif()
+ add_custom_command(TARGET thrift_python_and_py3_bindings
+   COMMAND ${CMAKE_COMMAND} -E env
+     "CFLAGS=${CMAKE_C_FLAGS}"
+     "CXXFLAGS=${CMAKE_CXX_FLAGS}"
+-    "CXX=${CMAKE_CXX_COMPILER}"
++    "CC=${_setup_py_cc}"
++    "CXX=${_setup_py_cxx}"
+     "LDFLAGS=${SETUP_LDFLAGS}"
+     "CYTHON_INCLUDE_PATH=${cython_include_path}"
+     "LIBRARY_DIRS=${library_dirs_str}"
+     "THRIFT_BUILD_TESTS=${THRIFT_BUILD_TESTS}"
+     ${Python3_EXECUTABLE} ${_lib_dir}/setup.py -v
++    build_ext --parallel ${_setup_py_parallel_jobs}
+     bdist_wheel --libpython ${python_libname}
+   WORKING_DIRECTORY ${_cybld}
+ )


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The cmake custom command that invokes `setup.py bdist_wheel` was not forwarding the compiler launcher (`CMAKE_C/CXX_COMPILER_LAUNCHER=sccache`) to the subprocess, and set CXX but not CC even though Python's distutils on this system uses CC (gcc) for C++ extension files. The build also had no parallelism: all ~40+ Cython extensions compiled one-at-a-time without sccache, causing a significant build-time regression.

The patch to fbthrift's `thrift/lib/python/CMakeLists.txt`:
- Sets `CC` and `CXX` to `"$LAUNCHER $COMPILER"` for both the `--api-only` (Cython header generation) and `bdist_wheel` commands.
- Extracts the parallel job count from `CMAKE_JOB_POOLS` (compile=N), falling back to `CMAKE_BUILD_PARALLEL_LEVEL` or `nproc`, and passes `build_ext --parallel N` before `bdist_wheel` so setuptools compiles extensions in parallel with sccache.

Note: This patch could also be applied upstream in fbthrift directly as well.

# Test Plan

Code still builds. Albeit faster.