### PR TITLE
[Nexthop] Fake SAI: replace (not append) port serdes attribute values

### DIFF
--- a/fboss/agent/hw/sai/fake/FakeSaiPort.cpp
+++ b/fboss/agent/hw/sai/fake/FakeSaiPort.cpp
@@ -1329,8 +1329,14 @@ sai_status_t set_port_serdes_attribute_fn(
   auto fs = FakeSai::getInstance();
   auto& portSerdes = fs->portSerdesManager.get(port_serdes_id);
   auto& port = fs->portManager.get(portSerdes.port);
+  // Replace (not append) the stored values: a set attribute call overwrites
+  // the serdes parameter. Using back_inserter here would accumulate across
+  // repeated sets of the same attribute (create sets it once, then
+  // SaiObjectStore::program re-sets it during reconciliation), doubling the
+  // vector and tripping the lane-count check below on platforms whose mapping
+  // carries TX FIR settings (e.g. Montblanc).
   auto fillVec = [](auto& vec, auto* list, size_t count) {
-    std::copy(list, list + count, std::back_inserter(vec));
+    vec.assign(list, list + count);
   };
   auto checkLanes = [&port](auto vec) {
     return port.lanes.size() == vec.size();


### PR DESCRIPTION
# Summary

`set_port_serdes_attribute_fn()` filled the stored serdes parameter vectors (preemphasis, TxFirPre1/2/3, TxFirMain, TxFirPost1/2/3, iDriver, ...) using `std::back_inserter`, i.e. it appended rather than overwrote. A SAI set is supposed to replace the attribute value, so every repeated set of the same serdes attribute grew the vector.

In practice the serdes object is programmed twice: once at create, then again when `SaiObjectStore::program` reconciles it. The second set doubled each vector (e.g. 4 -> 8 lanes), which then tripped the lane-count check (`port.lanes.size() == vec.size()`) and returned `SAI_STATUS_INVALID_ATTRIBUTE_0`, aborting the agent.

This only surfaces on platforms whose platform mapping carries per-lane TX FIR serdes settings (so the setters actually run). We hit it bringing up a container-based fake-SAI test environment (fboss-sim, not yet upstream) configured to emulate Montblanc: its mapping has tx pre/pre2/main values, whereas the mapping we had been using did not, so the serdes setters had never been exercised before.

Fix by using `vector::assign` so a set overwrites the stored value.

# Test Plan

Full `fboss2_integration_test` suite against the Montblanc-based fboss-sim container now passes:

```
[==========] 32 tests from 16 test suites ran.
[  PASSED  ] 30 tests.
[  SKIPPED ] 2 tests  (conditional GTEST_SKIP — configs without ports on the default VLAN)
```

Without this change it was failing because the agent was crashing on:

```
[port] Failed to set attribute PortSerdesSaiId(0) to TxFirPre1: [-32,-32,-32,-32]: INVALID ATTRIBUTE 0
```