### PR TITLE
[Nexthop] Extend buck_cmake_dep_checker to catch file-list inconsistencies.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,19 @@ repos:
       # Ruff formatter for all Python files in fboss/
       - id: ruff-format
         files: ^fboss/
+  # TODO: Uncomment once existing violations are fixed (run
+  # `fboss/oss/scripts/buck_cmake_dep_checker.py --check-files --check-sorted --from-commit HEAD~1`
+  # to see what would be flagged on a given commit).
+  # - repo: local
+  #   hooks:
+  #     - id: buck-cmake-checker
+  #       name: Check BUCK/cmake file-list consistency and sort order
+  #       language: system
+  #       entry: fboss/oss/scripts/buck_cmake_dep_checker.py --check-files --check-sorted --from-commit
+  #       args: [HEAD~1]
+  #       pass_filenames: false
+  #       always_run: true
+
   - repo: local
     hooks:
       - id: do-not-change-fboss-manifests

--- a/fboss/oss/scripts/buck_cmake_dep_checker.py
+++ b/fboss/oss/scripts/buck_cmake_dep_checker.py
@@ -10,8 +10,9 @@ This tool:
 """
 
 import argparse
-import os
 import re
+import subprocess
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -65,6 +66,28 @@ class MissingDependency:
     suggested_cmake_dep: Optional[str] = None  # Suggested cmake target to add
 
 
+@dataclass
+class FileInconsistency:
+    """Represents a source file present on one side but missing from the other"""
+
+    # "missing_from_cmake" or "missing_from_buck"
+    direction: str
+    file_path: str  # repo-root-relative path
+    cmake_target: CmakeTarget
+    buck_target: BuckTarget
+
+
+@dataclass
+class SortViolation:
+    """Represents an unsorted srcs/headers list in a build target"""
+
+    build_system: str  # "buck" or "cmake"
+    file_path: str  # path to the BUCK or cmake file
+    target_name: str  # full_name for Buck targets, name for cmake targets
+    list_name: str  # "srcs" or "headers"
+    items: list[str]  # the unsorted list as extracted from the file
+
+
 class BuckParser:
     """Parser for BUCK files"""
 
@@ -81,7 +104,7 @@ class BuckParser:
     def _parse_file(self, file_path: Path):
         """Parse a single BUCK file"""
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 content = f.read()
         except Exception as e:
             print(f"Warning: Could not read {file_path}: {e}")
@@ -91,8 +114,10 @@ class BuckParser:
         rel_path = file_path.parent.relative_to(self.repo_root)
         buck_path = "//" + str(rel_path).replace("\\", "/")
 
-        # Parse cpp_library targets
-        self._parse_cpp_library(content, buck_path, str(file_path))
+        # Parse cpp_library and executable-type targets (cpp_binary,
+        # cpp_unittest, cpp_benchmark). They all share the same srcs/deps shape.
+        for rule_type in ("cpp_library", "cpp_binary", "cpp_unittest", "cpp_benchmark"):
+            self._parse_cpp_rule(rule_type, content, buck_path, str(file_path))
 
         # Parse thrift_library targets
         self._parse_thrift_library(content, buck_path, str(file_path))
@@ -108,32 +133,36 @@ class BuckParser:
             return []
 
         list_content = match.group(2)
-        # Extract all quoted strings
-        items = re.findall(r'"([^"]*)"', list_content)
-        return items
+        return re.findall(r'"([^"]*)"', list_content)
 
     def _extract_deps_list(self, content: str, key: str) -> list[str]:
         """Extract a list of dependencies from a Buck stanza"""
         return self._extract_string_list(content, key)
 
-    def _parse_cpp_library(self, content: str, buck_path: str, file_path: str):
-        """Parse cpp_library declarations"""
-        # Find all cpp_library blocks
-        pattern = r'cpp_library\s*\(\s*name\s*=\s*"([^"]+)"'
+    def _parse_cpp_rule(
+        self, rule_type: str, content: str, buck_path: str, file_path: str
+    ):
+        """Parse cpp_library / cpp_binary / cpp_unittest / cpp_benchmark declarations"""
+        # Match the rule keyword; allow comments between '(' and 'name =' by
+        # extracting the full block first, then reading name from inside it.
+        pattern = rf"{rule_type}\s*\("
         for match in re.finditer(pattern, content):
-            name = match.group(1)
             start = match.start()
 
-            # Find the end of this target (matching parenthesis)
             block_content = self._extract_block(content, start)
             if not block_content:
                 continue
+
+            name_match = re.search(r'name\s*=\s*"([^"]+)"', block_content)
+            if not name_match:
+                continue
+            name = name_match.group(1)
 
             target = BuckTarget(
                 name=name,
                 buck_path=buck_path,
                 full_name=f"{buck_path}:{name}",
-                target_type="cpp_library",
+                target_type=rule_type,
                 srcs=self._extract_string_list(block_content, "srcs"),
                 headers=self._extract_string_list(block_content, "headers"),
                 deps=self._extract_deps_list(block_content, "deps"),
@@ -144,14 +173,18 @@ class BuckParser:
 
     def _parse_thrift_library(self, content: str, buck_path: str, file_path: str):
         """Parse thrift_library declarations"""
-        pattern = r'thrift_library\s*\(\s*name\s*=\s*"([^"]+)"'
+        pattern = r"thrift_library\s*\("
         for match in re.finditer(pattern, content):
-            name = match.group(1)
             start = match.start()
 
             block_content = self._extract_block(content, start)
             if not block_content:
                 continue
+
+            name_match = re.search(r'name\s*=\s*"([^"]+)"', block_content)
+            if not name_match:
+                continue
+            name = name_match.group(1)
 
             # thrift_srcs is a dict like {"file.thrift": [...]}
             thrift_srcs = self._extract_thrift_srcs(block_content)
@@ -175,8 +208,7 @@ class BuckParser:
             return []
         # Extract filenames from the dict keys
         dict_content = match.group(1)
-        files = re.findall(r'"([^"]+\.thrift)"', dict_content)
-        return files
+        return re.findall(r'"([^"]+\.thrift)"', dict_content)
 
     def _extract_block(self, content: str, start: int) -> Optional[str]:
         """Extract a complete block starting from a function call"""
@@ -237,7 +269,7 @@ class CmakeParser:
     def _parse_file(self, file_path: Path):
         """Parse a single cmake file"""
         try:
-            with open(file_path, "r") as f:
+            with open(file_path) as f:
                 content = f.read()
         except Exception as e:
             print(f"Warning: Could not read {file_path}: {e}")
@@ -268,18 +300,18 @@ class CmakeParser:
             # Extract values (split by whitespace/newlines, filter empty/comments)
             values = []
             for line in values_block.split("\n"):
-                for token in line.split():
-                    token = token.strip()
-                    if token and not token.startswith("#"):
-                        values.append(token)
+                for raw_token in line.split():
+                    stripped = raw_token.strip()
+                    if stripped and not stripped.startswith("#"):
+                        values.append(stripped)
             if values:
                 self.variables[var_name] = values
 
     def _expand_variables(self, deps: list[str]) -> list[str]:
         """Expand cmake ${VAR} references in dependency list"""
         expanded = []
-        for dep in deps:
-            dep = dep.strip()
+        for raw_dep in deps:
+            dep = raw_dep.strip()
             if not dep:
                 continue
             # Check if this is a variable reference like ${var_name}
@@ -386,10 +418,10 @@ class CmakeParser:
                 # Parse deps from the block (split by whitespace/newlines)
                 raw_deps = []
                 for line in deps_block.split("\n"):
-                    for token in line.split():
-                        token = token.strip()
-                        if token and not token.startswith("#"):
-                            raw_deps.append(token)
+                    for raw_token in line.split():
+                        stripped = raw_token.strip()
+                        if stripped and not stripped.startswith("#"):
+                            raw_deps.append(stripped)
                 # Expand any ${VAR} references
                 deps = self._expand_variables(raw_deps)
                 # Extend existing deps (don't overwrite - there may be multiple
@@ -399,15 +431,13 @@ class CmakeParser:
     def _extract_source_files(self, block: str) -> list[str]:
         """Extract source file paths from a cmake block"""
         files = []
-        for line in block.split("\n"):
-            line = line.strip()
-            # Skip comments and empty lines
-            if not line or line.startswith("#"):
+        for raw_line in block.split("\n"):
+            stripped = raw_line.strip()
+            if not stripped or stripped.startswith("#"):
                 continue
-            # Skip cmake keywords
-            if line in ("PUBLIC", "PRIVATE", "INTERFACE"):
+            if stripped in ("PUBLIC", "PRIVATE", "INTERFACE"):
                 continue
-            files.append(line)
+            files.append(stripped)
         return files
 
 
@@ -424,8 +454,10 @@ class DependencyAnalyzer:
         # Maps to help correlate Buck deps to cmake deps
         self.buck_to_cmake: dict[str, str] = {}  # buck full_name -> cmake name
 
-    def analyze(self) -> list[MissingDependency]:
-        """Run the full analysis and return missing dependencies"""
+    def _parse(self):
+        """Parse all BUCK and cmake files (shared by all analysis modes, idempotent)."""
+        if self.buck_targets:
+            return
         print("Parsing BUCK files...")
         self.buck_targets = self.buck_parser.parse_all()
         print(f"  Found {len(self.buck_targets)} Buck targets")
@@ -433,6 +465,10 @@ class DependencyAnalyzer:
         print("Parsing cmake files...")
         self.cmake_targets = self.cmake_parser.parse_all()
         print(f"  Found {len(self.cmake_targets)} cmake targets")
+
+    def analyze(self) -> list[MissingDependency]:
+        """Parse and check dependency consistency between Buck and cmake."""
+        self._parse()
 
         print("Matching targets by source files...")
         self.matches = self._match_targets()
@@ -442,8 +478,103 @@ class DependencyAnalyzer:
         self._build_dep_mapping()
 
         print("Analyzing missing dependencies...")
-        missing = self._find_missing_deps()
-        return missing
+        return self._find_missing_deps()
+
+    def check_files(
+        self, from_commit: Optional[str] = None, to_commit: Optional[str] = None
+    ) -> list["FileInconsistency"]:
+        """Parse and check file-list consistency between cmake and BUCK.
+
+        Without a commit range: reports files listed in cmake targets that are
+        absent from any BUCK target (cmake → BUCK direction only, because a
+        file can legitimately exist on disk yet be intentionally excluded from
+        cmake).
+
+        With a commit range: reports files changed in that range that are
+        present in one build system but absent from the other. The assumption
+        is that if you changed a file, it should be in both systems.
+        """
+        self._parse()
+
+        if from_commit is not None:
+            changed = self._get_changed_files(from_commit, to_commit or "HEAD")
+            print(f"  Checking {len(changed)} files changed in commit range")
+            return self._find_file_inconsistencies_changed(changed)
+        return self._find_file_inconsistencies_cmake_only()
+
+    def check_sorted(
+        self, from_commit: Optional[str] = None, to_commit: Optional[str] = None
+    ) -> list[SortViolation]:
+        """Parse and check that srcs/headers file lists are sorted alphabetically.
+
+        Checks Buck targets (srcs and headers) and cmake targets (srcs).
+        Sort order is case-insensitive (str.casefold) to match common conventions.
+
+        Without a commit range: checks all targets.
+        With a commit range: limits the check to targets defined in BUCK/*.cmake
+        files touched in that range, so the report only covers newly-edited lists
+        and is not flooded by pre-existing violations elsewhere in the repo.
+        """
+        self._parse()
+
+        # If a commit range is given, build a set of absolute paths to the
+        # build files changed in that range and skip targets defined elsewhere.
+        changed_build_files: Optional[set[str]] = None
+        if from_commit is not None:
+            all_changed = self._get_changed_files(from_commit, to_commit or "HEAD")
+            changed_build_files = {
+                str(self.repo_root / f)
+                for f in all_changed
+                if (
+                    f.endswith("/BUCK")
+                    or f == "BUCK"
+                    or f.endswith(".cmake")
+                    or f == "CMakeLists.txt"
+                )
+            }
+            print(
+                f"  Checking sort order in {len(changed_build_files)} "
+                f"changed build file(s)"
+            )
+
+        violations: list[SortViolation] = []
+
+        for bt in self.buck_targets.values():
+            if (
+                changed_build_files is not None
+                and bt.file_path not in changed_build_files
+            ):
+                continue
+            for list_name, items in (("srcs", bt.srcs), ("headers", bt.headers)):
+                if len(items) > 1 and items != sorted(items, key=str.casefold):
+                    violations.append(
+                        SortViolation(
+                            build_system="buck",
+                            file_path=bt.file_path,
+                            target_name=bt.full_name,
+                            list_name=list_name,
+                            items=items,
+                        )
+                    )
+
+        for ct in self.cmake_targets.values():
+            if (
+                changed_build_files is not None
+                and ct.file_path not in changed_build_files
+            ):
+                continue
+            if len(ct.srcs) > 1 and ct.srcs != sorted(ct.srcs, key=str.casefold):
+                violations.append(
+                    SortViolation(
+                        build_system="cmake",
+                        file_path=ct.file_path,
+                        target_name=ct.name,
+                        list_name="srcs",
+                        items=ct.srcs,
+                    )
+                )
+
+        return violations
 
     def _normalize_path(self, path: str, buck_path: str = "") -> str:
         """Normalize a source file path to a canonical form for comparison"""
@@ -462,11 +593,11 @@ class DependencyAnalyzer:
 
         return path
 
-    def _match_targets(self) -> list[TargetMatch]:
+    def _match_targets(self) -> list[TargetMatch]:  # noqa: PLR0912
         """Match cmake targets to Buck targets based on source files"""
         matches = []
 
-        for _, cmake_target in self.cmake_targets.items():
+        for cmake_target in self.cmake_targets.values():
             if not cmake_target.srcs:
                 continue
 
@@ -487,6 +618,8 @@ class DependencyAnalyzer:
             same_name_matching_srcs: list[str] = []
 
             for buck_target in self.buck_targets.values():
+                if buck_target.target_type not in ("cpp_library", "thrift_library"):
+                    continue
                 # Normalize Buck source files
                 buck_srcs = set()
                 for src in buck_target.srcs:
@@ -570,10 +703,7 @@ class DependencyAnalyzer:
         for match in self.matches:
             buck_full = match.buck_target.full_name
             # If there's a same-name match for this Buck target, use it
-            if buck_full in same_name_matches:
-                cmake_name = same_name_matches[buck_full]
-            else:
-                cmake_name = match.cmake_target.name
+            cmake_name = same_name_matches.get(buck_full, match.cmake_target.name)
 
             self.buck_to_cmake[buck_full] = cmake_name
             # Also map short form like ":name" within same BUCK file
@@ -607,7 +737,7 @@ class DependencyAnalyzer:
         if dep.startswith(":"):
             # Local reference within same BUCK file
             return f"{buck_path}{dep}"
-        elif dep.startswith("//"):
+        if dep.startswith("//"):
             return dep
         return dep
 
@@ -631,6 +761,208 @@ class DependencyAnalyzer:
             all_deps |= self._get_transitive_cmake_deps(dep, visited)
         return all_deps
 
+    def _is_shim_path(self, path: str) -> bool:
+        """Return True for paths that are OSS/internal shims and should be ignored."""
+        parts = path.split("/")
+        return "oss" in parts or "facebook" in parts
+
+    def _is_plain_cpp(self, src: str) -> bool:
+        """Return True if src looks like a plain .cpp filename (not a ref or glob)."""
+        return (
+            src.endswith(".cpp")
+            and not src.startswith(("//", ":", "${"))
+            and "*" not in src
+            and "?" not in src
+        )
+
+    def _build_global_cpp_corpora(self) -> tuple[set[str], set[str]]:
+        """Return (all_buck_cpp, all_cmake_cpp): repo-root-relative .cpp paths
+        known to each build system, excluding shims and non-existent files.
+
+        Buck `headers` lists can contain .cpp files (header-only / template
+        impl patterns), so we scan both srcs and headers when building the
+        Buck corpus.
+        """
+        all_buck_cpp: set[str] = set()
+        for bt in self.buck_targets.values():
+            for src in bt.srcs + bt.headers:
+                norm = self._normalize_path(src, bt.buck_path)
+                if not norm.startswith("fboss/"):
+                    continue
+                if (
+                    self._is_plain_cpp(norm)
+                    and not self._is_shim_path(norm)
+                    and (self.repo_root / norm).is_file()
+                ):
+                    all_buck_cpp.add(norm)
+
+        all_cmake_cpp: set[str] = set()
+        for ct in self.cmake_targets.values():
+            for src in ct.srcs:
+                if (
+                    self._is_plain_cpp(src)
+                    and not self._is_shim_path(src)
+                    and (self.repo_root / src).is_file()
+                ):
+                    all_cmake_cpp.add(src)
+
+        return all_buck_cpp, all_cmake_cpp
+
+    def _get_changed_files(self, from_commit: str, to_commit: str) -> set[str]:
+        """Return repo-root-relative paths of files changed in the commit range."""
+        result = subprocess.run(
+            ["git", "diff", "--name-only", from_commit, to_commit],
+            check=False,
+            capture_output=True,
+            text=True,
+            cwd=self.repo_root,
+        )
+        if result.returncode != 0:
+            print(f"Warning: git diff failed: {result.stderr.strip()}")
+            return set()
+        return set(result.stdout.splitlines())
+
+    def _find_file_inconsistencies_cmake_only(self) -> list[FileInconsistency]:
+        """Check that .cpp files in cmake targets also appear in the corresponding
+        BUCK target (cmake → BUCK direction only).
+
+        Uses same-name 1:1 pairing as a confidence gate so macro-generated
+        Buck targets (invisible to the parser) never produce false positives.
+        A file is only flagged if it is absent from the *entire* Buck corpus,
+        not just the paired target, to handle cases where cmake merges targets.
+        """
+        all_buck_cpp, _ = self._build_global_cpp_corpora()
+
+        # Index Buck targets by name, keyed by normalized name (hyphens → underscores)
+        # so cmake targets (which use underscores) match BUCK targets (which use hyphens).
+        buck_by_norm_name: dict[str, list[BuckTarget]] = {}
+        for bt in self.buck_targets.values():
+            norm = bt.name.replace("-", "_")
+            buck_by_norm_name.setdefault(norm, []).append(bt)
+
+        inconsistencies: list[FileInconsistency] = []
+
+        for cmake_name, cmake_target in self.cmake_targets.items():
+            cands = buck_by_norm_name.get(cmake_name.replace("-", "_"))
+            if not cands:
+                continue
+
+            c_cpp: set[str] = set()
+            for src in cmake_target.srcs:
+                if (
+                    self._is_plain_cpp(src)
+                    and not self._is_shim_path(src)
+                    and (self.repo_root / src).is_file()
+                ):
+                    c_cpp.add(src)
+
+            # Confidence gate: pick the Buck candidate with the most .cpp overlap.
+            best_buck: Optional[BuckTarget] = None
+            best_overlap = 0
+            for bt in cands:
+                b_cpp: set[str] = set()
+                for src in bt.srcs:
+                    norm = self._normalize_path(src, bt.buck_path)
+                    if (
+                        norm.startswith("fboss/")
+                        and self._is_plain_cpp(norm)
+                        and not self._is_shim_path(norm)
+                        and (self.repo_root / norm).is_file()
+                    ):
+                        b_cpp.add(norm)
+                overlap = len(c_cpp & b_cpp)
+                if overlap > best_overlap:
+                    best_overlap = overlap
+                    best_buck = bt
+
+            if best_buck is None or best_overlap == 0:
+                continue
+
+            for f in c_cpp:
+                if f not in all_buck_cpp:
+                    inconsistencies.append(
+                        FileInconsistency(
+                            direction="missing_from_buck",
+                            file_path=f,
+                            cmake_target=cmake_target,
+                            buck_target=best_buck,
+                        )
+                    )
+
+        return inconsistencies
+
+    def _find_file_inconsistencies_changed(  # noqa: PLR0912
+        self, changed_files: set[str]
+    ) -> list[FileInconsistency]:
+        """Check changed files bidirectionally.
+
+        Any .cpp file touched in the commit range is expected to be present in
+        both build systems.  We find it in cmake or BUCK, then verify the other
+        side also has it.  This catches both "added to BUCK but forgot cmake"
+        and "added to cmake but forgot BUCK".
+
+        Shim paths (oss/, facebook/) and files not on disk are silently ignored.
+        """
+        all_buck_cpp, all_cmake_cpp = self._build_global_cpp_corpora()
+
+        inconsistencies: list[FileInconsistency] = []
+
+        # Build an index for reporting: file → (cmake_target, buck_target)
+        cmake_file_to_target: dict[str, CmakeTarget] = {}
+        for ct in self.cmake_targets.values():
+            for src in ct.srcs:
+                if self._is_plain_cpp(src):
+                    cmake_file_to_target[src] = ct
+
+        buck_file_to_target: dict[str, BuckTarget] = {}
+        for bt in self.buck_targets.values():
+            for src in bt.srcs:
+                norm = self._normalize_path(src, bt.buck_path)
+                if self._is_plain_cpp(norm):
+                    buck_file_to_target[norm] = bt
+
+        for f in sorted(changed_files):
+            if not self._is_plain_cpp(f):
+                continue
+            if self._is_shim_path(f):
+                continue
+            if not (self.repo_root / f).is_file():
+                continue
+
+            in_cmake = f in all_cmake_cpp
+            in_buck = f in all_buck_cpp
+
+            if in_cmake and not in_buck:
+                cmake_target = cmake_file_to_target.get(f)
+                if cmake_target:
+                    # Use an empty sentinel BuckTarget for reporting
+                    inconsistencies.append(
+                        FileInconsistency(
+                            direction="missing_from_buck",
+                            file_path=f,
+                            cmake_target=cmake_target,
+                            buck_target=BuckTarget(
+                                name="(none)",
+                                buck_path="",
+                                full_name="",
+                                target_type="",
+                            ),
+                        )
+                    )
+            elif in_buck and not in_cmake:
+                buck_target = buck_file_to_target.get(f)
+                if buck_target:
+                    inconsistencies.append(
+                        FileInconsistency(
+                            direction="missing_from_cmake",
+                            file_path=f,
+                            cmake_target=CmakeTarget(name="(none)", target_type=""),
+                            buck_target=buck_target,
+                        )
+                    )
+
+        return inconsistencies
+
     def _find_missing_deps(self) -> list[MissingDependency]:
         """Find dependencies that exist in Buck but are missing in cmake"""
         missing = []
@@ -653,30 +985,28 @@ class DependencyAnalyzer:
                 # Check if we have a cmake equivalent
                 cmake_equiv = self.buck_to_cmake.get(full_buck_dep)
 
-                if cmake_equiv:
-                    # Check if cmake has this dependency (directly or transitively)
-                    if (
-                        cmake_equiv not in cmake_deps
-                        and cmake_equiv not in transitive_cmake_deps
-                    ):
-                        missing.append(
-                            MissingDependency(
-                                cmake_target=cmake_target,
-                                buck_target=buck_target,
-                                buck_dep=buck_dep,
-                                suggested_cmake_dep=cmake_equiv,
-                            )
+                if cmake_equiv and (
+                    cmake_equiv not in cmake_deps
+                    and cmake_equiv not in transitive_cmake_deps
+                ):
+                    missing.append(
+                        MissingDependency(
+                            cmake_target=cmake_target,
+                            buck_target=buck_target,
+                            buck_dep=buck_dep,
+                            suggested_cmake_dep=cmake_equiv,
                         )
+                    )
 
         return missing
 
 
-def print_report(
+def print_dep_report(
     missing_deps: list[MissingDependency],
     matches: list[TargetMatch],
     verbose: bool = False,
 ):
-    """Print a report of the analysis"""
+    """Print the dependency-consistency report."""
     if verbose:
         print("\n" + "=" * 80)
         print("TARGET MATCHES (cmake -> Buck)")
@@ -716,56 +1046,70 @@ def print_report(
             print(f"    Buck target: {md.buck_target.full_name}")
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Check for missing cmake dependencies compared to Buck",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
-Examples:
-  %(prog)s                    # Analyze current directory
-  %(prog)s -r /path/to/fboss  # Analyze specific repository
-  %(prog)s -v                 # Verbose output with match details
-  %(prog)s --target foo       # Only analyze target 'foo'
-""",
-    )
-    parser.add_argument(
-        "-r",
-        "--repo-root",
-        default=".",
-        help="Repository root directory (default: current directory)",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="store_true",
-        help="Show verbose output including all matches",
-    )
-    parser.add_argument("--target", help="Only analyze a specific cmake target")
-    parser.add_argument(
-        "--list-matches",
-        action="store_true",
-        help="List all cmake-to-Buck target matches",
-    )
-    parser.add_argument(
-        "--list-buck", action="store_true", help="List all Buck targets found"
-    )
-    parser.add_argument(
-        "--list-cmake", action="store_true", help="List all cmake targets found"
-    )
+def print_file_inconsistencies_report(
+    inconsistencies: list[FileInconsistency], mode_description: str
+):
+    """Print the file-list inconsistency report."""
+    print("\n" + "=" * 80)
+    print(f"FILE LIST INCONSISTENCIES ({mode_description})")
+    print("=" * 80)
 
-    args = parser.parse_args()
+    if not inconsistencies:
+        print("\nNo file list inconsistencies found!")
+        return
 
-    # Resolve the repo root
-    repo_root = Path(args.repo_root).resolve()
-    if not (repo_root / "cmake").is_dir():
-        print(f"Error: {repo_root}/cmake directory not found")
-        print("Make sure you're running from the fboss repository root")
-        return 1
+    missing_from_cmake = [
+        fi for fi in inconsistencies if fi.direction == "missing_from_cmake"
+    ]
+    missing_from_buck = [
+        fi for fi in inconsistencies if fi.direction == "missing_from_buck"
+    ]
 
-    analyzer = DependencyAnalyzer(str(repo_root))
-    missing = analyzer.analyze()
+    if missing_from_cmake:
+        print("\nIn BUCK but missing from cmake:")
+        for fi in sorted(missing_from_cmake, key=lambda x: x.file_path):
+            print(f"  {fi.file_path}")
+            print(f"    Buck target: {fi.buck_target.full_name}")
+            print(f"    Buck file:   {fi.buck_target.file_path}")
 
-    # Handle list commands
+    if missing_from_buck:
+        print("\nIn cmake but missing from BUCK:")
+        for fi in sorted(missing_from_buck, key=lambda x: x.file_path):
+            print(f"  {fi.file_path}")
+            print(f"    Target:    {fi.cmake_target.name}")
+            print(f"    cmake file: {fi.cmake_target.file_path}")
+
+
+def print_sort_violations_report(violations: list[SortViolation]):
+    """Print the sort-order violation report."""
+    print("\n" + "=" * 80)
+    print("FILE LIST SORT ORDER VIOLATIONS")
+    print("=" * 80)
+
+    if not violations:
+        print("\nAll file lists are sorted!")
+        return
+
+    by_file: dict[str, list[SortViolation]] = {}
+    for v in violations:
+        by_file.setdefault(v.file_path, []).append(v)
+
+    for file_path, file_violations in sorted(by_file.items()):
+        print(f"\n{file_path}:")
+        for v in sorted(file_violations, key=lambda x: x.target_name):
+            print(f"  [{v.build_system}] {v.target_name}  ({v.list_name})")
+            expected = sorted(v.items, key=str.casefold)
+            for i, (actual, exp) in enumerate(zip(v.items, expected)):
+                if actual != exp:
+                    print(
+                        f"    First unsorted entry at position {i}: "
+                        f"{actual!r} (expected {exp!r})"
+                    )
+                    break
+
+
+def _handle_list_commands(args, analyzer) -> Optional[int]:
+    """Print list-style debug output and return 0, or None if no list flag set."""
     if args.list_buck:
         print("\nBuck targets:")
         for name, target in sorted(analyzer.buck_targets.items()):
@@ -783,23 +1127,152 @@ Examples:
                 print(f"    srcs: {target.srcs[:3]}...")
         return 0
 
-    if args.list_matches:
+    if getattr(args, "list_matches", False):
         print("\nTarget matches (cmake -> Buck):")
         for match in sorted(analyzer.matches, key=lambda m: m.cmake_target.name):
             print(f"  {match.cmake_target.name} -> {match.buck_target.full_name}")
             print(f"    score: {match.match_score:.2%}")
         return 0
 
-    # Filter by target if specified
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check consistency between Buck and cmake builds",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s                              # Check dependency consistency (default)
+  %(prog)s --check-files                # Check cmake file lists against BUCK
+  %(prog)s --check-files \\
+      --from-commit HEAD~               # Check files changed since HEAD~
+  %(prog)s --check-files \\
+      --from-commit HEAD~ --to-commit HEAD  # Explicit commit range
+  %(prog)s --check-sorted               # Check sort order (all targets)
+  %(prog)s --check-sorted --from-commit HEAD~  # Sort check limited to changed build files
+  %(prog)s --check-files --check-sorted \\
+      --from-commit HEAD~               # Both checks, scoped to the commit
+  %(prog)s -r /path/to/fboss           # Analyze specific repository
+  %(prog)s -v                           # Verbose output with match details
+""",
+    )
+    parser.add_argument(
+        "-r",
+        "--repo-root",
+        default=".",
+        help="Repository root directory (default: current directory)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show verbose output including all matches (dep check only)",
+    )
+    parser.add_argument(
+        "--check-files",
+        action="store_true",
+        help=(
+            "Check file-list consistency instead of dependency consistency. "
+            "Without a commit range: reports cmake files absent from BUCK. "
+            "With --from-commit: reports changed files absent from either side."
+        ),
+    )
+    parser.add_argument(
+        "--from-commit",
+        metavar="REF",
+        help=(
+            "Start of commit range for --check-files / --check-sorted "
+            "(exclusive, like git diff A B)"
+        ),
+    )
+    parser.add_argument(
+        "--to-commit",
+        metavar="REF",
+        default="HEAD",
+        help="End of commit range for --check-files (inclusive, default: HEAD)",
+    )
+    parser.add_argument(
+        "--check-sorted",
+        action="store_true",
+        help=(
+            "Check that srcs/headers file lists are sorted alphabetically "
+            "(case-insensitive). Checks Buck targets (srcs and headers) and "
+            "cmake targets (srcs)."
+        ),
+    )
+    parser.add_argument("--target", help="Only analyze a specific cmake target")
+    parser.add_argument(
+        "--list-matches",
+        action="store_true",
+        help="List all cmake-to-Buck target matches",
+    )
+    parser.add_argument(
+        "--list-buck", action="store_true", help="List all Buck targets found"
+    )
+    parser.add_argument(
+        "--list-cmake", action="store_true", help="List all cmake targets found"
+    )
+
+    args = parser.parse_args()
+
+    if args.from_commit and not (args.check_files or args.check_sorted):
+        print("Error: --from-commit requires --check-files or --check-sorted")
+        return 1
+
+    # Resolve the repo root
+    repo_root = Path(args.repo_root).resolve()
+    if not (repo_root / "cmake").is_dir():
+        print(f"Error: {repo_root}/cmake directory not found")
+        print("Make sure you're running from the fboss repository root")
+        return 1
+
+    analyzer = DependencyAnalyzer(str(repo_root))
+
+    # --check-files and --check-sorted can be combined (they share one parse pass)
+    if args.check_files or args.check_sorted:
+        rc = _handle_list_commands(args, analyzer)
+        if rc is not None:
+            return rc
+        exit_code = 0
+        if args.check_files:
+            inconsistencies = analyzer.check_files(
+                from_commit=args.from_commit,
+                to_commit=args.to_commit if args.from_commit else None,
+            )
+            mode = (
+                f"changed files {args.from_commit}..{args.to_commit}"
+                if args.from_commit
+                else "cmake → BUCK"
+            )
+            print_file_inconsistencies_report(inconsistencies, mode)
+            if inconsistencies:
+                exit_code = 1
+        if args.check_sorted:
+            violations = analyzer.check_sorted(
+                from_commit=args.from_commit or None,
+                to_commit=args.to_commit if args.from_commit else None,
+            )
+            print_sort_violations_report(violations)
+            if violations:
+                exit_code = 1
+        if analyzer.cmake_parser.duplicate_errors:
+            exit_code = 1
+        return exit_code
+
+    # Default mode: dependency consistency check
+    missing = analyzer.analyze()
+    rc = _handle_list_commands(args, analyzer)
+    if rc is not None:
+        return rc
+
     if args.target:
         missing = [m for m in missing if m.cmake_target.name == args.target]
 
-    print_report(missing, analyzer.matches, args.verbose)
-
-    # Return non-zero if there are missing dependencies or duplicate targets
+    print_dep_report(missing, analyzer.matches, args.verbose)
     has_duplicates = len(analyzer.cmake_parser.duplicate_errors) > 0
     return 1 if missing or has_duplicates else 0
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
# Summary

Extends `fboss/oss/scripts/buck_cmake_dep_checker.py` with two new check modes and several bug fixes.

## New flags

```
  --check-files               cmake → BUCK direction; files in cmake must
                              also appear in some BUCK target
  --check-files --from-commit REF [--to-commit REF]
                              Bidirectional check for files changed in the
                              given commit range; any touched .cpp must be
                              in both build systems
  --check-sorted              Check that srcs/headers file lists in BUCK and
                              cmake targets are sorted alphabetically
  --check-sorted --from-commit REF
                              Limit the sort check to targets defined in
                              build files (BUCK/*.cmake) touched by the
                              commit range — avoids flooding output with
                              pre-existing violations in unrelated targets
```

`--check-files` and `--check-sorted` can be combined; they share one parse pass:

```
  buck_cmake_dep_checker.py --check-files --check-sorted --from-commit HEAD~
```

The pre-commit hook in `.pre-commit-config.yaml` is updated to use this combined invocation.

## Design choices (file-list check)
- Same-name 1:1 target pairing with >0 shared .cpp as confidence gate (excludes macro/glob-generated Buck targets invisible to the parser)
- Name normalization: cmake uses underscores (`fboss2_config_lib`) while BUCK uses hyphens (`fboss2-config-lib`); both sides are normalized before matching so the confidence gate works correctly
- Buck `headers` lists are included in the global corpus (some `.cpp` files live under `headers` in BUCK, not `srcs`); previously these appeared as false-positive "missing from BUCK" entries
- Files under `oss/` or `facebook/` path segments silently skipped (OSS shims)
- Only paths starting with `fboss/` considered

## Also fixes a pre-existing parser bug
- `cpp_library`/`thrift_library` blocks with comments between `(` and `name =` were silently skipped; fixed by extracting the block first then searching for `name=` inside it (21 additional targets now parsed)

# Test Plan

Tested against #1140 (`config/delete tunnel ip-in-ip`). With `--from-commit`, output is scoped to the 6 build files touched by that commit:

```
$ buck_cmake_dep_checker.py --check-files --check-sorted --from-commit 8caf0fc^

FILE LIST INCONSISTENCIES (changed files 8caf0fc^..HEAD)
================================================================================
No file list inconsistencies found!

FILE LIST SORT ORDER VIOLATIONS
================================================================================

fboss/cli/fboss2/test/config/BUCK:
  [buck] //fboss/cli/fboss2/test/config:cmd_config_test  (srcs)
    First unsorted entry at position 17: 'CmdConfigVlanDefaultTest.cpp'
    (expected 'CmdConfigTunnelIpInIpTest.cpp')
```

The `CmdConfigTunnelIpInIpTest.cpp` (T) was appended after `CmdConfigVlanDefaultTest.cpp` (V); alphabetically T < V so the test file should appear first.

Also validated against #1095 where `--check-files --from-commit` correctly flagged two integration test files added to `BUCK` but missing from cmake:

```
================================================================================
FILE LIST INCONSISTENCIES (changed files HEAD~1..HEAD)
================================================================================

In BUCK but missing from cmake:
  fboss/cli/fboss2/test/integration_test/ConfigInterfaceIpv6NdpTest.cpp
    Buck target: //fboss/cli/fboss2/test/integration_test:fboss2_integration_test
    Buck file:   /var/FBOSS/fboss/fboss/cli/fboss2/test/integration_test/BUCK
  fboss/cli/fboss2/test/integration_test/DeleteInterfaceIpv6NdpTest.cpp
    Buck target: //fboss/cli/fboss2/test/integration_test:fboss2_integration_test
    Buck file:   /var/FBOSS/fboss/fboss/cli/fboss2/test/integration_test/BUCK
```