### PR TITLE
[Nexthop] Fix fboss_hw_agent crash on NDP receive with PORT-type RIF interfaces

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiNeighborManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiNeighborManager.cpp
@@ -282,11 +282,18 @@ PortRifNeighbor::PortRifNeighbor(
   auto rifSaiId = std::get<RouterInterfaceSaiId>(saiPortAndIntf);
   auto adapterHostKey = SaiNeighborTraits::NeighborEntry(
       manager_->getSwitchSaiId(), rifSaiId, ip);
+  // Broadcom NPU SAI rejects SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL on PORT-type
+  // RIF neighbors with SAI_STATUS_FAILURE.  Don't pass it for PORT; the SAI
+  // default (true) is used instead.  SYSTEM_PORT (VOQ) still requires it.
+  std::optional<SaiNeighborTraits::Attributes::IsLocal> isLocalSai;
+  if (intfType_ != cfg::InterfaceType::PORT) {
+    isLocalSai = isLocal;
+  }
   auto createAttributes = SaiNeighborTraits::CreateAttributes{
       std::get<folly::MacAddress>(intfIDAndIpAndMac),
       metadata,
       encapIndex,
-      isLocal,
+      isLocalSai,
       noHostRoute};
   neighbor_ = manager_->createSaiObject(adapterHostKey, createAttributes);
   handle_->neighbor = neighbor_.get();


### PR DESCRIPTION
# Summary

`fboss_hw_agent-sai_impl` aborts whenever it receives an NDP (IPv6 Neighbor Advertisement) packet on a platform configured with `PORT`-type RIF (Router Interface) interfaces. The crash is reproducible and was triggered on a freshly imaged NH-4010-F. As long as the device receives NDP packets from a connected device, `fboss_hw_agent` keeps crashing, restarts every 30 s, and repeats until the neighboring device stops sending NDP.

In commit 155ad07c91 ("sai neighbor manager to create neighbor for port rif", Dec 10 2024), the code was changed to make `PORT`-type RIF neighbors flow through `PortRifNeighbor::PortRifNeighbor` instead of throwing `FbossError("Port router interface is not yet supported")`, which means the code was probably already crashing in this case before that commit, albeit with a different error message. However, it unconditionally passes the `SAI_NEIGHBOR_ENTRY_ATTR_IS_LOCAL` attribute to the SAI implementation for all neighbor types, including `PORT`-type RIF. The Broadcom SAI returns `SAI_STATUS_FAILURE` for this attribute on `PORT`-type RIF neighbors. `saiApiCheckError()` converts the failure to a `SaiApiError` (subclass of `FbossError`) which propagates uncaught out of the `fboss_hw_agent` thread, calling `std::terminate`, ultimately causing a `SIGABRT`.

## Details

The affected code is in `fboss/agent/hw/sai/switch/SaiNeighborManager.cpp` in the `PortRifNeighbor::PortRifNeighbor` [constructor](https://github.com/facebook/fboss/blob/4996cca7f91b8aa25551ab8a068f90aed2e3c2cb/fboss/agent/hw/sai/switch/SaiNeighborManager.cpp#L267) (introduced by the commit above).

Stack Trace (from `/var/facebook/logs/fboss/wedge_agent.log`)

```c++
F20260623 16:17:49 <tid> SaiNeighborManager.cpp] sai_create_neighbor_entry failed: SAI_STATUS_FAILURE

#0  std::terminate()
#1  __cxa_throw
#2  facebook::fboss::saiApiCheckError(sai_status_t, ...)
#3  facebook::fboss::SaiApi<facebook::fboss::NeighborApi>::create_(
       facebook::fboss::SaiNeighborTraits::AdapterHostKey const&,
       facebook::fboss::SaiNeighborTraits::CreateAttributes const&,
       unsigned long)
#4  facebook::fboss::PortRifNeighbor::PortRifNeighbor(
       facebook::fboss::SaiNeighborManager*,
       std::tuple<facebook::fboss::SaiPortDescriptor, unsigned long>,
       std::tuple<facebook::fboss::InterfaceID, folly::IPAddress, folly::MacAddress>,
       std::optional<unsigned int>,   // metadata
       std::optional<unsigned int>,   // encapIndex
       bool isLocal,                  // <-- passed to SAI even for PORT-type
       std::optional<bool>,           // noHostRoute
       facebook::fboss::cfg::InterfaceType)
#5  facebook::fboss::SaiNeighborManager::addNeighbor<facebook::fboss::NdpEntry>(
       std::shared_ptr<facebook::fboss::NdpEntry const> const&)
#6  facebook::fboss::SaiNeighborManager::changedNeighbor<facebook::fboss::NdpEntry>(
       ...)
#7  (state delta callback from sw_agent → hw_agent)

Process 1540 (fboss_hw_agent-) dumped core. Signal: 6 (ABRT)
```

Observed across 6 consecutive crash-loop iterations, confirmed with `SIGABRT` core dumps in `/var/lib/systemd/coredump/`.

## Reproduction Steps

1. Image a new device, normally all physical interfaces default to a PORT-type RIF configuration. Load up the FBOSS distro image on the device with a default config.
2. Confirm the DUT is configured with PORT-type RIFs (not VLAN-RIFs): `fboss2 show interface` — interfaces show type 3 (`PORT`) in the agent config.
3. Use a connected device to send one NDP Neighbor Advertisement with the following scapy script:
```python
sudo python3 - <<'PY'
from scapy.all import Ether, IPv6, ICMPv6ND_NA, ICMPv6NDOptDstLLAddr, sendp, get_if_hwaddr

iface  = "Ethernet64"      # replace with fanout port from `nh tb links <dut> --csv`
src_ip = "fe80::cafe:1"    # fake neighbor source (any link-local not already in NDP table)
tgt_ip = "fe80::cafe:1"
dst_ip = "ff02::1"
smac   = get_if_hwaddr(iface)

pkt = (
    Ether(dst="33:33:00:00:00:01", src=smac) /
    IPv6(src=src_ip, dst=dst_ip, hlim=255) /
    ICMPv6ND_NA(R=0, S=0, O=1, tgt=tgt_ip) /
    ICMPv6NDOptDstLLAddr(lladdr=smac)
)

sendp(pkt, iface=iface, count=1, verbose=False)
print(pkt.summary())
PY
```

Result: `fboss_hw_agent-sai_impl` crash within 1-2 seconds (PID changes, systemd logs `code=dumped, status=6/ABRT`, core dump written to `/var/lib/systemd/coredump/`).

## Fix

In `PortRifNeighbor::PortRifNeighbor`, conditionally pass the `isLocal` attribute to SAI only for non-`PORT` interface types (`VLAN` and `SYSTEM_PORT`). For `PORT`-type RIFs, omit the attribute entirely so Broadcom SAI uses its default behavior.

# Test Plan

Rebuilt `fboss_hw_agent` with this code change and deployed to my DUT. Sent 4 NDP Neighbor Advertisements from a neighbor fanout device with different fake source addresses (fe80::cafe:1 through fe80::dead:beef). All 4 neighbors were learned and appeared in `fboss2 show ndp` on interface eth1/9/1 (InterfaceID 2009, `PORT`-type RIF). `fboss_hw_agent` PID remained unchanged across all 4 NDP packets, there was no crash.