### PR TITLE
[Nexthop] [distro] Alias local_rpm_repo to kernel

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/root_files/etc/yum.repos.d/local_rpm_repo.repo
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/etc/yum.repos.d/local_rpm_repo.repo
@@ -4,3 +4,11 @@ baseurl=file:///usr/local/share/local_rpm_repo
 gpgcheck=0
 metadata_expire=6h
 enabled=1
+
+# Platform Manager explictly uses the 'kernel' repo for BSPs, satisfy with a local repo alias
+[kernel]
+name=Local Platform RPM repo (kernel alias)
+baseurl=file:///usr/local/share/local_rpm_repo
+gpgcheck=0
+metadata_expire=6h
+enabled=1


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Previously Platform Manager would attempt to load the BSPs from an explicitly named 'kernel' RPM repo, then fallback to using all repos. This was changed in 4aa09682ce4ba86ee305010178ad6b89513cc2d5 to only ever query the 'kernel' repo.

Distro images don't have a 'kernel' repo so loading the BSP RPM(s) would fail like so:
```
[root@dut ~]# systemctl status platform_manager.service
× platform_manager.service - FBOSS Platform Manager
     Loaded: loaded (/usr/lib/systemd/system/platform_manager.service; enabled; preset: disabled)
     Active: failed (Result: core-dump) since Fri 2026-06-12 16:54:06 UTC; 8min ago
    Process: 1523 ExecStart=/bin/bash -c source /opt/fboss/bin/setup_fboss_env && exec /opt/fboss/bin/platform_manager --run_once=false --thrift_ssl_policy=disabled (code=dumped, signal=ABRT)
   Main PID: 1523 (code=dumped, signal=ABRT)

Jun 12 17:02:09 dut systemd[1]: Failed to start FBOSS Platform Manager.
Jun 12 17:02:12 dut systemd[1]: platform_manager.service: Start request repeated too quickly.
Jun 12 17:02:12 dut systemd[1]: platform_manager.service: Failed with result 'core-dump'.
Jun 12 17:02:12 dut systemd[1]: Failed to start FBOSS Platform Manager.
Jun 12 17:02:14 dut systemd[1]: platform_manager.service: Start request repeated too quickly.
Jun 12 17:02:14 dut systemd[1]: platform_manager.service: Failed with result 'core-dump'.
Jun 12 17:02:14 dut systemd[1]: Failed to start FBOSS Platform Manager.
Jun 12 17:02:16 dut systemd[1]: platform_manager.service: Start request repeated too quickly.
Jun 12 17:02:16 dut systemd[1]: platform_manager.service: Failed with result 'core-dump'.
Jun 12 17:02:16 dut systemd[1]: Failed to start FBOSS Platform Manager.
[root@dut ~]# cd /opt/fboss/
[root@dut fboss]# source /opt/fboss/bin/setup_fboss_env && /opt/fboss/bin/platform_manager --run_once=false --thrift_ssl_policy=disabled
I0612 17:02:58.610355  4414 PlatformNameLib.cpp:80] Getting platform name from bios using dmidecode ...
I0612 17:02:58.612698  4414 PlatformNameLib.cpp:90] Platform name inferred from bios: NH-4010-F
I0612 17:02:58.612715  4414 PlatformNameLib.cpp:92] Platform name mapped: NH4010F
I0612 17:02:58.616100  4414 ConfigValidator.cpp:920] Validating platform_manager config
I0612 17:02:58.639423  4414 ConfigValidator.cpp:971] Validating SlotTypeConfig for Slot SCM_SLOT...
I0612 17:02:58.639431  4414 ConfigValidator.cpp:971] Validating SlotTypeConfig for Slot SMB_SLOT...
I0612 17:02:58.639435  4414 ConfigValidator.cpp:1018] Validating PmUnitConfig for PmUnit SCM in Slot SCM_SLOT...
I0612 17:02:58.640077  4414 ConfigValidator.cpp:1018] Validating PmUnitConfig for PmUnit SMB in Slot SMB_SLOT...
I0612 17:02:58.662190  4414 ConfigValidator.cpp:1069] Validating Symbolic links...
I0612 17:02:58.662586  4414 ConfigValidator.cpp:1079] Validating Transceiver symbolic links...
I0612 17:02:58.662644  4414 ConfigValidator.cpp:1094] Validating xcvr LED coverage...
I0612 17:02:58.662653  4414 ConfigValidator.cpp:1099] Validating xcvr ctrl coverage...
E0612 17:02:58.662760  4414 PlatformFsUtils.cpp:144] Received error code 2 from reading from path /run/devmap/metadata/config_hash: No such file or directory
I0612 17:02:58.662765  4414 ConfigUtils.cpp:98] No stored config hash found, can't determine if config has changed
Error: No matching Packages to list
I0612 17:02:58.842154  4414 PkgManager.cpp:217] BSP Kmods nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1 is not installed
E0612 17:02:58.842197  4414 PlatformFsUtils.cpp:144] Received error code 2 from reading from path /usr/local/nexthop_bsp/6.11.1-1.fboss.el9.x86_64/kmods.json: No such file or directory
W0612 17:02:58.927485  4414 PkgManager.cpp:396] Skipping BSP kmods unloading. Reason: /usr/local/nexthop_bsp/6.11.1-1.fboss.el9.x86_64/kmods.json doesn't exist; most likely because this is the first RPM installation.
I0612 17:02:59.012305  4414 PkgManager.cpp:470] Skipping removing old rpms. Reason: No rpms installed.
I0612 17:02:59.012329  4414 PkgManager.cpp:269] Installing BSP nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1, Attempt #0
Error: Unknown repo: 'kernel'
I0612 17:02:59.150860  4414 PkgManager.cpp:269] Installing BSP nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1, Attempt #1
Error: Unknown repo: 'kernel'
I0612 17:02:59.289882  4414 PkgManager.cpp:269] Installing BSP nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1, Attempt #2
Error: Unknown repo: 'kernel'
I0612 17:02:59.431552  4414 PlatformNameLib.cpp:104] Platform name read from cache: NH4010F
E0612 17:02:59.431591  4414 StructuredLogger.cpp:73] FBOSS_ALERT Failed to install rpm (nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1) with exit code 1 <event:unexpected_crash> <service:platform_manager> <platform:NH4010F>
F0612 17:02:59.431610  4414 Main.cpp:145] Platform Manager crashed with unexpected exception: Failed to install rpm (nexthop_bsp_kmods-6.11.1-1.fboss.el9.x86_64-1.0.0-1) with exit code 1
```

Rather than rename the local_rpm_repo to the incorrect name 'kernel' or pollute the production Platform Manager code with OSS-specific code, alias the local_rpm_repo in Distro Image to 'kernel' to satisfy this need.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Modified a Distro image and loaded on a dut, confirmed that platform manager successfully:
```
[root@dut ~]# systemctl status platform_manager.service
● platform_manager.service - FBOSS Platform Manager
     Loaded: loaded (/usr/lib/systemd/system/platform_manager.service; enabled; preset: disabled)
     Active: active (running) since Fri 2026-06-12 17:41:07 UTC; 22s ago
   Main PID: 876 (platform_manage)
      Tasks: 28 (limit: 203230)
     CGroup: /system.slice/platform_manager.service
             └─876 /opt/fboss/bin/platform_manager --run_once=false --thrift_ssl_policy=disabled

Jun 12 17:41:00 localhost systemd[1]: Starting FBOSS Platform Manager...
Jun 12 17:41:07 dut systemd[1]: Started FBOSS Platform Manager.
```