### PR TITLE
[Celestica] Leh800bcls: Fix AgentPortBandwidthPpsTest crash and rate verification failure on second NPU

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentPortBandWidthTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentPortBandWidthTests.cpp
@@ -48,7 +48,11 @@ class AgentPortBandwidthTest : public AgentHwTest {
     return ensemble.masterLogicalInterfacePortIds(switchID).at(0);
   }
 
-  PortID getPort0(SwitchID switchID = SwitchID(0)) const {
+  PortID getPort0() const {
+    return getPort0(getCurrentSwitchIdForTesting());
+  }
+
+  PortID getPort0(SwitchID switchID) const {
     return getPort0(*getAgentEnsemble(), switchID);
   }
 
@@ -120,12 +124,24 @@ class AgentPortBandwidthTest : public AgentHwTest {
         payload);
 
     std::optional<PortDescriptor> port{};
+    // VOQ switches (like Chenab) bypass traditional pipeline lookup on CPU tx
+    // packet, and thus require a targeted port descriptor for packet injection.
     if (getHwAsic()->getAsicVendor() ==
         HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
       port = PortDescriptor(getPort0());
+      getAgentEnsemble()->sendPacketAsync(
+          std::move(txPacket), port, std::nullopt);
+    } else {
+      // In multi-switch (multi-NPU) configurations, calling sendPacketAsync
+      // without a port descriptor would trigger the MultiHwSwitchHandler
+      // fallback, which silently routes switched packets to SwitchID(0).
+      //
+      // To ensure test traffic is correctly routed to the actual NPU under test
+      // (e.g., SwitchID(1) during npu1 tests), we must call the base class
+      // sendPacketSwitchedAsync helper, which automatically resolves and
+      // targets the correct active SwitchID.
+      sendPacketSwitchedAsync(std::move(txPacket));
     }
-    getAgentEnsemble()->sendPacketAsync(
-        std::move(txPacket), port, std::nullopt);
   }
 
   void sendUdpPkts(uint8_t dscpVal, int cnt = 256, int payloadLen = 0) {


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
Both cases AgentPortBandwidthPpsTest.VerifyPps and AgentPortBandwidthPpsTest.VerifyPpsDynamicChanges in the agent test failed on the following log during the switch1 test.
```
C++ exception with description "vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)" thrown in the test body.
```

# Root Cause
1. Range Check Crash during `getPort0()` resolution:
    The test helper `getPort0()` defaulted to a hardcoded `SwitchID(0)`:
```
PortID getPort0(SwitchID switchID = SwitchID(0))
```

In the single-switch test runner context for `switch1` (e.g., `hw_agent_test_1`), the active config contains only ports belonging to `switch1`. Thus, calling `ensemble.masterLogicalInterfacePortIds(SwitchID(0))` returned an empty vector. Invoking `.at(0)` on this empty vector triggered the `vector::_M_range_check` exception, crashing the test body.

2. Rate Verification Failure due to single-switch routing fallback:
    During traffic generation, `sendUdpPkt()` called `getAgentEnsemble()->sendPacketAsync` with a null port descriptor (for non-Chenab platforms like TH6). This routed traffic to `getSw()->sendPacketSwitchedAsync()`.
    In multi-NPU setups, invoking `sendPacketSwitchedAsync` without a specified target SwitchID triggers the single-switch fallback logic inside `MultiHwSwitchHandler`, which silently routes all switched packets to `switch0`. As a result, the actual NPU under test (`switch1`) received zero traffic, causing the PPS validation to fail.

# Solution
1. Dynamic SwitchID Resolution:
   Updated the no-argument overload of `getPort0()` in `AgentPortBandWidthTests.cpp` to dynamically fetch the active target switch via `getCurrentSwitchIdForTesting()` instead of defaulting to a hardcoded `SwitchID(0)`.

2. Switch-Aware Packet Injection:
   Refactored the switched packet path in `sendUdpPkt()`. If no explicit physical port injection is required (non-Chenab), it now invokes the base class `sendPacketSwitchedAsync(std::move(txPacket))` helper. This helper automatically resolves the target switch ID under test and explicitly appends it to the call, bypassing the default single-switch fallback and routing traffic correctly.

# Test Plan
Successfully ran and passed the entire `AgentPortBandwidthPpsTest` test suite locally on both NPUs:
- `AgentPortBandwidthPpsTest.VerifyPps` on `npu0`: Pass 
- `AgentPortBandwidthPpsTest.VerifyPps` on `npu1`: Pass
- `AgentPortBandwidthPpsTest.VerifyPpsDynamicChanges` on `npu0`: Pass
- `AgentPortBandwidthPpsTest.VerifyPpsDynamicChanges` on `npu1`: Pass
