### PR TITLE
[Arista] Config to monitor DIMM temperatures on systems with Icelake-D CPU's

### DIFF
--- a/fboss/platform/configs/blackwolf800banw/platform_manager.json
+++ b/fboss/platform/configs/blackwolf800banw/platform_manager.json
@@ -119,6 +119,10 @@
         {
           "pmUnitScopedName": "NVME_TEMP",
           "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "DIMM_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/icelake_dimm_temp.0"
         }
       ]
     },
@@ -1332,6 +1336,7 @@
     "/run/devmap/sensors/SCM_INLET": "/[SCM_INLET]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
     "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/DIMM_TEMP": "/[DIMM_TEMP]",
     "/run/devmap/fpgas/SMB_FPGA": "/SMB_SLOT@0/[SMB_FPGA]",
     "/run/devmap/fpgas/SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
     "/run/devmap/inforoms/SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
@@ -1594,11 +1599,12 @@
   "chassisEepromDevicePath": "/SMB_SLOT@0/[CHASSIS_EEPROM]",
   "numXcvrs": 68,
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.22-1",
+  "bspKmodsRpmVersion": "0.7.24-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",
     "scd",
-    "ledtrig_timer"
+    "ledtrig_timer",
+    "icelake_dimm_temp"
   ]
 }

--- a/fboss/platform/configs/blackwolf800banw/sensor_service.json
+++ b/fboss/platform/configs/blackwolf800banw/sensor_service.json
@@ -105,6 +105,26 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "DIMM1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DIMM2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/meru800bfa/platform_manager.json
+++ b/fboss/platform/configs/meru800bfa/platform_manager.json
@@ -96,6 +96,10 @@
         {
           "pmUnitScopedName": "NVME_TEMP",
           "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "DIMM_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/icelake_dimm_temp.0"
         }
       ]
     },
@@ -1155,6 +1159,7 @@
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
     "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/DIMM_TEMP": "/[DIMM_TEMP]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA0": "/SMB_SLOT@0/[SMB_FPGA0]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA1": "/SMB_SLOT@0/[SMB_FPGA1]",
     "/run/devmap/fpgas/MERU800BFA_SMB_FPGA2": "/SMB_SLOT@0/[SMB_FPGA2]",
@@ -1618,11 +1623,12 @@
   "chassisEepromDevicePath": "/SMB_SLOT@0/[IDPROM]",
   "numXcvrs": 128,
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.22-1",
+  "bspKmodsRpmVersion": "0.7.24-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",
     "scd",
-    "ledtrig_timer"
+    "ledtrig_timer",
+    "icelake_dimm_temp"
   ]
 }

--- a/fboss/platform/configs/meru800bfa/sensor_service.json
+++ b/fboss/platform/configs/meru800bfa/sensor_service.json
@@ -105,6 +105,26 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "DIMM1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DIMM2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/meru800bia/platform_manager.json
+++ b/fboss/platform/configs/meru800bia/platform_manager.json
@@ -95,6 +95,10 @@
         {
           "pmUnitScopedName": "NVME_TEMP",
           "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "DIMM_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/icelake_dimm_temp.0"
         }
       ]
     },
@@ -482,6 +486,7 @@
     "/run/devmap/sensors/CPU_MPS_PMBUS": "/[SCM_MPS_PMBUS]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
     "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/DIMM_TEMP": "/[DIMM_TEMP]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA": "/SMB_SLOT@0/[SMB_FPGA]",
     "/run/devmap/fpgas/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
     "/run/devmap/inforoms/MERU800BIA_SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
@@ -629,11 +634,12 @@
   "chassisEepromDevicePath": "/SMB_SLOT@0/[IDPROM]",
   "numXcvrs": 39,
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.22-1",
+  "bspKmodsRpmVersion": "0.7.24-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",
     "scd",
-    "ledtrig_timer"
+    "ledtrig_timer",
+    "icelake_dimm_temp"
   ]
 }

--- a/fboss/platform/configs/meru800bia/sensor_service.json
+++ b/fboss/platform/configs/meru800bia/sensor_service.json
@@ -105,6 +105,26 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "DIMM1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DIMM2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 95.0,
+            "maxAlarmVal": 85.0
+          },
+          "compute": "@/1000.0"
+        },
+        {
           "name": "SCM_ECB_VIN",
           "sysfsPath": "/run/devmap/sensors/CPU_MPS_PMBUS/in1_input",
           "type": 1,

--- a/fboss/platform/configs/saintpaul/platform_manager.json
+++ b/fboss/platform/configs/saintpaul/platform_manager.json
@@ -119,6 +119,10 @@
         {
           "pmUnitScopedName": "NVME_TEMP",
           "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "DIMM_TEMP",
+          "sysfsPath": "/sys/bus/platform/devices/icelake_dimm_temp.0"
         }
       ]
     },
@@ -991,6 +995,7 @@
     "/run/devmap/sensors/SCM_INLET": "/[SCM_INLET]",
     "/run/devmap/sensors/CPU_CORE_TEMP": "/[CPU_CORE_TEMP]",
     "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/DIMM_TEMP": "/[DIMM_TEMP]",
     "/run/devmap/fpgas/SMB_FPGA": "/SMB_SLOT@0/[SMB_FPGA]",
     "/run/devmap/fpgas/SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
     "/run/devmap/inforoms/SMB_FPGA_INFO_ROM": "/SMB_SLOT@0/[SMB_FPGA_INFO_ROM]",
@@ -1185,11 +1190,12 @@
   "chassisEepromDevicePath": "/SMB_SLOT@0/[CHASSIS_EEPROM]",
   "numXcvrs": 34,
   "bspKmodsRpmName": "arista_bsp_kmods",
-  "bspKmodsRpmVersion": "0.7.23-1",
+  "bspKmodsRpmVersion": "0.7.24-1",
   "requiredKmodsToLoad": [
     "spidev",
     "i2c_i801",
     "scd",
-    "ledtrig_timer"
+    "ledtrig_timer",
+    "icelake_dimm_temp"
   ]
 }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
This change introduces a config change to get better visibility in temperatures on DIMMs for systems with Icelake-D CPUs.

New sensor definitions make use of a recently added driver described here: https://github.com/facebookexternal/fboss.bsp.arista/pull/196

There are 2 slots on Fairywren so there are 2 sensors monitored.

# Test Plan

Verified the driver on Viper, Whistler, and BlackwolfP. Verified that the reported temperatures changed as ambient temperature changed.

On Saint Paul, the sensor definitions will be introduced by a subsequent PR. However, verified that the config changes did not affect existing functionality.