### PR TITLE
[Nexthop] Fake SAI: return SAI_STATUS_ITEM_NOT_FOUND for orphaned FDB entries

### DIFF
--- a/fboss/agent/hw/sai/fake/FakeSaiFdb.cpp
+++ b/fboss/agent/hw/sai/fake/FakeSaiFdb.cpp
@@ -58,6 +58,12 @@ sai_status_t set_fdb_entry_attribute_fn(
   auto fs = FakeSai::getInstance();
   auto mac = facebook::fboss::fromSaiMacAddress(fdb_entry->mac_address);
   auto fdbKey = std::make_tuple(fdb_entry->switch_id, fdb_entry->bv_id, mac);
+  // The entry may be temporarily orphaned when a VLAN object is recreated with
+  // a new SAI ID during reconciliation, leaving this key stale.  Return
+  // ITEM_NOT_FOUND rather than throwing so FBOSS can re-create the entry.
+  if (!fs->fdbManager.exists(fdbKey)) {
+    return SAI_STATUS_ITEM_NOT_FOUND;
+  }
   auto& fdbEntry = fs->fdbManager.get(fdbKey);
   switch (attr->id) {
     case SAI_FDB_ENTRY_ATTR_BRIDGE_PORT_ID:
@@ -79,6 +85,12 @@ sai_status_t get_fdb_entry_attribute_fn(
   auto fs = FakeSai::getInstance();
   auto mac = facebook::fboss::fromSaiMacAddress(fdb_entry->mac_address);
   auto fdbKey = std::make_tuple(fdb_entry->switch_id, fdb_entry->bv_id, mac);
+  // The entry may be temporarily orphaned when a VLAN object is recreated with
+  // a new SAI ID during reconciliation, leaving this key stale.  Return
+  // ITEM_NOT_FOUND rather than throwing so FBOSS can re-create the entry.
+  if (!fs->fdbManager.exists(fdbKey)) {
+    return SAI_STATUS_ITEM_NOT_FOUND;
+  }
   auto& fdbEntry = fs->fdbManager.get(fdbKey);
   for (int i = 0; i < attr_count; ++i) {
     switch (attr_list[i].id) {


### PR DESCRIPTION
## Summary

`get_fdb_entry_attribute_fn()` and `set_fdb_entry_attribute_fn()` called `FakeManager::get()` directly, which throws `std::out_of_range` if the key is absent. During VLAN reconciliation an existing VLAN SAI object can be deleted and recreated with a new SAI ID, leaving any FDB entries that reference the old `bv_id` key effectively orphaned. When FBOSS then tries to read or update those entries (e.g. after `SaiObjectEventPublisher` fires `afterCreate` for the new bridge port), the `unordered_map::at()` call in `get()` throws, propagating as an uncaught exception and aborting the agent.

Fix by adding an existence check in both functions and returning `SAI_STATUS_ITEM_NOT_FOUND` instead of throwing. FBOSS already handles this status code gracefully and will re-create the FDB entry with the correct (new) `bv_id`.

Observed while bringing up a container-based fake-SAI test environment (fboss-sim, emulating Montblanc) where platform mappings carry TX FIR serdes settings that trigger the reconciliation path.

This is a companion fix to the port-serdes `back_inserter` → `assign` fix sent earlier (#1250).

## Test plan

- Fake-SAI integration tests pass end-to-end on Montblanc fboss-sim
- `ConfigVlanStaticMacTest.AddAndDelete` no longer aborts the HW agent in fboss-sim