### PR TITLE
[G200][Cisco]Fix outer dest IP to match the mySID config

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropSrv6Tests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropSrv6Tests.cpp
@@ -164,7 +164,7 @@ TEST_F(AgentMirrorOnDropSrv6Test, Srv6Drops) {
   PortID collectorPortId = masterLogicalInterfacePortIds()[1];
   PortID injectionPortId = masterLogicalInterfacePortIds()[2];
 
-  const folly::IPAddressV6 kDecapNonLastDst{"3001:db8:ffff:1:2::"};
+  const folly::IPAddressV6 kDecapNonLastDst{"3001:db8:7fff:1:2::"};
   const folly::IPAddressV6 kBindingSidNonLastDst{"fc00:100:1:2::"};
   const folly::IPAddressV6 kMidpointValidDst{"fdad:ffff:1:2::"};
 

--- a/fboss/agent/test/agent_hw_tests/AgentSrv6DecapTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSrv6DecapTests.cpp
@@ -465,7 +465,7 @@ TYPED_TEST(AgentSrv6DecapTest, sendDecapPacketNonLastSegmentDropped) {
 
     // Outer dst IP matches the mySid /48 prefix but is not the last uSid.
     // The packet should be dropped.
-    const folly::IPAddressV6 kNonLastSegmentDst{"3001:db8:ffff:1:2::"};
+    const folly::IPAddressV6 kNonLastSegmentDst{"3001:db8:7fff:1:2::"};
 
     auto txPacket = utility::makeIpInIpTxPacket(
         this->getSw(),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Fix outer dest IP for the test related to drop packet if decap uSid is not the last sid
# Test Plan
Manually verified - AgentSrv6DecapTest/0.sendDecapPacketNonLastSegmentDropped

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
