### PR TITLE
[Nexthop] WEDGE800CNHP will be an alias for WEDGE800CACT

### DIFF
--- a/fboss/platform/helpers/PlatformNameLib.cpp
+++ b/fboss/platform/helpers/PlatformNameLib.cpp
@@ -44,6 +44,10 @@ std::string sanitizePlatformName(const std::string& platformNameFromBios) {
     return "MINIPACK3BA";
   }
 
+  if (platformNameUpper == "WEDGE800CNHP") {
+    return "WEDGE800CACT";
+  }
+
   return platformNameUpper;
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Wedge800CNHP and WEDGE800CACT should use the same platform code. Wedge800CNHP platform config updates will come from https://github.com/facebook/fboss/pull/1069

# Test Plan

FBOSS platform tests should run the same on both platforms.
