### PR TITLE
fboss2: zero-pad fractional seconds in parseTimeToTimeStamp

### DIFF
--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
@@ -227,9 +227,9 @@ const std::string parseTimeToTimeStamp(const long& timeToParse) {
   //      2021-10-27 00:00:06 PDT -> 2021-10-27 00:00:06.475 PDT
   int index = formattedTime.find_last_of(' ');
   return fmt::format(
-      "{}.{} {}",
+      "{}.{:03d} {}",
       formattedTime.substr(0, index), // Date and time
-      splitTime.tv_usec, // fractional seconds
+      splitTime.tv_usec, // fractional seconds (milliseconds, zero-padded)
       formattedTime.substr(index + 1)); // timezone
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`parseTimeToTimeStamp` in `fboss/cli/fboss2/utils/CmdUtilsCommon.cpp` formats the millisecond remainder (`timer % 1000`) of a timestamp using `"{}"`. Because the value isn't zero-padded, any fraction below 100 ms is rendered with too few digits.

For example, a timer of `6005` ms (6 seconds + 5 ms) rendered as:

```
2021-10-27 00:00:06.5 PDT
```

instead of the correct:

```
2021-10-27 00:00:06.005 PDT
```

This change uses `"{:03d}"` to zero-pad the millisecond fraction to 3 digits.

# Test Plan

- `pre-commit run --files fboss/cli/fboss2/utils/CmdUtilsCommon.cpp` -> `clang-format ... Passed`, all hooks pass.
- Formatting behavior:
  - `timer = 6475` -> `...:06.475` (unchanged, already correct)
  - `timer = 6005` -> `...:06.005` (previously `...:06.5`)
  - `timer = 6000` -> `...:06.000` (previously `...:06.0`)