### PR TITLE
enable building fboss oss on devservers

### DIFF
--- a/fboss-image/distro_cli/lib/paths.py
+++ b/fboss-image/distro_cli/lib/paths.py
@@ -7,6 +7,7 @@
 
 """Path resolution utilities for FBOSS image builder."""
 
+import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -15,11 +16,9 @@ from pathlib import Path
 def get_root_dir() -> Path:
     """Find the repository root directory.
 
-    This works by walking up from the current file until we find
-    the 'fboss-image' directory, then returning its parent.
-
-    Additionally verifies that both 'fboss-image' and 'fboss' directories
-    exist at the root to ensure we're in the correct repository structure.
+    If FBOSS_ROOT is set, uses that directly - this is particularly
+    helpful when using symlink-mapped directories. Otherwise walks up from
+    the current file until finding 'fboss-image' and 'fboss' directories.
 
     The result is cached after the first call for performance.
 
@@ -29,9 +28,15 @@ def get_root_dir() -> Path:
     Raises:
         RuntimeError: If the root directory cannot be determined
     """
+    override = os.environ.get("FBOSS_ROOT")
+    if override:
+        root = Path(override)
+        if root.is_dir():
+            return root
+        raise RuntimeError(f"FBOSS_ROOT={override} is not a valid directory")
+
     current = Path(__file__).resolve()
 
-    # Walk up the directory tree looking for fboss-image
     for parent in current.parents:
         if (parent / "fboss-image").is_dir() and (parent / "fboss").is_dir():
             return parent

--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -6,6 +6,16 @@ ARG USER_UID=0
 ARG USER_GID=0
 ARG USER_SHELL=/bin/bash
 ARG USE_CLANG=true
+ARG FBOSS_META_ENV=0
+ARG GITHUB_ROOT=.
+ARG FBCODE_BUILDER_PATH=build/fbcode_builder
+ARG http_proxy=
+ARG https_proxy=
+ENV http_proxy=${http_proxy} \
+    https_proxy=${https_proxy}
+RUN if [ -n "$http_proxy" ]; then \
+      echo "proxy=$http_proxy" >> /etc/dnf/dnf.conf; \
+    fi
 
 # Download and install sccache
 RUN version=v0.11.0 && \
@@ -34,6 +44,11 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     re2 re2-devel snappy-devel xxhash-devel xz-devel zlib-devel zlib-static \
     libxml2-devel expat-devel wget git sudo lsof `basename "$USER_SHELL"` \
     libcap-devel libmount-devel libpciaccess-devel
+
+RUN if [ "$FBOSS_META_ENV" = "1" ]; then \
+      dnf install -y podman-docker fuse-overlayfs && \
+      sed -i 's|#mount_program = "/usr/bin/fuse-overlayfs"|mount_program = "/usr/bin/fuse-overlayfs"|' /etc/containers/storage.conf; \
+    fi
 
 # Set up Python 3.12 as the system default.
 # Python 3.12 is chosen to match the getdeps python manifest which installs
@@ -72,13 +87,13 @@ RUN dnf download libtool && \
 
 RUN python3 -m pip install setuptools 'Cython>=3.0,<3.2' wheel auditwheel patchelf boto3 botocore gitpython meson jinja2 pyyaml filelock pytest
 
-COPY .pre-commit-config.yaml /tmp/.pre-commit-config.yaml
+COPY ${GITHUB_ROOT}/.pre-commit-config.yaml /tmp/.pre-commit-config.yaml
 COPY ./fboss/oss/docker/setup_clang.sh /tmp/setup_clang.sh
 RUN bash /tmp/setup_clang.sh && rm /tmp/setup_clang.sh
 
 # Use /var/FBOSS as the set location to clone the git repository and store the outputs of the build.
 WORKDIR /var/FBOSS/fboss
-COPY build/fbcode_builder /var/FBOSS/fboss/build/fbcode_builder
+COPY ${FBCODE_BUILDER_PATH} /var/FBOSS/fboss/build/fbcode_builder
 RUN if [ "$USE_CLANG" = "true" ]; then \
     find build/fbcode_builder/manifests -maxdepth 1 -type f -exec sed -i 's/^binutils/#binutils/' {} +; \
     fi && \
