### PR TITLE
[Celestica] Ladakh800bcls: Config: Support Netlake2.0

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -221,7 +221,9 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;
     } else if (modelName.find("ICETEA") == 0) {
       type_ = PlatformType::PLATFORM_ICETEA800BC;
-    } else if (modelName.find("LADAKH800BCLS") == 0) {
+    } else if (
+        modelName.find("LADAKH800BCLS") == 0 ||
+        modelName.find("LADAKH800BCLSM") == 0) {
       type_ = PlatformType::PLATFORM_LADAKH800BCLS;
     } else if (modelName.find("LEH800BCLS") == 0) {
       type_ = PlatformType::PLATFORM_LEH800BCLS;
@@ -314,7 +316,8 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_WEDGE800CACT;
     } else if (FLAGS_mode == "j4sim") {
       type_ = PlatformType::PLATFORM_J4SIM;
-    } else if (FLAGS_mode == "ladakh800bcls") {
+    } else if (
+        FLAGS_mode == "ladakh800bcls" || FLAGS_mode == "ladakh800bclsm") {
       type_ = PlatformType::PLATFORM_LADAKH800BCLS;
     } else if (FLAGS_mode == "leh800bcls") {
       type_ = PlatformType::PLATFORM_LEH800BCLS;

--- a/fboss/platform/configs/ladakh800bclsm/bsp_tests.json
+++ b/fboss/platform/configs/ladakh800bclsm/bsp_tests.json
@@ -1,0 +1,73 @@
+{
+  "testData": {
+    "LADAKH800BCLSM_MCB.MCB_CPLD": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x04",
+            "expected": "0xde"
+          }
+        ],
+        "i2cSetData": [
+          {
+            "reg": "0x04",
+            "value": "0xde"
+          }
+        ]
+      }
+    },
+    "LADAKH800BCLSM_MCB.MCB_FAN_CPLD": {
+      "i2cTestData": {
+        "i2cSetData": [
+          {
+            "reg": "0x32",
+            "value": "0x16"
+          },
+          {
+            "reg": "0x42",
+            "value": "0x16"
+          },
+          {
+            "reg": "0x52",
+            "value": "0x16"
+          },
+          {
+            "reg": "0x62",
+            "value": "0x16"
+          },
+          {
+            "reg": "0x72",
+            "value": "0x16"
+          },
+          {
+            "reg": "0x82",
+            "value": "0x16"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "fan1",
+          "fan2",
+          "fan3",
+          "fan4",
+          "fan5",
+          "fan6"
+        ]
+      },
+      "watchdogTestData": {
+        "numWatchdogs": 1
+      }
+    },
+    "LADAKH800BCLSM_MCB.48V_HSC_MONITOR": {
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "vin",
+          "vout1",
+          "pin",
+          "iout1"
+        ]
+      }
+    }
+  }
+}

--- a/fboss/platform/configs/ladakh800bclsm/fan_service.json
+++ b/fboss/platform/configs/ladakh800bclsm/fan_service.json
@@ -1,0 +1,300 @@
+{
+  "pwmBoostOnNumDeadFan": 2,
+  "pwmBoostOnNumDeadSensor": 0,
+  "pwmBoostOnNoQsfpAfterInSec": 0,
+  "pwmBoostValue": 70,
+  "pwmTransitionValue": 45,
+  "pwmLowerThreshold": 25,
+  "pwmUpperThreshold": 70,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_L_CPLD/th6_pwr_en; echo 0 > /run/devmap/cplds/SMB_R_CPLD/th6_pwr_en",
+  "watchdog": {
+    "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
+    "value": 0
+  },
+  "controlInterval": {
+    "sensorReadInterval": 5,
+    "pwmUpdateInterval": 5
+  },
+  "sensors": [
+    {
+      "sensorName": "COME_U1_CPU_UNCORE_TEMP",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
+      "pidSetting": {
+        "kp": -4,
+        "ki": -0.06,
+        "kd": 0,
+        "setPoint": 97.0,
+        "posHysteresis": 0.0,
+        "negHysteresis": 8.0
+      }
+    },
+    {
+      "sensorName": "RTM_L_U8_LM75_INLET_TEMP",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "30": 50,
+        "35": 60,
+        "37": 65,
+        "42": 70
+      },
+      "normalDownTable": {
+        "28": 50,
+        "33": 60,
+        "35": 65,
+        "40": 70
+      },
+      "failUpTable": {
+        "30": 55,
+        "35": 65,
+        "37": 70,
+        "42": 75
+      },
+      "failDownTable": {
+        "28": 55,
+        "33": 65,
+        "35": 70,
+        "40": 75
+      }
+    },
+    {
+      "sensorName": "RTM_R_U8_LM75_INLET_TEMP",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_FOUR_LINEAR_TABLE",
+      "normalUpTable": {
+        "30": 50,
+        "35": 60,
+        "37": 65,
+        "42": 70
+      },
+      "normalDownTable": {
+        "28": 50,
+        "33": 60,
+        "35": 65,
+        "40": 70
+      },
+      "failUpTable": {
+        "30": 55,
+        "35": 65,
+        "37": 70,
+        "42": 75
+      },
+      "failDownTable": {
+        "28": 55,
+        "33": 65,
+        "35": 70,
+        "40": 75
+      }
+    },
+    {
+      "sensorName": "MCB_PSP3_XP12R0V_PB3_TEMP",
+      "pwmCalcType": "SENSOR_PWM_CALC_TYPE_INCREMENTAL_PID",
+      "pidSetting": {
+        "kp": -8,
+        "ki": -0.06,
+        "kd": 0,
+        "setPoint": 105.0,
+        "posHysteresis": 0.0,
+        "negHysteresis": 3.0
+      }
+    }
+  ],
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 1,
+    "conditions": [
+      {
+        "sensorName": "SMB_L_U2_TH6_TEMP",
+        "overtempThreshold": 103.0,
+        "slidingWindowSize": 1
+      },
+      {
+        "sensorName": "SMB_R_U2_TH6_TEMP",
+        "overtempThreshold": 104.0,
+        "slidingWindowSize": 1
+      }
+    ]
+  },
+  "fans": [
+    {
+      "fanName": "FAN_1_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_1_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm1",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_2_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_2_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm2",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_3_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_3_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm3",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_4_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_4_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm4",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_5_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan9_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm5",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_5_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan10_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm5",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_6_F",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan11_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm6",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    },
+    {
+      "fanName": "FAN_6_R",
+      "rpmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan12_input",
+      "pwmSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/pwm6",
+      "presenceSysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_present",
+      "pwmMin": 0,
+      "pwmMax": 64,
+      "fanPresentVal": 1,
+      "fanMissingVal": 0,
+      "fanGoodLedVal": 1,
+      "fanFailLedVal": 2,
+      "rpmMin": 1500
+    }
+  ],
+  "zones": [
+    {
+      "zoneType": "ZONE_TYPE_MAX",
+      "zoneName": "zone1",
+      "sensorNames": [
+        "COME_U1_CPU_UNCORE_TEMP",
+        "RTM_L_U8_LM75_INLET_TEMP",
+        "RTM_R_U8_LM75_INLET_TEMP",
+        "MCB_PSP3_XP12R0V_PB3_TEMP"
+      ],
+      "fanNames": [
+        "FAN_1_F",
+        "FAN_1_R",
+        "FAN_2_F",
+        "FAN_2_R",
+        "FAN_3_F",
+        "FAN_3_R",
+        "FAN_4_F",
+        "FAN_4_R",
+        "FAN_5_F",
+        "FAN_5_R",
+        "FAN_6_F",
+        "FAN_6_R"
+      ],
+      "slope": 10
+    }
+  ]
+}

--- a/fboss/platform/configs/ladakh800bclsm/fw_util.json
+++ b/fboss/platform/configs/ladakh800bclsm/fw_util.json
@@ -1,0 +1,639 @@
+{
+  "fwConfigs": {
+    "bios": {
+      "preUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x15",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "internal"
+          }
+        }
+      ],
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal"
+        }
+      },
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "internal"
+        }
+      },
+      "postUpgrade": [
+        {
+          "commandType": "writeToPort",
+          "writeToPortArgs": {
+            "hexByteValue": "0x16",
+            "portFile": "/dev/port",
+            "hexOffset": "0xb2"
+          }
+        }
+      ],
+      "version": {
+        "versionType": "sysfs",
+        "path": "/sys/devices/virtual/dmi/id/bios_version"
+      },
+      "priority": 1
+    },
+    "iob_fpga": {
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/MCB_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
+    "dom_fpga1": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "66"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "9"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "66"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/RTM_L_DOM_INFO_ROM/fw_ver"
+      },
+      "priority": 3
+    },
+    "dom_fpga2": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "65"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "10"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+            "chip": [
+              "N25Q128..3E",
+              "W25Q128.V..M"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "10"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "65"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+          "chip": [
+            "N25Q128..3E",
+            "W25Q128.V..M"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/RTM_R_DOM_INFO_ROM/fw_ver"
+      },
+      "priority": 4
+    },
+    "mcb_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "3"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/MCB_CPLD/fw_ver"
+      },
+      "priority": 5
+    },
+    "smb_cpld1": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "0",
+            "gpioChipPin": "63"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "7"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "7"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "63"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SMB_L_CPLD/fw_ver"
+      },
+      "priority": 6
+    },
+    "smb_cpld2": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "63"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "61"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "61"
+          }
+        },
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "63"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SMB_R_CPLD/fw_ver"
+      },
+      "priority": 7
+    },
+    "scm_cpld": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "1"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/SCM_CPLD/fw_ver"
+      },
+      "priority": 8
+    },
+    "rtm_cpld1": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "66"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "0",
+            "gpioChipPin": "9"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "66"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/RTM_R_CPLD/fw_ver"
+      },
+      "priority": 9
+    },
+    "rtm_cpld2": {
+      "preUpgrade": [
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "1",
+            "gpioChipPin": "65"
+          }
+        },
+        {
+          "commandType": "gpioset",
+          "gpiosetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipValue": "0",
+            "gpioChipPin": "10"
+          }
+        }
+      ],
+      "upgrade": [
+        {
+          "commandType": "flashrom",
+          "flashromArgs": {
+            "programmer_type": "linux_spi:dev=",
+            "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+            "chip": [
+              "W25X20"
+            ]
+          }
+        }
+      ],
+      "postUpgrade": [
+        {
+          "commandType": "gpioget",
+          "gpiogetArgs": {
+            "gpioChip": "fboss_iob_pci.gpiochip.*",
+            "gpioChipPin": "65"
+          }
+        }
+      ],
+      "verify": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "read": {
+        "commandType": "flashrom",
+        "flashromArgs": {
+          "programmer_type": "linux_spi:dev=",
+          "programmer": "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1",
+          "chip": [
+            "W25X20"
+          ]
+        }
+      },
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/cplds/RTM_L_CPLD/fw_ver"
+      },
+      "priority": 10
+    }
+  }
+}

