### PR TITLE
[arista] SAINTPAUL: Manually handle SCM eeprom

### DIFF
--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -342,7 +342,8 @@ std::optional<std::string> PlatformExplorer::getPmUnitNameFromSlot(
     if ((platformConfig_.platformName().value() == "MERU800BFA" ||
          platformConfig_.platformName().value() == "MERU800BIA" ||
          platformConfig_.platformName().value() == "ICECUBE800BANW" ||
-         platformConfig_.platformName().value() == "BLACKWOLF800BANW") &&
+         platformConfig_.platformName().value() == "BLACKWOLF800BANW" ||
+         platformConfig_.platformName().value() == "SAINTPAUL") &&
         (!(idpromConfig.busName()->starts_with("INCOMING")) &&
          *idpromConfig.address() == "0x50")) {
       // ICECUBE800BANW has SMB at root level, others have SCM
@@ -1237,7 +1238,8 @@ void PlatformExplorer::genHumanReadableEeproms() {
   // See: https://github.com/facebookexternal/fboss.bsp.arista/pull/31/files
   if ((platformConfig_.platformName().value() == "MERU800BFA" ||
        platformConfig_.platformName().value() == "MERU800BIA" ||
-       platformConfig_.platformName().value() == "BLACKWOLF800BANW") &&
+       platformConfig_.platformName().value() == "BLACKWOLF800BANW" ||
+       platformConfig_.platformName().value() == "SAINTPAUL") &&
       std::filesystem::exists("/run/devmap/eeproms/MERU_SCM_EEPROM")) {
     writeEepromContent("/[IDPROM]", "/run/devmap/eeproms/MERU_SCM_EEPROM");
   }

--- a/fboss/platform/weutil/ConfigUtils.cpp
+++ b/fboss/platform/weutil/ConfigUtils.cpp
@@ -155,7 +155,8 @@ std::unordered_map<std::string, FruEeprom> ConfigUtils::getFruEepromList() {
   // have to add it explicitly. ```
   if (config_.platformName().value() == "MERU800BFA" ||
       config_.platformName().value() == "MERU800BIA" ||
-      config_.platformName().value() == "BLACKWOLF800BANW") {
+      config_.platformName().value() == "BLACKWOLF800BANW" ||
+      config_.platformName().value() == "SAINTPAUL") {
     std::string eepromName = "SCM";
     FruEeprom fruEeprom;
     fruEeprom.path = "/run/devmap/eeproms/MERU_SCM_EEPROM";


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Manually handle SCM eeprom in platform_manager and weutil to avoid the same issues present on the SCM of other MERU platforms.

# Test Plan

platform_manager_hw_test pass
weutil_hw_test pass