@@ -103,7 +118,7 @@ RUN dnf install -y perl-diagnostics perl-sort perl-English perl-Clone perl-Data-
     perl-Math-BigInt perl-YAML-LibYAML perl-Sys-Hostname perl-Time
 RUN ln -s /usr/bin/python3 /usr/bin/python
 # ============================================================
-COPY requirements-dev.txt /tmp/requirements-dev.txt
+COPY ${GITHUB_ROOT}/requirements-dev.txt /tmp/requirements-dev.txt
 RUN python3 -m pip install -r /tmp/requirements-dev.txt && rm /tmp/requirements-dev.txt
 
 # Configure sudoers to allow wheel group passwordless sudo
@@ -118,5 +133,10 @@ RUN if [ "$USERNAME" != "root" ] && [ "$USER_UID" != "0" ]; then \
 
 # Support sudo in a privileged container
 RUN chmod 600 /etc/shadow
+
+COPY fboss/oss/scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["bash"]
 
 USER ${USERNAME}

--- a/fboss/oss/scripts/build_docker.sh
+++ b/fboss/oss/scripts/build_docker.sh
@@ -1,7 +1,24 @@
 #!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# On devservers, run with sudo for --network=host to work:
+#   sudo -E ./fboss/oss/scripts/build_docker.sh
+set -euo pipefail
 
 fboss_dir=$(realpath "$(dirname "$0")/../../..")
-pushd $fboss_dir >/dev/null || exit 1
+pushd "$fboss_dir" >/dev/null || exit 1
+
+EXTRA_ARGS=()
+if [ "${FBOSS_META_ENV:-}" = "1" ]; then
+    echo "[fboss] Meta devserver detected — run with: sudo -E $0"
+    EXTRA_ARGS+=(--network=host
+                 --build-arg http_proxy=http://fwdproxy:8080
+                 --build-arg https_proxy=http://fwdproxy:8080
+                 --build-arg GITHUB_ROOT=fboss/github
+                 --build-arg FBCODE_BUILDER_PATH=opensource/fbcode_builder
+                 --build-arg FBOSS_META_ENV=1)
+fi
 
 DOCKER_BUILDKIT=1 docker build . -t fboss_builder -f fboss/oss/docker/Dockerfile \
-  --build-arg USE_CLANG=true
+  --build-arg USE_CLANG=true \
+  "${EXTRA_ARGS[@]}"

