### PR TITLE
[Celestica] Leh800bcls: Fix cold-boot bad_optional_access in getFECMode during PhyInfo collection in case AgentEnsembleLinkTest.xPhyInfoTest

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiPortManager.cpp
@@ -3786,10 +3786,15 @@ std::vector<sai_port_err_status_t> SaiPortManager::getPortErrStatus(
 
 phy::FecMode SaiPortManager::getFECMode(PortID portId) const {
   auto handle = getPortHandle(portId);
-  auto saiFecMode = GET_OPT_ATTR(Port, FecMode, handle->port->attributes());
-  auto profileID = platform_->getPort(portId)->getCurrentProfile();
-  return utility::getFecModeFromSaiFecMode(
-      static_cast<sai_port_fec_mode_t>(saiFecMode), profileID);
+  auto attr = std::get<std::optional<SaiPortTraits::Attributes::FecMode>>(
+      handle->port->attributes());
+  if (attr.has_value()) {
+    auto saiFecMode = attr.value().value();
+    auto profileID = platform_->getPort(portId)->getCurrentProfile();
+    return utility::getFecModeFromSaiFecMode(
+        static_cast<sai_port_fec_mode_t>(saiFecMode), profileID);
+  }
+  return phy::FecMode::NONE;
 }
 
 cfg::PortSpeed SaiPortManager::getSpeed(PortID portId) const {


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
A persistent std::bad_optional_access exception triggered during the periodic PhyInfo collection (updateAllPhyInfoLocked) under cold-boot multi-NPU configurations.  the log as below:
```
HwSwitch.cpp:241] Error running updateAllPhyInfo: std::bad_optional_access: bad optional access
```
This silent crash was the root cause behind the failure of AgentEnsembleLinkTest.xPhyInfoTest, where port eth1/3/1 (PortID 1) was unable to populate or fetch its PhyInfo diagnostics. Eventually, the following error is thrown:
```
Value of: phyInfo.has_value()
  Actual: false
Expected: true
eth1/3/1 has no xphy info.
```

# Root Cause
 Through step-by-step triage, the root cause as follows:

  1. Cold-boot Timing Race
    During a cold boot, the unified SwSwitch programs ports sequentially over a 1 to 2-minute window. However, the periodic
 updateAllPhyInfoLocked() monitoring loop runs every 10 seconds from the very beginning. This means it inevitably scans ports that are not yet programmed or ports that never have FEC enabled (such as MANAGEMENT_PORT or inactive ports).

  2. The GET_OPT_ATTR Crash Mechanics:
    In SaiPortManager::getFECMode, the code attempts to fetch the FEC mode from the port's creation attributes tuple:
    ```
      auto saiFecMode = GET_OPT_ATTR(Port, FecMode, handle->port->attributes());
    ```
    The GET_OPT_ATTR macro is defined with double .value() calls:
```
      #define GET_OPT_ATTR(obj, attr, tuple)                               \
        std::get<std::optional<Sai##obj##Traits::Attributes::attr>>(tuple) \
            .value()                                                       \
            .value()
```
    For unprogrammed ports or management ports, FecMode is not set during port creation and resides as std::nullopt inside the attributes() tuple. Calling the first .value() on this empty std::optional immediately throws a std::bad_optional_access exception.

  3. The Exception Deadlock Loop:
     - When std::bad_optional_access is thrown, the entire updateAllPhyInfoLocked execution is aborted midway.
     - Consequently, the crucial historical stats cache lastPhyInfos_ is never updated and remains completely empty.
     - In subsequent polling rounds (even after all ports are fully programmed and getFECMode no longer crashes), because lastPhyInfos_ is empty, downstream helper functions like PhyUtils.cpp::updateCorrectedBitsAndPreFECBer are forced to process a default-constructed empty oldRsFecInfo state.
     - This in turn causes other fields (such as correctedBits()) to be empty, throwing another std::bad_optional_access exception,
       trapping the stats update cycle in a perpetual crash loop and preventing getXphyInfo from ever returning data to the test suite.

  4. Why InterfaceType and MediaType do not crash:
     - InterfaceType: On the Tomahawk6 platform, PORT_INTERFACE_TYPE is explicitly unsupported(Tomahawk6Asic::isSupported returns false).
       The getInterfaceType getter bails out early at if (!isSupported) and never executes GET_OPT_ATTR, which is why reverting it is perfectly safe.
     - MediaType: This is a mandatory attribute specified during port creation across all active profiles, meaning it always holds a valid value inside the attributes() tuple and thus never triggers a crash.

# Solution
To resolve the root cause cleanly and non-invasively, we hardened SaiPortManager::getFECMode by replacing the raw GET_OPT_ATTR macro with a robust double-optional check:
1. Retrieve std::optional<SaiPortTraits::Attributes::FecMode> directly from the attributes tuple via std::get.
2. Perform a safe .has_value() check on the outer optional to verify the attribute's existence in the port's active configuration.
3. If present, extract the underlying raw value using .value().value().
4. If absent (e.g., unprogrammed or management ports), fallback to phy::FecMode::NONE as a safe, crash-free default.

# Test Plan
  - Link test T1 case AgentEnsembleLinkTest.xPhyInfoTest, AgentEnsembleQsfpFsdbTest.phy passed.
  - 0 Exception/crashes: The stats collection loop runs completely error-free throughout the entire boot cycle across all active switches, no bad_optional_access log found.
**before fix:**
```
[root@localhost LinkTestTx]# grep "Error running updateAllPhyInfo: std::bad_optional_access: bad optional access" qsfp_AgentEnsemble*.log | wc -l
4223
[root@localhost LinkTestTx]# grep -A 4 Expected link-test-AgentEnsemble*.log
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_141907.log:Expected: true
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_141907.log-eth1/3/1 has no xphy info.
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_141907.log-
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_141907.log-E0616 14:22:02.828735 1095188 AgentEnsembleLinkTest.cpp:171] Failed to dump i2c log for port eth1/3/1 Exception Can't find transceiver module for port name: eth1/3/1
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_141907.log-E0616 14:22:02.828866 1095188 AgentEnsembleLinkTest.cpp:171] Failed to dump i2c log for port eth1/4/1 Exception Can't find transceiver module for port name: eth1/4/1
--
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log:Expected equality of these values:
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-  states->size()
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-    Which is: 0
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-  xphyPorts.size()
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-    Which is: 412
--
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log:Expected equality of these values:
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-  stats->size()
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-    Which is: 0
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-  xphyPorts.size()
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_142354.log-    Which is: 412
[root@localhost LinkTestTx]#

```
**after fix:**
```
[root@localhost LinkTestTx]# grep bad_ qsfp_AgentEnsemble*.log
[root@localhost LinkTestTx]# grep " OK " link-test-AgentEnsemble*.log
link-test-AgentEnsembleLinkTest.xPhyInfoTest-20260616_143137.log:[       OK ] AgentEnsembleLinkTest.xPhyInfoTest (81939 ms)
link-test-AgentEnsembleQsfpFsdbTest.phy-20260616_143450.log:[       OK ] AgentEnsembleQsfpFsdbTest.phy (61657 ms)

```
