### PR TITLE
[Accton][minipack3bta] Add TU1-specific ACL qualifier set and action type list

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
@@ -1764,6 +1764,8 @@ std::set<cfg::AclTableQualifier> SaiAclTableManager::getSupportedQualifierSet(
       platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_TOMAHAWK5;
   bool isTomahawk6 =
       platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_TOMAHAWK6;
+  bool isTomahawkUltra1 = platform_->getAsic()->getAsicType() ==
+      cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1;
   bool isChenab = platform_->getAsic()->getAsicVendor() ==
       HwAsic::AsicVendor::ASIC_VENDOR_CHENAB;
 
@@ -1916,6 +1918,19 @@ std::set<cfg::AclTableQualifier> SaiAclTableManager::getSupportedQualifierSet(
     if (isTomahawk6) {
       bcmQualifiers.insert(cfg::AclTableQualifier::ETHER_TYPE);
       bcmQualifiers.erase(cfg::AclTableQualifier::OUT_PORT);
+    }
+    // TU1 SDK does not support these qualifiers
+    if (isTomahawkUltra1) {
+      bcmQualifiers.erase(cfg::AclTableQualifier::TCP_FLAGS);
+      bcmQualifiers.erase(cfg::AclTableQualifier::OUT_PORT);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV4_TYPE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV4_CODE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV6_TYPE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::ICMPV6_CODE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_L2);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_NEIGHBOR);
+      bcmQualifiers.erase(cfg::AclTableQualifier::LOOKUP_CLASS_ROUTE);
+      bcmQualifiers.erase(cfg::AclTableQualifier::TTL);
     }
     if (isFake) {
       bcmQualifiers.insert(cfg::AclTableQualifier::L4_DST_PORT_RANGE);

--- a/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
@@ -98,13 +98,19 @@ std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
         cfg::AsicType::ASIC_TYPE_JERICHO4;
     bool isChenab = platform_->getAsic()->getAsicVendor() ==
         HwAsic::AsicVendor::ASIC_VENDOR_CHENAB;
+    bool isTomahawkUltra1 = platform_->getAsic()->getAsicType() ==
+        cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1;
 
     std::vector<sai_int32_t> actionTypeList{
         SAI_ACL_ACTION_TYPE_PACKET_ACTION,
         SAI_ACL_ACTION_TYPE_COUNTER,
-        SAI_ACL_ACTION_TYPE_SET_TC,
         SAI_ACL_ACTION_TYPE_SET_DSCP,
         SAI_ACL_ACTION_TYPE_MIRROR_INGRESS};
+
+    // TomahawkUltra1 does not support SET_TC action
+    if (!isTomahawkUltra1) {
+      actionTypeList.push_back(SAI_ACL_ACTION_TYPE_SET_TC);
+    }
 
     if (!(isTajo || isJericho2 || isJericho3 || isJericho4 || isChenab)) {
       // Chenab supports egress mirror action in egress table


### PR DESCRIPTION

**Pre-submission checklist**
- [v] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [v] `pre-commit run`

# Summary

TomahawkUltra1 (BCM78920) does not support TTL, OUTER_VLAN, OUT_PORT,
TCP_FLAGS, LOOKUP_CLASS_L2, LOOKUP_CLASS_NEIGHBOR, LOOKUP_CLASS_ROUTE
qualifiers or SET_TC action at the SDK level. Without a dedicated branch,
getSupportedQualifierSet() falls through to the generic BCM set and ACL
table creation fails with SAI_STATUS_NOT_SUPPORTED.

Add a TU1 branch in getSupportedQualifierSet() and exclude SET_TC from
getActionTypeList(). This is the portion of #1168 accepted during review
(https://github.com/facebook/fboss/pull/1168#issuecomment-4541325833).

# Test Plan:

- SAI link tests on TU1 hardware pass.
