### PR TITLE
[Nexthop] [M4062NHP] Introduce platform with stub platform mapping

### DIFF
--- a/cmake/Agent.cmake
+++ b/cmake/Agent.cmake
@@ -164,6 +164,7 @@ target_link_libraries(utils
   j4sim_platform_mapping
   saintpaul_platform_mapping
   blackwolf800banw_platform_mapping
+  m4062nhp_platform_mapping
   icecube800banw_platform_mapping
   icecube800bc_platform_mapping
   icetea800bc_platform_mapping

--- a/cmake/AgentPlatformsCommon.cmake
+++ b/cmake/AgentPlatformsCommon.cmake
@@ -47,6 +47,7 @@ target_link_libraries(platform_mapping_utils
   tahan800bc_platform_mapping
   icecube800bc_platform_mapping
   blackwolf800banw_platform_mapping
+  m4062nhp_platform_mapping
   wedge800bact_platform_mapping
   icetea800bc_platform_mapping
   tahansb800bc_platform_mapping

--- a/cmake/AgentPlatformsCommonM4062nhp.cmake
+++ b/cmake/AgentPlatformsCommonM4062nhp.cmake
@@ -1,0 +1,12 @@
+# CMake to build libraries and binaries in fboss/agent/platforms/common/m4062nhp
+
+# In general, libraries and binaries in fboss/foo/bar are built by
+# cmake/FooBar.cmake
+
+add_library(m4062nhp_platform_mapping
+  fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.cpp
+)
+
+target_link_libraries(m4062nhp_platform_mapping
+  platform_mapping
+)

--- a/fboss/agent/platforms/common/BUCK
+++ b/fboss/agent/platforms/common/BUCK
@@ -47,6 +47,7 @@ cpp_library(
         "//fboss/agent/platforms/common/janga800bic:janga800bic_platform_mapping",
         "//fboss/agent/platforms/common/ladakh800bcls:ladakh800bcls_platform_mapping",
         "//fboss/agent/platforms/common/leh800bcls:leh800bcls_platform_mapping",
+        "//fboss/agent/platforms/common/m4062nhp:m4062nhp_platform_mapping",
         "//fboss/agent/platforms/common/meru800bfa:meru800bfa_platform_mapping",
         "//fboss/agent/platforms/common/meru800bia:meru800bia_platform_mapping",
         "//fboss/agent/platforms/common/minipack:minipack_platform_mapping",

--- a/fboss/agent/platforms/common/PlatformMappingUtils.cpp
+++ b/fboss/agent/platforms/common/PlatformMappingUtils.cpp
@@ -28,6 +28,7 @@
 #include "fboss/agent/platforms/common/janga800bic/Janga800bicPlatformMapping.h"
 #include "fboss/agent/platforms/common/ladakh800bcls/Ladakh800bclsPlatformMapping.h"
 #include "fboss/agent/platforms/common/leh800bcls/Leh800bclsPlatformMapping.h"
+#include "fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.h"
 #include "fboss/agent/platforms/common/meru800bfa/Meru800bfaP1PlatformMapping.h"
 #include "fboss/agent/platforms/common/meru800bfa/Meru800bfaPlatformMapping.h"
 #include "fboss/agent/platforms/common/meru800bia/Meru800biaPlatformMapping.h"
@@ -230,6 +231,10 @@ std::unique_ptr<PlatformMapping> initPlatformMapping(PlatformType type) {
       return platformMappingStr.empty()
           ? std::make_unique<Yangra2PlatformMapping>()
           : std::make_unique<Yangra2PlatformMapping>(platformMappingStr);
+    case PlatformType::PLATFORM_M4062NHP:
+      return platformMappingStr.empty()
+          ? std::make_unique<M4062nhpPlatformMapping>()
+          : std::make_unique<M4062nhpPlatformMapping>(platformMappingStr);
     case PlatformType::PLATFORM_FAKE_SAI: {
       std::vector<int> controllingPorts = getFakeSaiControllingPortIDs();
       return std::make_unique<FakeTestPlatformMapping>(controllingPorts);

--- a/fboss/agent/platforms/common/m4062nhp/BUCK
+++ b/fboss/agent/platforms/common/m4062nhp/BUCK
@@ -1,0 +1,16 @@
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("fboss_agent_push")
+
+cpp_library(
+    name = "m4062nhp_platform_mapping",
+    srcs = [
+        "M4062nhpPlatformMapping.cpp",
+    ],
+    headers = [
+        "M4062nhpPlatformMapping.h",
+    ],
+    exported_deps = [
+        "//fboss/agent/platforms/common:platform_mapping",
+    ],
+)

--- a/fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.cpp
+++ b/fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.cpp
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Nexthop Systems Inc.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.h"
+
+namespace {
+constexpr auto kJsonPlatformMappingStr = R"({})";
+} // namespace
+
+namespace facebook::fboss {
+
+M4062nhpPlatformMapping::M4062nhpPlatformMapping()
+    : PlatformMapping(kJsonPlatformMappingStr) {}
+
+M4062nhpPlatformMapping::M4062nhpPlatformMapping(
+    const std::string& platformMappingStr)
+    : PlatformMapping(platformMappingStr) {}
+
+} // namespace facebook::fboss

--- a/fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.h
+++ b/fboss/agent/platforms/common/m4062nhp/M4062nhpPlatformMapping.h
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2026 Nexthop Systems Inc.
+ *  SPDX-License-Identifier: BSD-3-Clause
+ */
+#pragma once
+
+#include "fboss/agent/platforms/common/PlatformMapping.h"
+
+namespace facebook::fboss {
+
+class M4062nhpPlatformMapping : public PlatformMapping {
+ public:
+  M4062nhpPlatformMapping();
+  explicit M4062nhpPlatformMapping(const std::string& platformMappingStr);
+
+ private:
+  M4062nhpPlatformMapping(M4062nhpPlatformMapping const&) = delete;
+  M4062nhpPlatformMapping& operator=(M4062nhpPlatformMapping const&) = delete;
+};
+
+} // namespace facebook::fboss

--- a/fboss/lib/if/fboss_common.thrift
+++ b/fboss/lib/if/fboss_common.thrift
@@ -63,6 +63,7 @@ enum PlatformType {
   PLATFORM_YANGRA2 = 50,
   PLATFORM_SAINTPAUL = 51,
   PLATFORM_LEH800BCLS = 52,
+  PLATFORM_M4062NHP = 53,
   PLATFORM_UNKNOWN = 1000, # Placeholder for unknown platform type
 }
 

--- a/fboss/lib/platforms/PlatformMode.h
+++ b/fboss/lib/platforms/PlatformMode.h
@@ -118,6 +118,8 @@ inline std::string toString(PlatformType mode) {
       return "YANGRA2";
     case PlatformType::PLATFORM_SAINTPAUL:
       return "SAINTPAUL";
+    case PlatformType::PLATFORM_M4062NHP:
+      return "M4062NHP";
     case PlatformType::PLATFORM_MERU400BIU_DEPRECATED:
       return "MERU400BIU";
     case PlatformType::PLATFORM_MERU400BFU_DEPRECATED:

--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -236,6 +236,9 @@ void PlatformProductInfo::initMode() {
     } else if (
         modelName.find("Saintpaul") == 0 || modelName.find("SAINTPAUL") == 0) {
       type_ = PlatformType::PLATFORM_SAINTPAUL;
+    } else if (
+        modelName.find("M4062nhp") == 0 || modelName.find("M4062NHP") == 0) {
+      type_ = PlatformType::PLATFORM_M4062NHP;
     } else {
       throw FbossError("invalid model name " + modelName);
     }
@@ -320,6 +323,8 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_YANGRA2;
     } else if (FLAGS_mode == "saintpaul") {
       type_ = PlatformType::PLATFORM_SAINTPAUL;
+    } else if (FLAGS_mode == "m4062nhp") {
+      type_ = PlatformType::PLATFORM_M4062NHP;
     } else {
       throw std::runtime_error("invalid mode " + FLAGS_mode);
     }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Registers M4062NHP as PlatformType::PLATFORM_M4062NHP = 53 end-to-end: thrift enum, PlatformMode toString, PlatformProductInfo modelName + FLAGS_mode detection, PlatformMappingUtils factory case, and Buck/CMake wiring.

The M4062nhpPlatformMapping stub loads R"({})" — the real port-config JSON, SAI platform classes, BSP mapping, LED manager, and QSFP dispatch will land in follow-up PRs.

# Test Plan

Passes build.
Pre-reviewed with the appropriate skills.
