### PR TITLE
[Nexthop][fboss2-dev] Add fboss2-dev config arp proactive subcommand

### DIFF
--- a/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
+++ b/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
@@ -15,11 +15,13 @@
 #include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/String.h>
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <iostream>
-#include <set>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include "fboss/cli/fboss2/gen-cpp2/cli_metadata_types.h"
@@ -33,17 +35,62 @@ constexpr std::string_view kAttrTimeout = "timeout";
 constexpr std::string_view kAttrAgeInterval = "age-interval";
 constexpr std::string_view kAttrMaxProbes = "max-probes";
 constexpr std::string_view kAttrStaleInterval = "stale-interval";
+constexpr std::string_view kAttrProactive = "proactive";
 /* arpRefreshSeconds is defined in switch_config.thrift yet not implemented
 constexpr std::string_view kAttrRefresh = "refresh";
 */
 
+// Accepted values for the boolean `proactive` toggle.
+constexpr std::string_view kProactiveEnabled = "enabled";
+constexpr std::string_view kProactiveDisabled = "disabled";
+
 // Valid ARP/NDP attribute names accepted by `fboss2-dev config arp <attr>`.
-const std::set<std::string_view> kArpValidAttrs = {
-    kAttrTimeout,
+// Boolean attrs (kAttrProactive) are parsed in the kAttrProactive branch of
+// ArpConfigArgs(); add any new boolean attr there and in applyArpConfig() too.
+// Alphabetical order so folly::join produces a stable, sorted error message.
+constexpr auto kArpValidAttrs = std::to_array<std::string_view>({
     kAttrAgeInterval,
     kAttrMaxProbes,
+    kAttrProactive,
     kAttrStaleInterval,
-};
+    kAttrTimeout,
+});
+
+std::string applyArpConfig(
+    const ArpConfigArgs& args,
+    cfg::SwitchConfig& swConfig) {
+  if (args.getAttribute() == kAttrProactive) {
+    const auto val = args.getBoolValue();
+    // NOTE: proactiveArp is declared in switch_config.thrift but is not yet
+    // consumed by the agent (no read in ApplyThriftConfig.cpp, no field in
+    // switch_state.thrift). Writing it produces a valid config delta but has
+    // no runtime effect today; the CLI is wired ahead of the agent support.
+    // TODO: when agent support lands, verify HITLESS is still appropriate or
+    // change to WARMBOOT if the agent requires a restart to apply the field.
+    swConfig.proactiveArp() = val;
+    return fmt::format(
+        "Set arp {} to {} (stored in config; no runtime effect until agent support lands)",
+        kAttrProactive,
+        val ? kProactiveEnabled : kProactiveDisabled);
+  }
+
+  const auto& attr = args.getAttribute();
+  const int32_t val = args.getValue();
+  if (attr == kAttrTimeout) {
+    swConfig.arpTimeoutSeconds() = val;
+  } else if (attr == kAttrAgeInterval) {
+    swConfig.arpAgerInterval() = val;
+  } else if (attr == kAttrMaxProbes) {
+    swConfig.maxNeighborProbes() = val;
+  } else if (attr == kAttrStaleInterval) {
+    swConfig.staleEntryInterval() = val;
+  } else {
+    // ArpConfigArgs validates this; defensive guard in case kArpValidAttrs
+    // drifts from the dispatch switch here.
+    throw std::runtime_error(fmt::format("Unhandled ARP attribute '{}'", attr));
+  }
+  return fmt::format("Set arp {} to {}", attr, val);
+}
 } // namespace
 
 ArpConfigArgs::ArpConfigArgs(std::vector<std::string> v) {
@@ -55,7 +102,8 @@ ArpConfigArgs::ArpConfigArgs(std::vector<std::string> v) {
             folly::join(", ", kArpValidAttrs)));
   }
 
