### PR TITLE
[Accton][minipack3bta] Disable unsupported ACL features for BCM78920

### DIFF
--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -76,7 +76,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SAI_UDF_HASH:
     case HwAsic::Feature::SEPARATE_BYTE_AND_PACKET_ACL_COUNTER:
     case HwAsic::Feature::SAI_EAPOL_TRAP:
-    case HwAsic::Feature::SAI_USER_DEFINED_TRAP:
     case HwAsic::Feature::ACL_COUNTER_LABEL:
     case HwAsic::Feature::SAI_FEC_CORRECTED_BITS:
     case HwAsic::Feature::SAI_FEC_CODEWORDS_STATS:
@@ -90,7 +89,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::INGRESS_PRIORITY_GROUP_SHARED_WATERMARK:
     case HwAsic::Feature::INGRESS_PRIORITY_GROUP_HEADROOM_WATERMARK:
     case HwAsic::Feature::BUFFER_POOL_HEADROOM_WATERMARK:
-    case HwAsic::Feature::SAI_SET_TC_WITH_USER_DEFINED_TRAP_CPU_ACTION:
     case HwAsic::Feature::EGRESS_POOL_AVAILABLE_SIZE_ATTRIBUTE_SUPPORTED:
     case HwAsic::Feature::PFC_WATCHDOG_TIMER_GRANULARITY:
     case HwAsic::Feature::RX_SNR:
@@ -110,7 +108,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
       return true;
     case HwAsic::Feature::MPLS:
     case HwAsic::Feature::MPLS_ECMP:
-    case HwAsic::Feature::ACL_METADATA_QUALIFER:
     case HwAsic::Feature::ARS_PORT_ATTRIBUTES:
     case HwAsic::Feature::ARS_FUTURE_PORT_LOAD:
     case HwAsic::Feature::ECMP_DLB_OFFSET:
@@ -238,6 +235,10 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ARS:
     case HwAsic::Feature::ARS_ALTERNATE_MEMBERS:
     case HwAsic::Feature::ACL_SET_ECMP_HASH_ALGORITHM:
+    // TU1 SDK 15.x: ACL metadata qualifier and user-defined trap not supported
+    case HwAsic::Feature::ACL_METADATA_QUALIFER:
+    case HwAsic::Feature::SAI_USER_DEFINED_TRAP:
+    case HwAsic::Feature::SAI_SET_TC_WITH_USER_DEFINED_TRAP_CPU_ACTION:
       return false;
   }
   return false;


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR.
- [x] `pre-commit run`

# Summary

Disable three HwAsic features that TU1 (BCM78920, XGS SDK 15.x) does not
support. These cause Agent HW test failures (e.g.
`AgentCoppTest/0.ArpRequestAndReplyToHighPriQ`) on TU1 hardware.

`ACL_METADATA_QUALIFER` (was true) causes the CoPP config code to generate
ACL entries with `lookupClassRoute` qualifier. TU1's default ACL table
does not include this qualifier, so config creation throws:
`No acl table found for acl entry cpuPolicing-high-myip-network-control-acl`

`SAI_USER_DEFINED_TRAP` (was true) causes ACL entries to include
`ACTION_SET_USER_DEFINED_TRAP`. SDK returns SAI_STATUS_NOT_SUPPORTED on
create_acl_entry.

`SAI_SET_TC_WITH_USER_DEFINED_TRAP_CPU_ACTION` (was true) causes ACL entries
to include `ACTION_SET_TC`. SDK returns SAI_STATUS_NOT_SUPPORTED on
create_acl_entry.

Move all three from supported to unconditional `return false` in
`TomahawkUltra1Asic::isSupported()`. CoPP path then skips lookupClassRoute
ACL entries and uses sendToQueue fallback (hostif trap to queue mapping).

# Test Plan

- Agent HW test `AgentCoppTest/0.ArpRequestAndReplyToHighPriQ` passes on TU1

[PASSED_mode1_agent_20260617_144125.zip](https://github.com/user-attachments/files/29036650/PASSED_mode1_agent_20260617_144125.zip)
[FAILED_mode1_agent_20260617_144054.zip](https://github.com/user-attachments/files/29036653/FAILED_mode1_agent_20260617_144054.zip)
