### PR TITLE
[Nexthop][fboss2-dev] Fix empty hash-fields no-op and LAG UDF group ID drop in SaiSwitchManager

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiSwitchManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiSwitchManager.cpp
@@ -512,6 +512,12 @@ void SaiSwitchManager::addOrUpdateEcmpLoadBalancer(
         hash, programmedLoadBalancer);
 
     ecmpV4Hash_ = std::move(hash);
+  } else if (ecmpV4Hash_) {
+    // IPv4 fields cleared to empty — detach the hash from the switch and
+    // release the object so it can be freed without OBJECT_IN_USE.
+    switch_->setOptionalAttribute(
+        SaiSwitchTraits::Attributes::EcmpHashV4{SAI_NULL_OBJECT_ID});
+    ecmpV4Hash_.reset();
   }
   if (newLb->getIPv6Fields().begin() != newLb->getIPv6Fields().end()) {
     // v6 ECMP
@@ -540,14 +546,17 @@ void SaiSwitchManager::addOrUpdateEcmpLoadBalancer(
         hash, programmedLoadBalancer);
 
     ecmpV6Hash_ = std::move(hash);
+  } else if (ecmpV6Hash_) {
+    // IPv6 fields cleared to empty — detach and release.
+    switch_->setOptionalAttribute(
+        SaiSwitchTraits::Attributes::EcmpHashV6{SAI_NULL_OBJECT_ID});
+    ecmpV6Hash_.reset();
   }
 }
 
 void SaiSwitchManager::programLagLoadBalancerParams(
     std::optional<sai_uint32_t> seed,
     std::optional<cfg::HashingAlgorithm> algo) {
-  // TODO(skhare) setLoadBalancer is called only for ECMP today. Add similar
-  // logic for LAG.
   auto hashSeed = seed ? seed.value() : 0;
   auto hashAlgo = algo ? toSaiHashAlgo(algo.value()) : SAI_HASH_ALGORITHM_CRC;
   switch_->setOptionalAttribute(
@@ -564,8 +573,13 @@ void SaiSwitchManager::addOrUpdateLagLoadBalancer(
   }
   programLagLoadBalancerParams(newLb->getSeed(), newLb->getAlgorithm());
 
+  auto udfGroupIds = getUdfGroupIds(newLb);
+
   if (newLb->getIPv4Fields().begin() != newLb->getIPv4Fields().end()) {
     // v4 LAG
+    auto programmedLoadBalancer =
+        getProgrammedHashAttr<SaiSwitchTraits::Attributes::LagHashV4>();
+
     cfg::Fields v4LagHashFields;
     std::for_each(
         newLb->getIPv4Fields().begin(),
@@ -580,13 +594,28 @@ void SaiSwitchManager::addOrUpdateLagLoadBalancer(
         [&v4LagHashFields](const auto& entry) {
           v4LagHashFields.transportFields()->insert(entry->cref());
         });
-    lagV4Hash_ = managerTable_->hashManager().getOrCreate(v4LagHashFields);
-    // Set the new lag v4 hash attribute on switch obj
+
+    auto hash =
+        managerTable_->hashManager().getOrCreate(v4LagHashFields, udfGroupIds);
+
+    // Detach the previously-programmed hash from the switch before the old
+    // lagV4Hash_ shared_ptr is dropped, otherwise SAI fails the remove call
+    // with OBJECT_IN_USE and terminate() fires from the SaiObject destructor.
+    setLoadBalancer<SaiSwitchTraits::Attributes::LagHashV4>(
+        hash, programmedLoadBalancer);
+
+    lagV4Hash_ = std::move(hash);
+  } else if (lagV4Hash_) {
+    // IPv4 fields cleared to empty — detach and release.
     switch_->setOptionalAttribute(
-        SaiSwitchTraits::Attributes::LagHashV4{lagV4Hash_->adapterKey()});
+        SaiSwitchTraits::Attributes::LagHashV4{SAI_NULL_OBJECT_ID});
+    lagV4Hash_.reset();
   }
   if (newLb->getIPv6Fields().begin() != newLb->getIPv6Fields().end()) {
     // v6 LAG
+    auto programmedLoadBalancer =
+        getProgrammedHashAttr<SaiSwitchTraits::Attributes::LagHashV6>();
+
     cfg::Fields v6LagHashFields;
     std::for_each(
         newLb->getIPv6Fields().begin(),
@@ -602,10 +631,18 @@ void SaiSwitchManager::addOrUpdateLagLoadBalancer(
           v6LagHashFields.transportFields()->insert(entry->cref());
         });
 
-    lagV6Hash_ = managerTable_->hashManager().getOrCreate(v6LagHashFields);
-    // Set the new lag v6 hash attribute on switch obj
+    auto hash =
+        managerTable_->hashManager().getOrCreate(v6LagHashFields, udfGroupIds);
+
+    setLoadBalancer<SaiSwitchTraits::Attributes::LagHashV6>(
+        hash, programmedLoadBalancer);
+
+    lagV6Hash_ = std::move(hash);
+  } else if (lagV6Hash_) {
+    // IPv6 fields cleared to empty — detach and release.
     switch_->setOptionalAttribute(
-        SaiSwitchTraits::Attributes::LagHashV6{lagV6Hash_->adapterKey()});
+        SaiSwitchTraits::Attributes::LagHashV6{SAI_NULL_OBJECT_ID});
+    lagV6Hash_.reset();
   }
 }
 

