### PR TITLE
[Celestica] Leh800bcls: fix multi-NPU config generation and startup crash during AgentCoppTest

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
@@ -95,11 +95,16 @@ class AgentCoppTest : public AgentHwTest {
     if (isTrunk) {
       return getTrunkInitialConfig(ensemble);
     }
-
+    auto switchId = this->getCurrentSwitchIdForTesting();
+    auto asic = checkSameAndGetAsic(
+        ensemble.getL3Asics(), static_cast<int32_t>(switchId));
     auto cfg = utility::onePortPerInterfaceConfig(
-        ensemble.getSw(),
-        ensemble.masterLogicalPortIds(),
-        true /*interfaceHasSubnet*/);
+        ensemble.getPlatformMapping(),
+        asic,
+        ensemble.masterLogicalPortIds(switchId),
+        ensemble.supportsAddRemovePort(),
+        asic->desiredLoopbackModes(),
+        ensemble.getSw()->getPlatformType());
 
     utility::addOlympicQosMaps(cfg, ensemble.getL3Asics());
     utility::setDefaultCpuTrafficPolicyConfig(
@@ -109,18 +114,22 @@ class AgentCoppTest : public AgentHwTest {
   }
 
   cfg::SwitchConfig getTrunkInitialConfig(const AgentEnsemble& ensemble) const {
+    auto switchId = this->getCurrentSwitchIdForTesting();
+    auto asic = checkSameAndGetAsic(
+        ensemble.getL3Asics(), static_cast<int32_t>(switchId));
+    auto interfacePorts = ensemble.masterLogicalInterfacePortIds(switchId);
     auto cfg = utility::oneL3IntfTwoPortConfig(
-        ensemble.getSw(),
-        ensemble.masterLogicalInterfacePortIds()[0],
-        ensemble.masterLogicalInterfacePortIds()[1]);
+        ensemble.getPlatformMapping(),
+        asic,
+        interfacePorts[0],
+        interfacePorts[1],
+        ensemble.supportsAddRemovePort(),
+        asic->desiredLoopbackModes(),
+        ensemble.getSw()->getPlatformType());
     utility::setDefaultCpuTrafficPolicyConfig(
         cfg, ensemble.getL3Asics(), ensemble.isSai());
     utility::addCpuQueueConfig(cfg, ensemble.getL3Asics(), ensemble.isSai());
-    utility::addAggPort(
-        1,
-        {ensemble.masterLogicalInterfacePortIds()[0],
-         ensemble.masterLogicalInterfacePortIds()[1]},
-        &cfg);
+    utility::addAggPort(1, {interfacePorts[0], interfacePorts[1]}, &cfg);
     return cfg;
   }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
On dual-NPU platforms such as leh800bcls and ladakh800bcls, running the AgentCoppTest resulted in hardware agent errors (Error: counter_get() failed(Invalid unit)) or test startup exit abnormally.

# Motivation
The investigation revealed a multi-layered issue in the test's configuration generation logic:

Lack of Multi-NPU Awareness: The initial problem was that `AgentCoppTest` used generic config utility functions that defaulted
to a single-NPU setup. It failed to pass the `platformType`, preventing the specific multi-NPU configuration logic for `leh800bcls` and `ladakh800bcls` from being triggered, which caused the "Invalid unit" hardware errors.

# Solution
This PR provides a comprehensive refactoring of the configuration generation within `AgentCoppTest` to resolve the identified issues:

Filters by `switchId`: The code now calls `this->getCurrentSwitchIdForTesting()` to get the active `switchId` for the test
run. This `switchId` is then used with `ensemble.masterLogicalPortIds(switchId)` and
`ensemble.masterLogicalInterfacePortIds(switchId)` to ensure the configuration is built using only the ports belonging to the NPU
under test.

Enables Multi-NPU Configuration: The code continues to pass the `platformType` to the config utility functions, ensuring the
base configuration correctly contains information for all NPUs on the platform.

# Test Plan
All the test cases below have passed on both Platform ladakh800bcls and Platform leh800bcls when the switch index is 0 and 1.

cold_boot.AgentCoppTest/1.UnresolvedRoutesToLowPriQueue
cold_boot.AgentCoppTest/1.LocalDstIpBgpPortToHighPriQ
cold_boot.AgentCoppTest/1.LocalDstIpNonBgpPortToMidPriQ
cold_boot.AgentCoppTest/1.Ipv6LinkLocalMcastToMidPriQ
cold_boot.AgentCoppTest/1.Ipv6LinkLocalMcastTxFromCpu
cold_boot.AgentCoppTest/1.Ipv6LinkLocalUcastToMidPriQ
cold_boot.AgentCoppTest/1.SlowProtocolsMacToHighPriQ
cold_boot.AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp
cold_boot.AgentCoppTest/1.Ipv6LinkLocalUcastIpNetworkControlDscpToHighPriQ
cold_boot.AgentCoppTest/1.Ipv6LinkLocalMcastNetworkControlDscpToHighPriQ
cold_boot.AgentCoppTest/1.ArpRequestAndReplyToHighPriQ
cold_boot.AgentCoppTest/1.NdpSolicitationToHighPriQ
cold_boot.AgentCoppTest/1.NdpSolicitNeighbor
cold_boot.AgentCoppTest/1.NdpAdvertisementToHighPriQ
cold_boot.AgentCoppTest/1.UnresolvedRoutesToLowPriQueue
cold_boot.AgentCoppTest/1.JumboFramesToQueues
cold_boot.AgentCoppTest/1.LldpProtocolToMidPriQ
cold_boot.AgentCoppTest/1.Ttl1PacketToLowPriQ
cold_boot.AgentCoppTest/1.DHCPv6SolicitToMidPriQ
cold_boot.AgentCoppTest/1.DHCPv6AdvertiseToMidPriQ
cold_boot.AgentCoppEapolTest/1.EapolToHighPriQ