### PR TITLE
[Celestica] Leh800bcls:Fix AgentMacLearningAndNeighborResolutionTest on multi-NPU platforms by making ensureSendPacketSwitched NPU-aware

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMacLearningAndNeighborResolutionTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMacLearningAndNeighborResolutionTests.cpp
@@ -25,6 +25,7 @@
 #include "fboss/agent/test/utils/L2LearningUpdateObserverUtil.h"
 #include "fboss/agent/test/utils/MacTestUtils.h"
 #include "fboss/agent/test/utils/NeighborTestUtils.h"
+#include "fboss/agent/test/utils/PacketSendUtils.h"
 #include "fboss/agent/test/utils/PacketTestUtils.h"
 #include "fboss/lib/CommonUtils.h"
 
@@ -187,7 +188,7 @@ class AgentMacLearningAndNeighborResolutionTest
       const AgentEnsemble& ensemble) const override {
     auto switchId = getSwitchIdUnderTest(ensemble);
     auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
-    auto configPorts = allConfigPorts(ensemble);
+    auto configPorts = allConfigPorts(ensemble, switchId);
     auto inConfig = utility::oneL3IntfNPortConfig(
         ensemble.getPlatformMapping(),
         asic,
@@ -330,7 +331,9 @@ class AgentMacLearningAndNeighborResolutionTest
   std::vector<PortID> physicalPortsExcluding(PortDescriptor& port) {
     std::vector<PortID> otherPorts;
     auto portDescrPorts = physicalPortsFor(port);
-    for (auto configPort : allConfigPorts(*getAgentEnsemble())) {
+    auto ensemble = getAgentEnsemble();
+    for (auto configPort :
+         allConfigPorts(*ensemble, getSwitchIdUnderTest(*ensemble))) {
       if (std::find(portDescrPorts.begin(), portDescrPorts.end(), configPort) ==
           portDescrPorts.end()) {
         otherPorts.emplace_back(configPort);
@@ -340,8 +343,10 @@ class AgentMacLearningAndNeighborResolutionTest
   }
 
  private:
-  std::vector<PortID> allConfigPorts(const AgentEnsemble& ensemble) const {
-    auto masterLogicalPorts = ensemble.masterLogicalPortIds();
+  std::vector<PortID> allConfigPorts(
+      const AgentEnsemble& ensemble,
+      SwitchID switchId) const {
+    auto masterLogicalPorts = ensemble.masterLogicalPortIds({switchId});
     return std::vector<PortID>(
         masterLogicalPorts.begin(), masterLogicalPorts.begin() + 4);
   }
@@ -374,8 +379,19 @@ class AgentMacLearningAndNeighborResolutionTest
         8000, // l4 src port
         8001 // l4 dst port
     );
+    auto switchId = getSwitchIdUnderTest(*getAgentEnsemble());
+    auto portIds = masterLogicalPortIds();
+    auto getHwPortStats = [this](const auto& ports) {
+      return getSw()->getHwPortStats(ports);
+    };
     EXPECT_TRUE(
-        getAgentEnsemble()->ensureSendPacketSwitched(std::move(txPacket)));
+        utility::ensureSendPacketSwitched(
+            getAgentEnsemble(),
+            std::move(txPacket),
+            switchId,
+            portIds,
+            getHwPortStats,
+            2000 /* msBetweenRetry */));
   }
 
   void applyNewStateWithProtectionIfSupported(

--- a/fboss/agent/test/utils/PacketSendUtils.cpp
+++ b/fboss/agent/test/utils/PacketSendUtils.cpp
@@ -10,6 +10,7 @@
 #include "fboss/agent/test/utils/PacketSendUtils.h"
 
 #include "fboss/agent/TxPacket.h"
+#include "fboss/agent/test/AgentEnsemble.h"
 #include "fboss/agent/test/TestEnsembleIf.h"
 
 #include <folly/logging/xlog.h>
@@ -204,6 +205,22 @@ bool ensureSendPacketSwitched(
       {},
       noopGetSysPortStats,
       msBetweenRetry);
+}
+
+bool ensureSendPacketSwitched(
+    TestEnsembleIf* ensemble,
+    std::unique_ptr<TxPacket> pkt,
+    SwitchID switchId,
+    const std::vector<PortID>& portIds,
+    const HwPortStatsFunc& getHwPortStats,
+    const int msBetweenRetry) {
+  auto originalPortStats = getHwPortStats(portIds);
+  auto* agentEnsemble = dynamic_cast<AgentEnsemble*>(ensemble);
+  CHECK(agentEnsemble)
+      << "Ensemble must be an AgentEnsemble for targeted NPU packet sending";
+  agentEnsemble->getSw()->sendPacketSwitchedAsync(std::move(pkt), {switchId});
+  return waitForAnyPorAndQueutOutBytesIncrement(
+      ensemble, originalPortStats, portIds, getHwPortStats, msBetweenRetry);
 }
 
 bool ensureSendPacketOutOfPort(

--- a/fboss/agent/test/utils/PacketSendUtils.h
+++ b/fboss/agent/test/utils/PacketSendUtils.h
@@ -43,6 +43,14 @@ bool ensureSendPacketSwitched(
     const HwPortStatsFunc& getHwPortStats,
     const int msBetweenRetry = 20);
 
+bool ensureSendPacketSwitched(
+    TestEnsembleIf* ensemble,
+    std::unique_ptr<TxPacket> pkt,
+    SwitchID switchId,
+    const std::vector<PortID>& portIds,
+    const HwPortStatsFunc& getHwPortStats,
+    const int msBetweenRetry = 20);
+
 bool ensureSendPacketOutOfPort(
     TestEnsembleIf* ensemble,
     std::unique_ptr<TxPacket> pkt,


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
When the following case runs on npu1 (switch 1), it fails with the following error:
```
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentMacLearningAndNeighborResolutionTests.cpp:378: Failure
Value of: getAgentEnsemble()->ensureSendPacketSwitched(std::move(txPacket))
  Actual: false
Expected: true
```
failed cases:
``` 
AgentMacLearningAndNeighborResolutionTest/0.learnMacAndProgramNeighbors
AgentMacLearningAndNeighborResolutionTest/0.learnMacProgramNeighborsAndAgeMac
AgentMacLearningAndNeighborResolutionTest/0.learnMacProgramNeighborsAndUpdateMac
AgentMacLearningAndNeighborResolutionTest/0.flapMacAndNeighbors
AgentMacLearningAndNeighborResolutionTest/0.learnMacLinkDownNeighborResolve
AgentMacLearningAndNeighborResolutionTest/1.learnMacAndProgramNeighbors
AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndAgeMac
AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndUpdateMac
AgentMacLearningAndNeighborResolutionTest/1.flapMacAndNeighbors
AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndMove
AgentMacLearningAndNeighborResolutionTest/1.learnMacLinkDownNeighborResolve
AgentMacLearningAndNeighborResolutionTest/2.learnMacAndProgramNeighbors
AgentMacLearningAndNeighborResolutionTest/2.learnMacProgramNeighborsAndAgeMac
AgentMacLearningAndNeighborResolutionTest/2.learnMacProgramNeighborsAndUpdateMac
AgentMacLearningAndNeighborResolutionTest/2.flapMacAndNeighbors
AgentMacLearningAndNeighborResolutionTest/2.learnMacLinkDownNeighborResolve
AgentMacLearningAndNeighborResolutionTest/3.learnMacAndProgramNeighbors
AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndAgeMac
AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndUpdateMac
AgentMacLearningAndNeighborResolutionTest/3.flapMacAndNeighbors
AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndMove
AgentMacLearningAndNeighborResolutionTest/3.learnMacLinkDownNeighborResolve
```
# Root Cause
The sync packet verification helper `utility::ensureSendPacketSwitched` lacked NPU awareness. 
It invoked `ensemble->sendPacketAsync`, which called `sendPacketSwitchedAsync` on `SwSwitch` without a `SwitchID`. This triggered a
fallback in `MultiHwSwitchHandler` that always routed packets to the first available switch (switch 0).
* On switch 0 test: Packet went to switch 0, stats monitored on switch 0. Passed.
* On switch 1 test: Packet went to switch 0, stats monitored on switch 1. Failed.

# Solution
1. New Utility Overload: Added an overload of `utility::ensureSendPacketSwitched` in `PacketSendUtils` accepting `SwitchID`.
2. Explicit Routing: Downcast `TestEnsembleIf*` to `AgentEnsemble*` and directly called the NPU-safe API:
  `getSw()->sendPacketSwitchedAsync(std::move(pkt), {switchId})`, forcing the packet onto the correct NPU's pipeline.
3. Update Test: Updated `verifySentPacket` in the test suite to query the current `SwitchID` and call the new NPU-aware utility.

# Test Plan
All 22 of the above test cases passed successfully under both scenarios, where the designated switch was 0 and 1, respectively.
