### PR TITLE
[Nexthop][qsfp_service] Fix use-after-free in QsfpModule::programTransceiver

### DIFF
--- a/fboss/qsfp_service/module/QsfpModule.cpp
+++ b/fboss/qsfp_service/module/QsfpModule.cpp
@@ -1415,12 +1415,10 @@ void QsfpModule::programTransceiver(
       // Don't consider ports for programming if they have a startHostLane >=
       // the number of lanes on the plugged in transceiver.
       auto hostLaneCount = numHostLanes();
-      for (auto portIt : programTcvrState.ports) {
+      std::erase_if(programTcvrState.ports, [hostLaneCount](const auto& port) {
         // startHostLane is 0-indexed hence the >= comparison
-        if (portIt.second.startHostLane >= hostLaneCount) {
-          programTcvrState.ports.erase(portIt.first);
-        }
-      }
+        return port.second.startHostLane >= hostLaneCount;
+      });
 
       if (!cacheIsValid()) {
         throw FbossError(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

`programTransceiver` iterates over `programTcvrState.ports` (a `std::map`) and erases entries whose `startHostLane >= numHostLanes()` within a range-for loop. Erasing a node invalidates the iterator; the range-for's next `++` dereferences the freed node, causing a SIGSEGV.

The condition triggers whenever a port's configured speed doesn't match the installed optic. The module rejects programming with "Unsupported Application", which puts `startHostLane` out of range for the plugged-in transceiver's lane count.

Fix: replace the loop with `std::erase_if` (C++20), which handles iterator invalidation correctly and is already used elsewhere in the codebase.

## Test plan

Verified on hardware (wedge800b): crash loop stops, qsfp_service remains stable through repeated `programTransceiver` calls with mismatched port speeds, including the exact ports that previously triggered the SIGSEGV.
