### PR TITLE
Add CMake symlink to bridge shipit path for bgp thrift files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1083,6 +1083,19 @@ set_property(
 find_package(Threads REQUIRED)
 enable_testing()
 
+# Shipit maps fbcode/neteng/fboss/bgp/public_tld/configerator/structs/neteng/
+# to configerator/structs/neteng/ in the OSS repo, but thrift includes and
+# CMake source paths reference the original internal path under public_tld.
+# Create a symlink to bridge the two so both paths resolve to the same files.
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/neteng/fboss/bgp/public_tld/configerator/structs/neteng")
+  file(MAKE_DIRECTORY
+    "${CMAKE_SOURCE_DIR}/neteng/fboss/bgp/public_tld/configerator/structs")
+  file(CREATE_LINK
+    "${CMAKE_SOURCE_DIR}/configerator/structs/neteng"
+    "${CMAKE_SOURCE_DIR}/neteng/fboss/bgp/public_tld/configerator/structs/neteng"
+    SYMBOLIC)
+endif()
+
 # Build all cmake files under cmake/*cmake
 file(GLOB_RECURSE cmakeFiles ${CMAKE_CURRENT_SOURCE_DIR}/cmake/*.cmake)
 foreach(cmakeFile ${cmakeFiles})


### PR DESCRIPTION
Summary:
Shipit maps `fbcode/neteng/fboss/bgp/public_tld/configerator/structs/neteng/` to `configerator/structs/neteng/` in the OSS repo, but the CMake build and thrift includes reference files at the original internal path under `public_tld/`. This causes the OSS (GitHub) CMake build to fail with missing source errors for `bgp_config.thrift` and related files.

Rather than adding a duplicate shipit mapping (which steals files from the existing broad mapping), create a symlink at CMake configure time from `neteng/fboss/bgp/public_tld/configerator/structs/neteng` to `configerator/structs/neteng`. This bridges the path gap so both the internal and shipit-mapped paths resolve to the same files.

The `if(NOT EXISTS)` guard makes this a no-op for ondiff builds where D105383235 already copies the directory.

Differential Revision: D107280822