--- a/fboss/agent/hw/sai/switch/tests/SwitchManagerTest.cpp
+++ b/fboss/agent/hw/sai/switch/tests/SwitchManagerTest.cpp
@@ -10,8 +10,10 @@
 #include "fboss/agent/hw/sai/api/AdapterKeySerializers.h"
 #include "fboss/agent/hw/sai/api/SwitchApi.h"
 #include "fboss/agent/hw/sai/switch/SaiSwitch.h"
+#include "fboss/agent/hw/sai/switch/SaiSwitchManager.h"
 #include "fboss/agent/hw/sai/switch/tests/ManagerTestBase.h"
 #include "fboss/agent/platforms/sai/SaiPlatform.h"
+#include "fboss/agent/state/LoadBalancer.h"
 
 #include <gtest/gtest.h>
 
@@ -19,7 +21,103 @@
 
 using namespace facebook::fboss;
 
-class SwitchManagerTest : public ManagerTestBase {};
+class SwitchManagerTest : public ManagerTestBase {
+ protected:
+  std::shared_ptr<LoadBalancer> makeLb(
+      cfg::LoadBalancerID id,
+      LoadBalancer::IPv4Fields v4,
+      LoadBalancer::IPv6Fields v6 = {},
+      LoadBalancer::TransportFields transport = {},
+      LoadBalancer::UdfGroupIds udfs = {}) {
+    return std::make_shared<LoadBalancer>(
+        id,
+        cfg::HashingAlgorithm::CRC16_CCITT,
+        uint32_t{0} /* seed */,
+        v4,
+        v6,
+        transport,
+        LoadBalancer::MPLSFields{},
+        udfs);
+  }
+
+  sai_object_id_t getEcmpHashV4() {
+    return saiApiTable->switchApi().getAttribute(
+        saiManagerTable->switchManager().getSwitchSaiId(),
+        SaiSwitchTraits::Attributes::EcmpHashV4{});
+  }
+  sai_object_id_t getEcmpHashV6() {
+    return saiApiTable->switchApi().getAttribute(
+        saiManagerTable->switchManager().getSwitchSaiId(),
+        SaiSwitchTraits::Attributes::EcmpHashV6{});
+  }
+  sai_object_id_t getLagHashV4() {
+    return saiApiTable->switchApi().getAttribute(
+        saiManagerTable->switchManager().getSwitchSaiId(),
+        SaiSwitchTraits::Attributes::LagHashV4{});
+  }
+  sai_object_id_t getLagHashV6() {
+    return saiApiTable->switchApi().getAttribute(
+        saiManagerTable->switchManager().getSwitchSaiId(),
+        SaiSwitchTraits::Attributes::LagHashV6{});
+  }
+};
+
+// Regression test: setting hash-fields to empty ("none") must clear the SAI
+// switch attribute rather than silently leaving the old hash programmed.
+TEST_F(SwitchManagerTest, clearEcmpHashFieldsClearsSwitch) {
+  auto lbWithFields = makeLb(
+      cfg::LoadBalancerID::ECMP,
+      {cfg::IPv4Field::SOURCE_ADDRESS, cfg::IPv4Field::DESTINATION_ADDRESS},
+      {cfg::IPv6Field::SOURCE_ADDRESS, cfg::IPv6Field::DESTINATION_ADDRESS});
+  saiManagerTable->switchManager().addOrUpdateLoadBalancer(lbWithFields);
+
+  EXPECT_NE(getEcmpHashV4(), SAI_NULL_OBJECT_ID);
+  EXPECT_NE(getEcmpHashV6(), SAI_NULL_OBJECT_ID);
+
+  // Clear both field sets to empty.
+  auto lbCleared = makeLb(cfg::LoadBalancerID::ECMP, {}, {});
+  saiManagerTable->switchManager().changeLoadBalancer(lbWithFields, lbCleared);
+
+  EXPECT_EQ(getEcmpHashV4(), SAI_NULL_OBJECT_ID);
+  EXPECT_EQ(getEcmpHashV6(), SAI_NULL_OBJECT_ID);
+}
+
+TEST_F(SwitchManagerTest, clearLagHashFieldsClearsSwitch) {
+  auto lbWithFields = makeLb(
+      cfg::LoadBalancerID::AGGREGATE_PORT,
+      {cfg::IPv4Field::SOURCE_ADDRESS, cfg::IPv4Field::DESTINATION_ADDRESS},
+      {cfg::IPv6Field::SOURCE_ADDRESS, cfg::IPv6Field::DESTINATION_ADDRESS});
+  saiManagerTable->switchManager().addOrUpdateLoadBalancer(lbWithFields);
+
+  EXPECT_NE(getLagHashV4(), SAI_NULL_OBJECT_ID);
+  EXPECT_NE(getLagHashV6(), SAI_NULL_OBJECT_ID);
+
+  auto lbCleared = makeLb(cfg::LoadBalancerID::AGGREGATE_PORT, {}, {});
+  saiManagerTable->switchManager().changeLoadBalancer(lbWithFields, lbCleared);
+
+  EXPECT_EQ(getLagHashV4(), SAI_NULL_OBJECT_ID);
+  EXPECT_EQ(getLagHashV6(), SAI_NULL_OBJECT_ID);
+}
+
+// Regression test: clearing only IPv4 fields must not disturb IPv6.
+TEST_F(SwitchManagerTest, clearEcmpHashV4OnlyLeavesV6Intact) {
+  auto lbFull = makeLb(
+      cfg::LoadBalancerID::ECMP,
+      {cfg::IPv4Field::SOURCE_ADDRESS},
+      {cfg::IPv6Field::SOURCE_ADDRESS});
+  saiManagerTable->switchManager().addOrUpdateLoadBalancer(lbFull);
+
+  auto v6Before = getEcmpHashV6();
+  EXPECT_NE(v6Before, SAI_NULL_OBJECT_ID);
+
+  // Clear only IPv4 fields; keep IPv6 unchanged.
+  auto lbV4Cleared =
+      makeLb(cfg::LoadBalancerID::ECMP, {}, {cfg::IPv6Field::SOURCE_ADDRESS});
+  saiManagerTable->switchManager().changeLoadBalancer(lbFull, lbV4Cleared);
+
+  EXPECT_EQ(getEcmpHashV4(), SAI_NULL_OBJECT_ID);
+  EXPECT_EQ(getEcmpHashV6(), v6Before);
+}
 
 TEST_F(SwitchManagerTest, serDeser) {
   auto saiSwitch = static_cast<SaiSwitch*>(saiPlatform->getHwSwitch());

--- a/fboss/cli/fboss2/test/integration_test/ConfigLoadBalancingTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigLoadBalancingTest.cpp
@@ -285,19 +285,15 @@ TEST_F(ConfigLoadBalancingTest, EcmpHashFieldsMpls) {
 // LAG (LoadBalancerID = 2 / AGGREGATE_PORT)
 // ============================================================
 
-// LAG tests disabled pending the UDF-group-ID fix in SaiSwitchManager:
-// addOrUpdateLagLoadBalancer did not pass udfGroupIds to
-// hashManager().getOrCreate(), so any LAG hash update on a DUT with UDF groups
-// would silently drop them.
-TEST_F(ConfigLoadBalancingTest, DISABLED_LagHashAlgorithm) {
+TEST_F(ConfigLoadBalancingTest, LagHashAlgorithm) {
   testAlgorithm("lag", kLagIdValue, "crc32-lo", 3);
 }
 
-TEST_F(ConfigLoadBalancingTest, DISABLED_LagHashSeed) {
+TEST_F(ConfigLoadBalancingTest, LagHashSeed) {
   testSeed("lag", kLagIdValue, 271828);
 }
 
-TEST_F(ConfigLoadBalancingTest, DISABLED_LagHashFieldsIpv4) {
+TEST_F(ConfigLoadBalancingTest, LagHashFieldsIpv4) {
   testFields(
       "lag",
       kLagIdValue,


### PR DESCRIPTION
## Summary

This PR is the agent-side bug fix split out from #1105 at the FBOSS team's request.

#1105 adds the `fboss2-dev config load-balancing` CLI subcommands.  During integration testing we discovered two related bugs in `SaiSwitchManager::addOrUpdateLagLoadBalancer` that cause incorrect behavior and, in the hash-fields case, a hard crash of `fboss_hw_agent`.  Those fixes were originally bundled in #1105 but are now separated here so each PR has a single concern.

**Merge order: #1105 first, then this PR.**

### Bug 1: LAG UDF group ID drop

`addOrUpdateLagLoadBalancer` called `hashManager().getOrCreate(hashFields)` without passing `udfGroupIds`.  On any DUT that has UDF groups wired into its LAG load-balancer, every CLI-triggered hash update would silently recreate the hash object without those UDF groups, corrupting the LAG hashing policy in place.

Fix: extract `udfGroupIds` before the `if`-blocks and thread it into both `getOrCreate(v4LagHashFields, udfGroupIds)` and `getOrCreate(v6LagHashFields, udfGroupIds)`, matching what the ECMP path already did.

### Bug 2: Empty hash-fields no-op (ECMP and LAG)

When the new load-balancer config carries an empty IPv4 or IPv6 field set (i.e. the user cleared all fields), the `if (fields.begin() != fields.end())` guard skipped the `getOrCreate` call entirely — but never detached the old hash object from the switch attribute or released the `shared_ptr`.  The old hash stayed programmed and occupied memory indefinitely.

Fix: add `else if (lagV4Hash_)` / `else if (lagV6Hash_)` (and matching `ecmpV4Hash_` / `ecmpV6Hash_`) branches that call `switch_->setOptionalAttribute(... SAI_NULL_OBJECT_ID)` before `reset()`-ing the stored `shared_ptr`, mirroring the clear-before-release discipline used in the non-empty path.

## Relationship to #1105

#1105 disables the three LAG integration tests (`DISABLED_LagHashAlgorithm`, `DISABLED_LagHashSeed`, `DISABLED_LagHashFieldsIpv4`) because they all call `addOrUpdateLagLoadBalancer` and would be affected by the UDF group ID bug on DUTs with UDF groups configured.  This PR re-enables all three and adds unit tests for both bugs.

## Test Plan

### Unit tests (new in this PR)

```
$ ./fboss/oss/scripts/bazel.sh test \
    //fboss/agent/hw/sai/switch/tests:switch_manager_test \
    --test_output=errors

//fboss/agent/hw/sai/switch/tests:switch_manager_test               PASSED in 2.1s
```

Three new test cases in `SwitchManagerTest`:

- `clearEcmpHashFieldsClearsSwitch` — sets ECMP hash fields, clears both IPv4 and IPv6 to empty, asserts switch attributes return `SAI_NULL_OBJECT_ID`
- `clearLagHashFieldsClearsSwitch` — same for LAG
- `clearEcmpHashV4OnlyLeavesV6Intact` — clears only IPv4 fields; asserts IPv4 attribute becomes null while IPv6 is unchanged

### Integration tests (re-enabled from #1105)

After installing the patched `fboss_hw_agent-sai_impl` on the DUT (NH-4010-F):

```
$ ssh $DUT "/tmp/fboss2_it_nos6212e --gtest_filter='ConfigLoadBalancingTest.*'"

[----------] 9 tests from ConfigLoadBalancingTest (1034 ms total)
[  PASSED  ] 9 tests.
```

All nine pass, including the three LAG tests that were disabled in #1105.