### PR TITLE
[Darwin_netos] Update fan_service to control fan leds

### DIFF
--- a/fboss/platform/configs/darwin_netos/fan_service.json
+++ b/fboss/platform/configs/darwin_netos/fan_service.json
@@ -99,50 +99,65 @@
       "rpmSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_input",
       "pwmSysfsPath": "/run/devmap/sensors/FAN_CPLD/pwm1",
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan1_present",
+      "goodLedSysfsPath": "/sys/class/leds/fan1:blue:status",
+      "failLedSysfsPath": "/sys/class/leds/fan1:amber:status",
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
-      "fanMissingVal": 0
+      "fanMissingVal": 0,
+      "rpmMin": 2400
     },
     {
       "fanName": "fan_2",
       "rpmSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_input",
       "pwmSysfsPath": "/run/devmap/sensors/FAN_CPLD/pwm2",
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan2_present",
+      "goodLedSysfsPath": "/sys/class/leds/fan2:blue:status",
+      "failLedSysfsPath": "/sys/class/leds/fan2:amber:status",
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
-      "fanMissingVal": 0
+      "fanMissingVal": 0,
+      "rpmMin": 2400
     },
     {
       "fanName": "fan_3",
       "rpmSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_input",
       "pwmSysfsPath": "/run/devmap/sensors/FAN_CPLD/pwm3",
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan3_present",
+      "goodLedSysfsPath": "/sys/class/leds/fan3:blue:status",
+      "failLedSysfsPath": "/sys/class/leds/fan3:amber:status",
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
-      "fanMissingVal": 0
+      "fanMissingVal": 0,
+      "rpmMin": 2400
     },
     {
       "fanName": "fan_4",
       "rpmSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_input",
       "pwmSysfsPath": "/run/devmap/sensors/FAN_CPLD/pwm4",
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan4_present",
+      "goodLedSysfsPath": "/sys/class/leds/fan4:blue:status",
+      "failLedSysfsPath": "/sys/class/leds/fan4:amber:status",
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
-      "fanMissingVal": 0
+      "fanMissingVal": 0,
+      "rpmMin": 2400
     },
     {
       "fanName": "fan_5",
       "rpmSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_input",
       "pwmSysfsPath": "/run/devmap/sensors/FAN_CPLD/pwm5",
       "presenceSysfsPath": "/run/devmap/sensors/FAN_CPLD/fan5_present",
+      "goodLedSysfsPath": "/sys/class/leds/fan5:blue:status",
+      "failLedSysfsPath": "/sys/class/leds/fan5:amber:status",
       "pwmMin": 1,
       "pwmMax": 255,
       "fanPresentVal": 1,
-      "fanMissingVal": 0
+      "fanMissingVal": 0,
+      "rpmMin": 2400
     },
     {
       "fanName": "fan_6",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Updates the fan_service to control leds. Add rpmMin to fan configs for immediate fan failure detection.

Without rpmMin, fan_service relies solely on the 300s kFanFailThresholdInSec timeout to detect fan failure. When a fan is removed, fanRpm defaults to 0 but fanFailed stays false until 5minutes of continuous access failures elapse — leaving the LED green the entire time.

Adding rpmMin=2400 enables the immediate rpmMin check in ControlLogic.cpp: fanRpm (0) < rpmMin (2400) triggers fanFailed=true on the very next control loop cycle, bypassing the 300s delay.

The value 2400 is ~10% below the hardware minimum RPM floor of 2739, measured on rkd340 at PWM=0. This also catches degraded fans that can't maintain the CPLD's minimum speed.

# Test Plan

fan_service_hw_test PASSES
fan leds update correctly on fan insertion/removal