### PR TITLE
[arista] SAINTPAUL: Add initial sensor_service config file and associated platform_manager config changes

### DIFF
--- a/fboss/platform/configs/saintpaul/platform_manager.json
+++ b/fboss/platform/configs/saintpaul/platform_manager.json
@@ -243,15 +243,6 @@
               "description": "0: PSU3 not present\n1: PSU3 present"
             },
             {
-              "name": "psu4_present",
-              "regAddr": "0xC0",
-              "bitOffset": 3,
-              "flags": [
-                "show_notes"
-              ],
-              "description": "0: PSU4 not present\n1: PSU4 present"
-            },
-            {
               "name": "psu1_input_ok",
               "regAddr": "0xC1",
               "flags": [
@@ -278,15 +269,6 @@
               "description": "0: PSU3 input not OK\n1: PSU3 input OK"
             },
             {
-              "name": "psu4_input_ok",
-              "regAddr": "0xC1",
-              "bitOffset": 3,
-              "flags": [
-                "show_notes"
-              ],
-              "description": "0: PSU4 input not OK\n1: PSU4 input OK"
-            },
-            {
               "name": "psu1_output_ok",
               "regAddr": "0xC2",
               "flags": [
@@ -311,15 +293,6 @@
                 "show_notes"
               ],
               "description": "0: PSU3 output not OK\n1: PSU3 output OK"
-            },
-            {
-              "name": "psu4_output_ok",
-              "regAddr": "0xC2",
-              "bitOffset": 3,
-              "flags": [
-                "show_notes"
-              ],
-              "description": "0: PSU4 output not OK\n1: PSU4 output OK"
             }
           ]
         },
@@ -379,19 +352,295 @@
           "busName": "SMB_I2C_MASTER_0@0",
           "address": "0x1c",
           "kernelDeviceName": "amax31732",
