### PR TITLE
[Celestica] Ladakh800bcls: HW Test: Fix failure case PlatformManagerHwTest.XcvrLedFiles

### DIFF
--- a/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
+++ b/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
@@ -221,6 +221,12 @@ TEST_F(PlatformManagerHwTest, XcvrLedFiles) {
   EXPECT_FALSE(fs::exists("/run/devmap/xcvrs"));
   explorationOk();
 
+  if (platformConfig_.platformName().value().find("LADAKH800BCLS") !=
+      std::string::npos) {
+    GTEST_SKIP()
+        << "Skipping this test because the platform doesn't have xcvrs.";
+  }
+
   auto primaryColor = xcvrLib_.getPrimaryLedColor();
   auto secondaryColor = fboss::XcvrLib::LedColor::AMBER;
 

--- a/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
+++ b/fboss/platform/platform_manager/hw_test/PlatformManagerHwTest.cpp
@@ -221,18 +221,15 @@ TEST_F(PlatformManagerHwTest, XcvrLedFiles) {
   EXPECT_FALSE(fs::exists("/run/devmap/xcvrs"));
   explorationOk();
 
-  if (platformConfig_.platformName().value().find("LADAKH800BCLS") !=
-      std::string::npos) {
-    GTEST_SKIP()
-        << "Skipping this test because the platform doesn't have xcvrs.";
-  }
-
   auto primaryColor = xcvrLib_.getPrimaryLedColor();
   auto secondaryColor = fboss::XcvrLib::LedColor::AMBER;
 
   for (auto xcvrNum = 1; xcvrNum <= xcvrLib_.getNumTransceivers(); xcvrNum++) {
-    auto numLeds = xcvrLib_.getNumLedsForTransceiver(xcvrNum).value();
-    for (auto ledNum = 1; ledNum <= numLeds; ledNum++) {
+    auto numLeds = xcvrLib_.getNumLedsForTransceiver(xcvrNum);
+    if (!numLeds) {
+      continue;
+    }
+    for (auto ledNum = 1; ledNum <= *numLeds; ledNum++) {
       auto primaryLedDir = fs::path(
           xcvrLib_.getLedSysfsPath(xcvrNum, ledNum, primaryColor).value());
       auto secondaryLedDir = fs::path(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

## Issue

```
unknown file: Failure
C++ exception with description "bad optional access" thrown in the test body.

[  FAILED  ] PlatformManagerHwTest.XcvrLedFiles (31313 ms)
[----------] 8 tests from PlatformManagerHwTest (250796 ms total)

[----------] Global test environment tear-down
[==========] 8 tests from 1 test suite ran. (250796 ms total)
[  PASSED  ] 7 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] PlatformManagerHwTest.XcvrLedFiles

 1 FAILED TEST
```

## RCA

1. `Ladakh800bcls` has no OSFP. 
2. The LEDs of QSFP28 are controlled by `MCB_CPLD` instead of `DOM_FPGA`.
3. There is no need to add `ledCtrlConfigs` in `platform_manager.json`.

**The issue has been solved once.** Git commit: [c28aa0e](https://github.com/facebook/fboss/commit/c28aa0eb0db2070910e113432dfb84fe14ad7a31)

**The issue was introduced again.** Git commit: [b603b2b](https://github.com/facebook/fboss/commit/b603b2b412117ae31b0b97c8b6cc30f20d14f3b4)

## Solution

Use `numLeds` to check the existence of `ledCtrlConfigs`.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```bash
Note: Google Test filter = PlatformManagerHwTest.XcvrLedFiles
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from PlatformManagerHwTest
[ RUN      ] PlatformManagerHwTest.XcvrLedFiles
[       OK ] PlatformManagerHwTest.XcvrLedFiles (3608 ms)
[----------] 1 test from PlatformManagerHwTest (3608 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (3608 ms total)
[  PASSED  ] 1 test.
```

