### PR TITLE
[Nexthop][run_scripts] Fix systemctl enable failure with SELinux enforcing

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/services/fsdb_service_utils.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/services/fsdb_service_utils.py
@@ -15,7 +15,7 @@ _FSDB_SERVICE_FOR_TESTING = "fsdb_service_for_testing"
 # Introduce an oss version of fsdb_service to run in oss environment.
 _FSDB_SERVICE_OSS = "fsdb_service_oss"
 
-_FSDB_SERVICE_UNIT_FILE_PATH = f"/tmp/{_FSDB_SERVICE_OSS}.service"
+_FSDB_SERVICE_UNIT_FILE_PATH = f"/run/systemd/system/{_FSDB_SERVICE_OSS}.service"
 
 
 def _setup_fsdb_service(

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/services/qsfp_service_utils.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/services/qsfp_service_utils.py
@@ -16,7 +16,7 @@ _QSFP_SERVICE_PROD = "qsfp_service"
 _QSFP_SERVICE_FOR_TESTING = "qsfp_service_for_testing"
 # Introduce an oss version of qsfp_service to run in oss environment.
 _QSFP_SERVICE_OSS = "qsfp_service_oss"
-_QSFP_SERVICE_UNIT_FILE_PATH = f"/tmp/{_QSFP_SERVICE_OSS}.service"
+_QSFP_SERVICE_UNIT_FILE_PATH = f"/run/systemd/system/{_QSFP_SERVICE_OSS}.service"
 
 
 def _setup_qsfp_service(


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Write qsfp/fsdb OSS service unit files to `/run/systemd/system/` instead of `/tmp/`.

Files in `/tmp/` carry the `tmp_t` SELinux label. On CentOS Stream 9 with SELinux in enforcing mode, `systemctl enable /tmp/*.service` fails because the policy blocks symlinking from `/etc/systemd/system/` to `tmp_t` targets. The existing enable/disable lifecycle is otherwise correct.

`/run/systemd/system/` is the systemd-designated directory for dynamically-generated, non-persistent unit files. Files written there inherit `systemd_unit_file_t` automatically, so `systemctl enable` works without any label manipulation. Files are cleaned up on reboot, matching the transient nature of test services.

Changed files:
- `services/qsfp_service_utils.py`: `_QSFP_SERVICE_UNIT_FILE_PATH` `/tmp/` -> `/run/systemd/system/`
- `services/fsdb_service_utils.py`: `_FSDB_SERVICE_UNIT_FILE_PATH` `/tmp/` -> `/run/systemd/system/`

# Test plan

- Verified on a FBOSS platform running CentOS Stream 9 with SELinux enforcing: services start and stop cleanly, `systemctl enable/disable` succeed, link tests pass.
- Existing behavior on platforms without SELinux enforcing is unchanged.
