### PR TITLE
[Celestica] Leh800bcls: resolve multi-switch L2 aging failures in AgentMacLearningTests

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMacLearningTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMacLearningTests.cpp
@@ -275,14 +275,18 @@ class AgentMacLearningTest : public AgentHwTest {
     };
 
     auto verify = [this, portDescr]() {
+      auto macPort = masterLogicalPortIds()[0];
+      auto switchIdForMac =
+          getSw()->getScopeResolver()->scope(macPort).switchId();
       // Disable aging, so entry stays in L2 table when we verify.
-      utility::setMacAgeTimerSeconds(getAgentEnsemble(), 0);
+      utility::setMacAgeTimerSeconds(getAgentEnsemble(), 0, switchIdForMac);
       bringDownPort(masterLogicalPortIds()[1]);
       sendPkt();
       EXPECT_TRUE(wasMacLearnt(portDescr, kSourceMac()));
 
       // Force MAC aging to as fast as possible but min is still 1 second
-      utility::setMacAgeTimerSeconds(getAgentEnsemble(), kMinAgeInSecs());
+      utility::setMacAgeTimerSeconds(
+          getAgentEnsemble(), kMinAgeInSecs(), switchIdForMac);
       EXPECT_TRUE(wasMacLearnt(portDescr, kSourceMac(), false /* MAC aged */));
     };
 
