### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -11,6 +11,10 @@ on:
     # Run daily at 1:36PM UTC = 6:36AM PDT
     # Run daily at 7:36PM UTC = 12:36PM PDT
     - cron: '36 1,13,19 * * *'
+
+permissions:
+  contents: read
+
 jobs:
   Agent-Service-Build:
     runs-on: 32-core-ubuntu

--- a/.github/workflows/distro_image_build.yml
+++ b/.github/workflows/distro_image_build.yml
@@ -12,6 +12,10 @@ on:
     paths:
       - 'fboss-image/**'
 
+
+permissions:
+  contents: read
+
 jobs:
   Distro-Image-Build:
     runs-on: 32-core-ubuntu

--- a/.github/workflows/export-centos-docker-image.yml
+++ b/.github/workflows/export-centos-docker-image.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     # Run weekly on Mondays
     - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+
 jobs:
   export-centos-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/export-debian-docker-image.yml
+++ b/.github/workflows/export-debian-docker-image.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     # Run weekly on Mondays
     - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+
 jobs:
   export-debian-docker-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/fboss2-cli.yml
+++ b/.github/workflows/fboss2-cli.yml
@@ -19,6 +19,10 @@ on:
     # Run daily at 1:36PM UTC = 6:36AM PDT
     # Run daily at 7:36PM UTC = 12:36PM PDT
     - cron: '36 1,13,19 * * *'
+
+permissions:
+  contents: read
+
 jobs:
   fboss2-CLI-Build:
     if: github.repository_owner == 'facebook'


### PR DESCRIPTION
This PR adds a workflow-level `permissions: contents: read` to 5 workflow(s) that currently have no `permissions:` block (and therefore get the default broad read-write token). Each affected workflow was inspected and only reads repository contents; no publish/release/push/comment paths, so the change is non-functional in steady state and just shrinks the blast radius.

GitHub's documented Actions security recommendation. Happy to split per-file or adjust naming if preferred.