### PR TITLE
[Celestica] Leh800bcls: Fix switched packet routing fallback in triggerPfcGeneration for multi-NPU

### DIFF
--- a/fboss/agent/test/utils/PfcTestUtils.cpp
+++ b/fboss/agent/test/utils/PfcTestUtils.cpp
@@ -467,8 +467,9 @@ void triggerPfcGeneration(
               std::vector<uint8_t>(2000, 0xff));
 
           if (vlanId.has_value()) {
-            ensemble->sendPacketAsync(
-                std::move(txPacket), std::nullopt, pfcPriority);
+            ensemble->getSw()->sendPacketSwitchedAsync(
+                std::move(txPacket),
+                {ensemble->scopeResolver().scope(port).switchId()});
           } else {
             ensemble->sendPacketAsync(
                 std::move(txPacket), PortDescriptor(port), pfcPriority);


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
This PR addresses a deterministic traffic-routing bug inside the test utility triggerPfcGeneration() which consistently causes lossless  PFC watermark tests to fail on multi-NPU/Split-Agent platforms (e.g., Leh800bcls with two Tomahawk 6 NPUs). 

By explicitly targeting the injected switched packets to the correct SwitchID of the active port under test, we restore 100% deterministic  queue buildup and PFC frame generation on secondary NPUs (e.g. switch1), preventing flaky test failures.

# Root Cause
Switched Packet Routing Fallback (PfcTestUtils):
     * Root Cause: On multi-NPU environments, calling sendPacketAsync with std::nullopt causes the routing handler MultiHwSwitchHandler::sendPacketSwitchedAsync to fallback and route all packets to SwitchID(0).
     * Result: When running tests on switch1, congestion traffic is incorrectly sent to switch0, leaving switch1 with zero traffic, zero PFC, and zero watermarks.


# Solution
 Switch-Aware Packet Injection in triggerPfcGeneration:
    Retrieve the targeted port's active parent SwitchID via ensemble->scopeResolver().scope(port).switchId(), and explicitly route switched packets through SwSwitch::sendPacketSwitchedAsync to target the active NPU under test, guaranteeing correct traffic injection.

# Test Plan
The following 3 Agent T1 test cases passed successfully on both NPU 0 and NPU 1.
```
[root@localhost log]# grep -h " OK " AgentTxNpu0/multi_switch_*.log
[       OK ] AgentTrafficPfcGenTest.verifyBufferPoolWatermarks (60775 ms)
[       OK ] AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks (60216 ms)
[       OK ] AgentTrafficPfcWatchdogTest.PfcWatchdogDetection (66896 ms)
[root@localhost log]# grep -h " OK " AgentTxNpu1/multi_switch_*.log
[       OK ] AgentTrafficPfcGenTest.verifyBufferPoolWatermarks (62278 ms)
[       OK ] AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks (60163 ms)
[       OK ] AgentTrafficPfcWatchdogTest.PfcWatchdogDetection (68499 ms)
[root@localhost log]#

```