--- a/fboss/platform/configs/ladakh800bclsm/led_manager.json
+++ b/fboss/platform/configs/ladakh800bclsm/led_manager.json
@@ -1,0 +1,112 @@
+{
+  "systemLedConfig": {
+    "presentLedSysfsPath": "/sys/class/leds/sys_led:blue:status/brightness",
+    "absentLedSysfsPath": "/sys/class/leds/sys_led:amber:status/brightness"
+  },
+  "fruTypeLedConfigs": {
+    "FAN": {
+      "presentLedSysfsPath": "/sys/class/leds/fan_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/fan_led:amber:status/brightness"
+    },
+    "PWR": {
+      "presentLedSysfsPath": "/sys/class/leds/psu_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/psu_led:amber:status/brightness"
+    },
+    "SMB": {
+      "presentLedSysfsPath": "/sys/class/leds/smb_led:blue:status/brightness",
+      "absentLedSysfsPath": "/sys/class/leds/smb_led:amber:status/brightness"
+    }
+  },
+  "fruConfigs": [
+    {
+      "fruName": "FAN1",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN2",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN3",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN4",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN5",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "FAN6",
+      "fruType": "FAN",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "PWR",
+      "fruType": "PWR",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/hs_48v_pg",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "SMB_L",
+      "fruType": "SMB",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/smbl_present",
+          "desiredValue": 1
+        }
+      }
+    },
+    {
+      "fruName": "SMB_R",
+      "fruType": "SMB",
+      "presenceDetection": {
+        "sysfsFileHandle": {
+          "presenceFilePath": "/run/devmap/cplds/MCB_CPLD/smbr_present",
+          "desiredValue": 1
+        }
+      }
+    }
+  ]
+}

