### PR TITLE
[Celestica] Leh800bcls: Fix bcmcfg_parse_error in AgentTrafficPfc*Test tests case due to fragile hardcoded YAML indentation

### DIFF
--- a/fboss/agent/test/utils/NetworkAITestUtils.cpp
+++ b/fboss/agent/test/utils/NetworkAITestUtils.cpp
@@ -379,10 +379,27 @@ void applyBackendAsicConfig(
         std::string toReplace("LOSSY");
         if (std::size_t pos = yamlCfg.find(toReplace);
             pos != std::string::npos) {
+          // Dynamically determine the line indentation before replacing "LOSSY"
+          // to ensure that the newly inserted "SKIP_BUFFER_RESERVATION: 1"
+          // matches the parent's YAML indentation style (e.g., 6 spaces before
+          // vs 12 spaces now). This prevents Broadcom SDKLT config parser
+          // (bcmcfg) block mapping syntax errors (bcmcfg_parse_error) during
+          // boot.
+          std::size_t lineStart = yamlCfg.rfind('\n', pos);
+          if (lineStart == std::string::npos) {
+            lineStart = 0;
+          } else {
+            lineStart += 1;
+          }
+          std::string indent = "";
+          while (lineStart < pos && std::isspace(yamlCfg[lineStart])) {
+            indent += yamlCfg[lineStart];
+            lineStart++;
+          }
           yamlCfg.replace(
               pos,
               toReplace.length(),
-              "LOSSY_AND_LOSSLESS\n      SKIP_BUFFER_RESERVATION: 1");
+              "LOSSY_AND_LOSSLESS\n" + indent + "SKIP_BUFFER_RESERVATION: 1");
         }
 
         // Do not force qgroups on in backend tests.


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
When running AgentTrafficPfcTests and AgentNetworkAIQosTests (such as verifyPfcWithDefaultCfg) in cold boot mode, the hardware agents (fboss_hw_agent-sai_impl) crash during the SDK initialization stage (init soc). The SDK throws a fatal YAML block mapping parse error: <nounit>:bcmcfg_parse_error: <string>:1900:7: did not find expected key while parsing a block mapping. This halts the SDKLT Base Driver component initialization (Component BD (2)), causing the hardware agents to exit with SIGABRT and leading to test suite timeouts/failures.
```
<nounit>:bcmcfg_parse_error: <string>:1900:7: did not find expected key while parsing a block mapping
```

# Root Cause
The issue stems from a fragile, string-replacement-based YAML configuration override mechanism used to enable lossless traffic configurations dynamically during PFC tests.

 In fboss/agent/test/utils/NetworkAITestUtils.cpp, the utility::applyBackendAsicConfig function rewrites the platform's yamlConfig by replacing "LOSSY" with a multiline string:
```
yamlCfg.replace(
    pos,
    toReplace.length(),
    "LOSSY_AND_LOSSLESS\n      SKIP_BUFFER_RESERVATION: 1");
```
 This hardcodes exactly 6 leading spaces of indentation for the newly inserted SKIP_BUFFER_RESERVATION: 1 attribute.

While this hardcoded indentation aligns properly on before platforms whose original YAML configs use 6-space indentation, it breaks catastrophically on current platforms like leh800bcls.

 In the agent configuration file loaded on the device, the original TM_THD_CONFIG logic table uses 12 spaces of indentation:
```
        TM_THD_CONFIG:
            THRESHOLD_MODE: LOSSY
```
 When the string replacement executes on this platform, the generated YAML results in an inconsistent indentation structure:
```
        TM_THD_CONFIG:
            THRESHOLD_MODE: LOSSY_AND_LOSSLESS
      SKIP_BUFFER_RESERVATION: 1
```
 The line "      SKIP_BUFFER_RESERVATION: 1" is indented with only 6 spaces (sitting invalidly between the 4 spaces of 0: and the 8 spaces of TM_THD_CONFIG:). 
 According to YAML block mapping rules, this indentation mismatch is a syntax violation. Consequently, Broadcom SDKLT's YAML parser (bcmcfg) fails during the early config-parsing phase at column 7 of that line (exactly where the key character S in SKIP_BUFFER is located):
```
<nounit>:bcmcfg_parse_error: <string>:1900:7: did not find expected key while parsing a block mapping
```
 Since the config parsing fails, the Base Driver initialization aborts, causing the hardware agents to crash.

# Solution
Refactored utility::applyBackendAsicConfig in fboss/agent/test/utils/NetworkAITestUtils.cpp to dynamically find the beginning of the line containing "LOSSY", compute its exact leading indentation string (whether spaces or tabs), and prepend this exact indentation sequence to the newly inserted "SKIP_BUFFER_RESERVATION: 1" line. 

# Test Plan
 All 7 previously crashing tests now pass successfully on both npu0 and npu1 test:

```
[root@localhost log]# grep -h " OK " AgentTxNpu0/multi_switch_agent-AgentTrafficPfc*.log
[       OK ] AgentTrafficPfcTest.verifyPfcWithDefaultCfg (53185 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithMapChanges_0 (61869 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithMapChanges_1 (61143 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithScaleCfg (83953 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithZeroGlobalHeadRoomCfg (61579 ms)
[       OK ] AgentTrafficPfcZeroPgHeadroomTest.verifyPfcWithZeroPgHeadRoomCfg (61397 ms)
[       OK ] AgentTrafficPfcZeroPgHeadroomTest.verifyWithScaleCfgInCongestionDrops (83696 ms)
[root@localhost log]# grep -h " OK " AgentTxNpu1/multi_switch_agent-AgentTrafficPfc*.log
[       OK ] AgentTrafficPfcTest.verifyPfcWithDefaultCfg (60288 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithMapChanges_0 (62246 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithMapChanges_1 (61547 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithScaleCfg (86895 ms)
[       OK ] AgentTrafficPfcTest.verifyPfcWithZeroGlobalHeadRoomCfg (62268 ms)
[       OK ] AgentTrafficPfcZeroPgHeadroomTest.verifyPfcWithZeroPgHeadRoomCfg (60695 ms)
[       OK ] AgentTrafficPfcZeroPgHeadroomTest.verifyWithScaleCfgInCongestionDrops (89329 ms)
[root@localhost log]#

```