### PR TITLE
[Celestica] Leh800bcls: Fix multi-NPU config generation in AgentNeighborTests

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentNeighborTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentNeighborTests.cpp
@@ -127,9 +127,21 @@ class AgentNeighborTest : public AgentHwTest {
     auto switchId = getSwitchIdUnderTest(ensemble);
     auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
     auto ports = ensemble.masterLogicalPortIds({switchId});
-    auto cfg = programToTrunk
-        ? utility::oneL3IntfTwoPortConfig(ensemble.getSw(), ports[0], ports[1])
-        : utility::onePortPerInterfaceConfig(ensemble.getSw(), ports);
+    auto cfg = programToTrunk ? utility::oneL3IntfTwoPortConfig(
+                                    ensemble.getPlatformMapping(),
+                                    asic,
+                                    ports[0],
+                                    ports[1],
+                                    ensemble.supportsAddRemovePort(),
+                                    asic->desiredLoopbackModes(),
+                                    ensemble.getSw()->getPlatformType())
+                              : utility::onePortPerInterfaceConfig(
+                                    ensemble.getPlatformMapping(),
+                                    asic,
+                                    ports,
+                                    ensemble.supportsAddRemovePort(),
+                                    asic->desiredLoopbackModes(),
+                                    ensemble.getSw()->getPlatformType());
     if (programToTrunk) {
       // Keep member size to be less than/equal to HW limitation, but first add
       // the two ports for testing. Only use ports from masterLogicalPortIds()


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
When running the current agent case, the hw agent crashes with the error: Error: counter_get() failed(Invalid unit)
```
AgentNeighborTest/1.AddPendingEntry
AgentNeighborTest/1.ResolvePendingEntry
AgentNeighborTest/1.ResolveLinkLocalEntry
AgentNeighborTest/1.UnresolveResolvedEntry
AgentNeighborTest/1.ResolveThenUnresolveEntry
AgentNeighborTest/1.RemoveResolvedEntry
AgentNeighborTest/1.AddPendingRemovedEntry
AgentNeighborTest/1.LinkDownOnResolvedEntry
AgentNeighborTest/1.LinkDownAndUpOnResolvedEntry
AgentNeighborTest/3.AddPendingEntry
AgentNeighborTest/3.ResolvePendingEntry
AgentNeighborTest/3.ResolveLinkLocalEntry
AgentNeighborTest/3.UnresolveResolvedEntry
AgentNeighborTest/3.ResolveThenUnresolveEntry
AgentNeighborTest/3.RemoveResolvedEntry
AgentNeighborTest/3.AddPendingRemovedEntry
AgentNeighborTest/3.LinkDownOnResolvedEntry
AgentNeighborTest/3.LinkDownAndUpOnResolvedEntry
AgentNeighborResolutionTest/1.ResolveNeighborAndCheckCache
AgentNeighborResolutionTest/3.ResolveNeighborAndCheckCache
AgentNeighborMetadataTest/1.ResolvePendingEntryThenChangeLookupClass
AgentNeighborMetadataTest/3.ResolvePendingEntryThenChangeLookupClass
```
# Root Cause
In multi-NPU platforms like Leh800bcls and Ladakh800bcls, the initial switch configuration generator must be fully aware of the multi-NPU (multi-unit/multi-ASIC) topology to correctly map resources and hardware counter units.

 Previously, AgentNeighborTest::initialConfig() utilized the legacy, multi-NPU-unaware overload of utility::onePortPerInterfaceConfig(ensemble.getSw(), ports). Under the hood, because this overload lacks parameters for explicit PlatformType and HwAsic bindings:
  1. The config generator fell back to generating configuration only for a single NPU (SwitchID 0 / Unit 0).
  2. Consequently, no configuration or routing structure was generated for the second NPU (SwitchID 1 / Unit 1).
  3. When test cases were executed or neighbor counters were queried on the second NPU (NPU 1), the underlying SDK threw the counter_get() failed(Invalid unit) error because Unit 1 was completely unrecognized and unconfigured in the system's generated topology.

# Solution
Replaced the legacy, multi-NPU-unaware configuration helper calls in AgentNeighborTest::initialConfig() with the multi-NPU-aware overloads:
  1. Updated both onePortPerInterfaceConfig and oneL3IntfTwoPortConfig branches to take explicit hardware arguments:
     - ensemble.getPlatformMapping()
     - asic
     - ensemble.supportsAddRemovePort()
     - asic->desiredLoopbackModes()
     - ensemble.getSw()->getPlatformType() (Crucially provides the specific platform type)
  2. By explicitly passing PlatformType::PLATFORM_LEH800BCLS, the configuration generator (genPortVlanCfg()) detects the dual-NPU hardware layout and generates a complete, valid switch configuration covering both SwitchID(0) and SwitchID(1).
  3. This ensures all SDK resources and units are correctly mapped and initialized, completely resolving the counter_get() failed(Invalid unit) errors and allowing all 22 cases under AgentNeighborTest to successfully pass on both NPU 0 and NPU 1.

# Test Plan
Run fboss agent test can reproduce and verify it. Command example as below.
```
        LD_LIBRARY_PATH=/root/agent/lib/ /root/agent/img/multi_switch_agent_hw_test \
                       --gtest_filter=${filter} \
                       --fruid_filepath /root/agent/cfg/fruid.json \
                       --config /root/agent/cfg/agent.conf \
                       --multi_npu_platform_mapping \
                       -hw_agent_for_testing \
                       --switch_id_for_testing ${NPU} \
                       --logging=DBG5
```
All listed cases passed successfully under both NPU 0 and NPU 1 test environments.

**before fix**: 
- the log in NPU0 as below:
```
[root@localhost AgentTxNpu0]# grep "FbossError: Waiting for HwSwitch" multi_switch_agent-AgentNeighbor*.log | wc -l
22
[root@localhost AgentTxNpu0]# grep "FbossError: Waiting for HwSwitch" multi_switch_agent-AgentNeighbor*.log
multi_switch_agent-AgentNeighborMetadataTest-1.ResolvePendingEntryThenChangeLookupClass-20260616_064536.log:F0616 06:47:46.378514 1029552 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborMetadataTest-3.ResolvePendingEntryThenChangeLookupClass-20260616_064759.log:F0616 06:50:09.595562 1029928 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborResolutionTest-1.ResolveNeighborAndCheckCache-20260616_064049.log:F0616 06:43:00.081709 1028796 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborResolutionTest-3.ResolveNeighborAndCheckCache-20260616_064313.log:F0616 06:45:23.234681 1029173 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.AddPendingEntry-20260616_055753.log:F0616 06:00:03.193299 1020897 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.AddPendingRemovedEntry-20260616_061212.log:F0616 06:14:22.193331 1023274 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.LinkDownAndUpOnResolvedEntry-20260616_061658.log:F0616 06:19:08.483237 1024023 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.LinkDownOnResolvedEntry-20260616_061435.log:F0616 06:16:45.280675 1023652 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.RemoveResolvedEntry-20260616_060948.log:F0616 06:11:59.062569 1022894 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.ResolveLinkLocalEntry-20260616_060239.log:F0616 06:04:49.518522 1021799 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.ResolvePendingEntry-20260616_060016.log:F0616 06:02:26.350293 1021427 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.ResolveThenUnresolveEntry-20260616_060725.log:F0616 06:09:35.843622 1022521 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-1.UnresolveResolvedEntry-20260616_060502.log:F0616 06:07:12.676431 1022154 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.AddPendingEntry-20260616_061921.log:F0616 06:21:31.573822 1024402 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.AddPendingRemovedEntry-20260616_063340.log:F0616 06:35:50.627502 1027664 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.LinkDownAndUpOnResolvedEntry-20260616_063826.log:F0616 06:40:36.887602 1028419 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.LinkDownOnResolvedEntry-20260616_063603.log:F0616 06:38:13.785476 1028045 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.RemoveResolvedEntry-20260616_063117.log:F0616 06:33:27.493632 1027281 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.ResolveLinkLocalEntry-20260616_062407.log:F0616 06:26:17.951850 1025162 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.ResolvePendingEntry-20260616_062144.log:F0616 06:23:54.771738 1024781 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.ResolveThenUnresolveEntry-20260616_062854.log:F0616 06:31:04.300574 1026857 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
multi_switch_agent-AgentNeighborTest-3.UnresolveResolvedEntry-20260616_062630.log:F0616 06:28:41.120616 1026189 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Waiting for HwSwitch to be connected cancelled
[root@localhost AgentTxNpu0]# grep counter_get fboss_hw_agent*.log | wc -l
22
[root@localhost AgentTxNpu0]# grep counter_get fboss_hw_agent*.log
fboss_hw_agent0_AgentNeighborMetadataTest-1.ResolvePendingEntryThenChangeLookupClass_20260616_064533.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborMetadataTest-3.ResolvePendingEntryThenChangeLookupClass_20260616_064756.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborResolutionTest-1.ResolveNeighborAndCheckCache_20260616_064046.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborResolutionTest-3.ResolveNeighborAndCheckCache_20260616_064310.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.AddPendingEntry_20260616_055750.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.AddPendingRemovedEntry_20260616_061209.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.LinkDownAndUpOnResolvedEntry_20260616_061655.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.LinkDownOnResolvedEntry_20260616_061432.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.RemoveResolvedEntry_20260616_060945.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.ResolveLinkLocalEntry_20260616_060236.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.ResolvePendingEntry_20260616_060013.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.ResolveThenUnresolveEntry_20260616_060722.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-1.UnresolveResolvedEntry_20260616_060459.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.AddPendingEntry_20260616_061918.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.AddPendingRemovedEntry_20260616_063337.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.LinkDownAndUpOnResolvedEntry_20260616_063823.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.LinkDownOnResolvedEntry_20260616_063600.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.RemoveResolvedEntry_20260616_063114.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.ResolveLinkLocalEntry_20260616_062404.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.ResolvePendingEntry_20260616_062141.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.ResolveThenUnresolveEntry_20260616_062851.log:Error: counter_get() failed(Invalid unit).
fboss_hw_agent0_AgentNeighborTest-3.UnresolveResolvedEntry_20260616_062627.log:Error: counter_get() failed(Invalid unit).

```

- the log in NPU1 as below:
```
[root@localhost AgentTxNpu1]# grep 'Failed to create initial config' multi_switch_agent-AgentNeighbor*.log | wc -l
22
[root@localhost AgentTxNpu1]# grep 'Failed to create initial config' multi_switch_agent-AgentNeighbor*.log
multi_switch_agent-AgentNeighborMetadataTest-1.ResolvePendingEntryThenChangeLookupClass-20260616_065450.log:F0616 06:54:51.031995 1032552 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborMetadataTest-3.ResolvePendingEntryThenChangeLookupClass-20260616_065503.log:F0616 06:55:04.047994 1032660 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborResolutionTest-1.ResolveNeighborAndCheckCache-20260616_065424.log:F0616 06:54:25.047028 1032334 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborResolutionTest-3.ResolveNeighborAndCheckCache-20260616_065437.log:F0616 06:54:38.043907 1032442 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.AddPendingEntry-20260616_065030.log:F0616 06:50:30.629629 1030313 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.AddPendingRemovedEntry-20260616_065148.log:F0616 06:51:48.735873 1030991 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.LinkDownAndUpOnResolvedEntry-20260616_065214.log:F0616 06:52:14.840095 1031214 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.LinkDownOnResolvedEntry-20260616_065201.log:F0616 06:52:01.790691 1031102 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.RemoveResolvedEntry-20260616_065135.log:F0616 06:51:35.709753 1030880 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.ResolveLinkLocalEntry-20260616_065056.log:F0616 06:50:56.647915 1030543 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.ResolvePendingEntry-20260616_065043.log:F0616 06:50:43.637027 1030427 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.ResolveThenUnresolveEntry-20260616_065122.log:F0616 06:51:22.683048 1030766 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-1.UnresolveResolvedEntry-20260616_065109.log:F0616 06:51:09.670082 1030656 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.AddPendingEntry-20260616_065227.log:F0616 06:52:27.888059 1031325 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.AddPendingRemovedEntry-20260616_065345.log:F0616 06:53:45.988842 1031999 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.LinkDownAndUpOnResolvedEntry-20260616_065411.log:F0616 06:54:12.045974 1032222 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.LinkDownOnResolvedEntry-20260616_065358.log:F0616 06:53:59.037988 1032112 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.RemoveResolvedEntry-20260616_065332.log:F0616 06:53:32.977991 1031887 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.ResolveLinkLocalEntry-20260616_065253.log:F0616 06:52:53.881998 1031552 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.ResolvePendingEntry-20260616_065240.log:F0616 06:52:40.888103 1031437 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.ResolveThenUnresolveEntry-20260616_065319.log:F0616 06:53:19.927783 1031775 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0
multi_switch_agent-AgentNeighborTest-3.UnresolveResolvedEntry-20260616_065306.log:F0616 06:53:06.875756 1031665 AgentHwTest.cpp:66] Failed to create initial config: HwAsic not found for SwitchID: 0

```

**after fix**:
- the log in NPU0 as below:
```
[root@localhost AgentTxNpu0]# grep " OK " multi_switch_agent-AgentNeighbor*.log | wc -l
22
[root@localhost AgentTxNpu0]# grep " OK " multi_switch_agent-AgentNeighbor*.log
multi_switch_agent-AgentNeighborMetadataTest-1.ResolvePendingEntryThenChangeLookupClass-20260616_071359.log:[       OK ] AgentNeighborMetadataTest/1.ResolvePendingEntryThenChangeLookupClass (27948 ms)
multi_switch_agent-AgentNeighborMetadataTest-3.ResolvePendingEntryThenChangeLookupClass-20260616_071437.log:[       OK ] AgentNeighborMetadataTest/3.ResolvePendingEntryThenChangeLookupClass (27336 ms)
multi_switch_agent-AgentNeighborResolutionTest-1.ResolveNeighborAndCheckCache-20260616_071244.log:[       OK ] AgentNeighborResolutionTest/1.ResolveNeighborAndCheckCache (27369 ms)
multi_switch_agent-AgentNeighborResolutionTest-3.ResolveNeighborAndCheckCache-20260616_071322.log:[       OK ] AgentNeighborResolutionTest/3.ResolveNeighborAndCheckCache (27215 ms)
multi_switch_agent-AgentNeighborTest-1.AddPendingEntry-20260616_070123.log:[       OK ] AgentNeighborTest/1.AddPendingEntry (27486 ms)
multi_switch_agent-AgentNeighborTest-1.AddPendingRemovedEntry-20260616_070508.log:[       OK ] AgentNeighborTest/1.AddPendingRemovedEntry (27555 ms)
multi_switch_agent-AgentNeighborTest-1.LinkDownAndUpOnResolvedEntry-20260616_070624.log:[       OK ] AgentNeighborTest/1.LinkDownAndUpOnResolvedEntry (30630 ms)
multi_switch_agent-AgentNeighborTest-1.LinkDownOnResolvedEntry-20260616_070545.log:[       OK ] AgentNeighborTest/1.LinkDownOnResolvedEntry (28478 ms)
multi_switch_agent-AgentNeighborTest-1.RemoveResolvedEntry-20260616_070430.log:[       OK ] AgentNeighborTest/1.RemoveResolvedEntry (27333 ms)
multi_switch_agent-AgentNeighborTest-1.ResolveLinkLocalEntry-20260616_070238.log:[       OK ] AgentNeighborTest/1.ResolveLinkLocalEntry (27382 ms)
multi_switch_agent-AgentNeighborTest-1.ResolvePendingEntry-20260616_070201.log:[       OK ] AgentNeighborTest/1.ResolvePendingEntry (27292 ms)
multi_switch_agent-AgentNeighborTest-1.ResolveThenUnresolveEntry-20260616_070353.log:[       OK ] AgentNeighborTest/1.ResolveThenUnresolveEntry (27258 ms)
multi_switch_agent-AgentNeighborTest-1.UnresolveResolvedEntry-20260616_070316.log:[       OK ] AgentNeighborTest/1.UnresolveResolvedEntry (27273 ms)
multi_switch_agent-AgentNeighborTest-3.AddPendingEntry-20260616_070704.log:[       OK ] AgentNeighborTest/3.AddPendingEntry (27533 ms)
multi_switch_agent-AgentNeighborTest-3.AddPendingRemovedEntry-20260616_071048.log:[       OK ] AgentNeighborTest/3.AddPendingRemovedEntry (27350 ms)
multi_switch_agent-AgentNeighborTest-3.LinkDownAndUpOnResolvedEntry-20260616_071205.log:[       OK ] AgentNeighborTest/3.LinkDownAndUpOnResolvedEntry (29596 ms)
multi_switch_agent-AgentNeighborTest-3.LinkDownOnResolvedEntry-20260616_071126.log:[       OK ] AgentNeighborTest/3.LinkDownOnResolvedEntry (28832 ms)
multi_switch_agent-AgentNeighborTest-3.RemoveResolvedEntry-20260616_071011.log:[       OK ] AgentNeighborTest/3.RemoveResolvedEntry (27391 ms)
multi_switch_agent-AgentNeighborTest-3.ResolveLinkLocalEntry-20260616_070819.log:[       OK ] AgentNeighborTest/3.ResolveLinkLocalEntry (26577 ms)
multi_switch_agent-AgentNeighborTest-3.ResolvePendingEntry-20260616_070742.log:[       OK ] AgentNeighborTest/3.ResolvePendingEntry (26884 ms)
multi_switch_agent-AgentNeighborTest-3.ResolveThenUnresolveEntry-20260616_070933.log:[       OK ] AgentNeighborTest/3.ResolveThenUnresolveEntry (27462 ms)
multi_switch_agent-AgentNeighborTest-3.UnresolveResolvedEntry-20260616_070856.log:[       OK ] AgentNeighborTest/3.UnresolveResolvedEntry (27502 ms)

```

- the log in NPU1 as below:
```
[root@localhost AgentTxNpu1]# grep " OK " multi_switch_agent-AgentNeighbor*.log | wc -l
22
[root@localhost AgentTxNpu1]# grep " OK " multi_switch_agent-AgentNeighbor*.log
multi_switch_agent-AgentNeighborMetadataTest-1.ResolvePendingEntryThenChangeLookupClass-20260616_072755.log:[       OK ] AgentNeighborMetadataTest/1.ResolvePendingEntryThenChangeLookupClass (27831 ms)
multi_switch_agent-AgentNeighborMetadataTest-3.ResolvePendingEntryThenChangeLookupClass-20260616_072833.log:[       OK ] AgentNeighborMetadataTest/3.ResolvePendingEntryThenChangeLookupClass (27948 ms)
multi_switch_agent-AgentNeighborResolutionTest-1.ResolveNeighborAndCheckCache-20260616_072640.log:[       OK ] AgentNeighborResolutionTest/1.ResolveNeighborAndCheckCache (27262 ms)
multi_switch_agent-AgentNeighborResolutionTest-3.ResolveNeighborAndCheckCache-20260616_072718.log:[       OK ] AgentNeighborResolutionTest/3.ResolveNeighborAndCheckCache (27270 ms)
multi_switch_agent-AgentNeighborTest-1.AddPendingEntry-20260616_071516.log:[       OK ] AgentNeighborTest/1.AddPendingEntry (27296 ms)
multi_switch_agent-AgentNeighborTest-1.AddPendingRemovedEntry-20260616_071901.log:[       OK ] AgentNeighborTest/1.AddPendingRemovedEntry (27561 ms)
multi_switch_agent-AgentNeighborTest-1.LinkDownAndUpOnResolvedEntry-20260616_072018.log:[       OK ] AgentNeighborTest/1.LinkDownAndUpOnResolvedEntry (29412 ms)
multi_switch_agent-AgentNeighborTest-1.LinkDownOnResolvedEntry-20260616_071939.log:[       OK ] AgentNeighborTest/1.LinkDownOnResolvedEntry (29156 ms)
multi_switch_agent-AgentNeighborTest-1.RemoveResolvedEntry-20260616_071823.log:[       OK ] AgentNeighborTest/1.RemoveResolvedEntry (27367 ms)
multi_switch_agent-AgentNeighborTest-1.ResolveLinkLocalEntry-20260616_071631.log:[       OK ] AgentNeighborTest/1.ResolveLinkLocalEntry (27182 ms)
multi_switch_agent-AgentNeighborTest-1.ResolvePendingEntry-20260616_071554.log:[       OK ] AgentNeighborTest/1.ResolvePendingEntry (27298 ms)
multi_switch_agent-AgentNeighborTest-1.ResolveThenUnresolveEntry-20260616_071746.log:[       OK ] AgentNeighborTest/1.ResolveThenUnresolveEntry (27189 ms)
multi_switch_agent-AgentNeighborTest-1.UnresolveResolvedEntry-20260616_071708.log:[       OK ] AgentNeighborTest/1.UnresolveResolvedEntry (27718 ms)
multi_switch_agent-AgentNeighborTest-3.AddPendingEntry-20260616_072057.log:[       OK ] AgentNeighborTest/3.AddPendingEntry (27479 ms)
multi_switch_agent-AgentNeighborTest-3.AddPendingRemovedEntry-20260616_072445.log:[       OK ] AgentNeighborTest/3.AddPendingRemovedEntry (27259 ms)
multi_switch_agent-AgentNeighborTest-3.LinkDownAndUpOnResolvedEntry-20260616_072601.log:[       OK ] AgentNeighborTest/3.LinkDownAndUpOnResolvedEntry (29634 ms)
multi_switch_agent-AgentNeighborTest-3.LinkDownOnResolvedEntry-20260616_072522.log:[       OK ] AgentNeighborTest/3.LinkDownOnResolvedEntry (28465 ms)
multi_switch_agent-AgentNeighborTest-3.RemoveResolvedEntry-20260616_072406.log:[       OK ] AgentNeighborTest/3.RemoveResolvedEntry (28167 ms)
multi_switch_agent-AgentNeighborTest-3.ResolveLinkLocalEntry-20260616_072213.log:[       OK ] AgentNeighborTest/3.ResolveLinkLocalEntry (28637 ms)
multi_switch_agent-AgentNeighborTest-3.ResolvePendingEntry-20260616_072135.log:[       OK ] AgentNeighborTest/3.ResolvePendingEntry (28091 ms)
multi_switch_agent-AgentNeighborTest-3.ResolveThenUnresolveEntry-20260616_072329.log:[       OK ] AgentNeighborTest/3.ResolveThenUnresolveEntry (27207 ms)
multi_switch_agent-AgentNeighborTest-3.UnresolveResolvedEntry-20260616_072252.log:[       OK ] AgentNeighborTest/3.UnresolveResolvedEntry (27462 ms)
[root@localhost AgentTxNpu1]#

```