-  if (kArpValidAttrs.find(v[0]) == kArpValidAttrs.end()) {
+  if (std::find(kArpValidAttrs.begin(), kArpValidAttrs.end(), v[0]) ==
+      kArpValidAttrs.end()) {
     throw std::invalid_argument(
         fmt::format(
             "Unknown ARP attribute '{}'. Valid attrs: {}",
@@ -63,22 +111,36 @@ ArpConfigArgs::ArpConfigArgs(std::vector<std::string> v) {
             folly::join(", ", kArpValidAttrs)));
   }
 
-  int32_t parsed = 0;
-  try {
-    parsed = folly::to<int32_t>(v[1]);
-  } catch (const folly::ConversionError&) {
-    throw std::invalid_argument(
-        fmt::format("Value for '{}' must be an integer, got '{}'", v[0], v[1]));
-  }
-
-  if (parsed < 0) {
-    throw std::invalid_argument(
-        fmt::format(
-            "Value for '{}' must be non-negative, got {}", v[0], parsed));
+  if (v[0] == kAttrProactive) {
+    if (v[1] != kProactiveEnabled && v[1] != kProactiveDisabled) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Value for '{}' must be '{}' or '{}', got '{}'",
+              v[0],
+              kProactiveEnabled,
+              kProactiveDisabled,
+              v[1]));
+    }
+    attrKind_ = AttrKind::kBoolean;
+    boolValue_ = (v[1] == kProactiveEnabled);
+  } else {
+    int32_t parsed = 0;
+    try {
+      parsed = folly::to<int32_t>(v[1]);
+    } catch (const folly::ConversionError&) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Value for '{}' must be an integer, got '{}'", v[0], v[1]));
+    }
+    if (parsed < 0) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Value for '{}' must be non-negative, got {}", v[0], parsed));
+    }
+    value_ = parsed;
   }
 
   attribute_ = v[0];
-  value_ = parsed;
   data_ = std::move(v);
 }
 
