### PR TITLE
[Nexthop] WEDGE800BNHP will be an alias for WEDGE800BACT

### DIFF
--- a/fboss/platform/helpers/PlatformNameLib.cpp
+++ b/fboss/platform/helpers/PlatformNameLib.cpp
@@ -44,6 +44,10 @@ std::string sanitizePlatformName(const std::string& platformNameFromBios) {
     return "MINIPACK3BA";
   }
 
+  if (platformNameUpper == "WEDGE800BNHP") {
+    return "WEDGE800BACT";
+  }
+
   return platformNameUpper;
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

WEDGE800BNHP and WEDGE800BACT should use the same platform code. Maps the WEDGE800BNHP BIOS platform name to WEDGE800BACT in sanitizePlatformName(), mirroring the existing platform aliasing.

# Test Plan

FBOSS platform tests should run the same on both platforms.
