### PR TITLE
[Nexthop][fboss2-dev] ConfigPfcTest: disable PFC in TearDown 

### DIFF
--- a/fboss/cli/fboss2/test/integration_test/ConfigPfcTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigPfcTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <initializer_list>
+#include <optional>
 #include <string>
 #include <vector>
 #include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
@@ -58,6 +59,46 @@ class ConfigPfcTest : public Fboss2IntegrationTest {
     XLOG(INFO) << "Using buffer-pool: " << bufferPoolName_;
     XLOG(INFO) << "Using pg-policy:  " << policyName_;
   }
+
+  void TearDown() override {
+    if (pfcIntfName_.has_value()) {
+      // Disable PFC so subsequent tests (e.g. flow-control/PAUSE tests) can
+      // use the same port without hitting the "PAUSE and PFC cannot be enabled
+      // on the same port" rejection from the agent.
+      XLOG(INFO) << "TearDown: disabling PFC on " << *pfcIntfName_
+                 << " (port used by this test)";
+      bool anyFailed = false;
+      for (const auto* dir : {"tx", "rx"}) {
+        auto result = runCli(
+            {"config",
+             "interface",
+             *pfcIntfName_,
+             "pfc-config",
+             dir,
+             "disabled"});
+        if (result.exitCode != 0) {
+          XLOG(WARN) << "TearDown: failed to disable pfc-config " << dir
+                     << " on " << *pfcIntfName_ << ": " << result.stderr;
+          anyFailed = true;
+        } else {
+          XLOG(INFO) << "TearDown: pfc-config " << dir << " disabled on "
+                     << *pfcIntfName_;
+        }
+      }
+      auto commitResult = runCli({"config", "session", "commit"});
+      if (commitResult.exitCode != 0) {
+        XLOG(WARN) << "TearDown: commit after PFC disable failed: "
+                   << commitResult.stderr;
+      } else if (!anyFailed) {
+        XLOG(INFO) << "TearDown: PFC cleanup committed successfully on "
+                   << *pfcIntfName_;
+      }
+    }
+    Fboss2IntegrationTest::TearDown();
+  }
+
+  // Recorded by the test body so TearDown knows which interface to clean up.
+  std::optional<std::string> pfcIntfName_;
 
   void configureBufferPool(int sharedBytes, int headroomBytes) {
     ASSERT_EQ(
@@ -146,6 +187,7 @@ class ConfigPfcTest : public Fboss2IntegrationTest {
 
 TEST_F(ConfigPfcTest, BufferPoolPriorityGroupAndPortPfc) {
   Interface intf = findFirstEthInterface();
+  pfcIntfName_ = intf.name;
   XLOG(INFO) << "Using test interface " << intf.name;
 
   XLOG(INFO) << "[Step 1] Configuring buffer pool...";


### PR DESCRIPTION
…l test

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Although run-test.py is engineered to snapshot and restore config for each test, doing this in individual test suite lets us directly run the fboss2_integration_test directly as well without harming anything. PFC test was preserving the test config state polluting the DUT for next set of tests. So using teardown to restore the original config.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
Same set of PFC integration tests.