--- a/fboss/platform/configs/ladakh800bclsm/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bclsm/platform_manager.json
@@ -1,0 +1,1731 @@
+{
+  "platformName": "LADAKH800BCLSM",
+  "rootPmUnitName": "LADAKH800BCLSM_MCB",
+  "rootSlotType": "MCB_SLOT",
+  "slotTypeConfigs": {
+    "MCB_SLOT": {
+      "numOutgoingI2cBuses": 0,
+      "idpromConfig": {
+        "busName": "CPU_BUS@0",
+        "address": "0x53",
+        "kernelDeviceName": "24c02"
+      }
+    },
+    "RUNBMC_SLOT": {
+      "numOutgoingI2cBuses": 1,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x51",
+        "kernelDeviceName": "24c64"
+      }
+    },
+    "COMESE_SLOT": {
+      "numOutgoingI2cBuses": 2,
+      "idpromConfig": {
+        "busName": "INCOMING@1",
+        "address": "0x56",
+        "kernelDeviceName": "24c128"
+      }
+    },
+    "RTM_L_SLOT": {
+      "numOutgoingI2cBuses": 3,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      }
+    },
+    "RTM_R_SLOT": {
+      "numOutgoingI2cBuses": 3,
+      "idpromConfig": {
+        "busName": "INCOMING@0",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      }
+    },
+    "SMB_L_SLOT": {
+      "numOutgoingI2cBuses": 5,
+      "idpromConfig": {
+        "busName": "INCOMING@2",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      }
+    },
+    "SMB_R_SLOT": {
+      "numOutgoingI2cBuses": 5,
+      "idpromConfig": {
+        "busName": "INCOMING@4",
+        "address": "0x50",
+        "kernelDeviceName": "24c64"
+      }
+    }
+  },
+  "i2cAdaptersFromCpu": [
+    "CPU_BUS@0"
+  ],
+  "versionedPmUnitConfigs": {
+    "NETLAKE20": [
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_HWMON1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_HWMON2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_HWMON3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_INLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 2
+      }
+    ]
+  },
+  "pmUnitConfigs": {
+    "LADAKH800BCLSM_MCB": {
+      "pluggedInSlotType": "MCB_SLOT",
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_CORE_TEMP",
+          "sysfsPath": "/sys/bus/pci/drivers/k10temp/0000:00:18.3"
+        }
+      ],
+      "pciDeviceConfigs": [
+        {
+          "pmUnitScopedName": "MCB_IOB",
+          "vendorId": "0x1d9b",
+          "deviceId": "0x0011",
+          "subSystemVendorId": "0x10ee",
+          "subSystemDeviceId": "0x0007",
+          "i2cAdapterBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "MCB_IOB_I2C_MASTER",
+              "deviceName": "iob_i2c_master",
+              "csrOffsetCalc": "0x4000 + ({adapterIndex} - {startAdapterIndex})*0x100",
+              "startAdapterIndex": 1,
+              "numAdapters": 31
+            },
+            {
+              "pmUnitScopedNamePrefix": "RTM_L_DOM_I2C_MASTER",
+              "deviceName": "dom1_i2c_master",
+              "csrOffsetCalc": "0x4c000 + ({adapterIndex} - {startAdapterIndex})*0x100",
+              "startAdapterIndex": 1,
+              "numAdapters": 2
+            },
+            {
+              "pmUnitScopedNamePrefix": "RTM_R_DOM_I2C_MASTER",
+              "deviceName": "dom2_i2c_master",
+              "csrOffsetCalc": "0x44000 + ({adapterIndex} - {startAdapterIndex})*0x100",
+              "startAdapterIndex": 1,
+              "numAdapters": 2
+            }
+          ],
+          "gpioChipConfigs": [
+            {
+              "pmUnitScopedName": "MCB_GPIO_CHIP_1",
+              "deviceName": "gpiochip",
+              "csrOffset": "0x0400"
+            }
+          ],
+          "spiMasterConfigs": [
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_1",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10000",
+                "iobufOffset": "0x12000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_1_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_2",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10080",
+                "iobufOffset": "0x12400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_2_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_3",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10100",
+                "iobufOffset": "0x12800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_3_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_4",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10180",
+                "iobufOffset": "0x12c00"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_4_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_5",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10200",
+                "iobufOffset": "0x13000"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_5_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_6",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10280",
+                "iobufOffset": "0x13400"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_6_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MCB_SPI_MASTER_7",
+                "deviceName": "spi_master",
+                "csrOffset": "0x10300",
+                "iobufOffset": "0x13800"
+              },
+              "spiDeviceConfigs": [
+                {
+                  "pmUnitScopedName": "MCB_SPI_MASTER_7_DEVICE_1",
+                  "modalias": "spidev",
+                  "chipSelect": 0,
+                  "maxSpeedHz": 25000000
+                }
+              ]
+            }
+          ],
+          "xcvrCtrlBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "IOB",
+              "deviceName": "xcvr_ctrl",
+              "csrOffsetCalc": "0x1030 + ({portNum} - {startPort})*0x4",
+              "numPorts": 2,
+              "startPort": 1
+            }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "MCB_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            },
+            {
+              "pmUnitScopedName": "RTM_R_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x40000"
+            },
+            {
+              "pmUnitScopedName": "RTM_L_DOM_INFO_ROM",
+              "deviceName": "fpga_info_dom",
+              "csrOffset": "0x48000"
+            }
+          ],
+          "mdioBusBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "RTM_L_MDIO_BUS",
+              "deviceName": "mdio_controller",
+              "csrOffsetCalc": "0x48200 + {busIndex}*0x20",
+              "numBuses": 16,
+              "iobufOffsetCalc": "0x480c0 + {busIndex}*0x4"
+            },
+            {
+              "pmUnitScopedNamePrefix": "RTM_R_MDIO_BUS",
+              "deviceName": "mdio_controller",
+              "csrOffsetCalc": "0x40200 + {busIndex}*0x20",
+              "numBuses": 16,
+              "iobufOffsetCalc": "0x400c0 + {busIndex}*0x4"
+            }
+          ]
+        }
+      ],
+      "i2cDeviceConfigs": [
+        {
+          "busName": "MCB_IOB_I2C_MASTER_2",
+          "address": "0x70",
+          "kernelDeviceName": "pca9546",
+          "pmUnitScopedName": "MCB_MUX",
+          "numOutgoingChannels": 4
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_3",
+          "address": "0x35",
+          "kernelDeviceName": "anacapa_scmcpld",
+          "pmUnitScopedName": "SCM_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x60",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_1",
+          "initRegSettings": [
+            {
+              "__comment__": "Set the page to 0 to ensure the driver can read the correct registers",
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x61",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_2",
+          "initRegSettings": [
+            {
+              "__comment__": "Set the page to 0 to ensure the driver can read the correct registers",
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_5",
+          "address": "0x62",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "PMBUS_3",
+          "initRegSettings": [
+            {
+              "__comment__": "Set the page to 0 to ensure the driver can read the correct registers",
+              "regOffset": 0,
+              "ioBuf": [
+                0
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_6",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "PWR_BRICK_INLET_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_13",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_COME_OUTLET_R_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_13",
+          "address": "0x4e",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "MCB_COME_OUTLET_L_TSENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x33",
+          "kernelDeviceName": "anacapa_fancpld",
+          "pmUnitScopedName": "MCB_FAN_CPLD",
+          "isWatchdog": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_14",
+          "address": "0x60",
+          "kernelDeviceName": "anacapa_mcbcpld",
+          "pmUnitScopedName": "MCB_CPLD"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_15",
+          "address": "0x53",
+          "kernelDeviceName": "24c64",
+          "pmUnitScopedName": "CHASSIS_EEPROM",
+          "isEeprom": true
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x4c",
+          "kernelDeviceName": "tps25990",
+          "pmUnitScopedName": "LOAD_SWITCH_MONITOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC1_MONITOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Advanced configuration register setting for mode select",
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_16",
+          "address": "0x37",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "MCB_ADC2_MONITOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Advanced configuration register setting for mode select",
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_19",
+          "address": "0x70",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "MCB_MUX_FAN",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "MCB_MUX_FAN@1",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN1_SENSOR"
+        },
+        {
+          "busName": "MCB_MUX_FAN@2",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN2_SENSOR"
+        },
+        {
+          "busName": "MCB_MUX_FAN@3",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN3_SENSOR"
+        },
+        {
+          "busName": "MCB_MUX_FAN@4",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN4_SENSOR"
+        },
+        {
+          "busName": "MCB_MUX_FAN@5",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN5_SENSOR"
+        },
+        {
+          "busName": "MCB_MUX_FAN@6",
+          "address": "0x40",
+          "kernelDeviceName": "ina238",
+          "pmUnitScopedName": "MCB_FAN6_SENSOR"
+        },
+        {
+          "busName": "MCB_IOB_I2C_MASTER_23",
+          "address": "0x70",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "HSCB_MUX",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "HSCB_MUX@0",
+          "address": "0x11",
+          "kernelDeviceName": "ltc4287",
+          "pmUnitScopedName": "48V_HSC_MONITOR"
+        },
+        {
+          "busName": "HSCB_MUX@1",
+          "address": "0x4d",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "HSCB_TSENSOR_1"
+        },
+        {
+          "busName": "HSCB_MUX@2",
+          "address": "0x4f",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "HSCB_TSENSOR_2"
+        }
+      ],
+      "outgoingSlotConfigs": {
+        "RUNBMC_SLOT@0": {
+          "slotType": "RUNBMC_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_1"
+          ]
+        },
+        "COMESE_SLOT@0": {
+          "slotType": "COMESE_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_MUX@1",
+            "MCB_IOB_I2C_MASTER_18"
+          ]
+        },
+        "RTM_L_SLOT@0": {
+          "slotType": "RTM_L_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_26",
+            "RTM_L_DOM_I2C_MASTER_1",
+            "RTM_L_DOM_I2C_MASTER_2"
+          ]
+        },
+        "RTM_R_SLOT@0": {
+          "slotType": "RTM_R_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_27",
+            "RTM_R_DOM_I2C_MASTER_1",
+            "RTM_R_DOM_I2C_MASTER_2"
+          ]
+        },
+        "SMB_L_SLOT@0": {
+          "slotType": "SMB_L_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_7",
+            "MCB_IOB_I2C_MASTER_8",
+            "MCB_IOB_I2C_MASTER_10",
+            "MCB_IOB_I2C_MASTER_11",
+            "MCB_IOB_I2C_MASTER_12"
+          ]
+        },
+        "SMB_R_SLOT@0": {
+          "slotType": "SMB_R_SLOT",
+          "outgoingI2cBusNames": [
+            "MCB_IOB_I2C_MASTER_9",
+            "MCB_IOB_I2C_MASTER_21",
+            "MCB_IOB_I2C_MASTER_22",
+            "MCB_IOB_I2C_MASTER_24",
+            "MCB_IOB_I2C_MASTER_31"
+          ]
+        }
+      }
+    },
+    "BMC": {
+      "pluggedInSlotType": "RUNBMC_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x4a",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RUNBMC_THERMAL_SENSOR"
+        }
+      ]
+    },
+    "NETLAKE20": {
+      "pluggedInSlotType": "COMESE_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x20",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "COME_HWMON1"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x21",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "COME_HWMON2"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x40",
+          "kernelDeviceName": "ina230",
+          "pmUnitScopedName": "COME_HWMON3"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x4a",
+          "kernelDeviceName": "tmp75",
+          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x50",
+          "kernelDeviceName": "spd5118",
+          "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x51",
+          "kernelDeviceName": "spd5118",
+          "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+        }
+      ]
+    },
+    "RTM_L": {
+      "pluggedInSlotType": "RTM_L_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x33",
+          "kernelDeviceName": "fbg_rtmcpld",
+          "pmUnitScopedName": "RTM_L_CPLD",
+          "cpldSysfsAttrs": [
+            {
+              "name": "version_id",
+              "regAddr": "0x00",
+              "bitOffset": 4,
+              "numBits": 4,
+              "description": "Hardware version ID"
+            },
+            {
+              "name": "board_id",
+              "regAddr": "0x00",
+              "numBits": 4,
+              "description": "Board ID"
+            },
+            {
+              "name": "cpld_ver",
+              "regAddr": "0x01",
+              "numBits": 7,
+              "description": "CPLD major version"
+            },
+            {
+              "name": "cpld_minor_ver",
+              "regAddr": "0x02",
+              "numBits": 8,
+              "description": "CPLD minor version"
+            },
+            {
+              "name": "cpld_sub_ver",
+              "regAddr": "0x03",
+              "numBits": 8,
+              "description": "CPLD sub version"
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x71",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "RTM_L_MUX_1",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "RTM_L_MUX_1@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_1",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 3, 4, 7 and 8"
+        },
+        {
+          "busName": "RTM_L_MUX_1@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_2",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 11, 12, 15 and 16"
+        },
+        {
+          "busName": "RTM_L_MUX_1@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_3",
+          "__comment__": "Voltage sensor for XP0R9V_RTM_AVDD of ASIC 1-8 and XP0R9V_RTM_AVDD of ASIC 9-16"
+        },
+        {
+          "busName": "RTM_L_MUX_1@5",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "RTM_L_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Advanced configuration register setting for mode select",
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "RTM_L_MUX_1@6",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RTM_L_TSENSOR_1"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x72",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "RTM_L_MUX_2",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "RTM_L_MUX_2@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_4",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 1, 2, 5 and 6"
+        },
+        {
+          "busName": "RTM_L_MUX_2@2",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "RTM_L_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Advanced configuration register setting for mode select",
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "RTM_L_MUX_2@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_5",
+          "__comment__": "Voltage sensor for XP1R5V_RTM_AVDD of ASIC 1-8 and XP0R75V_RTM_AVDD of ASIC 1-8"
+        },
+        {
+          "busName": "RTM_L_MUX_2@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_6",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 9, 10, 13 and 14"
+        },
+        {
+          "busName": "RTM_L_MUX_2@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_L_ASIC_VOLTAGE_7",
+          "__comment__": "Voltage sensor for XP1R5V_RTM_AVDD of ASIC 9-16 and XP0R75V_RTM_AVDD of ASIC 9-16"
+        },
+        {
+          "busName": "RTM_L_MUX_2@6",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RTM_L_TSENSOR_2"
+        },
+        {
+          "busName": "RTM_L_MUX_2@7",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "RTM_L_OUTLET_TSENSOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for high byte.",
+              "regOffset": 21,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for low byte.",
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "RTM_R": {
+      "pluggedInSlotType": "RTM_R_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x33",
+          "kernelDeviceName": "fbg_rtmcpld",
+          "pmUnitScopedName": "RTM_R_CPLD",
+          "cpldSysfsAttrs": [
+            {
+              "name": "version_id",
+              "regAddr": "0x00",
+              "bitOffset": 4,
+              "numBits": 4,
+              "description": "Hardware version ID"
+            },
+            {
+              "name": "board_id",
+              "regAddr": "0x00",
+              "numBits": 4,
+              "description": "Board ID"
+            },
+            {
+              "name": "cpld_ver",
+              "regAddr": "0x01",
+              "numBits": 7,
+              "description": "CPLD major version"
+            },
+            {
+              "name": "cpld_minor_ver",
+              "regAddr": "0x02",
+              "numBits": 8,
+              "description": "CPLD minor version"
+            },
+            {
+              "name": "cpld_sub_ver",
+              "regAddr": "0x03",
+              "numBits": 8,
+              "description": "CPLD sub version"
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x71",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "RTM_R_MUX_1",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "RTM_R_MUX_1@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_1",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 3, 4, 7 and 8"
+        },
+        {
+          "busName": "RTM_R_MUX_1@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_2",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 11, 12, 15 and 16"
+        },
+        {
+          "busName": "RTM_R_MUX_1@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_3",
+          "__comment__": "Voltage sensor for XP0R9V_RTM_AVDD of ASIC 1-8 and XP0R9V_RTM_AVDD of ASIC 9-16"
+        },
+        {
+          "busName": "RTM_R_MUX_1@5",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "RTM_R_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "RTM_R_MUX_1@6",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RTM_R_TSENSOR_1"
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x72",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "RTM_R_MUX_2",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "RTM_R_MUX_2@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_4",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 1, 2, 5 and 6"
+        },
+        {
+          "busName": "RTM_R_MUX_2@2",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "RTM_R_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "RTM_R_MUX_2@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_5",
+          "__comment__": "Voltage sensor for XP1R5V_RTM_AVDD of ASIC 1-8 and XP0R75V_RTM_AVDD of ASIC 1-8"
+        },
+        {
+          "busName": "RTM_R_MUX_2@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_6",
+          "__comment__": "Voltage sensor for XP0R75V_RTM_DVDD of ASIC 9, 10, 13 and 14"
+        },
+        {
+          "busName": "RTM_R_MUX_2@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "RTM_R_ASIC_VOLTAGE_7",
+          "__comment__": "Voltage sensor for XP1R5V_RTM_AVDD of ASIC 9-16 and XP0R75V_RTM_AVDD of ASIC 9-16"
+        },
+        {
+          "busName": "RTM_R_MUX_2@6",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "RTM_R_TSENSOR_2"
+        },
+        {
+          "busName": "RTM_R_MUX_2@7",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "RTM_R_OUTLET_TSENSOR",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for high byte.",
+              "regOffset": 21,
+              "ioBuf": [
+                100
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for low byte.",
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "SMB_L": {
+      "pluggedInSlotType": "SMB_L_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x74",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "SMB_L_MUX",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "SMB_L_MUX@0",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_0"
+        },
+        {
+          "busName": "SMB_L_MUX@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_1"
+        },
+        {
+          "busName": "SMB_L_MUX@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_L_TH6_SENSOR_TMP432_1",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                92
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                92
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for high byte.",
+              "regOffset": 21,
+              "ioBuf": [
+                92
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for low byte.",
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_L_MUX@2",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_2"
+        },
+        {
+          "busName": "SMB_L_MUX@2",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_L_OUTLET_TH6_TSENSOR"
+        },
+        {
+          "busName": "SMB_L_MUX@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_3"
+        },
+        {
+          "busName": "SMB_L_MUX@3",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_L_TH6_SENSOR_TMP432_2",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                92
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                92
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_L_MUX@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_4"
+        },
+        {
+          "busName": "SMB_L_MUX@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_5_1"
+        },
+        {
+          "busName": "SMB_L_MUX@5",
+          "address": "0x6a",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_5_2"
+        },
+        {
+          "busName": "SMB_L_MUX@6",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_6"
+        },
+        {
+          "busName": "SMB_L_MUX@7",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_L_ASIC_VOLTAGE_7"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_L_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x33",
+          "kernelDeviceName": "th6_smbcpld",
+          "pmUnitScopedName": "SMB_L_CPLD"
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_L_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_L_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x76",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SMB_L_VDDCORE"
+        }
+      ]
+    },
+    "SMB_R": {
+      "pluggedInSlotType": "SMB_R_SLOT",
+      "i2cDeviceConfigs": [
+        {
+          "busName": "INCOMING@0",
+          "address": "0x48",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_R_INLET_TSENSOR"
+        },
+        {
+          "busName": "INCOMING@0",
+          "address": "0x76",
+          "kernelDeviceName": "pmbus",
+          "pmUnitScopedName": "SMB_R_VDDCORE"
+        },
+        {
+          "busName": "INCOMING@1",
+          "address": "0x1f",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_R_ADC1_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@2",
+          "address": "0x35",
+          "kernelDeviceName": "adc128d818",
+          "pmUnitScopedName": "SMB_R_ADC2_SENSOR",
+          "initRegSettings": [
+            {
+              "regOffset": 11,
+              "ioBuf": [
+                2
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "INCOMING@3",
+          "address": "0x74",
+          "kernelDeviceName": "pca9548",
+          "pmUnitScopedName": "SMB_R_MUX",
+          "numOutgoingChannels": 8
+        },
+        {
+          "busName": "SMB_R_MUX@0",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_0"
+        },
+        {
+          "busName": "SMB_R_MUX@1",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_1"
+        },
+        {
+          "busName": "SMB_R_MUX@1",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_R_TH6_SENSOR_TMP432_1",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                94
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                94
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for high byte.",
+              "regOffset": 21,
+              "ioBuf": [
+                94
+              ]
+            },
+            {
+              "__comment__": "Remote temp2 high limit setting for low byte.",
+              "regOffset": 23,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_R_MUX@2",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_2"
+        },
+        {
+          "busName": "SMB_R_MUX@2",
+          "address": "0x49",
+          "kernelDeviceName": "lm75b",
+          "pmUnitScopedName": "SMB_R_OUTLET_TH6_TSENSOR"
+        },
+        {
+          "busName": "SMB_R_MUX@3",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_3"
+        },
+        {
+          "busName": "SMB_R_MUX@3",
+          "address": "0x4c",
+          "kernelDeviceName": "tmp432",
+          "pmUnitScopedName": "SMB_R_TH6_SENSOR_TMP432_2",
+          "initRegSettings": [
+            {
+              "__comment__": "Local temperature high limit for high byte.",
+              "regOffset": 11,
+              "ioBuf": [
+                94
+              ]
+            },
+            {
+              "__comment__": "Local temperature high limit for low byte.",
+              "regOffset": 61,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for high byte.",
+              "regOffset": 13,
+              "ioBuf": [
+                94
+              ]
+            },
+            {
+              "__comment__": "Remote temp1 high limit setting for low byte.",
+              "regOffset": 19,
+              "ioBuf": [
+                0
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote1.",
+              "regOffset": 39,
+              "ioBuf": [
+                5
+              ]
+            },
+            {
+              "__comment__": "N-factor correction remote2.",
+              "regOffset": 40,
+              "ioBuf": [
+                5
+              ]
+            }
+          ]
+        },
+        {
+          "busName": "SMB_R_MUX@4",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_4"
+        },
+        {
+          "busName": "SMB_R_MUX@5",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_5_1"
+        },
+        {
+          "busName": "SMB_R_MUX@5",
+          "address": "0x6a",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_5_2"
+        },
+        {
+          "busName": "SMB_R_MUX@6",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_6"
+        },
+        {
+          "busName": "SMB_R_MUX@7",
+          "address": "0x70",
+          "kernelDeviceName": "xdpe15284",
+          "pmUnitScopedName": "SMB_R_ASIC_VOLTAGE_7"
+        },
+        {
+          "busName": "INCOMING@4",
+          "address": "0x33",
+          "kernelDeviceName": "th6_smbcpld",
+          "pmUnitScopedName": "SMB_R_CPLD"
+        }
+      ]
+    }
+  },
+  "symbolicLinkToDevicePath": {
+    "/run/devmap/eeproms/MCB_EEPROM": "/[IDPROM]",
+    "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_EEPROM]",
+    "/run/devmap/eeproms/RUNBMC_EEPROM": "/RUNBMC_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/COME_EEPROM": "/COMESE_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/RTM_L_EEPROM": "/RTM_L_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/RTM_R_EEPROM": "/RTM_R_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/SMB_L_EEPROM": "/SMB_L_SLOT@0/[IDPROM]",
+    "/run/devmap/eeproms/SMB_R_EEPROM": "/SMB_R_SLOT@0/[IDPROM]",
+    "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
+    "/run/devmap/sensors/PMBUS_1": "/[PMBUS_1]",
+    "/run/devmap/sensors/PMBUS_2": "/[PMBUS_2]",
+    "/run/devmap/sensors/PMBUS_3": "/[PMBUS_3]",
+    "/run/devmap/sensors/MCB_COME_INLET_TSENSOR": "/[MCB_COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/PWR_BRICK_INLET_TSENSOR": "/[PWR_BRICK_INLET_TSENSOR]",
+    "/run/devmap/sensors/MCB_COME_OUTLET_L_TSENSOR": "/[MCB_COME_OUTLET_L_TSENSOR]",
+    "/run/devmap/sensors/MCB_COME_OUTLET_R_TSENSOR": "/[MCB_COME_OUTLET_R_TSENSOR]",
+    "/run/devmap/sensors/MCB_FAN_CPLD": "/[MCB_FAN_CPLD]",
+    "/run/devmap/sensors/LOAD_SWITCH_MONITOR": "/[LOAD_SWITCH_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC1_MONITOR": "/[MCB_ADC1_MONITOR]",
+    "/run/devmap/sensors/MCB_ADC2_MONITOR": "/[MCB_ADC2_MONITOR]",
+    "/run/devmap/sensors/MCB_FAN1_SENSOR": "/[MCB_FAN1_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN2_SENSOR": "/[MCB_FAN2_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN3_SENSOR": "/[MCB_FAN3_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN4_SENSOR": "/[MCB_FAN4_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN5_SENSOR": "/[MCB_FAN5_SENSOR]",
+    "/run/devmap/sensors/MCB_FAN6_SENSOR": "/[MCB_FAN6_SENSOR]",
+    "/run/devmap/sensors/48V_HSC_MONITOR": "/[48V_HSC_MONITOR]",
+    "/run/devmap/sensors/HSCB_TSENSOR_2": "/[HSCB_TSENSOR_2]",
+    "/run/devmap/sensors/HSCB_TSENSOR_1": "/[HSCB_TSENSOR_1]",
+    "/run/devmap/cplds/SCM_CPLD": "/[SCM_CPLD]",
+    "/run/devmap/cplds/MCB_CPLD": "/[MCB_CPLD]",
+    "/run/devmap/cplds/RTM_L_CPLD": "/RTM_L_SLOT@0/[RTM_L_CPLD]",
+    "/run/devmap/cplds/RTM_R_CPLD": "/RTM_R_SLOT@0/[RTM_R_CPLD]",
+    "/run/devmap/fpgas/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/fpgas/RTM_L_DOM_INFO_ROM": "/[RTM_L_DOM_INFO_ROM]",
+    "/run/devmap/fpgas/RTM_R_DOM_INFO_ROM": "/[RTM_R_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/MCB_IOB_INFO_ROM": "/[MCB_IOB_INFO_ROM]",
+    "/run/devmap/inforoms/RTM_L_DOM_INFO_ROM": "/[RTM_L_DOM_INFO_ROM]",
+    "/run/devmap/inforoms/RTM_R_DOM_INFO_ROM": "/[RTM_R_DOM_INFO_ROM]",
+    "/run/devmap/watchdogs/FAN_WATCHDOG": "/[MCB_FAN_CPLD]",
+    "/run/devmap/i2c-busses/XCVR_1": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/i2c-busses/XCVR_2": "/[MCB_IOB_I2C_MASTER_30]",
+    "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
+    "/run/devmap/xcvrs/xcvr_io_1": "/[MCB_IOB_I2C_MASTER_28]",
+    "/run/devmap/xcvrs/xcvr_ctrl_1": "/[IOB_XCVR_CTRL_PORT_1]",
+    "/run/devmap/xcvrs/xcvr_io_2": "/[MCB_IOB_I2C_MASTER_30]",
+    "/run/devmap/xcvrs/xcvr_ctrl_2": "/[IOB_XCVR_CTRL_PORT_2]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_3_DEVICE_1": "/[MCB_SPI_MASTER_3_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_4_DEVICE_1": "/[MCB_SPI_MASTER_4_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_5_DEVICE_1": "/[MCB_SPI_MASTER_5_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_6_DEVICE_1": "/[MCB_SPI_MASTER_6_DEVICE_1]",
+    "/run/devmap/flashes/MCB_SPI_MASTER_7_DEVICE_1": "/[MCB_SPI_MASTER_7_DEVICE_1]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_1": "/[RTM_L_MDIO_BUS_1]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_2": "/[RTM_L_MDIO_BUS_2]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_3": "/[RTM_L_MDIO_BUS_3]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_4": "/[RTM_L_MDIO_BUS_4]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_5": "/[RTM_L_MDIO_BUS_5]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_6": "/[RTM_L_MDIO_BUS_6]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_7": "/[RTM_L_MDIO_BUS_7]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_8": "/[RTM_L_MDIO_BUS_8]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_9": "/[RTM_L_MDIO_BUS_9]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_10": "/[RTM_L_MDIO_BUS_10]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_11": "/[RTM_L_MDIO_BUS_11]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_12": "/[RTM_L_MDIO_BUS_12]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_13": "/[RTM_L_MDIO_BUS_13]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_14": "/[RTM_L_MDIO_BUS_14]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_15": "/[RTM_L_MDIO_BUS_15]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_l_16": "/[RTM_L_MDIO_BUS_16]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_1": "/[RTM_L_MDIO_BUS_1]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_2": "/[RTM_L_MDIO_BUS_2]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_3": "/[RTM_L_MDIO_BUS_3]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_4": "/[RTM_L_MDIO_BUS_4]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_5": "/[RTM_L_MDIO_BUS_5]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_6": "/[RTM_L_MDIO_BUS_6]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_7": "/[RTM_L_MDIO_BUS_7]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_8": "/[RTM_L_MDIO_BUS_8]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_9": "/[RTM_L_MDIO_BUS_9]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_10": "/[RTM_L_MDIO_BUS_10]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_11": "/[RTM_L_MDIO_BUS_11]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_12": "/[RTM_L_MDIO_BUS_12]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_13": "/[RTM_L_MDIO_BUS_13]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_14": "/[RTM_L_MDIO_BUS_14]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_15": "/[RTM_L_MDIO_BUS_15]",
+    "/run/devmap/mdio-busses/mdio_bus_io_l_16": "/[RTM_L_MDIO_BUS_16]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_1": "/[RTM_R_MDIO_BUS_1]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_2": "/[RTM_R_MDIO_BUS_2]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_3": "/[RTM_R_MDIO_BUS_3]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_4": "/[RTM_R_MDIO_BUS_4]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_5": "/[RTM_R_MDIO_BUS_5]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_6": "/[RTM_R_MDIO_BUS_6]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_7": "/[RTM_R_MDIO_BUS_7]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_8": "/[RTM_R_MDIO_BUS_8]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_9": "/[RTM_R_MDIO_BUS_9]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_10": "/[RTM_R_MDIO_BUS_10]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_11": "/[RTM_R_MDIO_BUS_11]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_12": "/[RTM_R_MDIO_BUS_12]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_13": "/[RTM_R_MDIO_BUS_13]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_14": "/[RTM_R_MDIO_BUS_14]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_15": "/[RTM_R_MDIO_BUS_15]",
+    "/run/devmap/mdio-busses/mdio_bus_ctrl_r_16": "/[RTM_R_MDIO_BUS_16]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_1": "/[RTM_R_MDIO_BUS_1]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_2": "/[RTM_R_MDIO_BUS_2]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_3": "/[RTM_R_MDIO_BUS_3]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_4": "/[RTM_R_MDIO_BUS_4]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_5": "/[RTM_R_MDIO_BUS_5]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_6": "/[RTM_R_MDIO_BUS_6]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_7": "/[RTM_R_MDIO_BUS_7]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_8": "/[RTM_R_MDIO_BUS_8]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_9": "/[RTM_R_MDIO_BUS_9]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_10": "/[RTM_R_MDIO_BUS_10]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_11": "/[RTM_R_MDIO_BUS_11]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_12": "/[RTM_R_MDIO_BUS_12]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_13": "/[RTM_R_MDIO_BUS_13]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_14": "/[RTM_R_MDIO_BUS_14]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_15": "/[RTM_R_MDIO_BUS_15]",
+    "/run/devmap/mdio-busses/mdio_bus_io_r_16": "/[RTM_R_MDIO_BUS_16]",
+    "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
+    "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
+    "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
+    "/run/devmap/sensors/COME_HWMON3": "/COMESE_SLOT@0/[COME_HWMON3]",
+    "/run/devmap/sensors/COME_INLET_TSENSOR": "/COMESE_SLOT@0/[COME_INLET_TSENSOR]",
+    "/run/devmap/sensors/COME_OUTLET_TSENSOR": "/COMESE_SLOT@0/[COME_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/COME_DIMM1_TSENSOR": "/COMESE_SLOT@0/[COME_DIMM1_TSENSOR]",
+    "/run/devmap/sensors/COME_DIMM2_TSENSOR": "/COMESE_SLOT@0/[COME_DIMM2_TSENSOR]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_1]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_2]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_3]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_4]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_5]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_6]",
+    "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7": "/RTM_L_SLOT@0/[RTM_L_ASIC_VOLTAGE_7]",
+    "/run/devmap/sensors/RTM_L_ADC1_SENSOR": "/RTM_L_SLOT@0/[RTM_L_ADC1_SENSOR]",
+    "/run/devmap/sensors/RTM_L_ADC2_SENSOR": "/RTM_L_SLOT@0/[RTM_L_ADC2_SENSOR]",
+    "/run/devmap/sensors/RTM_L_TSENSOR_1": "/RTM_L_SLOT@0/[RTM_L_TSENSOR_1]",
+    "/run/devmap/sensors/RTM_L_TSENSOR_2": "/RTM_L_SLOT@0/[RTM_L_TSENSOR_2]",
+    "/run/devmap/sensors/RTM_L_OUTLET_TSENSOR": "/RTM_L_SLOT@0/[RTM_L_OUTLET_TSENSOR]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_1]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_2]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_3]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_4]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_5]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_6]",
+    "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7": "/RTM_R_SLOT@0/[RTM_R_ASIC_VOLTAGE_7]",
+    "/run/devmap/sensors/RTM_R_ADC1_SENSOR": "/RTM_R_SLOT@0/[RTM_R_ADC1_SENSOR]",
+    "/run/devmap/sensors/RTM_R_ADC2_SENSOR": "/RTM_R_SLOT@0/[RTM_R_ADC2_SENSOR]",
+    "/run/devmap/sensors/RTM_R_TSENSOR_1": "/RTM_R_SLOT@0/[RTM_R_TSENSOR_1]",
+    "/run/devmap/sensors/RTM_R_TSENSOR_2": "/RTM_R_SLOT@0/[RTM_R_TSENSOR_2]",
+    "/run/devmap/sensors/RTM_R_OUTLET_TSENSOR": "/RTM_R_SLOT@0/[RTM_R_OUTLET_TSENSOR]",
+    "/run/devmap/cplds/SMB_L_CPLD": "/SMB_L_SLOT@0/[SMB_L_CPLD]",
+    "/run/devmap/cplds/SMB_R_CPLD": "/SMB_R_SLOT@0/[SMB_R_CPLD]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_0]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_1]",
+    "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_1": "/SMB_L_SLOT@0/[SMB_L_TH6_SENSOR_TMP432_1]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_2]",
+    "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_OUTLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_3]",
+    "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_2": "/SMB_L_SLOT@0/[SMB_L_TH6_SENSOR_TMP432_2]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_4]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_5_1]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_5_2]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_6]",
+    "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7": "/SMB_L_SLOT@0/[SMB_L_ASIC_VOLTAGE_7]",
+    "/run/devmap/sensors/SMB_L_ADC1_SENSOR": "/SMB_L_SLOT@0/[SMB_L_ADC1_SENSOR]",
+    "/run/devmap/sensors/SMB_L_ADC2_SENSOR": "/SMB_L_SLOT@0/[SMB_L_ADC2_SENSOR]",
+    "/run/devmap/sensors/SMB_L_INLET_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_VDDCORE": "/SMB_L_SLOT@0/[SMB_L_VDDCORE]",
+    "/run/devmap/sensors/SMB_L_CPLD": "/SMB_L_SLOT@0/[SMB_L_CPLD]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_0]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_1]",
+    "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_1": "/SMB_R_SLOT@0/[SMB_R_TH6_SENSOR_TMP432_1]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_2]",
+    "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_OUTLET_TH6_TSENSOR]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_3]",
+    "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_2": "/SMB_R_SLOT@0/[SMB_R_TH6_SENSOR_TMP432_2]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_4]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_5_1]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_5_2]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_6]",
+    "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_7]",
+    "/run/devmap/sensors/SMB_R_ADC1_SENSOR": "/SMB_R_SLOT@0/[SMB_R_ADC1_SENSOR]",
+    "/run/devmap/sensors/SMB_R_ADC2_SENSOR": "/SMB_R_SLOT@0/[SMB_R_ADC2_SENSOR]",
+    "/run/devmap/sensors/SMB_R_INLET_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_R_VDDCORE": "/SMB_R_SLOT@0/[SMB_R_VDDCORE]",
+    "/run/devmap/sensors/SMB_R_CPLD": "/SMB_R_SLOT@0/[SMB_R_CPLD]"
+  },
+  "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
+  "numXcvrs": 2,
+  "bspKmodsRpmName": "fboss_bsp_kmods",
+  "bspKmodsRpmVersion": "4.2.0-1",
+  "requiredKmodsToLoad": [
+    "i2c_i801",
+    "spidev",
+    "fboss_iob_pci",
+    "fboss_iob_i2c",
+    "fboss_iob_spi",
+    "ledtrig_timer"
+  ]
+}

--- a/fboss/platform/configs/ladakh800bclsm/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bclsm/platform_manager.json
@@ -407,9 +407,16 @@
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
           "address": "0x33",
-          "kernelDeviceName": "anacapa_fancpld",
+          "kernelDeviceName": "fbfancpld",
           "pmUnitScopedName": "MCB_FAN_CPLD",
-          "isWatchdog": true
+          "isWatchdog": true,
+          "fanCpldConfig": {
+            "numFans": 6,
+            "pwmMax": 64,
+            "speedMultiplier": 300,
+            "hasRearTach": true,
+            "hasLeds": false
+          }
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
@@ -1719,13 +1726,15 @@
   "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
   "numXcvrs": 2,
   "bspKmodsRpmName": "fboss_bsp_kmods",
-  "bspKmodsRpmVersion": "4.2.0-1",
+  "bspKmodsRpmVersion": "4.4.0-1",
   "requiredKmodsToLoad": [
     "i2c_i801",
     "spidev",
     "fboss_iob_pci",
     "fboss_iob_i2c",
     "fboss_iob_spi",
+    "fboss_iob_gpio",
+    "fboss_iob_led",
     "ledtrig_timer"
   ]
 }

--- a/fboss/platform/configs/ladakh800bclsm/rma_showtech.json
+++ b/fboss/platform/configs/ladakh800bclsm/rma_showtech.json
@@ -1,0 +1,3 @@
+{
+  "i2cBusIgnore": []
+}

--- a/fboss/platform/configs/ladakh800bclsm/sensor_service.json
+++ b/fboss/platform/configs/ladakh800bclsm/sensor_service.json
@@ -1,0 +1,6259 @@
+{
+  "platformName": "LADAKH800BCLSM",
+  "pmUnitSensorsList": [
+    {
+      "slotPath": "/",
+      "pmUnitName": "LADAKH800BCLSM_MCB",
+      "sensors": [
+        {
+          "name": "MCB_U59_XP1R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.575,
+            "minAlarmVal": 1.425,
+            "upperCriticalVal": 1.65,
+            "lowerCriticalVal": 1.35
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP3R3V_MCB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP3R3V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP2R5V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.75,
+            "lowerCriticalVal": 2.25
+          },
+          "compute": "2*@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP1R1V_OOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 1.045,
+            "upperCriticalVal": 1.21,
+            "lowerCriticalVal": 0.99
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP3R3V_I210",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP12R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "11*@/1000.0"
+        },
+        {
+          "name": "MCB_U59_XP5R0V_COME",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC1_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP1R0V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.95,
+            "upperCriticalVal": 1.1,
+            "lowerCriticalVal": 0.9
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP3R3V_STBY",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP3R3V_MCB_PH",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP1R8V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP1R2V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.14,
+            "upperCriticalVal": 1.32,
+            "lowerCriticalVal": 1.08
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP3R3V_IOB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP12R0V_SSD",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13,
+            "minAlarmVal": 11,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "11*@/1000.0"
+        },
+        {
+          "name": "MCB_U130_XP5R0V_USB",
+          "sysfsPath": "/run/devmap/sensors/MCB_ADC2_MONITOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.25,
+            "minAlarmVal": 4.75,
+            "upperCriticalVal": 5.5,
+            "lowerCriticalVal": 4.5
+          },
+          "compute": "5.7*@/1000.0"
+        },
+        {
+          "name": "MCB_U165_LM75_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U206_LM75_OUTLET_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_OUTLET_L_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U132_LM75_OUTLET_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_COME_OUTLET_R_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U202_LM75_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PWR_BRICK_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U167_FAN1_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U167_FAN1_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U167_FAN1_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U167_FAN1_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U167_FAN1_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN1_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U168_FAN2_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U168_FAN2_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U168_FAN2_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U168_FAN2_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U168_FAN2_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN2_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U169_FAN3_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U169_FAN3_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U169_FAN3_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U169_FAN3_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U169_FAN3_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN3_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U170_FAN4_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U170_FAN4_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U170_FAN4_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U170_FAN4_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U170_FAN4_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN4_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U188_FAN5_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN5_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U188_FAN5_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN5_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U188_FAN5_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN5_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U188_FAN5_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN5_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U188_FAN5_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN5_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U189_FAN6_INA238_VSHUNT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN6_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 45,
+            "upperCriticalVal": 163.8
+          }
+        },
+        {
+          "name": "MCB_U189_FAN6_INA238_VBUS",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN6_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U189_FAN6_INA238_IOUT",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN6_SENSOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 3.6,
+            "upperCriticalVal": 4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_U189_FAN6_INA238_POWER",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN6_SENSOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 180,
+            "upperCriticalVal": 200
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "MCB_U189_FAN6_INA238_TEMP",
+          "sysfsPath": "/run/devmap/sensors/MCB_FAN6_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP1_XP12R0V_PB1_VIN",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "minAlarmVal": 40,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP1_XP12R0V_PB1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP1_XP12R0V_PB1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 145,
+            "upperCriticalVal": 167
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP1_XP12R0V_PB1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -25,
+            "upperCriticalVal": 120,
+            "lowerCriticalVal": -25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP2_XP12R0V_PB2_VIN",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "minAlarmVal": 40,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP2_XP12R0V_PB2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP2_XP12R0V_PB2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 145,
+            "upperCriticalVal": 167
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP2_XP12R0V_PB2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -25,
+            "upperCriticalVal": 120,
+            "lowerCriticalVal": -25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP3_XP12R0V_PB3_VIN",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 60,
+            "minAlarmVal": 40,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP3_XP12R0V_PB3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.6,
+            "minAlarmVal": 10.5,
+            "upperCriticalVal": 14,
+            "lowerCriticalVal": 10
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_PSP3_XP12R0V_PB3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/PMBUS_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 120,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_UP15_XP12R0V_COME_VIN",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2,
+            "lowerCriticalVal": 10.8
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_UP15_XP12R0V_COME_VOUT",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_UP15_XP12R0V_COME_TEMP",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "MCB_UP15_XP12R0V_COME_IIN",
+          "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 10,
+            "upperCriticalVal": 15
+          },
+          "compute": "0.274*@/1000.0"
+        },
+        {
+          "name": "HSCB_UP1_XP48R0V_HOTSWAP_VIN",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "HSCB_UP1_XP48R0V_HOTSWAP_VOUT",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 62,
+            "minAlarmVal": 42,
+            "upperCriticalVal": 64,
+            "lowerCriticalVal": 40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "HSCB_UP1_XP48R0V_HOTSWAP_IOUT",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 130,
+            "upperCriticalVal": 135
+          },
+          "compute": "2.4*@/1000.0"
+        },
+        {
+          "name": "HSCB_UP1_XP48R0V_HOTSWAP_TEMP",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "minAlarmVal": -40,
+            "upperCriticalVal": 125,
+            "lowerCriticalVal": -40
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "HSCB_UP1_XP48R0V_HOTSWAP_PIN",
+          "sysfsPath": "/run/devmap/sensors/48V_HSC_MONITOR/power1_input",
+          "type": 0,
+          "thresholds": {
+            "maxAlarmVal": 5300,
+            "upperCriticalVal": 5500
+          },
+          "compute": "0.0024*@/1000.0"
+        },
+        {
+          "name": "HSCB_U177_LM75_OUTLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/HSCB_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "HSCB_U132_LM75_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/HSCB_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 75,
+            "upperCriticalVal": 80
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U1_CPU_UNCORE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U1_CPU_CORE0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U1_CPU_CORE1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_CORE_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "MCB_UP24_FAN_1_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP24_FAN_1_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_UP25_FAN_2_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP25_FAN_2_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_UP26_FAN_3_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP26_FAN_3_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_UP27_FAN_4_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP27_FAN_4_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_UP28_FAN_5_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan9_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP28_FAN_5_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan10_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_UP29_FAN_6_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan11_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34100,
+                "minAlarmVal": 2790,
+                "upperCriticalVal": 34100,
+                "lowerCriticalVal": 2790
+              }
+            },
+            {
+              "name": "MCB_UP29_FAN_6_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan12_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 30800,
+                "minAlarmVal": 2520,
+                "upperCriticalVal": 30800,
+                "lowerCriticalVal": 2520
+              }
+            },
+            {
+              "name": "MCB_PSP3_XP12R0V_PB3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/PMBUS_3/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 108,
+                "upperCriticalVal": 130
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 1,
+          "productSubVersion": 0
+        },
+        {
+          "sensors": [
+            {
+              "name": "MCB_UP24_FAN_1_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan1_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP24_FAN_1_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan2_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_UP25_FAN_2_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan3_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP25_FAN_2_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan4_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_UP26_FAN_3_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan5_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP26_FAN_3_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan6_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_UP27_FAN_4_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan7_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP27_FAN_4_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan8_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_UP28_FAN_5_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan9_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP28_FAN_5_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan10_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_UP29_FAN_6_F_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan11_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 40150,
+                "minAlarmVal": 3285,
+                "upperCriticalVal": 40150,
+                "lowerCriticalVal": 3285
+              }
+            },
+            {
+              "name": "MCB_UP29_FAN_6_R_RPM",
+              "sysfsPath": "/run/devmap/sensors/MCB_FAN_CPLD/fan12_input",
+              "type": 4,
+              "thresholds": {
+                "maxAlarmVal": 34760,
+                "minAlarmVal": 2844,
+                "upperCriticalVal": 34760,
+                "lowerCriticalVal": 2844
+              }
+            },
+            {
+              "name": "MCB_PSP3_XP12R0V_PB3_IOUT",
+              "sysfsPath": "/run/devmap/sensors/PMBUS_3/curr1_input",
+              "type": 2,
+              "thresholds": {
+                "maxAlarmVal": 145,
+                "upperCriticalVal": 167
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 2,
+          "productVersion": 1,
+          "productSubVersion": 0
+        }
+      ]
+    },
+    {
+      "slotPath": "/RUNBMC_SLOT@0",
+      "pmUnitName": "BMC",
+      "sensors": [
+        {
+          "name": "BMC_U9_LM75B_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 70,
+            "upperCriticalVal": 75
+          },
+          "compute": "@/1000.0"
+        }
+      ]
+    },
+    {
+      "slotPath": "/COMESE_SLOT@0",
+      "pmUnitName": "NETLAKE20",
+      "sensors": [
+        {
+          "name": "COME_U6_INA230_P12V_STBY_POUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/power1_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 117.46
+          },
+          "compute": "@/100000.0"
+        },
+        {
+          "name": "COME_U6_INA230_P12V_STBY_VOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 13.22,
+            "minAlarmVal": 10.82,
+            "upperCriticalVal": 13.35,
+            "lowerCriticalVal": 10.71
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U6_INA230_P12V_STBY_IOUT",
+          "sysfsPath": "/run/devmap/sensors/COME_HWMON3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.87,
+            "upperCriticalVal": 10.97
+          },
+          "compute": "10*@/1000.0"
+        },
+        {
+          "name": "COME_U28_INLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 46.3,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_U29_OUTLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 65.4,
+            "upperCriticalVal": 100
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_JCN1_DIMM_CHA_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_DIMM1_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 79,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 85,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "COME_JCN2_DIMM_CHB_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_DIMM2_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 79,
+            "minAlarmVal": 10,
+            "upperCriticalVal": 85,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 3,
+          "productSubVersion": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 3,
+          "productSubVersion": 2
+        }
+      ]
+    },
+    {
+      "slotPath": "/RTM_L_SLOT@0",
+      "pmUnitName": "RTM_L",
+      "sensors": [
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_3_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP38_XP0R75V_RTM_DVDD_7_8_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_11_12_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP24_XP0R75V_RTM_DVDD_15_16_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.925,
+            "minAlarmVal": 0.875,
+            "upperCriticalVal": 0.945,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.925,
+            "minAlarmVal": 0.875,
+            "upperCriticalVal": 0.945,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP16_XP0R9V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_1_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP29_XP0R75V_RTM_DVDD_5_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_4/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.575,
+            "lowerCriticalVal": 1.425
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP1R5V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP28_XP0R75V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_5/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_9_10_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP20_XP0R75V_RTM_DVDD_13_14_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_6/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.575,
+            "lowerCriticalVal": 1.425
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP1R5V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_UP31_XP0R75V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ASIC_VOLTAGE_7/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_L_U67_XP1R8V_RTM_VDDIO_R",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U67_XP1R8V_RTM_VDDIO_L",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U67_XP3R3V_CLK",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.399,
+            "minAlarmVal": 3.201,
+            "upperCriticalVal": 3.465,
+            "lowerCriticalVal": 3.135
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "RTM_L_U67_XP1R8V_CLK",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U68_XP1R8V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U68_XP2R5V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.7,
+            "lowerCriticalVal": 2.3
+          },
+          "compute": "1.364*@/1000.0"
+        },
+        {
+          "name": "RTM_L_U68_XP1R1V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC2_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.13,
+            "minAlarmVal": 1.08,
+            "upperCriticalVal": 1.155,
+            "lowerCriticalVal": 1.045
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U68_XP3R3V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.399,
+            "minAlarmVal": 3.201,
+            "upperCriticalVal": 3.465,
+            "lowerCriticalVal": 3.135
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "RTM_L_U8_LM75_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_L_U7_LM75_OUTLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_L_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "RTM_L_U10_TMP432_LOCAL_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_L_OUTLET_TSENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "RTM_L_U10_TMP432_REMOTE1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_L_OUTLET_TSENSOR/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "RTM_L_U10_TMP432_REMOTE2_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_L_OUTLET_TSENSOR/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 11
+        }
+      ]
+    },
+    {
+      "slotPath": "/RTM_R_SLOT@0",
+      "pmUnitName": "RTM_R",
+      "sensors": [
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_3_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP38_XP0R75V_RTM_DVDD_7_8_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_11_12_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP24_XP0R75V_RTM_DVDD_15_16_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.925,
+            "minAlarmVal": 0.875,
+            "upperCriticalVal": 0.945,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.925,
+            "minAlarmVal": 0.875,
+            "upperCriticalVal": 0.945,
+            "lowerCriticalVal": 0.855
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP16_XP0R9V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_1_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP29_XP0R75V_RTM_DVDD_5_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_4/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.575,
+            "lowerCriticalVal": 1.425
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP1R5V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP28_XP0R75V_RTM_AVDD_L_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_5/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_9_10_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP20_XP0R75V_RTM_DVDD_13_14_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_6/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.575,
+            "lowerCriticalVal": 1.425
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 9.4
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/power1_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP1R5V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_VIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 12.6,
+            "minAlarmVal": 11.4,
+            "upperCriticalVal": 13.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_VOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.7875,
+            "lowerCriticalVal": 0.7125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_IIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -1
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_IOUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 26
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_PIN",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/power2_input",
+          "type": 0,
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_UP31_XP0R75V_RTM_AVDD_R_POUT",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ASIC_VOLTAGE_7/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "RTM_R_U67_XP1R8V_RTM_VDDIO_R",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U67_XP1R8V_RTM_VDDIO_L",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U67_XP3R3V_CLK",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.399,
+            "minAlarmVal": 3.201,
+            "upperCriticalVal": 3.465,
+            "lowerCriticalVal": 3.135
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "RTM_R_U67_XP1R8V_CLK",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U68_XP1R8V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.944,
+            "lowerCriticalVal": 1.656
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U68_XP2R5V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.625,
+            "minAlarmVal": 2.375,
+            "upperCriticalVal": 2.7,
+            "lowerCriticalVal": 2.3
+          },
+          "compute": "1.364*@/1000.0"
+        },
+        {
+          "name": "RTM_R_U68_XP1R1V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC2_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.13,
+            "minAlarmVal": 1.08,
+            "upperCriticalVal": 1.155,
+            "lowerCriticalVal": 1.045
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U68_XP3R3V_DOM",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.399,
+            "minAlarmVal": 3.201,
+            "upperCriticalVal": 3.465,
+            "lowerCriticalVal": 3.135
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "RTM_R_U8_LM75_INLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_TSENSOR_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "RTM_R_U7_LM75_OUTLET_TEMP",
+          "sysfsPath": "/run/devmap/sensors/RTM_R_TSENSOR_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "RTM_R_U10_TMP432_LOCAL_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_R_OUTLET_TSENSOR/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "RTM_R_U10_TMP432_REMOTE1_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_R_OUTLET_TSENSOR/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "RTM_R_U10_TMP432_REMOTE2_TEMP",
+              "sysfsPath": "/run/devmap/sensors/RTM_R_OUTLET_TSENSOR/temp3_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 95
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 11
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_L_SLOT@0",
+      "pmUnitName": "SMB_L",
+      "sensors": [
+        {
+          "name": "SMB_L_PU2978_XP0R8V_TH6_VDDC_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_VDDCORE/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2978_XP0R8V_TH6_VDDC_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_VDDCORE/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2978_XP0R8V_TH6_VDDC_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_VDDCORE/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2978_XP0R8V_TH6_VDDC_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_VDDCORE/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 1300
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2978_XP0R8V_TH6_VDDC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_VDDCORE/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U8_LM75B_TH6_INLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R8V_PT_VDDC_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R8V_PT_VDDC_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R8V_PT_VDDC_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R8V_PT_VDDC_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/in2_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R75V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R75V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R75V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R75V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R8V_PT_VDDC_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R8V_PT_VDDC_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R8V_PT_VDDC_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1502_XP0R8V_PT_VDDC_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_U29_LEFT_TMP432_1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U29_LEFT_TMP432_1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U29_LEFT_TMP432_1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_1/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2056_XP0R8V_PT_VDDC_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_U7_LM75B_TH6_OUTLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R8V_PT_VDDC_7_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R8V_PT_VDDC_7_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R8V_PT_VDDC_7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R8V_PT_VDDC_7_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R72V_PB_TRVDD_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R72V_PB_TRVDD_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1745_XP0R72V_PB_TRVDD_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_U30_RIGHT_TMP432_2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U30_RIGHT_TMP432_2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 92
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP0R8V_PT_VDDC_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP0R8V_PT_VDDC_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP0R8V_PT_VDDC_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP0R8V_PT_VDDC_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP1R5V_TH6_RVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP1R5V_TH6_RVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP1R5V_TH6_RVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1342_XP1R5V_TH6_RVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_4/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP0R8V_PT_VDDC_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP0R8V_PT_VDDC_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP0R8V_PT_VDDC_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP0R8V_PT_VDDC_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP1R5V_TH6_RVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP1R5V_TH6_RVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP1R5V_TH6_RVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU2052_XP1R5V_TH6_RVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R75V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R75V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R75V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R75V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R8V_PT_VDDC_5_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R8V_PT_VDDC_5_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R8V_PT_VDDC_5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1937_XP0R8V_PT_VDDC_5_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_5_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R9V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R9V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R9V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R9V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R72V_PB_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R72V_PB_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1497_XP0R72V_PB_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R9V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R9V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R9V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R9V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R72V_TH6_TRVDD_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R72V_TH6_TRVDD_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_PU1746_XP0R72V_TH6_TRVDD_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP3R3V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP1R8V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP0R75V_TH6_PT_RESCAL",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP0R8V_TH6_VDDA",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.824,
+            "minAlarmVal": 0.776,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP1R8V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.854,
+            "minAlarmVal": 1.746,
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP1R5V_TH6_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP1R2V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.236,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U21_XP0R9V_TH6_PVDD_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC1_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP1R8V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP1R2V_TH6_VDDHTX",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.3,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP3R3V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP0R9V_TH6_PVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP0R9V_TH6_PVDD_3",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP0R9V_TH6_PVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP1R8V_SMB",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2,
+            "minAlarmVal": 1.81,
+            "upperCriticalVal": 2.1,
+            "lowerCriticalVal": 1.71
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U22_XP1R5V_TH6_PVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_ADC2_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.56,
+            "minAlarmVal": 1.44,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_L_U2_TH6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 103
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1746_XP0R72V_TH6_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 1,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_L_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_L_PU1746_XP0R72V_TH6_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_L_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 10
+        }
+      ]
+    },
+    {
+      "slotPath": "/SMB_R_SLOT@0",
+      "pmUnitName": "SMB_R",
+      "sensors": [
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_PIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/power1_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/power2_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_VIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/in1_input",
+          "type": 1,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_IIN",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "lowerCriticalVal": -16
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 1300
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2978_XP0R8V_TH6_VDDC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_VDDCORE/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U8_LM75B_TH6_INLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R8V_PT_VDDC_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R8V_PT_VDDC_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R8V_PT_VDDC_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R8V_PT_VDDC_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R72V_PB_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R72V_PB_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2203_XP0R72V_PB_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R75V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R75V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R75V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R75V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R8V_PT_VDDC_2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R8V_PT_VDDC_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R8V_PT_VDDC_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1502_XP0R8V_PT_VDDC_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_U29_LEFT_TMP432_1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 94
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U29_LEFT_TMP432_1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 94
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U29_LEFT_TMP432_1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_1/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 94
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_4_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2056_XP0R8V_PT_VDDC_4_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_U7_LM75B_TH6_OUTLET",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 90
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R8V_PT_VDDC_7_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R8V_PT_VDDC_7_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R8V_PT_VDDC_7_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R8V_PT_VDDC_7_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R72V_PB_TRVDD_2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R72V_PB_TRVDD_2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1745_XP0R72V_PB_TRVDD_2_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_U30_RIGHT_TMP432_2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 94
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U30_RIGHT_TMP432_2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 94
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP0R8V_PT_VDDC_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP0R8V_PT_VDDC_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP0R8V_PT_VDDC_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP0R8V_PT_VDDC_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP1R5V_TH6_RVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP1R5V_TH6_RVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP1R5V_TH6_RVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1342_XP1R5V_TH6_RVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_4/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP0R8V_PT_VDDC_6_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP0R8V_PT_VDDC_6_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP0R8V_PT_VDDC_6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP0R8V_PT_VDDC_6_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP1R5V_TH6_RVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP1R5V_TH6_RVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 22
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP1R5V_TH6_RVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU2052_XP1R5V_TH6_RVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_1/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R75V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R75V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 60
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R75V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R75V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R8V_PT_VDDC_5_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.582,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R8V_PT_VDDC_5_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 70
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R8V_PT_VDDC_5_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1937_XP0R8V_PT_VDDC_5_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_5_2/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R9V_TH6_TRVDD_0_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R9V_TH6_TRVDD_0_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R9V_TH6_TRVDD_0_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R9V_TH6_TRVDD_0_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R72V_PB_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R72V_PB_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1497_XP0R72V_PB_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R9V_TH6_TRVDD_1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.927,
+            "minAlarmVal": 0.873,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R9V_TH6_TRVDD_1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/curr3_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R9V_TH6_TRVDD_1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R9V_TH6_TRVDD_1_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/power3_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R72V_TH6_TRVDD_3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/curr4_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 61
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R72V_TH6_TRVDD_3_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 115,
+            "upperCriticalVal": 125
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_PU1746_XP0R72V_TH6_TRVDD_3_POUT",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/power4_input",
+          "type": 0,
+          "thresholds": {
+            "minAlarmVal": 0
+          },
+          "compute": "@/1000000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP3R3V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP1R8V_CLK_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP0R75V_TH6_PT_RESCAL",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.7725,
+            "minAlarmVal": 0.7275,
+            "upperCriticalVal": 0.863,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP0R8V_TH6_VDDA",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.824,
+            "minAlarmVal": 0.776,
+            "upperCriticalVal": 0.92,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP1R8V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.854,
+            "minAlarmVal": 1.746,
+            "upperCriticalVal": 2.07,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP1R5V_TH6_AVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.545,
+            "minAlarmVal": 1.455,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP1R2V_TH6_VDDO",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.236,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U21_XP0R9V_TH6_PVDD_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC1_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP1R8V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in0_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.71,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.62
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP1R2V_TH6_VDDHTX",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in1_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.3,
+            "minAlarmVal": 1.164,
+            "upperCriticalVal": 1.38,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP3R3V_CLK_2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 3.135,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.97
+          },
+          "compute": "(5/3)*@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP0R9V_TH6_PVDD_1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP0R9V_TH6_PVDD_3",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP0R9V_TH6_PVDD_0",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.95,
+            "minAlarmVal": 0.864,
+            "upperCriticalVal": 1.035,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP1R8V_SMB",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2,
+            "minAlarmVal": 1.81,
+            "upperCriticalVal": 2.1,
+            "lowerCriticalVal": 1.71
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U22_XP1R5V_TH6_PVDD",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_ADC2_SENSOR/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.56,
+            "minAlarmVal": 1.44,
+            "upperCriticalVal": 1.725,
+            "lowerCriticalVal": 0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U2_TH6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 104
+          },
+          "compute": "@/1000.0"
+        }
+      ],
+      "versionedSensors": [
+        {
+          "sensors": [
+            {
+              "name": "SMB_R_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1746_XP0R72V_TH6_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.816,
+                "minAlarmVal": 0.792,
+                "upperCriticalVal": 0.92,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 1,
+          "productSubVersion": 10
+        },
+        {
+          "sensors": [
+            {
+              "name": "SMB_R_PU2203_XP0R72V_PB_TRVDD_0_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1745_XP0R72V_PB_TRVDD_2_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_3/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1497_XP0R72V_PB_TRVDD_1_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_6/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "SMB_R_PU1746_XP0R72V_TH6_TRVDD_3_VOUT",
+              "sysfsPath": "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_7/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 0.742,
+                "minAlarmVal": 0.698,
+                "upperCriticalVal": 0.828,
+                "lowerCriticalVal": 0
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productProductionState": 1,
+          "productVersion": 2,
+          "productSubVersion": 10
+        }
+      ]
+    }
+  ],
+  "powerConfig": {
+    "perSlotPowerConfigs": [
+      {
+        "__comment__": "48V HOTSWAP LTC4287 monitors the power consumption of the main input",
+        "name": "HSC1",
+        "powerSensorName": "HSCB_UP1_XP48R0V_HOTSWAP_PIN"
+      }
+    ],
+    "__comment__1": "48V HOTSWAP INA238+TPS16851 monitors the power consumption of the fans",
+    "otherPowerSensorNames": [
+      "MCB_U167_FAN1_INA238_POWER",
+      "MCB_U168_FAN2_INA238_POWER",
+      "MCB_U169_FAN3_INA238_POWER",
+      "MCB_U170_FAN4_INA238_POWER",
+      "MCB_U188_FAN5_INA238_POWER",
+      "MCB_U189_FAN6_INA238_POWER"
+    ],
+    "__comment__2": "48V HOTSWAP TPS16851 Standby Power Estimation: average 10W, max 48v * 0.6A = 28.8W",
+    "powerDelta": 10,
+    "inputVoltageSensors": [
+      "HSCB_UP1_XP48R0V_HOTSWAP_VIN",
+      "MCB_U167_FAN1_INA238_VBUS",
+      "MCB_U168_FAN2_INA238_VBUS",
+      "MCB_U169_FAN3_INA238_VBUS",
+      "MCB_U170_FAN4_INA238_VBUS",
+      "MCB_U188_FAN5_INA238_VBUS",
+      "MCB_U189_FAN6_INA238_VBUS"
+    ]
+  },
+  "temperatureConfigs": [
+    {
+      "name": "ASIC1",
+      "temperatureSensorNames": [
+        "SMB_L_U29_LEFT_TMP432_1_TEMP2",
+        "SMB_L_U29_LEFT_TMP432_1_TEMP3",
+        "SMB_L_U30_RIGHT_TMP432_2_TEMP2"
+      ]
+    },
+    {
+      "name": "ASIC2",
+      "temperatureSensorNames": [
+        "SMB_R_U29_LEFT_TMP432_1_TEMP2",
+        "SMB_R_U29_LEFT_TMP432_1_TEMP3",
+        "SMB_R_U30_RIGHT_TMP432_2_TEMP2"
+      ]
+    }
+  ]
+}

--- a/fboss/platform/configs/ladakh800bclsm/sensor_service.json
+++ b/fboss/platform/configs/ladakh800bclsm/sensor_service.json
@@ -983,9 +983,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 1,
-          "productSubVersion": 0
+          "productionState": 1,
+          "productionSubState": 1,
+          "respinVariantIndicator": 0
         },
         {
           "sensors": [
@@ -1132,9 +1132,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 2,
-          "productVersion": 1,
-          "productSubVersion": 0
+          "productionState": 2,
+          "productionSubState": 1,
+          "respinVariantIndicator": 0
         }
       ]
     },
