### PR TITLE
[Celestica] montblancm: Add QSFP and LED service support for montblancm

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -127,6 +127,8 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_MINIPACK3BTA;
     } else if (
         modelName.find("Montblanc") == 0 || modelName.find("MONTBLANC") == 0 ||
+        modelName.find("Montblancm") == 0 ||
+        modelName.find("MONTBLANCM") == 0 ||
         modelName.find("MINIPACK3_CHASSIS_BUNDLE") == 0 ||
         modelName.find("MINIPACK3") == 0 ||
         modelName.find("MINIPACK3-48V-ORV3") == 0) {
@@ -283,7 +285,9 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_WEDGE400C_VOQ;
     } else if (FLAGS_mode == "wedge400c_fabric") {
       type_ = PlatformType::PLATFORM_WEDGE400C_FABRIC;
-    } else if (FLAGS_mode == "montblanc" || FLAGS_mode == "minipack3ba") {
+    } else if (
+        FLAGS_mode == "montblanc" || FLAGS_mode == "montblancm" ||
+        FLAGS_mode == "minipack3ba") {
       type_ = PlatformType::PLATFORM_MONTBLANC;
     } else if (FLAGS_mode == "icecube800bc") {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;


### PR DESCRIPTION
**Pre-submission checklist**
- [✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [✓ ] `pre-commit run`

# Summary

Following the montblancm platform support for Netlake2.0 [PR#1245](https://github.com/facebook/fboss/pull/1245), this update registers the platform in PlatformProductInfo.cpp. This enablement allows the platform to leverage existing qsfp_service and led_service logic. By ensuring correct PlatformType identification, it also enables the successful execution of qsfp_hw_test and led_service_hw_test without necessitating redundant hardware-specific code.

# Test Plan
**qsfp_hw_test:**
Run T0 QSFP tests with the "mode": "montblancm" in qsfp.conf.
Run T0 QSFP tests with the "Product Name": "MONTBLANCM" in fruid.json.
Result: Platform identified successfully; all functional tests PASSED.
Execution Command:
/opt/fboss/bin/run_test.py qsfp --filter_file=/opt/fboss/share/hw_sanity_tests/t0_qsfp_hw_tests.conf --qsfp-config /opt/fboss/tmp/qsfp.conf > t0_qsfp-hw-test_log.txt 2>&1

**led_service_hw_test:**
Run led_service_hw_test with the "mode": "montblancm" in led.conf.
Run led_service_hw_test the "Product Name": "MONTBLANCM" in fruid.json.
Result: Platform identified successfully; all functional tests PASSED.
Execution Commands:
/opt/fboss/bin/led_service_hw_test --logging=DBG --gtest_filter=LedServiceTest.checkLedColorChange --led-config ./tmp/led.conf --visual_delay_sec 1 > checkLedColorChange_log.txt 2>&1

/opt/fboss/bin/led_service_hw_test --gtest_filter=LedServiceTest.checkLedBlinking --led-config ./tmp/led.conf --visual_delay_sec 0 > checkLedBlinking_log.txt 2>&1
# Detailed logs:
Please see the detailed logs:
[montblancm_qsfp_led_service_hw_test_log.zip](https://github.com/user-attachments/files/29276000/montblancm_qsfp_led_service_hw_test_log.zip)
