### PR TITLE
[Celestica] Ladakh800bcls: Rma-showtech: Support printing sysfs attribute lists of power good status

### DIFF
--- a/fboss/platform/configs/darwin/rma_showtech.json
+++ b/fboss/platform/configs/darwin/rma_showtech.json
@@ -108,9 +108,11 @@
     }
   ],
   "scPowerGood": {
-    "sysfsAttribute": {
-      "name": "SMB_POWERGOOD",
-      "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
-    }
+    "sysfsAttributes": [
+      {
+        "name": "SMB_POWERGOOD",
+        "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
+      }
+    ]
   }
 }

--- a/fboss/platform/configs/darwin48v/rma_showtech.json
+++ b/fboss/platform/configs/darwin48v/rma_showtech.json
@@ -110,9 +110,11 @@
     }
   ],
   "scPowerGood": {
-    "sysfsAttribute": {
-      "name": "SMB_POWERGOOD",
-      "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
-    }
+    "sysfsAttributes": [
+      {
+        "name": "SMB_POWERGOOD",
+        "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
+      }
+    ]
   }
 }

--- a/fboss/platform/configs/darwin_netos/rma_showtech.json
+++ b/fboss/platform/configs/darwin_netos/rma_showtech.json
@@ -108,9 +108,11 @@
     }
   ],
   "scPowerGood": {
-    "sysfsAttribute": {
-      "name": "SMB_POWERGOOD",
-      "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
-    }
+    "sysfsAttributes": [
+      {
+        "name": "SMB_POWERGOOD",
+        "path": "/run/devmap/cplds/BLACKHAWK_CPLD/switch_card_pwr_status"
+      }
+    ]
   }
 }

--- a/fboss/platform/configs/ladakh800bcls/rma_showtech.json
+++ b/fboss/platform/configs/ladakh800bcls/rma_showtech.json
@@ -1,3 +1,15 @@
 {
-  "i2cBusIgnore": []
+  "i2cBusIgnore": [],
+  "scPowerGood": {
+    "sysfsAttributes": [
+      {
+        "name": "SMB_L_POWERGOOD",
+        "path": "/run/devmap/cplds/MCB_CPLD/smbl_pg"
+      },
+      {
+        "name": "SMB_R_POWERGOOD",
+        "path": "/run/devmap/cplds/MCB_CPLD/smbr_pg"
+      }
+    ]
+  }
 }

--- a/fboss/platform/rma-showtech/Utils.cpp
+++ b/fboss/platform/rma-showtech/Utils.cpp
@@ -307,10 +307,11 @@ void Utils::printNvmeDetails() {
 void Utils::printPowerGoodDetails() {
   std::cout << "##### Power Good Information #####" << std::endl;
 
-  if (config_.scPowerGood() && config_.scPowerGood()->sysfsAttribute()) {
+  if (config_.scPowerGood() && config_.scPowerGood()->sysfsAttributes()) {
     std::cout << "Reading scPowerGood from sysfs" << std::endl;
-    auto pgSysfs = *config_.scPowerGood()->sysfsAttribute();
-    printSysfsAttribute(*pgSysfs.name(), *pgSysfs.path());
+    for (const auto& pgSysfs : *config_.scPowerGood()->sysfsAttributes()) {
+      printSysfsAttribute(*pgSysfs.name(), *pgSysfs.path());
+    }
   } else if (config_.scPowerGood() && config_.scPowerGood()->gpioAttribute()) {
     std::cout << "Reading scPowerGood from gpio" << std::endl;
     auto pgGpio = *config_.scPowerGood()->gpioAttribute();

--- a/fboss/platform/rma-showtech/showtech_config.thrift
+++ b/fboss/platform/rma-showtech/showtech_config.thrift
@@ -115,9 +115,10 @@ struct FanSpinnerDevice {
 
 // Switch card power good status configuration.
 //
-// `sysfsAttribute`: Power good status via a sysfs attribute. Use this when
-// the power good signal is exposed as a sysfs file. See SysfsAttribute
-// struct below.
+// `sysfsAttributes`: List of sysfs attributes to read from this device.
+// These typically include power good status. Use these when
+// the power good signals are exposed as sysfs files.
+// See SysfsAttribute struct below.
 //
 // `gpioAttribute`: Power good status via a GPIO signal. Use this when the
 // power good signal is connected to a GPIO pin. See Gpio struct above.
@@ -125,7 +126,7 @@ struct FanSpinnerDevice {
 // Note: Only one of sysfsAttribute or gpioAttribute should be set,
 // depending on how the power good signal is exposed in the hardware.
 struct SwitchCardPowerGoodStatus {
-  1: optional SysfsAttribute sysfsAttribute;
+  1: optional list<SysfsAttribute> sysfsAttributes;
   2: optional Gpio gpioAttribute;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Some platform such as `Ladakh800bcls` may have several power good sysfs attributes, need to show all.

1. Update `sysfsAttribute` in `SwitchCardPowerGoodStatus` to lists
2. Update print function `printPowerGoodDetails`
3. Update all affected platforms' configs

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```bash
##### Power Good Information #####
Reading scPowerGood from sysfs
SMB_L_POWERGOOD: 0x1
SMB_R_POWERGOOD: 0x1
```

[showtech.log](https://github.com/user-attachments/files/28296685/showtech.log)