@@ -1373,9 +1373,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 1
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 1
         },
         {
           "sensors": [
@@ -1515,9 +1515,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 3,
-          "productSubVersion": 1
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 1
         },
         {
           "sensors": [
@@ -1657,9 +1657,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 2
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 2
         },
         {
           "sensors": [
@@ -1799,9 +1799,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 3,
-          "productSubVersion": 2
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 2
         }
       ]
     },
@@ -2881,9 +2881,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 11
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 11
         }
       ]
     },
@@ -3963,9 +3963,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 11
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 11
         }
       ]
     },
@@ -5023,9 +5023,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 1,
-          "productSubVersion": 10
+          "productionState": 1,
+          "productionSubState": 1,
+          "respinVariantIndicator": 10
         },
         {
           "sensors": [
@@ -5078,9 +5078,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 10
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 10
         }
       ]
     },
@@ -6147,9 +6147,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 1,
-          "productSubVersion": 10
+          "productionState": 1,
+          "productionSubState": 1,
+          "respinVariantIndicator": 10
         },
         {
           "sensors": [
@@ -6202,9 +6202,9 @@
               "compute": "@/1000.0"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 10
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 10
         }
       ]
     }

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1502,7 +1502,8 @@ bool ConfigValidator::isValidLedCtrlBlockXcvrCoverage(
   const auto& platformName = *config.platformName();
 
   // TODO: Remove once ladakh/leh ledCtrlBlockConfigs cover all xcvrs
-  if (platformName == "LADAKH800BCLS" || platformName == "LEH800BCLS") {
+  if (platformName == "LADAKH800BCLS" || platformName == "LEH800BCLS" ||
+      platformName == "LADAKH800BCLSM") {
     return true;
   }
 

--- a/fboss/platform/platform_manager/platform_manager_validators.thrift
+++ b/fboss/platform/platform_manager/platform_manager_validators.thrift
@@ -64,6 +64,7 @@ const list<string> ALLOWED_PMUNIT_NAMES = [
   // This is for platforms reliant on NETLAKE BIOS.
   "ICECUBE_MCB",
   "LADAKH800BCLS_MCB",
+  "LADAKH800BCLSM_MCB",
   "LEH800BCLS_MCB",
   "MINIPACK3_MCB",
   "MINIPACK3M_MCB",

--- a/fboss/platform/xcvr_lib/XcvrLib.cpp
+++ b/fboss/platform/xcvr_lib/XcvrLib.cpp
@@ -184,7 +184,8 @@ void XcvrLib::validateXcvrInfos() {
   const auto& platformName = *pmConfig_.platformName();
 
   // TODO: Remove once ladakh/lei ledCtrlBlockConfigs cover all xcvrs
-  if (platformName == "LADAKH800BCLS" || platformName == "LEH800BCLS") {
+  if (platformName == "LADAKH800BCLS" || platformName == "LEH800BCLS" ||
+      platformName == "LADAKH800BCLSM") {
     return;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

To support Netlake2.0, need to add new platform of `LADAKH800BCLSM`.

## Configuration

### platform_manager.json

1. Standardize CPU bus naming using the virtual bus "CPU_BUS".
2. Implement the pmUnitConfig and versionedPmUnitConfigs for "NETLAKE20" hardware identification.
3. Update symbolicLinkToDevicePath and "CPU_CORE_TEMP" sysfs paths to align with "NETLAKE20" I2C topology.

### sensor_service.json
1. Add the "NETLAKE20" sensor definitions, thresholds and sysfs paths to support the new hardware layout.

### fw_util.json
1. Update the fw_util config for BIOS upgrade to support the "NETLAKE20" specific flash sequences.

### fan_service.json
1. Use "NETLAKE20" sensors for FSC.

## Code

1. Fix configuration check failures.
2. Fix HW tests failures.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Services running normally.
[services.zip](https://github.com/user-attachments/files/28384210/services.zip)

HW tests passed.
[HwTest.zip](https://github.com/user-attachments/files/28384222/HwTest.zip)

The QSFP with PAI HW test case `EmptyHwTest.CheckInit` passed.
[qsfp_hw_test.zip](https://github.com/user-attachments/files/28384246/qsfp_hw_test.zip)
