### PR TITLE
[Celestica] Ladakh800bcls: Agent Test: Fix AgentQueuePerHostL2Tests*  AgentQueuePerHostRouteTests* init conf…

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
@@ -27,10 +27,16 @@ class AgentQueuePerHostL2Test : public AgentHwTest {
  protected:
   cfg::SwitchConfig initialConfig(
       const AgentEnsemble& ensemble) const override {
+    auto switchId = getCurrentSwitchIdForTesting();
+    auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
     auto cfg = utility::oneL3IntfTwoPortConfig(
-        ensemble.getSw(),
-        ensemble.masterLogicalInterfacePortIds()[0],
-        ensemble.masterLogicalInterfacePortIds()[1]);
+        ensemble.getSw()->getPlatformMapping(),
+        asic,
+        ensemble.masterLogicalPortIds()[0],
+        ensemble.masterLogicalPortIds()[1],
+        ensemble.getSw()->getPlatformSupportsAddRemovePort(),
+        asic->desiredLoopbackModes(),
+        ensemble.getSw()->getPlatformType());
     cfg.switchSettings()->l2LearningMode() = cfg::L2LearningMode::SOFTWARE;
     utility::addQueuePerHostQueueConfig(&cfg);
     utility::addQueuePerHostAcls(&cfg, ensemble.isSai());

--- a/fboss/agent/test/agent_hw_tests/AgentQueuePerHostRouteTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentQueuePerHostRouteTests.cpp
@@ -33,10 +33,16 @@ class AgentQueuePerHostRouteTest : public AgentHwTest {
  protected:
   cfg::SwitchConfig initialConfig(
       const AgentEnsemble& ensemble) const override {
+    auto switchId = getCurrentSwitchIdForTesting();
+    auto asic = ensemble.getSw()->getHwAsicTable()->getHwAsic(switchId);
     auto cfg = utility::oneL3IntfTwoPortConfig(
-        ensemble.getSw(),
+        ensemble.getSw()->getPlatformMapping(),
+        asic,
         ensemble.masterLogicalPortIds()[0],
-        ensemble.masterLogicalPortIds()[1]);
+        ensemble.masterLogicalPortIds()[1],
+        ensemble.getSw()->getPlatformSupportsAddRemovePort(),
+        asic->desiredLoopbackModes(),
+        ensemble.getSw()->getPlatformType());
     utility::addQueuePerHostQueueConfig(&cfg);
     utility::addQueuePerHostAcls(&cfg, ensemble.isSai());
     return cfg;


### PR DESCRIPTION

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed


# Summary

when run AgentQueuePerHostL2Tests*  AgentQueuePerHostRouteTests*  test cases,  error info , agent can't create unit 1,  because error config generated, need change initconfig 

Replaced the legacy, multi-NPU-unaware configuration helper calls in AgentNeighborTest::initialConfig() with the multi-NPU-aware overloads:

Updated oneL3IntfTwoPortConfig branches to take explicit hardware arguments:
ensemble.getPlatformMapping()
asic
ensemble.supportsAddRemovePort()
asic->desiredLoopbackModes()
ensemble.getSw()->getPlatformType() (Crucially provides the specific platform type)
By explicitly passing PlatformType::PLATFORM_LEH800BCLS, the configuration generator (genPortVlanCfg()) detects the dual-NPU hardware layout and generates a complete, valid switch configuration covering both SwitchID(0) and SwitchID(1).
This ensures all SDK resources and units are correctly mapped and initialized

# Test Plan

run test cases    AgentQueuePerHostL2Tests*  AgentQueuePerHostRouteTests*   on unit 0 and 1  all passed

=== Cold boot: AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (switch_id=1) ===
Waiting for config files...
Config files ready after 1s
Starting hw_agent processes...
=== Warm boot: AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (switch_id=1) ===

=== Test Results ===
Cold boot: PASSED (exit code 0)
Warm boot: PASSED (exit code 0)

=== Cold boot: AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (switch_id=1) ===
Waiting for config files...
Config files ready after 1s
Starting hw_agent processes...
=== Warm boot: AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (switch_id=1) ===

=== Test Results ===
Cold boot: PASSED (exit code 0)
Warm boot: PASSED (exit code 0)

passed === Cold boot: AgentQueuePerHostRouteTest/0.VerifyHostToQueueMappingClassID (switch_id=0) ===
Waiting for config files...
Config files ready after 1s
Starting hw_agent processes...
=== Warm boot: AgentQueuePerHostRouteTest/0.VerifyHostToQueueMappingClassID (switch_id=0) ===

=== Test Results ===
Cold boot: PASSED (exit code 0)
Warm boot: PASSED (exit code 0)

=== Cold boot: AgentQueuePerHostRouteTest/1.VerifyHostToQueueMappingClassIDBlock (switch_id=1) ===
Waiting for config files...
Config files ready after 1s
Starting hw_agent processes...
=== Warm boot: AgentQueuePerHostRouteTest/1.VerifyHostToQueueMappingClassIDBlock (switch_id=1) ===

=== Test Results ===
Cold boot: PASSED (exit code 0)
Warm boot: PASSED (exit code 0)



