### PR TITLE
[Celestica] Leh800bcls: Unify Ladakh800bcls and Leh800bcls xphy FW versions to PAI SDK 4.1

### DIFF
--- a/fboss/qsfp_service/test/hw_test/HwXphyFirmwareTest.cpp
+++ b/fboss/qsfp_service/test/hw_test/HwXphyFirmwareTest.cpp
@@ -68,9 +68,12 @@ TEST_F(HwXphyFirmwareTest, CheckDefaultXphyFirmwareVersion) {
       desiredFw.minorVersion() = 0;
       break;
     case PlatformType::PLATFORM_LADAKH800BCLS:
-      // PAI fw does not Firmware Minor version
-      desiredFw.version() = 0xE006;
-      desiredFw.versionStr() = "57350"; // 0xE006 = 57350 decimal
+    case PlatformType::PLATFORM_LEH800BCLS:
+      // PAI fw does not support Firmware Minor version
+      // Both Ladakh and Leh platforms are on PAI SDK 4.1 and expect 0xD003
+      // (from AGR3_1_1)
+      desiredFw.version() = 0xD003;
+      desiredFw.versionStr() = "53251"; // 0xD003 = 53251 decimal
       break;
     default:
       throw FbossError("No xphys to check FW version on");


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
The test case `HwXphyFirmwareTest.CheckDefaultXphyFirmwareVersion` failed consistently on the `leh800bcls` platform. 
Initially, the test crashed during the setup phase, throwing a C++ exception: `"No xphys to check FW version on"`. After introducing basic platform support, the test encountered a Gtest assertion failure complaining that `actualFw.version()` and `desiredFw.version()` did not match, displaying raw byte object inequalities on `field_ref` wrappers.
```
/var/FBOSS/fboss/fboss/qsfp_service/test/hw_test/HwXphyFirmwareTest.cpp:107: Failure
Expected equality of these values:
  actualFw.version()
    Which is: 24-byte object <50-A0 19-F3 FF-7F 00-00 80-A0 19-F3 FF-7F 00-00 00-00 A2-07 00-00 00-00>
  desiredFw.version()
    Which is: 24-byte object <10-A0 19-F3 FF-7F 00-00 40-A0 19-F3 FF-7F 00-00 00-00 32-35 31-00 00-00>
```
# Root Cause
1. Missing Platform Enum Support: In FBOSS, `PlatformType::PLATFORM_LADAKH800BCLS` (45) and `PlatformType::PLATFORM_LEH800BCLS` (51) are treated as two distinct platform enums. The firmware version check test only had a switch case for `PLATFORM_LADAKH800BCLS`, completely missing `PLATFORM_LEH800BCLS`. Running the test on Leh platform triggered the `default` block, throwing the exception.
2. Firmware Version Mismatch (SDK Transition): Once the enum was added, the test expected `0xE006` (`57350`) which was hardcoded for Ladakh800bcls/Leh800bcls. However, all XPHYs on the active hardware reported `53251` (hex `0xD003`). 
Investigation of the Broadcom PAI source code revealed that this discrepancy is caused by the SDK version transition:
- The legacy PAI SDK 4.0 (`AGR3_0_4`) bundled firmware `0xE006`.
- The newer PAI SDK 4.1 (`AGR3_1_1`) bundled firmware `0xD003`.
Since `leh800bcls` is built on PAI SDK 4.1, it runs `0xD003`. Since `ladakh800bcls` has also transitioned to SDK 4.1, maintaining `0xE006` for Ladakh800bcls would eventually trigger regression failures on Ladakh800bcls tests.

# Solution
1. Unified `PlatformType::PLATFORM_LADAKH800BCLS` and `PlatformType::PLATFORM_LEH800BCLS` case branches in `HwXphyFirmwareTest.cpp`.
2. Updated the expected default firmware version for both platforms to **`0xD003`** (string **`"53251"`**) to align with the active PAI SDK 4.1 specification.

# Test Plan

Test case HwXphyFirmwareTest.CheckDefaultXphyFirmwareVersion passed.
```
[root@localhost TC_HwXphyFirmwareTest.CheckDefaultXphyFirmwareVersion-20260614_034206]# grep " OK " qsfp_hw_test-HwXphyFirmwareTest.CheckDefaultXphyFirmwareVersion-20260614_032453.log
[       OK ] HwXphyFirmwareTest.CheckDefaultXphyFirmwareVersion (145228 ms)
```