### PR TITLE
[Celestica] Ladakh800bcls: Agent Test: fix AgentAqmEcnProbabilisticMarkingTest.verifyEcnProbabilisticMarking test, enable ECN_PROBABILISTIC_MARKING  on th6

### DIFF
--- a/fboss/agent/hw/switch_asics/Tomahawk6Asic.cpp
+++ b/fboss/agent/hw/switch_asics/Tomahawk6Asic.cpp
@@ -119,6 +119,7 @@ bool Tomahawk6Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::BULK_CREATE_ECMP_MEMBER:
     case HwAsic::Feature::RX_SERDES_PARAMETERS:
     case HwAsic::Feature::LINK_TRAINING:
+    case HwAsic::Feature::ECN_PROBABILISTIC_MARKING:
       return true;
     // features not working well with bcmsim
     case HwAsic::Feature::MIRROR_PACKET_TRUNCATION:
@@ -235,7 +236,6 @@ bool Tomahawk6Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::INGRESS_BUFFER_POOL_SIZE_EXCLUDES_HEADROOM:
     case HwAsic::Feature::PORT_LEVEL_BUFFER_CONFIGURATION_SUPPORT:
     case HwAsic::Feature::ARS_FUTURE_PORT_LOAD:
-    case HwAsic::Feature::ECN_PROBABILISTIC_MARKING:
     case HwAsic::Feature::SRV6_MYSID_DISCARD_COUNTER:
     case HwAsic::Feature::SRV6_MYSID_RESOURCE_COUNTER:
     case HwAsic::Feature::DEVICE_WATERMARK_SUPPORT:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary

when test AgentAqmEcnProbabilisticMarkingTest.verifyEcnProbabilisticMarking on Anacapa, we found it failed.
fail log
'V1013 18:45:02.231204 977523 OlympicTestUtils.cpp:346] Configuring ECN probabilistic marking for queue 2 with minThresh: 10240 bytes, maxThresh: 31457280 bytes, probability: 50%
V1013 18:45:02.236378 977550 SwSwitch.cpp:1899] preparing state update applying new config; # Pending updates 0
[E1013](https://l.workplace.com/l.php?u=https%3A%2F%2Fwww.internalfb.com%2Fservicelab%2Fexperiment%2F1013&h=AUB7VXJu0DlvEXzHVtf-rXk_rY99hMC4I2cD-lgzqoPoYGsIrqbY84xVnONPM4zH5nbMup1lgBuGAHs1htIEpx6ECKzgR47vkLlX0GCsWU43BnaQSlXzDQ_82OdfrbPDjZHjHijm1aefmP4P&__tn__=-UK-R&c[0]=AUADLAwv8rH4BW1DgaaXsUbOCHdqzVgnW3gjZAQh808BjmWIQ8EV7EI2wy-DnTnL5Svemmaw4XqFy8L70KeiiYoFAWUSeiM2wdBZD6rUU2dcH_cId_82-PDzGDA6Me8FiP2WY7rjLpVk3Fqdfpm9lqPBR6zX3yKdiq4btmR56yHfxg) 18:45:02.254306 977550 ValidateStateUpdate.cpp:50] Port 1 queue \x02 has invalid ECN probability: 50 (must be exactly 100% when ECN probabilistic marking is not supported)
[E1013](https://l.workplace.com/l.php?u=https%3A%2F%2Fwww.internalfb.com%2Fservicelab%2Fexperiment%2F1013&h=AUB7VXJu0DlvEXzHVtf-rXk_rY99hMC4I2cD-lgzqoPoYGsIrqbY84xVnONPM4zH5nbMup1lgBuGAHs1htIEpx6ECKzgR47vkLlX0GCsWU43BnaQSlXzDQ_82OdfrbPDjZHjHijm1aefmP4P&__tn__=-UK-R&c[0]=AUADLAwv8rH4BW1DgaaXsUbOCHdqzVgnW3gjZAQh808BjmWIQ8EV7EI2wy-DnTnL5Svemmaw4XqFy8L70KeiiYoFAWUSeiM2wdBZD6rUU2dcH_cId_82-PDzGDA6Me8FiP2WY7rjLpVk3Fqdfpm9lqPBR6zX3yKdiq4btmR56yHfxg) 18:45:02.254318 977550 ValidateStateUpdate.cpp:99] Changed port 1 has invalid queues
[E1013](https://l.workplace.com/l.php?u=https%3A%2F%2Fwww.internalfb.com%2Fservicelab%2Fexperiment%2F1013&h=AUB7VXJu0DlvEXzHVtf-rXk_rY99hMC4I2cD-lgzqoPoYGsIrqbY84xVnONPM4zH5nbMup1lgBuGAHs1htIEpx6ECKzgR47vkLlX0GCsWU43BnaQSlXzDQ_82OdfrbPDjZHjHijm1aefmP4P&__tn__=-UK-R&c[0]=AUADLAwv8rH4BW1DgaaXsUbOCHdqzVgnW3gjZAQh808BjmWIQ8EV7EI2wy-DnTnL5Svemmaw4XqFy8L70KeiiYoFAWUSeiM2wdBZD6rUU2dcH_cId_82-PDzGDA6Me8FiP2WY7rjLpVk3Fqdfpm9lqPBR6zX3yKdiq4btmR56yHfxg) 18:45:02.254344 977550 ValidateStateUpdate.cpp:283] State update is not valid."
root cause: after debug , I found in fboss/agent/hw/switch_asics/Tomahawk6Asic.cpp case HwAsic::Feature::ECN_PROBABILISTIC_MARKING: return false, which make ECN probabilistic marking must be 100%,
solution
I checked Tomahawk5Asic.cpp I found it supported, and asked broadcom AI Search about th6 Reply supported., so I changed isSupported case HwAsic::Feature::ECN_PROBABILISTIC_MARKING to true, test passed

# Test Plan

=== Cold boot: AgentAqmEcnProbabilisticMarkingTest.verifyEcnProbabilisticMarking (switch_id=0) ===
Waiting for config files...
Config files ready after 1s
Starting hw_agent processes...
=== Warm boot: AgentAqmEcnProbabilisticMarkingTest.verifyEcnProbabilisticMarking (switch_id=0) ===
=== Test Results ===
Cold boot: PASSED (exit code 0)
Warm boot: PASSED (exit code 0)