--- a/fboss/oss/scripts/entrypoint.sh
+++ b/fboss/oss/scripts/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+#
+# Creates fboss_src/ staging layout when running on a Meta devserver.
+# Expects fbcode/ mounted at /var/FBOSS/fbcode via docker run -v.
+# No-op on GitHub CI where fboss_src comes from the repo clone.
+
+FBCODE="/var/FBOSS/fbcode"
+FBOSS_SRC="/var/FBOSS/fboss"
+
+if [ "$FBOSS_META_ENV" = "1" ]; then
+    export FBOSS_ROOT="$FBOSS_SRC"
+    echo "export FBOSS_ROOT=$FBOSS_SRC" > /etc/profile.d/fboss.sh
+fi
+
+if [ "$FBOSS_META_ENV" = "1" ]; then
+    mkdir -p "$FBOSS_SRC/build"
+    rm -rf "$FBOSS_SRC/build/fbcode_builder"
+    ln -sfn "$FBCODE/fboss/github/CMakeLists.txt" "$FBOSS_SRC/CMakeLists.txt"
+    ln -sfn "$FBCODE/fboss/github/functions.cmake" "$FBOSS_SRC/functions.cmake"
+    ln -sfn "$FBCODE/fboss/github/cmake" "$FBOSS_SRC/cmake"
+    ln -sfn "$FBCODE/fboss" "$FBOSS_SRC/fboss"
+    ln -sfn "$FBCODE/fboss/common" "$FBOSS_SRC/common"
+    ln -sfn "$FBCODE/configerator" "$FBOSS_SRC/configerator"
+    cp -r "$FBCODE/opensource/fbcode_builder" "$FBOSS_SRC/build/fbcode_builder"
+    ln -sfn "$FBCODE/fboss/github/fboss-image" "$FBOSS_SRC/fboss-image"
+    ln -sfn "$FBCODE/fboss/github/sdk_dependencies.txt" "$FBOSS_SRC/sdk_dependencies.txt"
+    ln -sfn "$FBCODE/fboss/github/README.md" "$FBOSS_SRC/README.md"
+    cp -r "$FBCODE/fboss/github/.pre-commit-config.yaml" "$FBOSS_SRC/.pre-commit-config.yaml"
+    ln -sfn "$FBCODE/fboss/github/requirements-dev.txt" "$FBOSS_SRC/requirements-dev.txt"
+    ln -sfn "$FBCODE/fboss/github/getdeps.sh" "$FBOSS_SRC/getdeps.sh"
+    ln -sfn "$FBCODE/fboss/github/docs" "$FBOSS_SRC/docs"
+    ln -sfn "$FBCODE/fboss/github/ruff.toml" "$FBOSS_SRC/ruff.toml"
+    ln -sfn "$FBCODE/fboss/github/LICENSE" "$FBOSS_SRC/LICENSE"
+    ln -sfn "$FBCODE/fboss/github/PATENTS" "$FBOSS_SRC/PATENTS"
+    ln -sfn "$FBCODE/fboss/github/CONTRIBUTING.md" "$FBOSS_SRC/CONTRIBUTING.md"
+    ln -sfn "$FBCODE/fboss/github/CODE_OF_CONDUCT.md" "$FBOSS_SRC/CODE_OF_CONDUCT.md"
+    ln -sfn "$FBCODE/fboss/github/BUILD.md" "$FBOSS_SRC/BUILD.md"
+    ln -sfn "$FBCODE/fboss/github/.clang-format" "$FBOSS_SRC/.clang-format"
+    ln -sfn "$FBCODE/fboss/github/.gitignore" "$FBOSS_SRC/.gitignore"
+fi
+
+exec "$@"

--- a/fboss/oss/scripts/run-getdeps.py
+++ b/fboss/oss/scripts/run-getdeps.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import sysconfig
 import tempfile
+from pathlib import Path
 
 
 def print_info(msg):
@@ -183,7 +184,14 @@ def parse_args():
 
 
 def path_to(*args):
-    return os.path.join(os.path.dirname(__file__), "..", "..", "..", *args)
+    root = os.environ.get("FBOSS_ROOT") or os.path.join(
+        os.path.dirname(__file__), "..", "..", ".."
+    )
+
+    if not Path(root).is_dir():
+        raise FileNotFoundError(f"Provided root is not valid={root}")
+
+    return os.path.join(root, *args)
 
 
 def detect_toolchain():

--- a/fboss/oss/scripts/setup_devserver_oss_build.sh
+++ b/fboss/oss/scripts/setup_devserver_oss_build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Sets up a Meta devserver for building FBOSS OSS directly from fbsource.
+#
+# What it does:
+#   1. Exports FBOSS_META_ENV=1 (signals Meta environment to build scripts)
+#   2. Installs podman-docker if not already installed
+#
+# Usage — add to .bashrc/.bash_profile:
+#   source /path/to/fbsource/fbcode/fboss/oss/scripts/setup_devserver_oss_build.sh
+
+# Signal Meta environment to build scripts (Dockerfile, build_docker.sh, entrypoint.sh)
+export FBOSS_META_ENV=1
+
+# --- Install podman-docker if needed ---
+if ! command -v docker &>/dev/null; then
+    echo "[fboss-devserver] docker not found. Installing podman-docker..."
+    sudo dnf install -y podman-docker
+fi


### PR DESCRIPTION
Summary:
Adds container infrastructure for running FBOSS OSS builds directly on Meta
devservers using fbsource, eliminating the need to clone the GitHub repo.

- setup_devserver_oss_build.sh: exports FBOSS_META_ENV and FBOSS_ROOT, installs podman
- entrypoint.sh: creates symlink staging layout inside the container mapping
  the GitHub repo structure from fbcode paths
- Dockerfile: adds proxy support, podman-docker + fuse-overlayfs for
  nested container builds, entrypoint setup
- build_docker.sh: detects Meta environment, passes proxy and path build args

Reviewed By: KevinYakar

Differential Revision: D104170950


