### PR TITLE
fboss2: guard against unset USER env var in getUnixname

### DIFF
--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
@@ -248,7 +248,8 @@ std::string getUserInfo() {
 
 std::string getUnixname() {
   auto envuser = getenv("USER");
-  if (strcmp(envuser, "root") != 0 && strcmp(envuser, "netops") != 0) {
+  if (envuser && *envuser && strcmp(envuser, "root") != 0 &&
+      strcmp(envuser, "netops") != 0) {
     return envuser;
   }
   // Last resort get unixname from user input


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`getUnixname()` in `fboss/cli/fboss2/utils/CmdUtilsCommon.cpp` calls `getenv("USER")` and passes the result directly to `strcmp()`:

```cpp
auto envuser = getenv("USER");
if (strcmp(envuser, "root") != 0 && strcmp(envuser, "netops") != 0) {
```

`getenv` returns `nullptr` when the variable is not set, so `strcmp(nullptr, ...)` is a null-pointer dereference and crashes the CLI. This is inconsistent with `getUserInfo()` directly above, which already null-checks the result of `getenv`.

This change guards for `nullptr` and empty string before the `strcmp` calls. An unset or empty `USER` now falls through to the existing interactive prompt instead of crashing.

# Test Plan

- `pre-commit run --files fboss/cli/fboss2/utils/CmdUtilsCommon.cpp` -> `clang-format ... Passed`, all hooks pass.
- Behavior:
  - `USER=alice` -> returns `alice` (unchanged)
  - `USER=root` -> falls through to interactive prompt (unchanged)
  - `USER` unset / empty -> falls through to interactive prompt (previously crashed)