### PR TITLE
[Nexthop][fboss2-dev] Add config admin-distance CLI command

### DIFF
--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -787,6 +787,10 @@ add_library(fboss2_config_lib
   fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.cpp
   fboss/cli/fboss2/commands/config/CmdConfigReload.h
   fboss/cli/fboss2/commands/config/CmdConfigReload.cpp
+  fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.cpp
+  fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h
+  fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.cpp
+  fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h
   fboss/cli/fboss2/commands/config/arp/CmdConfigArp.cpp
   fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h
   fboss/cli/fboss2/commands/config/copp/CmdConfigCopp.cpp

--- a/cmake/CliFboss2TestConfig.cmake
+++ b/cmake/CliFboss2TestConfig.cmake
@@ -4,6 +4,7 @@
 add_executable(fboss2_cmd_config_test
   fboss/util/oss/TestMain.cpp
   fboss/cli/fboss2/oss/config/CmdListImpl.cpp
+  fboss/cli/fboss2/test/config/CmdConfigAdminDistanceTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigAppliedInfoTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigArpTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigCoppTest.cpp

--- a/cmake/CliFboss2TestIntegrationTest.cmake
+++ b/cmake/CliFboss2TestIntegrationTest.cmake
@@ -8,6 +8,7 @@
 add_executable(fboss2_integration_test
   fboss/cli/fboss2/oss/config/CmdListImpl.cpp
   fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigAdminDistanceTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigArpTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigConcurrentSessionsTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigCoppTest.cpp

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -1040,6 +1040,8 @@ cpp_library(
         "CmdListConfig.cpp",
         "commands/config/CmdConfigAppliedInfo.cpp",
         "commands/config/CmdConfigReload.cpp",
+        "commands/config/switch/CmdConfigSwitch.cpp",
+        "commands/config/switch/admin_distance/CmdConfigAdminDistance.cpp",
         "commands/config/arp/CmdConfigArp.cpp",
         "commands/config/copp/CmdConfigCopp.cpp",
         "commands/config/dhcp/CmdConfigDhcp.cpp",
@@ -1172,6 +1174,8 @@ cpp_library(
     headers = [
         "commands/config/CmdConfigAppliedInfo.h",
         "commands/config/CmdConfigReload.h",
+        "commands/config/switch/CmdConfigSwitch.h",
+        "commands/config/switch/admin_distance/CmdConfigAdminDistance.h",
         "commands/config/arp/CmdConfigArp.h",
         "commands/config/copp/CmdConfigCopp.h",
         "commands/config/dhcp/CmdConfigDhcp.h",

--- a/fboss/cli/fboss2/CmdListConfig.cpp
+++ b/fboss/cli/fboss2/CmdListConfig.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include "fboss/cli/fboss2/CmdList.h"
-
 #include "fboss/cli/fboss2/commands/config/CmdConfigAppliedInfo.h"
 #include "fboss/cli/fboss2/commands/config/CmdConfigReload.h"
 #include "fboss/cli/fboss2/commands/config/arp/CmdConfigArp.h"
@@ -110,6 +109,8 @@
 #include "fboss/cli/fboss2/commands/config/session/CmdConfigSessionCommit.h"
 #include "fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.h"
 #include "fboss/cli/fboss2/commands/config/session/CmdConfigSessionRebase.h"
+#include "fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h"
+#include "fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h"
 #include "fboss/cli/fboss2/commands/config/tunnel/CmdConfigTunnel.h"
 #include "fboss/cli/fboss2/commands/config/tunnel/ip_in_ip/CmdConfigTunnelIpInIp.h"
 #include "fboss/cli/fboss2/commands/config/tunnel/ip_in_ip/decap/CmdConfigTunnelIpInIpDecap.h"
@@ -137,6 +138,20 @@ namespace facebook::fboss {
 
 const CommandTree& kConfigCommandTree() {
   static CommandTree root = {
+      {
+          "config",
+          "switch",
+          "Configure switch-level settings",
+          commandHandler<CmdConfigSwitch>,
+          argRegistrar<CmdConfigSwitchTraits>,
+          {{
+              "admin-distance",
+              "Set administrative distance for a routing client",
+              commandHandler<CmdConfigAdminDistance>,
+              argRegistrar<CmdConfigAdminDistanceTraits>,
+          }},
+      },
+
       {"config",
        "applied-info",
        "Show config applied information",

--- a/fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.cpp
+++ b/fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.cpp
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h"
+
+#include "fboss/cli/fboss2/CmdHandler.cpp"
+
+#include <iostream>
+
+namespace facebook::fboss {
+
+CmdConfigSwitchTraits::RetType CmdConfigSwitch::queryClient(
+    const HostInfo& /* hostInfo */) {
+  return "Switch configuration commands. Use subcommands: admin-distance";
+}
+
+void CmdConfigSwitch::printOutput(const RetType& output) {
+  std::cout << output << std::endl;
+}
+
+// Explicit template instantiation
+template void CmdHandler<CmdConfigSwitch, CmdConfigSwitchTraits>::run();
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h
+++ b/fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include "fboss/cli/fboss2/CmdHandler.h"
+
+namespace facebook::fboss {
+
+struct CmdConfigSwitchTraits : public WriteCommandTraits {
+  using ObjectArgType = utils::NoneArgType;
+  using RetType = std::string;
+};
+
+class CmdConfigSwitch
+    : public CmdHandler<CmdConfigSwitch, CmdConfigSwitchTraits> {
+ public:
+  using ObjectArgType = CmdConfigSwitchTraits::ObjectArgType;
+  using RetType = CmdConfigSwitchTraits::RetType;
+
+  RetType queryClient(const HostInfo& /* hostInfo */);
+
+  void printOutput(const RetType& output);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.cpp
+++ b/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.cpp
@@ -1,0 +1,139 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include "fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h"
+
+#include "fboss/cli/fboss2/CmdHandler.cpp"
+
+#include <fmt/format.h>
+#include <folly/Conv.h>
+#include <iostream>
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+
+namespace facebook::fboss {
+
+namespace {
+constexpr int32_t kMaxAdminDistance = 255;
+
+// ClientIDs whose admin distance is hardcoded in the agent and cannot be
+// overridden via clientIdToAdminDistance config:
+//   STATIC_ROUTE (1)         -> AdminDistance::STATIC_ROUTE
+//   INTERFACE_ROUTE (2)      -> AdminDistance::DIRECTLY_CONNECTED
+//   LINKLOCAL_ROUTE (3)      -> AdminDistance::DIRECTLY_CONNECTED
+//   REMOTE_INTERFACE_ROUTE (4) -> AdminDistance::DIRECTLY_CONNECTED
+const std::unordered_map<int32_t, std::string>& forbiddenClients() {
+  static const std::unordered_map<int32_t, std::string> kForbidden = {
+      {1,
+       "STATIC_ROUTE is hardcoded to AdminDistance::STATIC_ROUTE in the agent"},
+      {2,
+       "INTERFACE_ROUTE is hardcoded to AdminDistance::DIRECTLY_CONNECTED in the agent"},
+      {3,
+       "LINKLOCAL_ROUTE is hardcoded to AdminDistance::DIRECTLY_CONNECTED in the agent"},
+      {4,
+       "REMOTE_INTERFACE_ROUTE is hardcoded to AdminDistance::DIRECTLY_CONNECTED in the agent"},
+  };
+  return kForbidden;
+}
+} // namespace
+
+AdminDistanceArg::AdminDistanceArg(std::vector<std::string> v) {
+  if (v.size() != 2) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Expected exactly two arguments: <client-id> <distance>, got {}",
+            v.size()));
+  }
+
+  try {
+    clientId_ = folly::to<int32_t>(v[0]);
+  } catch (const folly::ConversionError&) {
+    throw std::invalid_argument(
+        fmt::format("Invalid client-id '{}': must be an integer", v[0]));
+  }
+  if (clientId_ < 0) {
+    throw std::invalid_argument(
+        fmt::format("client-id must be a non-negative integer, got {}", v[0]));
+  }
+
+  const auto& forbidden = forbiddenClients();
+  auto it = forbidden.find(clientId_);
+  if (it != forbidden.end()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "FBOSS does not allow changing admin distance for client-id {}: {}",
+            clientId_,
+            it->second));
+  }
+
+  try {
+    distance_ = folly::to<int32_t>(v[1]);
+  } catch (const folly::ConversionError&) {
+    throw std::invalid_argument(
+        fmt::format("Invalid distance '{}': must be an integer", v[1]));
+  }
+  if (distance_ < 0 || distance_ > kMaxAdminDistance) {
+    throw std::invalid_argument(
+        fmt::format(
+            "distance must be in the range [0, {}], got {}",
+            kMaxAdminDistance,
+            v[1]));
+  }
+
+  data_ = std::move(v);
+}
+
+CmdConfigAdminDistanceTraits::RetType CmdConfigAdminDistance::queryClient(
+    const HostInfo& /* hostInfo */,
+    const ObjectArgType& arg) {
+  auto& session = ConfigSession::getInstance();
+  auto& config = session.getAgentConfig();
+  auto& swConfig = *config.sw();
+
+  int32_t clientId = arg.getClientId();
+  int32_t distance = arg.getDistance();
+
+  // Read-modify-write a single map entry, preserving all other clientId
+  // mappings already present in the config.
+  auto& adminDistanceMap = *swConfig.clientIdToAdminDistance();
+  auto it = adminDistanceMap.find(clientId);
+  if (it != adminDistanceMap.end()) {
+    if (it->second == distance) {
+      return fmt::format(
+          "Admin distance for client-id {} is already set to {}",
+          clientId,
+          distance);
+    }
+    it->second = distance;
+  } else {
+    adminDistanceMap.emplace(clientId, distance);
+  }
+
+  // clientIdToAdminDistance is only consulted at route-program time; existing
+  // routes are not re-stamped when the map changes. A coldboot is required to
+  // flush and re-program all routes with the updated admin distances.
+  session.saveConfig(
+      cli::ServiceType::AGENT, cli::ConfigActionLevel::AGENT_COLDBOOT);
+
+  return fmt::format(
+      "Successfully set admin distance for client-id {} to {}. "
+      "A coldboot is required to apply the change to existing routes.",
+      clientId,
+      distance);
+}
+
+void CmdConfigAdminDistance::printOutput(const RetType& output) {
+  std::cout << output << "\n";
+}
+
+// Explicit template instantiation
+template void
+CmdHandler<CmdConfigAdminDistance, CmdConfigAdminDistanceTraits>::run();
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h
+++ b/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "fboss/cli/fboss2/CmdHandler.h"
+#include "fboss/cli/fboss2/commands/config/switch/CmdConfigSwitch.h"
 
 namespace facebook::fboss {
 
@@ -40,6 +41,7 @@ class AdminDistanceArg : public utils::BaseObjectArgType<std::string> {
 };
 
 struct CmdConfigAdminDistanceTraits : public WriteCommandTraits {
+  using ParentCmd = CmdConfigSwitch;
   static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
     cmd.add_option(
         "client_distance",

--- a/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h
+++ b/fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#pragma once
+
+#include "fboss/cli/fboss2/CmdHandler.h"
+
+namespace facebook::fboss {
+
+// Parses the two positional arguments of
+//   config switch admin-distance <client-id> <distance>
+// where <client-id> is a routing ClientID (e.g. 0=BGP, 786=OpenR)
+// and <distance> is the administrative distance to associate with it.
+// ClientIDs 1 (STATIC_ROUTE), 2 (INTERFACE_ROUTE), 3 (LINKLOCAL_ROUTE),
+// and 4 (REMOTE_INTERFACE_ROUTE) are forbidden: their admin distances are
+// hardcoded in the agent and cannot be changed via config.
+class AdminDistanceArg : public utils::BaseObjectArgType<std::string> {
+ public:
+  /* implicit */ AdminDistanceArg( // NOLINT(google-explicit-constructor)
+      std::vector<std::string> v);
+
+  int32_t getClientId() const {
+    return clientId_;
+  }
+
+  int32_t getDistance() const {
+    return distance_;
+  }
+
+ private:
+  int32_t clientId_{0};
+  int32_t distance_{0};
+};
+
+struct CmdConfigAdminDistanceTraits : public WriteCommandTraits {
+  static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    cmd.add_option(
+        "client_distance",
+        args,
+        "<client-id> <distance> - admin distance for a routing client "
+        "(client-id: 0=BGP, 786=OpenR; distance: 0-255). "
+        "Client-ids 1/2/3/4 are hardcoded and cannot be changed.");
+  }
+  using ObjectArgType = AdminDistanceArg;
+  using RetType = std::string;
+};
+
+class CmdConfigAdminDistance
+    : public CmdHandler<CmdConfigAdminDistance, CmdConfigAdminDistanceTraits> {
+ public:
+  using ObjectArgType = CmdConfigAdminDistanceTraits::ObjectArgType;
+  using RetType = CmdConfigAdminDistanceTraits::RetType;
+
+  RetType queryClient(const HostInfo& hostInfo, const ObjectArgType& arg);
+
+  void printOutput(const RetType& output);
+};
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/BUCK
+++ b/fboss/cli/fboss2/test/config/BUCK
@@ -7,6 +7,7 @@ cpp_unittest(
     name = "cmd_config_test",
     srcs = [
         "BgpConfigSessionTest.cpp",
+        "CmdConfigAdminDistanceTest.cpp",
         "CmdConfigAppliedInfoTest.cpp",
         "CmdConfigArpTest.cpp",
         "CmdConfigCoppTest.cpp",

--- a/fboss/cli/fboss2/test/config/CmdConfigAdminDistanceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigAdminDistanceTest.cpp
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "fboss/cli/fboss2/commands/config/switch/admin_distance/CmdConfigAdminDistance.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+// Seed mirrors the production clientIdToAdminDistance map shipped on Meta
+// devices: every routing client is mapped (BGP=20, static=1, interface/
+// linklocal/remote=0, local-BGP/OpenR=10, internal=255). The CLI mutates a
+// single entry, so the test asserts the other entries survive untouched.
+class CmdConfigAdminDistanceTestFixture : public CmdConfigTestBase {
+ public:
+  CmdConfigAdminDistanceTestFixture()
+      : CmdConfigTestBase(
+            "fboss_admin_distance_test_%%%%-%%%%-%%%%-%%%%",
+            R"({
+  "sw": {
+    "clientIdToAdminDistance": {
+      "0": 20,
+      "1": 1,
+      "2": 0,
+      "3": 0,
+      "4": 0,
+      "700": 255,
+      "786": 10
+    }
+  }
+})") {}
+
+ protected:
+  const std::string setPrefix_ = "config switch admin-distance";
+};
+
+// ==============================================================================
+// AdminDistanceArg Validation Tests
+// ==============================================================================
+
+TEST_F(CmdConfigAdminDistanceTestFixture, argValidation) {
+  // Valid values
+  EXPECT_EQ(AdminDistanceArg({"0", "20"}).getClientId(), 0);
+  EXPECT_EQ(AdminDistanceArg({"0", "20"}).getDistance(), 20);
+  EXPECT_EQ(AdminDistanceArg({"786", "10"}).getClientId(), 786);
+  EXPECT_EQ(AdminDistanceArg({"700", "255"}).getDistance(), 255);
+
+  // Invalid: empty
+  EXPECT_THROW(AdminDistanceArg({}), std::invalid_argument);
+
+  // Invalid: wrong arity
+  EXPECT_THROW(AdminDistanceArg({"0"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"0", "20", "30"}), std::invalid_argument);
+
+  // Invalid: non-integer
+  EXPECT_THROW(AdminDistanceArg({"bgp", "20"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"0", "twenty"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"0", "20.5"}), std::invalid_argument);
+
+  // Invalid: negative client-id
+  EXPECT_THROW(AdminDistanceArg({"-1", "20"}), std::invalid_argument);
+
+  // Invalid: distance out of [0, 255]
+  EXPECT_THROW(AdminDistanceArg({"0", "-1"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"0", "256"}), std::invalid_argument);
+
+  // Invalid: forbidden client IDs whose admin distance is hardcoded in agent.
+  // STATIC_ROUTE(1)           -> AdminDistance::STATIC_ROUTE
+  // INTERFACE_ROUTE(2)        -> AdminDistance::DIRECTLY_CONNECTED
+  // LINKLOCAL_ROUTE(3)        -> AdminDistance::DIRECTLY_CONNECTED
+  // REMOTE_INTERFACE_ROUTE(4) -> AdminDistance::DIRECTLY_CONNECTED
+  EXPECT_THROW(AdminDistanceArg({"1", "5"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"2", "5"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"3", "5"}), std::invalid_argument);
+  EXPECT_THROW(AdminDistanceArg({"4", "5"}), std::invalid_argument);
+}
+
+// ==============================================================================
+// Set Command Tests
+// ==============================================================================
+
+TEST_F(CmdConfigAdminDistanceTestFixture, updateExistingClient) {
+  setupTestableConfigSession(setPrefix_, "0 30");
+  CmdConfigAdminDistance cmd;
+  HostInfo hostInfo("testhost");
+  AdminDistanceArg arg({"0", "30"});
+
+  auto result = cmd.queryClient(hostInfo, arg);
+  EXPECT_THAT(result, HasSubstr("30"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  const auto& map = *config.sw()->clientIdToAdminDistance();
+  EXPECT_EQ(map.at(0), 30);
+
+  // Other entries must survive untouched.
+  EXPECT_EQ(map.at(1), 1);
+  EXPECT_EQ(map.at(2), 0);
+  EXPECT_EQ(map.at(3), 0);
+  EXPECT_EQ(map.at(4), 0);
+  EXPECT_EQ(map.at(700), 255);
+  EXPECT_EQ(map.at(786), 10);
+  EXPECT_EQ(map.size(), 7);
+}
+
+TEST_F(CmdConfigAdminDistanceTestFixture, addNewClient) {
+  setupTestableConfigSession(setPrefix_, "800 2");
+  CmdConfigAdminDistance cmd;
+  HostInfo hostInfo("testhost");
+  AdminDistanceArg arg({"800", "2"});
+
+  auto result = cmd.queryClient(hostInfo, arg);
+  EXPECT_THAT(result, HasSubstr("800"));
+
+  auto& config = ConfigSession::getInstance().getAgentConfig();
+  const auto& map = *config.sw()->clientIdToAdminDistance();
+  EXPECT_EQ(map.at(800), 2);
+  // All original entries preserved; new key added.
+  EXPECT_EQ(map.at(0), 20);
+  EXPECT_EQ(map.at(1), 1);
+  EXPECT_EQ(map.at(2), 0);
+  EXPECT_EQ(map.at(3), 0);
+  EXPECT_EQ(map.at(4), 0);
+  EXPECT_EQ(map.at(700), 255);
+  EXPECT_EQ(map.at(786), 10);
+  EXPECT_EQ(map.size(), 8);
+}
+
+TEST_F(CmdConfigAdminDistanceTestFixture, alreadySet) {
+  // Seed has client-id 786 -> 10; setting to 10 is a no-op.
+  setupTestableConfigSession(setPrefix_, "786 10");
+  CmdConfigAdminDistance cmd;
+  HostInfo hostInfo("testhost");
+  AdminDistanceArg arg({"786", "10"});
+
+  auto result = cmd.queryClient(hostInfo, arg);
+  EXPECT_THAT(result, HasSubstr("already"));
+}
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -16,6 +16,7 @@ oncall("fboss_oss")
 cpp_binary(
     name = "fboss2_integration_test",
     srcs = [
+        "ConfigAdminDistanceTest.cpp",
         "ConfigArpTest.cpp",
         "ConfigConcurrentSessionsTest.cpp",
         "ConfigCoppTest.cpp",

--- a/fboss/cli/fboss2/test/integration_test/ConfigAdminDistanceTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigAdminDistanceTest.cpp
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+/**
+ * End-to-end test for:
+ *   fboss2-dev config switch admin-distance <client-id> <distance>
+ *
+ * Reads the current clientIdToAdminDistance map, picks an existing allowed
+ * client, changes its distance, verifies the new value round-trips through the
+ * agent's running config (and that the other entries survive), then restores
+ * the original. The change requires a coldboot because existing routes are not
+ * re-stamped when the map changes — only newly programmed routes pick up the
+ * new distance.
+ *
+ * A second test verifies that forbidden client IDs (STATIC_ROUTE,
+ * INTERFACE_ROUTE, LINKLOCAL_ROUTE, REMOTE_INTERFACE_ROUTE) are rejected by
+ * the CLI before any config is modified.
+ */
+
+#include <folly/json/dynamic.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <map>
+#include <string>
+#include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+
+using namespace facebook::fboss;
+
+class ConfigAdminDistanceTest : public Fboss2IntegrationTest {
+ protected:
+  std::map<int, int> getAdminDistances() const {
+    std::map<int, int> result;
+    auto config = getRunningConfig();
+    const auto& sw = config["sw"];
+    if (!sw.count("clientIdToAdminDistance")) {
+      return result;
+    }
+    for (const auto& [clientId, distance] :
+         sw["clientIdToAdminDistance"].items()) {
+      result[folly::to<int>(clientId.asString())] = distance.asInt();
+    }
+    return result;
+  }
+
+  auto runAdminDistance(int clientId, int distance) {
+    return runCli(
+        {"config",
+         "switch",
+         "admin-distance",
+         std::to_string(clientId),
+         std::to_string(distance)});
+  }
+
+  void setAdminDistance(int clientId, int distance) {
+    auto result = runAdminDistance(clientId, distance);
+    ASSERT_EQ(result.exitCode, 0)
+        << "admin-distance CLI failed: " << result.stderr;
+    commitConfig();
+    waitForAgentReady();
+  }
+};
+
+TEST_F(ConfigAdminDistanceTest, SetAndRestoreAdminDistance) {
+  XLOG(INFO) << "[Step 1] Reading current admin distances...";
+  auto original = getAdminDistances();
+  ASSERT_FALSE(original.empty())
+      << "Running config has no clientIdToAdminDistance entries to test with";
+
+  // Skip hardcoded client IDs (1-4) when picking the target.
+  static const std::set<int> kForbidden = {1, 2, 3, 4};
+  auto it = original.begin();
+  while (it != original.end() && kForbidden.count(it->first)) {
+    ++it;
+  }
+  ASSERT_NE(it, original.end())
+      << "No allowed client-id found in clientIdToAdminDistance";
+
+  int clientId = it->first;
+  int originalDistance = it->second;
+  XLOG(INFO) << "  client-id " << clientId << " -> " << originalDistance;
+
+  // Pick a distinct, valid distance in [0, 255].
+  int newDistance = (originalDistance == 42) ? 43 : 42;
+
+  XLOG(INFO) << "[Step 2] Setting client-id " << clientId << " to "
+             << newDistance << "...";
+  setAdminDistance(clientId, newDistance);
+  auto updated = getAdminDistances();
+  EXPECT_EQ(updated[clientId], newDistance);
+
+  // The other entries must survive untouched.
+  for (const auto& [id, distance] : original) {
+    if (id != clientId) {
+      EXPECT_EQ(updated[id], distance)
+          << "client-id " << id << " changed unexpectedly";
+    }
+  }
+
+  XLOG(INFO) << "[Step 3] Restoring client-id " << clientId << " to "
+             << originalDistance << "...";
+  setAdminDistance(clientId, originalDistance);
+  EXPECT_EQ(getAdminDistances()[clientId], originalDistance);
+
+  XLOG(INFO) << "TEST PASSED";
+}
+
+TEST_F(ConfigAdminDistanceTest, ForbiddenClientIdsRejected) {
+  // client-ids 1-4 have hardcoded admin distances in the agent; the CLI must
+  // reject them before touching config so no coldboot is triggered.
+  const std::vector<std::pair<int, std::string>> forbidden = {
+      {1, "STATIC_ROUTE"},
+      {2, "INTERFACE_ROUTE"},
+      {3, "LINKLOCAL_ROUTE"},
+      {4, "REMOTE_INTERFACE_ROUTE"},
+  };
+  for (const auto& [clientId, name] : forbidden) {
+    XLOG(INFO) << "  Verifying client-id " << clientId << " (" << name
+               << ") is rejected...";
+    auto result = runAdminDistance(clientId, 50);
+    EXPECT_NE(result.exitCode, 0)
+        << "Expected failure for forbidden client-id " << clientId << " ("
+        << name << ") but CLI succeeded";
+  }
+  XLOG(INFO) << "TEST PASSED";
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

Adds a new write command:

    fboss2-dev config switch admin-distance <client-id> <distance>

Sets the administrative distance for a routing client in the agent running config via a COLDBOOT config session.

### What

- New command CmdConfigAdminDistance with AdminDistanceArg validating two positional args: client-id (non-negative integer) and distance (0-255)
- Read-modify-write on clientIdToAdminDistance map - all other client entries survive untouched
- No-op detection - if the value is already set, returns early without saving
- Registered under `config switch` as a switch-level setting
- Blocks client-ids 1/2/3/4 (STATIC_ROUTE, INTERFACE_ROUTE, LINKLOCAL_ROUTE, REMOTE_INTERFACE_ROUTE) whose admin distances are hardcoded in the agent and cannot be changed via config
- Wired into CMake (fboss2_config_lib, fboss2_cmd_config_test, fboss2_integration_test) and BUCK

# Test Plan

Validated by a full CI run of this PR rebased onto the latest stable commit (`ac0f8c3e61`): complete unit-test suite plus the fboss2 CLI integration suite against a fake-SAI simulator running the split sw/hw agents.

### Unit tests — full suite: 1592/1592 passed

    Start  325: CmdConfigAdminDistanceTestFixture.argValidation
    Start  326: CmdConfigAdminDistanceTestFixture.updateExistingClient
    Start  327: CmdConfigAdminDistanceTestFixture.addNewClient
    Start  328: CmdConfigAdminDistanceTestFixture.alreadySet
    325/1592 Test  #325: CmdConfigAdminDistanceTestFixture.argValidation ........... Passed 2.30 sec
    326/1592 Test  #326: CmdConfigAdminDistanceTestFixture.updateExistingClient .... Passed 2.29 sec
    327/1592 Test  #327: CmdConfigAdminDistanceTestFixture.addNewClient ............ Passed 2.29 sec
    328/1592 Test  #328: CmdConfigAdminDistanceTestFixture.alreadySet .............. Passed 2.29 sec
    ...
    100% tests passed, 0 tests failed out of 1592

### Integration tests — fboss2_integration_test on fake-SAI sim: 99/99 passed (31 suites)

    [----------] 2 tests from ConfigAdminDistanceTest
    [ RUN      ] ConfigAdminDistanceTest.SetAndRestoreAdminDistance
    I0702 13:58:56] [Step 1] Reading current admin distances...
    I0702 13:58:56]   client-id 0 -> 20
    I0702 13:58:56] [Step 2] Setting client-id 0 to 42...
    I0702 13:58:56] Running CLI command: config switch admin-distance 0 42
    I0702 13:58:57] Running CLI command: config session commit
    ...
    [       OK ] ConfigAdminDistanceTest.SetAndRestoreAdminDistance (59146 ms)
    [ RUN      ] ConfigAdminDistanceTest.ForbiddenClientIdsRejected
    I0702 13:59:56]   Verifying client-id 1 (STATIC_ROUTE) is rejected...
    E0702 13:59:56] Error in command execution: Invalid argument: FBOSS does not allow changing admin distance for client-id 1: STATIC_ROUTE is hardcoded to AdminDistance::STATIC_ROUTE in the agent
    ...
    [       OK ] ConfigAdminDistanceTest.ForbiddenClientIdsRejected
    ...
    [==========] 99 tests from 31 test suites ran. (184487 ms total)
    [  PASSED  ] 99 tests.