-          "pmUnitScopedName": "SMB_DUAL_CORE"
+          "pmUnitScopedName": "SMB_DUAL_CORE",
+          "initRegSettings": [
+            {
+              "regOffset": 37,
+              "ioBuf": [
+                90
+              ]
+            },
+            {
+              "regOffset": 38,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 29,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 30,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 31,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 32,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 33,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 34,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 35,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 36,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 45,
+              "ioBuf": [
+                85
+              ]
+            },
+            {
+              "regOffset": 41,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 42,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 43,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 44,
+              "ioBuf": [
+                105
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_I2C_MASTER_0@0",
           "address": "0x1e",
           "kernelDeviceName": "amax31732",
-          "pmUnitScopedName": "SMB_JE0_PERIPH"
+          "pmUnitScopedName": "SMB_JE0_PERIPH",
+          "initRegSettings": [
+            {
+              "regOffset": 37,
+              "ioBuf": [
+                90
+              ]
+            },
+            {
+              "regOffset": 38,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 29,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 30,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 31,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 32,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 33,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 34,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 35,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 36,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 45,
+              "ioBuf": [
+                85
+              ]
+            },
+            {
+              "regOffset": 41,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 42,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 43,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 44,
+              "ioBuf": [
+                105
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_I2C_MASTER_0@0",
           "address": "0x4c",
           "kernelDeviceName": "amax31732",
-          "pmUnitScopedName": "SMB_JE1_PERIPH"
+          "pmUnitScopedName": "SMB_JE1_PERIPH",
+          "initRegSettings": [
+            {
+              "regOffset": 37,
+              "ioBuf": [
+                90
+              ]
+            },
+            {
+              "regOffset": 38,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 29,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 30,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 31,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 32,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 33,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 34,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 35,
+              "ioBuf": [
+                110
+              ]
+            },
+            {
+              "regOffset": 36,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "regOffset": 45,
+              "ioBuf": [
+                85
+              ]
+            },
+            {
+              "regOffset": 41,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 42,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 43,
+              "ioBuf": [
+                105
+              ]
+            },
+            {
+              "regOffset": 44,
+              "ioBuf": [
+                105
+              ]
+            }
+          ]
         },
         {
           "busName": "SMB_I2C_MASTER_0@1",
@@ -504,6 +753,45 @@
         }
       ],
       "outgoingSlotConfigs": {
+        "PSU_SLOT@0": {
+          "slotType": "PSU_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/SMB_SLOT@0/[CHASSIS_CPLD]",
+              "presenceFileName": "psu1_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "PSU_MUX@0"
+          ]
+        },
+        "PSU_SLOT@1": {
+          "slotType": "PSU_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/SMB_SLOT@0/[CHASSIS_CPLD]",
+              "presenceFileName": "psu2_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "PSU_MUX@1"
+          ]
+        },
+        "PSU_SLOT@2": {
+          "slotType": "PSU_SLOT",
+          "presenceDetection": {
+            "sysfsFileHandle": {
+              "devicePath": "/SMB_SLOT@0/[CHASSIS_CPLD]",
+              "presenceFileName": "psu3_present",
+              "desiredValue": 1
+            }
+          },
+          "outgoingI2cBusNames": [
+            "PSU_MUX@2"
+          ]
+        },
         "FAN_SLOT@0": {
           "slotType": "FAN_SLOT",
           "presenceDetection": {
@@ -889,7 +1177,10 @@
     "/run/devmap/xcvrs/xcvr_io_33": "/SMB_SLOT@0/[SMB_I2C_MASTER_7@6]",
     "/run/devmap/xcvrs/xcvr_ctrl_33": "/SMB_SLOT@0/[QSFP_XCVR_CTRL_PORT_33]",
     "/run/devmap/xcvrs/xcvr_io_34": "/SMB_SLOT@0/[SMB_I2C_MASTER_7@7]",
-    "/run/devmap/xcvrs/xcvr_ctrl_34": "/SMB_SLOT@0/[QSFP_XCVR_CTRL_PORT_34]"
+    "/run/devmap/xcvrs/xcvr_ctrl_34": "/SMB_SLOT@0/[QSFP_XCVR_CTRL_PORT_34]",
+    "/run/devmap/sensors/PSU1_PMBUS": "/SMB_SLOT@0/PSU_SLOT@0/[PSU_PMBUS]",
+    "/run/devmap/sensors/PSU2_PMBUS": "/SMB_SLOT@0/PSU_SLOT@1/[PSU_PMBUS]",
+    "/run/devmap/sensors/PSU3_PMBUS": "/SMB_SLOT@0/PSU_SLOT@2/[PSU_PMBUS]"
   },
   "chassisEepromDevicePath": "/SMB_SLOT@0/[CHASSIS_EEPROM]",
   "numXcvrs": 34,

--- a/fboss/platform/configs/saintpaul/sensor_service.json
+++ b/fboss/platform/configs/saintpaul/sensor_service.json
@@ -1,0 +1,656 @@
+{
+  "platformName": "SAINTPAUL",
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "SCM",
+      "sensors": [
+        {
+          "name": "CPU_PACKAGE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp6_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp7_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp8_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_CORE7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp9_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 100.0,
+            "maxAlarmVal": 90.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 80.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SCM_ECB_VIN",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 10.5
+          },
+          "compute": "@/32000.0"
+        },
+        {
+          "name": "SCM_ECB_VOUT",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in2_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/32000.0"
+        },
+        {
+          "name": "SCM_ECB_IOUT",
+          "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SCM_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SCM_INLET/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 75.0,
+            "maxAlarmVal": 70.0
+          },
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0",
+      "pmUnitName": "SMB",
+      "sensors": [
+        {
+          "name": "FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN3_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN4_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "FAN5_RPM",
+          "sysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 14900.0,
+            "lowerCriticalVal": 1100.0
+          }
+        },
+        {
+          "name": "SMB_DUAL_CORE_LOCAL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_DUAL_CORE/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 90.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE0_PCB_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_DUAL_CORE/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_PCB_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_DUAL_CORE/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE0_D0_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_DUAL_CORE/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_D0_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_DUAL_CORE/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE0_PERIPH_LOCAL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE0_PERIPH/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 90.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE0_FAB0_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE0_PERIPH/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE0_FAB1_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE0_PERIPH/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_PERIPH_LOCAL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE1_PERIPH/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 90.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_FAB0_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE1_PERIPH/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_FAB1_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE1_PERIPH/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_NIF0_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE1_PERIPH/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_JE1_NIF1_DIE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_JE1_PERIPH/temp5_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 110.0,
+            "maxAlarmVal": 105.0
+          },
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0/PSU_SLOT@0",
+      "pmUnitName": "PSU",
+      "sensors": [
+        {
+          "name": "PSU1_VIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in1_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU1_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 70.0,
+            "maxAlarmVal": 65.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 130.0,
+            "maxAlarmVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 120.0,
+            "maxAlarmVal": 112.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/curr2_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_PIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "PSU1_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1_PMBUS/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0/PSU_SLOT@1",
+      "pmUnitName": "PSU",
+      "sensors": [
+        {
+          "name": "PSU2_VIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in1_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU2_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 70.0,
+            "maxAlarmVal": 65.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 130.0,
+            "maxAlarmVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 120.0,
+            "maxAlarmVal": 112.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/curr2_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_PIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "PSU2_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2_PMBUS/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_SLOT@0/PSU_SLOT@2",
+      "pmUnitName": "PSU",
+      "sensors": [
+        {
+          "name": "PSU3_VIN",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/in1_input",
+          "type": 1,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/in3_input",
+          "type": 1,
+          "thresholds": {
+            "upperCriticalVal": 14.4,
+            "lowerCriticalVal": 9.6
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU3_FAN2_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/fan2_input",
+          "type": 4,
+          "thresholds": {
+            "upperCriticalVal": 25500.0,
+            "lowerCriticalVal": 0.0
+          }
+        },
+        {
+          "name": "PSU3_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 70.0,
+            "maxAlarmVal": 65.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 130.0,
+            "maxAlarmVal": 120.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 120.0,
+            "maxAlarmVal": 112.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/curr1_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/curr2_input",
+          "type": 2,
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_PIN",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "PSU3_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3_PMBUS/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        }
+      ]
+    }
+  ],
+  "powerConfig": {
+    "perSlotPowerConfigs": [
+      {
+        "name": "PSU1",
+        "powerSensorName": "PSU1_PIN",
+        "slotPath": "/SMB_SLOT@0/PSU_SLOT@0"
+      },
+      {
+        "name": "PSU2",
+        "powerSensorName": "PSU2_PIN",
+        "slotPath": "/SMB_SLOT@0/PSU_SLOT@1"
+      },
+      {
+        "name": "PSU3",
+        "powerSensorName": "PSU3_PIN",
+        "slotPath": "/SMB_SLOT@0/PSU_SLOT@2"
+      }
+    ],
+    "inputVoltageSensors": [
+      "PSU1_VIN",
+      "PSU2_VIN",
+      "PSU3_VIN"
+    ],
+    "minAcPsuCount": 2
+  },
+  "temperatureConfigs": [
+    {
+      "name": "ASIC1",
+      "temperatureSensorNames": [
+        "SMB_JE0_D0_DIE_TEMP",
+        "SMB_JE0_FAB0_DIE_TEMP",
+        "SMB_JE0_FAB1_DIE_TEMP",
+        "SMB_JE0_PCB_TEMP"
+      ]
+    },
+    {
+      "name": "ASIC2",
+      "temperatureSensorNames": [
+        "SMB_JE1_D0_DIE_TEMP",
+        "SMB_JE1_FAB0_DIE_TEMP",
+        "SMB_JE1_FAB1_DIE_TEMP",
+        "SMB_JE1_NIF0_DIE_TEMP",
+        "SMB_JE1_NIF1_DIE_TEMP",
+        "SMB_JE1_PCB_TEMP"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

This adds the initial sensor_service.json config file.
It also makes some changes to the platform_manager config file initially added here: https://github.com/facebook/fboss/pull/1219
- Initializes the correct amount of PSUs (3)
- Initializes the MAX31732 thresholds.



# Test Plan

platform_manager_hw_test passes.
sensor_service_hw_test passes.
