### PR TITLE
[Nexthop][fboss2-dev] emulate PFC ingress priority groups in fake SAI so PFC tests work in FBOSS-sim

### DIFF
--- a/fboss/agent/hw/sai/fake/FakeSaiBuffer.cpp
+++ b/fboss/agent/hw/sai/fake/FakeSaiBuffer.cpp
@@ -382,6 +382,42 @@ sai_status_t get_ingress_priority_group_attribute_fn(
   return SAI_STATUS_SUCCESS;
 }
 
+/*
+ * In fake sai there isn't a dataplane, so all ingress priority group stats
+ * stay at 0. Mirrors the buffer pool stats handling above.
+ */
+sai_status_t get_ingress_priority_group_stats_fn(
+    sai_object_id_t /*ingress_priority_group_id*/,
+    uint32_t number_of_counters,
+    const sai_stat_id_t* /*counter_ids*/,
+    uint64_t* counters) {
+  for (auto i = 0; i < number_of_counters; ++i) {
+    counters[i] = 0;
+  }
+  return SAI_STATUS_SUCCESS;
+}
+
+sai_status_t get_ingress_priority_group_stats_ext_fn(
+    sai_object_id_t ingress_priority_group_id,
+    uint32_t number_of_counters,
+    const sai_stat_id_t* counter_ids,
+    sai_stats_mode_t /*mode*/,
+    uint64_t* counters) {
+  return get_ingress_priority_group_stats_fn(
+      ingress_priority_group_id, number_of_counters, counter_ids, counters);
+}
+
+/*
+ * noop clear stats API. Since fake doesn't have a dataplane stats are always
+ * set to 0, so no need to clear them.
+ */
+sai_status_t clear_ingress_priority_group_stats_fn(
+    sai_object_id_t /*ingress_priority_group_id*/,
+    uint32_t /*number_of_counters*/,
+    const sai_stat_id_t* /*counter_ids*/) {
+  return SAI_STATUS_SUCCESS;
+}
+
 namespace facebook::fboss {
 
 static sai_buffer_api_t _buffer_api;
@@ -404,6 +440,12 @@ void populate_buffer_api(sai_buffer_api_t** buffer_api) {
       &get_ingress_priority_group_attribute_fn;
   _buffer_api.set_ingress_priority_group_attribute =
       &set_ingress_priority_group_attribute_fn;
+  _buffer_api.get_ingress_priority_group_stats =
+      &get_ingress_priority_group_stats_fn;
+  _buffer_api.get_ingress_priority_group_stats_ext =
+      &get_ingress_priority_group_stats_ext_fn;
+  _buffer_api.clear_ingress_priority_group_stats =
+      &clear_ingress_priority_group_stats_fn;
   *buffer_api = &_buffer_api;
 }
 

--- a/fboss/agent/hw/sai/fake/FakeSaiPort.cpp
+++ b/fboss/agent/hw/sai/fake/FakeSaiPort.cpp
@@ -371,6 +371,25 @@ sai_status_t create_port_fn(
         SAI_QUEUE_TYPE_UNICAST, *port_id, queueId, *port_id);
     port.queueIdList.push_back(saiQueueId);
   }
+  // Real SAI auto-creates a fixed set of ingress priority groups for each port
+  // at port-create time and exposes them via
+  // SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST /
+  // SAI_PORT_ATTR_NUMBER_OF_INGRESS_PRIORITY_GROUPS. The agent never creates
+  // these objects itself; it only reads them back (see
+  // SaiPortManager::getIngressPriorityGroupSaiIds) and attaches buffer profiles
+  // to them when programming PFC (SaiPortManager::changePfcBuffers). Emulate
+  // that here so PFC buffer programming has IPGs to operate on instead of
+  // dereferencing a null handle. IPGs are owned-by-adapter, mirroring the queue
+  // auto-creation above.
+  if (ingressPriorityGroupList.empty()) {
+    constexpr uint8_t kNumIngressPriorityGroups = 8;
+    for (uint8_t pgIndex = 0; pgIndex < kNumIngressPriorityGroups; ++pgIndex) {
+      auto saiIpgId = fs->ingressPriorityGroupManager.create(
+          *port_id, pgIndex, std::nullopt /* bufferProfile */);
+      port.ingressPriorityGroupList.push_back(saiIpgId);
+    }
+    port.numberOfIngressPriorityGroups = port.ingressPriorityGroupList.size();
+  }
   port.interface_type = interface_type;
   if (priorityFlowControlMode.has_value()) {
     port.priorityFlowControlMode = priorityFlowControlMode.value();


### PR DESCRIPTION
…fcTest matches upstream

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
PFC tests were failing in FBOSS simulator which uses Fake SAI because of:
1. **Missing ingress priority groups (IPGs).** Real SAI auto-creates a
fixed set of IPGs per port at port-create time and exposes them via
`SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST` /
`..._NUMBER_OF_INGRESS_PRIORITY_GROUPS`; the agent only reads them. Fake
SAI never created them, so `SaiPortManager::changePfcBuffers` indexed an
empty handle map and dereferenced a null `unique_ptr` → hw_agent crash
when PFC config was applied.

2. **Missing IPG stats functions.** `populate_buffer_api` never wired up
`get`/`get_ext`/`clear_ingress_priority_group_stats`. Once IPGs exist
and have buffer profiles attached, the periodic stats collector
(`SaiBufferManager::updateIngressPriorityGroupStats`) called the null
function pointer → SIGSEGV, dropping the hw↔sw connection and triggering
a cold-boot cascade that broke every following test with "Channel got
EOF".

## Changes

**fake SAI** — `FakeSaiPort.cpp`: auto-create 8 IPGs per port at
port-create (mirrors the existing per-port queue auto-creation and real
SAI; IPGs are owned-by-adapter so `SaiStore` preserves them across
warmboot). `FakeSaiBuffer.cpp`: implement + register the three IPG stats
functions (return 0, no dataplane).

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
Built `fboss_fake_agent_targets` + `fboss2_targets` (fake SAI), packaged
the fboss-sim runtime image, and ran the integration suite:

- **Full suite: 30 passed, 0 failed, 2 skipped** (the 2 skips are
pre-existing `ConfigVlanDefaultTest.*` self-skips).
- `ConfigPfcTest.BufferPoolPriorityGroupAndPortPfc` passes; ran it
repeated + forced a warm-boot restart with the persisted PFC config →
`NRestarts=0`, agents healthy.
- No `SIGSEGV`, no `changePfcBuffers` null-deref, no "Channel got EOF"
cascade.
- Baseline (before the stats fix) reproduced the cascade exactly:
`ConfigPfcTest` left PFC config persisted → SIGSEGV in IPG stats →
`ConfigInterfaceMtuTest` / `ConfigInterfaceProfileTest` /
`ConfigPtpTest` failed with "Channel got EOF".

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