@@ -424,12 +428,13 @@ class AgentMacSwLearningModeTest : public AgentMacLearningTest {
   cfg::SwitchConfig initialConfig(
       const AgentEnsemble& ensemble) const override {
     auto switchId = getCurrentSwitchIdForTesting();
+    auto switchPorts = ensemble.masterLogicalPortIds(switchId);
     auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
     auto cfg = utility::oneL3IntfTwoPortConfig(
         ensemble.getSw()->getPlatformMapping(),
         asic,
-        ensemble.masterLogicalPortIds()[0],
-        ensemble.masterLogicalPortIds()[1],
+        switchPorts[0],
+        switchPorts[1],
         ensemble.getSw()->getPlatformSupportsAddRemovePort(),
         asic->desiredLoopbackModes(),
         ensemble.getSw()->getPlatformType());
@@ -504,7 +509,11 @@ class AgentMacSwLearningModeTest : public AgentMacLearningTest {
 
       // Force MAC aging to as fast as possible but min is still 1 second
       l2LearningObserver_.reset();
-      utility::setMacAgeTimerSeconds(getAgentEnsemble(), kMinAgeInSecs());
+      auto macPort = masterLogicalPortIds()[0];
+      auto switchIdForMac =
+          getSw()->getScopeResolver()->scope(macPort).switchId();
+      utility::setMacAgeTimerSeconds(
+          getAgentEnsemble(), kMinAgeInSecs(), switchIdForMac);
 
       // Verify if we get DELETE (aging) callback for VALIDATED entry
       verifyL2TableCallback(
@@ -932,8 +941,12 @@ TEST_F(AgentMacSwLearningModeTest, VerifyCallbacksOnMacEntryChange) {
           break;
         case MacOp::DELETE:
           XLOG(DBG2) << " Removing mac";
+          auto macPort = physPortDescr().phyPortID();
+          auto switchIdForMac =
+              getSw()->getScopeResolver()->scope(macPort).switchId();
           // Force MAC aging to as fast as possible but min is still 1 second
-          utility::setMacAgeTimerSeconds(getAgentEnsemble(), kMinAgeInSecs());
+          utility::setMacAgeTimerSeconds(
+              getAgentEnsemble(), kMinAgeInSecs(), switchIdForMac);
 
           // Verify if we get DELETE (aging) callback for VALIDATED entry
           verifyL2TableCallback(
@@ -989,12 +1002,13 @@ class AgentMacLearningMacMoveTest : public AgentMacLearningTest {
   cfg::SwitchConfig initialConfig(
       const AgentEnsemble& ensemble) const override {
     auto switchId = getCurrentSwitchIdForTesting();
+    auto switchPorts = ensemble.masterLogicalPortIds(switchId);
     auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
     auto cfg = utility::oneL3IntfTwoPortConfig(
         ensemble.getSw()->getPlatformMapping(),
         asic,
-        ensemble.masterLogicalPortIds()[0],
-        ensemble.masterLogicalPortIds()[1],
+        switchPorts[0],
+        switchPorts[1],
         ensemble.getSw()->getPlatformSupportsAddRemovePort(),
         asic->desiredLoopbackModes(),
         ensemble.getSw()->getPlatformType());

--- a/fboss/agent/test/utils/MacTestUtils.cpp
+++ b/fboss/agent/test/utils/MacTestUtils.cpp
@@ -1,6 +1,7 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 #include "fboss/agent/test/utils/MacTestUtils.h"
+#include "fboss/agent/HwSwitchMatcher.h"
 #include "fboss/agent/HwSwitchThriftClientTable.h"
 #include "fboss/agent/SwSwitch.h"
 #include "fboss/agent/state/SwitchState.h"
@@ -21,6 +22,23 @@ void setMacAgeTimerSeconds(
         return newState;
       },
       "set mac age timer");
+}
+
+void setMacAgeTimerSeconds(
+    facebook::fboss::TestEnsembleIf* ensemble,
+    uint32_t seconds,
+    SwitchID targetSwitchId) {
+  ensemble->applyNewState(
+      [&](const std::shared_ptr<SwitchState>& in) {
+        auto newState = in->clone();
+        HwSwitchMatcher matcher(std::unordered_set<SwitchID>{targetSwitchId});
+        auto switchSettings =
+            newState->getSwitchSettings()->getNode(matcher.matcherString());
+        auto newSwitchSettings = switchSettings->modify(&newState);
+        newSwitchSettings->setL2AgeTimerSeconds(seconds);
+        return newState;
+      },
+      "set mac age timer for specific switch");
 }
 
 std::vector<L2EntryThrift> getL2Table(SwSwitch* sw_, bool sdk) {

--- a/fboss/agent/test/utils/MacTestUtils.h
+++ b/fboss/agent/test/utils/MacTestUtils.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "fboss/agent/if/gen-cpp2/ctrl_types.h"
+#include "fboss/agent/types.h"
 
 #include <folly/MacAddress.h>
 
@@ -24,6 +25,10 @@ namespace utility {
 void setMacAgeTimerSeconds(
     facebook::fboss::TestEnsembleIf* ensemble,
     uint32_t seconds);
+void setMacAgeTimerSeconds(
+    facebook::fboss::TestEnsembleIf* ensemble,
+    uint32_t seconds,
+    SwitchID targetSwitchId);
 std::vector<L2EntryThrift> getL2Table(SwSwitch* sw_, bool sdk = false);
 
 } // namespace utility


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
This change resolves a series of test failures within AgentMacLearningTests.cpp that occurred when running on multi-NPU platforms like Ladakh800bcls/Leh800bcls. Specifically, tests involving L2 entry aging (e.g., VerifyCallbacksOnMacEntryChange, VerifySwAgingForPort, VerifyHwAgingForPort) would hang and time out when targeting any non-zero SwitchID (e.g., NPU1).

# Root Cause
The root cause was a combination of two legacy issues from the single-NPU era:

1. Non-Multi-NPU-Aware Test Utility: The `utility::setMacAgeTimerSeconds` helper function used `utility::getFirstNodeIf`, which hardcoded the `SwitchSettings` modification to always apply to `SwitchID(0)`. This meant aging was never correctly configured for other NPUs.
2.  Unsafe Test Initialization: The `initialConfig` in the affected test classes used the global `ensemble.masterLogicalPortIds()` list to select ports. In a multi-NPU environment.

# Solution
This commit addresses both issues comprehensively:

1.  Targeted `setMacAgeTimerSeconds`:
     Overloaded the `setMacAgeTimerSeconds` utility to accept a `targetSwitchId`.
     The new overload uses `HwSwitchMatcher` to generate the correct map key (e.g., `"id=1"`) and precisely modifies the `SwitchSettings` for only the NPU under test, preventing side effects.
   
 2.  Multi-NPU-Aware `initialConfig`:
      Refactored the `initialConfig` in `AgentMacSwLearningModeTest` and `AgentMacLearningMacMoveTest` to use `ensemble.masterLogicalPortIds(switchId)`, ensuring the test is configured with ports belonging exclusively to the target NPU.

# Test Plan
```
LD_LIBRARY_PATH=/opt/fboss/lib/ /root/img/multi_switch_agent_hw_test \
                       --gtest_filter=AgentMacSwLearningModeTest.VerifyCallbacksOnMacEntryChange \
                       --fruid_filepath /root/cfg/fruid.json \
                       --config /root/cfg/agent.conf \
                       --multi_npu_platform_mapping \
                       -hw_agent_for_testing \
                       --switch_id_for_testing 1 \
                       --logging=DBG5
LD_LIBRARY_PATH=/opt/fboss/lib/  /root/img/multi_switch_agent_hw_test \
                       --gtest_filter=AgentMacSwLearningModeTest.VerifySwAgingForPort \
                       --fruid_filepath /root/cfg/fruid.json \
                       --config /root/cfg/agent.conf \
                       --multi_npu_platform_mapping \
                       -hw_agent_for_testing \
                       --switch_id_for_testing 1 \
                       --logging=DBG5
LD_LIBRARY_PATH=/opt/fboss/lib/ /root/img/multi_switch_agent_hw_test \
                       --gtest_filter=AgentMacSwLearningModeTest.VerifySwAgingForTrunk \
                       --fruid_filepath /root/cfg/fruid.json \
                       --config /root/cfg/agent.conf \
                       --multi_npu_platform_mapping \
                       -hw_agent_for_testing \
                       --switch_id_for_testing 1 \
                       --logging=DBG5

```

# Test Result
The following cases all passed on both switch 0 and switch 1.
- AgentMacSwLearningModeTest.VerifyCallbacksOnMacEntryChange
- AgentMacSwLearningModeTest.VerifySwAgingForPort
- AgentMacSwLearningModeTest.VerifySwAgingForTrunk