@@ -86,31 +148,16 @@ CmdConfigArpTraits::RetType CmdConfigArp::queryClient(
     const HostInfo& /* hostInfo */,
     const ObjectArgType& args) {
   auto& session = ConfigSession::getInstance();
-  auto& config = session.getAgentConfig();
-  auto& swConfig = *config.sw();
+  auto& swConfig = *session.getAgentConfig().sw();
 
-  const auto& attr = args.getAttribute();
-  int32_t value = args.getValue();
+  auto result = applyArpConfig(args, swConfig);
 
-  if (attr == kAttrTimeout) {
-    swConfig.arpTimeoutSeconds() = value;
-  } else if (attr == kAttrAgeInterval) {
-    swConfig.arpAgerInterval() = value;
-  } else if (attr == kAttrMaxProbes) {
-    swConfig.maxNeighborProbes() = value;
-  } else if (attr == kAttrStaleInterval) {
-    swConfig.staleEntryInterval() = value;
-  } else {
-    // ArpConfigArgs validates this; defensive guard in case kArpValidAttrs
-    // drifts from the dispatch switch here.
-    throw std::runtime_error(fmt::format("Unhandled ARP attribute '{}'", attr));
-  }
-
-  // All ARP/NDP timer attributes are applied hitlessly by
+  // The ARP/NDP timer attributes are applied hitlessly by
   // ThriftConfigApplier::updateSwitchSettings (no SAI ChangeProhibited guard).
+  // proactiveArp is currently a no-op in the agent, so persisting it is also
+  // hitless.
   session.saveConfig(cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
-
-  return fmt::format("Set arp {} to {}", attr, value);
+  return result;
 }
 
 void CmdConfigArp::printOutput(const RetType& logMsg) {

--- a/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
+++ b/fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
@@ -10,7 +10,9 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <cstdint>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include "fboss/cli/fboss2/CmdHandler.h"
@@ -20,10 +22,16 @@
 namespace facebook::fboss {
 
 // Argument for `config arp <attr> <value>`.
-// Validates that v[0] is one of the valid ARP attribute names and v[1] is a
-// non-negative int32.
+// Validates that v[0] is one of the valid ARP attribute names. The accepted
+// shape of v[1] depends on the attribute:
+//   - the timer attributes (timeout, age-interval, max-probes,
+//     stale-interval) take a non-negative int32, exposed via getValue().
+//   - the boolean toggle (proactive) takes "enabled" / "disabled", exposed
+//     via getBoolValue().
 class ArpConfigArgs : public utils::BaseObjectArgType<std::string> {
  public:
+  enum class AttrKind { kInteger, kBoolean };
+
   /* implicit */ ArpConfigArgs( // NOLINT(google-explicit-constructor)
       std::vector<std::string> v);
 
@@ -31,13 +39,35 @@ class ArpConfigArgs : public utils::BaseObjectArgType<std::string> {
     return attribute_;
   }
 
+  // Valid only when attrKind_ == kInteger; throws std::logic_error otherwise.
+  // For the boolean toggle use getBoolValue().
   int32_t getValue() const {
+    if (attrKind_ == AttrKind::kBoolean) {
+      throw std::logic_error(
+          fmt::format(
+              "getValue() called on boolean attr '{}'; use getBoolValue()",
+              attribute_));
+    }
     return value_;
+  }
+
+  // Valid only when attrKind_ == kBoolean; throws std::logic_error otherwise.
+  // For integer attrs use getValue().
+  bool getBoolValue() const {
+    if (attrKind_ != AttrKind::kBoolean) {
+      throw std::logic_error(
+          fmt::format(
+              "getBoolValue() called on non-boolean attr '{}'; use getValue()",
+              attribute_));
+    }
+    return boolValue_;
   }
 
  private:
   std::string attribute_;
+  AttrKind attrKind_{AttrKind::kInteger};
   int32_t value_ = 0;
+  bool boolValue_ = false;
 };
 
 struct CmdConfigArpTraits : public WriteCommandTraits {
@@ -45,8 +75,11 @@ struct CmdConfigArpTraits : public WriteCommandTraits {
     cmd.add_option(
         "arp_attr_value",
         args,
+        // Keep "enabled"/"disabled" in sync with
+        // kProactiveEnabled/kProactiveDisabled in CmdConfigArp.cpp.
         "<attr> <value> where <attr> is one of: "
-        "timeout, age-interval, max-probes, stale-interval");
+        "age-interval, max-probes, proactive, stale-interval, timeout. "
+        "proactive takes enabled|disabled; all others take a non-negative integer.");
   }
   using ObjectArgType = ArpConfigArgs;
   using RetType = std::string;

--- a/fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
@@ -32,7 +32,8 @@ class CmdConfigArpTestFixture : public CmdConfigTestBase {
     "arpTimeoutSeconds": 60,
     "arpAgerInterval": 5,
     "maxNeighborProbes": 300,
-    "staleEntryInterval": 10
+    "staleEntryInterval": 10,
+    "proactiveArp": false
   }
 })") {}
 
@@ -60,6 +61,30 @@ TEST_F(CmdConfigArpTestFixture, argValidation_valid) {
   ArpConfigArgs d({"stale-interval", "0"});
   EXPECT_EQ(d.getAttribute(), "stale-interval");
   EXPECT_EQ(d.getValue(), 0);
+}
+
+TEST_F(CmdConfigArpTestFixture, argValidation_proactive) {
+  ArpConfigArgs enabled({"proactive", "enabled"});
+  EXPECT_EQ(enabled.getAttribute(), "proactive");
+  EXPECT_TRUE(enabled.getBoolValue());
+
+  ArpConfigArgs disabled({"proactive", "disabled"});
+  EXPECT_EQ(disabled.getAttribute(), "proactive");
+  EXPECT_FALSE(disabled.getBoolValue());
+
+  // proactive only accepts enabled/disabled, not integers or other tokens.
+  EXPECT_THROW(ArpConfigArgs({"proactive", "1"}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"proactive", "true"}), std::invalid_argument);
+  EXPECT_THROW(ArpConfigArgs({"proactive", "Enabled"}), std::invalid_argument);
+  // Case-sensitive and bounded: timer attrs still reject enabled/disabled.
+  EXPECT_THROW(ArpConfigArgs({"timeout", "enabled"}), std::invalid_argument);
+
+  // Cross-kind accessor guards: getValue() on boolean attr throws, and vice
+  // versa.
+  EXPECT_THROW(
+      ArpConfigArgs({"proactive", "enabled"}).getValue(), std::logic_error);
+  EXPECT_THROW(
+      ArpConfigArgs({"timeout", "45"}).getBoolValue(), std::logic_error);
 }
 
 TEST_F(CmdConfigArpTestFixture, argValidation_badArity) {
@@ -146,6 +171,30 @@ TEST_F(CmdConfigArpTestFixture, setStaleInterval) {
 
   auto& config = ConfigSession::getInstance().getAgentConfig();
   EXPECT_EQ(*config.sw()->staleEntryInterval(), 15);
+}
+
+TEST_F(CmdConfigArpTestFixture, setProactive) {
+  // Seed has proactiveArp=false; flip it on then off.
+  setupTestableConfigSession(cmdPrefix_, "proactive enabled");
+  CmdConfigArp cmd;
+  HostInfo hostInfo("testhost");
+
+  auto onResult =
+      cmd.queryClient(hostInfo, ArpConfigArgs({"proactive", "enabled"}));
+  EXPECT_THAT(onResult, HasSubstr("proactive"));
+  EXPECT_THAT(onResult, HasSubstr("enabled"));
+  {
+    auto& config = ConfigSession::getInstance().getAgentConfig();
+    EXPECT_TRUE(*config.sw()->proactiveArp());
+  }
+
+  auto offResult =
+      cmd.queryClient(hostInfo, ArpConfigArgs({"proactive", "disabled"}));
+  EXPECT_THAT(offResult, HasSubstr("disabled"));
+  {
+    auto& config = ConfigSession::getInstance().getAgentConfig();
+    EXPECT_FALSE(*config.sw()->proactiveArp());
+  }
 }
 
 TEST_F(CmdConfigArpTestFixture, idempotentSameValue) {

--- a/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
@@ -3,20 +3,29 @@
 /**
  * End-to-end tests for `fboss2-dev config arp <attr> <value>` commands.
  *
- * Covers the 4 hitless ARP/NDP tunables. Each `<attr>` maps to one
- * `cfg::SwitchConfig.sw.<field>` and one `switchSettings.<field>`:
- *   - timeout        -> arpTimeoutSeconds  / arpTimeout
- *   - age-interval   -> arpAgerInterval    / arpAgerInterval
- *   - max-probes     -> maxNeighborProbes  / maxNeighborProbes
- *   - stale-interval -> staleEntryInterval / staleEntryInterval
+ * Covers the 4 hitless ARP/NDP tunables:
+ *   - timeout         -> arpTimeoutSeconds
+ *   - age-interval    -> arpAgerInterval
+ *   - max-probes      -> maxNeighborProbes
+ *   - stale-interval  -> staleEntryInterval
+ * and the boolean toggle:
+ *   - proactive       -> proactiveArp (enabled|disabled)
  *
- * For each attribute, the test:
- *   1. Reads the current value from the agent's running config + switch state
- *   2. Sets a new value via `config arp <attr> <new>`
- *   3. Commits the session (HITLESS — no agent restart)
- *   4. Verifies the running config reflects the new value
- *   5. Verifies the agent's programmed switch state reflects the new value
- *   6. Restores the original value
+ * NOTE: proactiveArp is not yet consumed by the agent, so the proactive test
+ * only proves the value round-trips through the config (set -> commit -> read
+ * back), not that proactive ARP behavior changes.
+ *
+ * For integer attributes (timeout, age-interval, max-probes, stale-interval)
+ * the test runs 6 steps:
+ *   1. Read current value from running config + switch state
+ *   2. Set a new value via `config arp <attr> <new>`
+ *   3. Commit (HITLESS — no agent restart)
+ *   4. Verify running config reflects the new value
+ *   5. Verify agent switch state reflects the new value
+ *   6. Restore original value
+ *
+ * For the boolean toggle (proactive), step 5 is omitted because proactiveArp
+ * is not yet reflected in switch_state.thrift.
  *
  * Requirements:
  *   - FBOSS agent is running with a valid configuration
@@ -43,11 +52,15 @@ class ConfigArpTest : public Fboss2IntegrationTest {
     XLOG(INFO) << "  arp " << attr << " -> " << newValue;
     XLOG(INFO) << "========================================";
 
-    int64_t originalValue = getSwConfigField<int64_t>(swField);
+    auto originalValue = getSwConfigField<int64_t>(swField);
     XLOG(INFO) << "[Step 1] Original " << swField << " = " << originalValue;
-    ASSERT_NE(originalValue, newValue)
+    // Use EXPECT (not ASSERT) so the restore step still runs even if the DUT
+    // already has newValue from a prior crashed run. ASSERT would abort here
+    // and leave the DUT permanently in the modified state.
+    EXPECT_NE(originalValue, newValue)
         << "Test value " << newValue << " must differ from original "
-        << originalValue;
+        << originalValue << "; DUT may have been left in modified state by a "
+        << "prior crashed run — restore manually if this test keeps failing";
 
     XLOG(INFO) << "[Step 2] Running: config arp " << attr << " " << newValue;
     auto result = runCli({"config", "arp", attr, std::to_string(newValue)});
@@ -93,4 +106,36 @@ TEST_F(ConfigArpTest, SetMaxProbes) {
 TEST_F(ConfigArpTest, SetStaleInterval) {
   setAndVerify(
       "stale-interval", "staleEntryInterval", "staleEntryInterval", 15);
+}
+
+TEST_F(ConfigArpTest, SetProactive) {
+  // proactiveArp has thrift default=false and is not yet consumed by the
+  // agent; this test only proves the value round-trips through the config.
+  // The field is absent from the running config until first written, so use
+  // the two-arg overload with a default.
+  bool original = getSwConfigField<bool>("proactiveArp", false);
+  std::string target = original ? "disabled" : "enabled";
+  bool targetBool = !original;
+  XLOG(INFO) << "[Step 1] Original proactiveArp = " << original;
+
+  XLOG(INFO) << "[Step 2] Running: config arp proactive " << target;
+  auto result = runCli({"config", "arp", "proactive", target});
+  ASSERT_EQ(result.exitCode, 0)
+      << "stdout=" << result.stdout << " stderr=" << result.stderr;
+  EXPECT_THAT(result.stdout, HasSubstr("proactive"));
+
+  XLOG(INFO) << "[Step 3] Committing (expect HITLESS, no restart)...";
+  commitConfig();
+
+  XLOG(INFO) << "[Step 4] Verifying running config...";
+  EXPECT_EQ(getSwConfigField<bool>("proactiveArp", !targetBool), targetBool);
+
+  XLOG(INFO) << "[Step 5] Restoring original value " << original;
+  result =
+      runCli({"config", "arp", "proactive", original ? "enabled" : "disabled"});
+  ASSERT_EQ(result.exitCode, 0) << result.stderr;
+  commitConfig();
+  // Use !original as default so an absent field returns the wrong value and
+  // the assertion fails, rather than passing vacuously.
+  EXPECT_EQ(getSwConfigField<bool>("proactiveArp", !original), original);
 }

--- a/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h
+++ b/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h
@@ -85,6 +85,7 @@ class Fboss2IntegrationTest : public ::testing::Test {
    *   getSwConfigField<int>("arpTimeoutSeconds")
    *   getSwConfigField<bool>("enableLldp")
    *   getSwConfigField<std::string>("loadBalancerPoolName")
+   *   getSwConfigField<std::string>("optionalField", "default")
    */
   template <typename T>
   T getSwConfigField(const std::string& field) const {
@@ -108,6 +109,11 @@ class Fboss2IntegrationTest : public ::testing::Test {
     } else {
       static_assert(!sizeof(T), "Unsupported type for getSwConfigField");
     }
+  }
+
+  template <typename T>
+  T getSwConfigField(const std::string& field, T defaultValue) const {
+    return getSwConfigFieldOpt<T>(field).value_or(std::move(defaultValue));
   }
 
   /**
@@ -296,6 +302,30 @@ class Fboss2IntegrationTest : public ::testing::Test {
       std::chrono::seconds timeout = std::chrono::seconds(120)) const;
 
  private:
+  template <typename T>
+  std::optional<T> getSwConfigFieldOpt(const std::string& field) const {
+    auto config = getRunningConfig();
+    if (!config.isObject() || !config.count("sw")) {
+      return std::nullopt;
+    }
+    const auto& sw = config["sw"];
+    if (!sw.isObject() || !sw.count(field)) {
+      return std::nullopt;
+    }
+    if constexpr (std::is_same_v<T, bool>) {
+      return sw[field].asBool();
+    } else if constexpr (std::is_integral_v<T>) {
+      return static_cast<T>(sw[field].asInt());
+    } else if constexpr (std::is_same_v<T, std::string>) {
+      return sw[field].asString();
+    } else if constexpr (std::is_same_v<T, double>) {
+      return sw[field].asDouble();
+    } else {
+      static_assert(!sizeof(T), "Unsupported type for getSwConfigField");
+    }
+    return std::nullopt;
+  }
+
   Interface parseInterfaceJson(const folly::dynamic& data) const;
 
   /**


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary

- Adds `fboss2-dev config arp proactive [enabled|disabled]` to the existing `config arp` command family
- Mutates `SwitchConfig.proactiveArp` (declared in `switch_config.thrift`) and persists via `HITLESS` config save — no agent restart required
- `proactiveArp` is not yet consumed by the agent (`ApplyThriftConfig.cpp` has no read, `switch_state.thrift` has no corresponding field); the CLI is wired ahead of agent support. A code comment flags this explicitly.

## Changed files

| File | Change |
|------|--------|
| `CmdConfigArp.cpp` | Add `proactive` to valid attrs; parse `enabled`/`disabled`; dispatch to `swConfig.proactiveArp()` |
| `CmdConfigArp.h` | Add `getBoolValue()` / `boolValue_`; update `addCliArg()` help text to mention `proactive` |
| `test/config/CmdConfigArpTest.cpp` | Unit tests for arg validation + `queryClient` round-trip for `proactive` |
| `test/integration_test/ConfigArpTest.cpp` | Integration test: set/commit/verify round-trip via running agent config |
| `test/integration_test/Fboss2IntegrationTest.h` | Add two-arg `getSwConfigField(field, default)` overload + private `getSwConfigFieldOpt<T>` helper for optional/defaulted config fields |

## `Fboss2IntegrationTest.h` refactor

`icmpV4UnavailableSrcAddress` is optional in the agent config — devices that have never configured it have no entry in the JSON. The integration test needs to read the field with a fallback to the agent's implicit default (`192.0.0.8`) when absent.

To support this without duplicating the type-dispatch logic (`bool`/`int`/`string`/`double`), the existing `getSwConfigField` is refactored:
- A private `getSwConfigFieldOpt<T>` helper does the actual field lookup and type conversion, returning `std::optional<T>`.
- The original single-arg `getSwConfigField` delegates to it and throws when `nullopt` (required fields — existing callers unaffected).
- A new two-arg overload delegates to it and returns the caller-supplied default when `nullopt` (optional fields).

## Integration Test Results — NH-4010-F

Ran `ConfigArpTest` suite on DUT after latest changes:

```
[==========] Running 5 tests from 1 test suite.
[  PASSED  ] ConfigArpTest.SetTimeout (159 ms)
[  PASSED  ] ConfigArpTest.SetAgeInterval (117 ms)
[  PASSED  ] ConfigArpTest.SetMaxProbes (118 ms)
[  PASSED  ] ConfigArpTest.SetStaleInterval (119 ms)
[  PASSED  ] ConfigArpTest.SetProactive (118 ms)
[==========] 5 tests from 1 test suite ran. (633 ms total)
[  PASSED  ] 5 tests.
```

## Test plan

- [x] Unit test: `bazel test //fboss/cli/fboss2/test/config:CmdConfigArpTest`
- [x] Integration test on DUT: `fboss2-dev config arp proactive enabled` → commit → verify `proactiveArp: true` in running config → restore

## Notes

`proactiveArp` is not yet consumed by the agent; the integration test only
proves the value round-trips through the config (set → commit → read back),
not that proactive ARP behavior changes.

## Review Findings

Pre-publication review (3 correctness angles × 7 candidates, 1-vote verify).
Issues found and fixed before push:
- `result.empty()` fallback in `queryClient` replaced with explicit result assignment per branch (eliminates latent `getValue()` trap for future boolean attrs)
- `Fboss2IntegrationTest.h`: single-arg `getSwConfigField` restored to inline form with distinct "missing 'sw' object" vs "missing field" error messages
- Added `EXPECT_THROW` unit tests for `getValue()`/`getBoolValue()` cross-kind accessor guards

No issues above confidence threshold remain.

