### PR TITLE
fboss2: remove no-op lrint in splitFractionalSecondsFromTimer

### DIFF
--- a/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
+++ b/fboss/cli/fboss2/utils/CmdUtilsCommon.cpp
@@ -198,9 +198,7 @@ const std::string getPrettyElapsedTime(const int64_t& start_time) {
 timeval splitFractionalSecondsFromTimer(const long& timer) {
   struct timeval tv;
   tv.tv_sec = timer / 1000; // get total amount of seconds
-  tv.tv_usec = (timer % 1000); // get fractional seconds
-
-  tv.tv_usec = lrint(tv.tv_usec); // round fs to nearest decimal
+  tv.tv_usec = (timer % 1000); // get fractional milliseconds
   return tv;
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

In `splitFractionalSecondsFromTimer` (`fboss/cli/fboss2/utils/CmdUtilsCommon.cpp`):

```cpp
tv.tv_usec = (timer % 1000); // get fractional seconds
tv.tv_usec = lrint(tv.tv_usec); // round fs to nearest decimal
```

`tv.tv_usec` is a `long` that was just assigned the integer result of `timer % 1000`. Calling `lrint()` on an already-integral value is a no-op, and the "round fs to nearest decimal" comment is misleading -- there is nothing fractional to round.

This change removes the dead line and corrects the comment to note the value is milliseconds (it is the `timer % 1000` remainder, not microseconds despite the `tv_usec` field name).

# Test Plan

Pure cleanup with no behavioral change.

- `pre-commit run --files fboss/cli/fboss2/utils/CmdUtilsCommon.cpp` -> `clang-format ... Passed`, all hooks pass.
- Behavior unchanged: `timer = 6475` still yields `{tv_sec = 6, tv_usec = 475}`, which `parseTimeToTimeStamp` continues to render identically.