### PR TITLE
[Celestica] Leh800bcls: Fix AgentHwAclQualifierTest SIGSEGV crash under multi-Switch Split Agent mode

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentHwAclQualifierTest.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentHwAclQualifierTest.cpp
@@ -177,13 +177,20 @@ class AgentHwAclQualifierTest : public AgentHwTest {
     return newCfg;
   }
 
+  SwitchID resolveSwitchId(std::optional<SwitchID> switchID) const {
+    return switchID.value_or(getCurrentSwitchIdForTesting());
+  }
+
   void configureAllHwQualifiers(
       cfg::AclEntry* acl,
       bool enable,
-      SwitchID switchID = SwitchID(0)) {
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     auto masterLogicalPorts =
         getAgentEnsemble()->masterLogicalInterfacePortIds({switchID});
-    configureQualifier(acl->srcPort(), enable, masterLogicalPorts[0]);
+    CHECK_GE(masterLogicalPorts.size(), 1);
+    configureQualifier(acl->srcPort(), enable, masterLogicalPorts.at(0));
+
     if ((hwAsicForSwitch(switchID)->getAsicType() !=
          cfg::AsicType::ASIC_TYPE_JERICHO2) &&
         (hwAsicForSwitch(switchID)->getAsicVendor() !=
@@ -198,13 +205,15 @@ class AgentHwAclQualifierTest : public AgentHwTest {
       // No out support on Chenab in ingress stage
       // No out port support on TU1 in ingress stage
       // No out port support on TH6 in ingress stage
-      configureQualifier(acl->dstPort(), enable, masterLogicalPorts[1]);
+      CHECK_GE(masterLogicalPorts.size(), 2);
+      configureQualifier(acl->dstPort(), enable, masterLogicalPorts.at(1));
     }
   }
 
   void configureAllL2QualifiersHelper(
       cfg::AclEntry* acl,
-      SwitchID switchID = SwitchID(0)) {
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     auto asic = hwAsicForSwitch(switchID);
     bool dstMacEnabled =
         (asic->getAsicVendor() != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB);
@@ -242,7 +251,8 @@ class AgentHwAclQualifierTest : public AgentHwTest {
 
   void configureIp4QualifiersHelper(
       cfg::AclEntry* acl,
-      SwitchID switchID = SwitchID(0)) {
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     auto asicType = getAsicType(switchID);
     auto asicVendor = getAsicVendor(switchID);
     bool enableSrcIpQualifier =
@@ -269,7 +279,8 @@ class AgentHwAclQualifierTest : public AgentHwTest {
 
   void configureIp6QualifiersHelper(
       cfg::AclEntry* acl,
-      SwitchID switchID = SwitchID(0)) {
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     auto asicType = getAsicType(switchID);
     auto asicVendor = getAsicVendor(switchID);
     auto enableSrcIpQualifier =
@@ -304,7 +315,8 @@ class AgentHwAclQualifierTest : public AgentHwTest {
       bool isIpV4,
       QualifierType lookupClassType,
       bool enableQualifiers = false,
-      SwitchID switchID = SwitchID(0)) {
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     this->addQualifiers = enableQualifiers;
     auto newCfg = initialConfig(*getAgentEnsemble());
     if (FLAGS_enable_acl_table_group) {
@@ -328,17 +340,18 @@ class AgentHwAclQualifierTest : public AgentHwTest {
           cfg::AclTableQualifier::OUTER_VLAN,
       };
 
-      if (getAsicVendor() != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
+      if (getAsicVendor(switchID) != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
         defaultQualifiers.clear();
       }
       std::vector<cfg::AclTableActionType> actions = {};
-      if (this->getAsicType() == cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1) {
+      if (this->getAsicType(switchID) ==
+          cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1) {
         defaultQualifiers =
-            utility::genAclQualifiersConfig(this->getAsicType());
-        actions = utility::genAclActionTypesConfig(this->getAsicType());
+            utility::genAclQualifiersConfig(this->getAsicType(switchID));
+        actions = utility::genAclActionTypesConfig(this->getAsicType(switchID));
       }
       std::vector<cfg::AclTableQualifier> qualifiers = enableQualifiers
-          ? utility::genAclQualifiersConfig(this->getAsicType())
+          ? utility::genAclQualifiersConfig(this->getAsicType(switchID))
           : defaultQualifiers;
       utility::addAclTable(
           &newCfg,
@@ -391,7 +404,8 @@ class AgentHwAclQualifierTest : public AgentHwTest {
   }
 
   void aclVerifyHelper() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    SwitchID switchID = getCurrentSwitchIdForTesting();
+    auto client = getAgentEnsemble()->getHwAgentTestClient(switchID);
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, kAclName(), FLAGS_enable_acl_table_group)
@@ -402,11 +416,15 @@ class AgentHwAclQualifierTest : public AgentHwTest {
     EXPECT_TRUE(client->sync_isAclEntrySame(acl, utility::kDefaultAclTable()));
   }
 
-  cfg::AsicType getAsicType(SwitchID switchID = SwitchID(0)) {
+  cfg::AsicType getAsicType(
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     return hwAsicForSwitch(switchID)->getAsicType();
   }
 
-  HwAsic::AsicVendor getAsicVendor(SwitchID switchID = SwitchID(0)) {
+  HwAsic::AsicVendor getAsicVendor(
+      std::optional<SwitchID> switchIDOpt = std::nullopt) {
+    SwitchID switchID = resolveSwitchId(switchIDOpt);
     return hwAsicForSwitch(switchID)->getAsicVendor();
   }
 };
@@ -430,7 +448,8 @@ TEST_F(AgentHwAclQualifierTest, AclIp4TcpQualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, "ip4_tcp", FLAGS_enable_acl_table_group)
@@ -463,7 +482,8 @@ TEST_F(AgentHwAclQualifierTest, AclIp6TcpQualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, "ip6_tcp", FLAGS_enable_acl_table_group)
@@ -496,7 +516,8 @@ TEST_F(AgentHwAclQualifierTest, AclIcmp4Qualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, "icmp4", FLAGS_enable_acl_table_group)
@@ -535,7 +556,8 @@ TEST_F(AgentHwAclQualifierTest, AclIcmp6Qualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, "icmp6", FLAGS_enable_acl_table_group)
@@ -586,7 +608,8 @@ TEST_F(AgentHwAclQualifierTest, AclRemove) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl = utility::getAclEntry(state, "acl1", FLAGS_enable_acl_table_group)
                    ->toThrift();
@@ -631,7 +654,8 @@ TEST_F(AgentHwAclQualifierTest, AclModifyQualifier) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl = utility::getAclEntry(state, "acl0", FLAGS_enable_acl_table_group)
                    ->toThrift();
@@ -681,7 +705,8 @@ TEST_F(AgentHwAclQualifierTest, AclEmptyCodeIcmp) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     auto acl =
         utility::getAclEntry(state, "acl0", FLAGS_enable_acl_table_group);
@@ -711,7 +736,8 @@ TEST_F(AgentHwAclQualifierTest, AclVlanIDQualifier) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
     EXPECT_EQ(
         client->sync_getAclTableNumAclEntries(utility::kDefaultAclTable()), 1);
@@ -737,7 +763,8 @@ TEST_F(AgentHwAclQualifierTest, AclIp4Qualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
 
     EXPECT_EQ(
@@ -770,7 +797,8 @@ TEST_F(AgentHwAclQualifierTest, AclIp6Qualifiers) {
   };
 
   auto verify = [=, this]() {
-    auto client = getAgentEnsemble()->getHwAgentTestClient(SwitchID(0));
+    auto client = getAgentEnsemble()->getHwAgentTestClient(
+        getCurrentSwitchIdForTesting());
     auto state = getAgentEnsemble()->getProgrammedState();
 
     EXPECT_EQ(


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
When running the `AgentHwAclQualifierTest` test suite (such as `AclIp4TcpQualifiers`, `AclIcmp4Qualifiers`, etc.) on secondary NPUs in a multi-NPU (Split Agent) setup (e.g., NPU 1/switch1), the test process crashes immediately during cold boot setup with a Segmentation Fault (`SIGSEGV` / Signal 11).
```
*** Aborted at 1781805835 (Unix time, try 'date -d @1781805835') ***
*** Signal 11 (SIGSEGV) (0x0) received by PID 1307696 (pthread TID 0x7fbe05fcd580) (linux TID 1307696) (code: address not mapped to object), stack trace: ***
```

# Root Cause
In `fboss/agent/test/agent_hw_tests/AgentHwAclQualifierTest.cpp`:
1. Several test helper methods (`configureAllHwQualifiers`, `configureAllL2QualifiersHelper`, `configureIp4QualifiersHelper`, `configureIp6QualifiersHelper`, and `aclSetupHelper`) had their `SwitchID` parameters hardcoded with a default parameter value of `SwitchID(0)`.
2. Inside `configureAllHwQualifiers`, calling `getAgentEnsemble()->masterLogicalInterfacePortIds({SwitchID(0)})` was executed using this default `SwitchID(0)`. Since `switch0` is unconfigured on the active runner for `switch1`, this call returned an empty vector (`std::vector<PortID>`).
3. Attempting to index elements out-of-bounds on this empty vector via `masterLogicalPorts[0]` and `masterLogicalPorts[1]` triggered undefined behavior (accessing unmapped memory / null reference), resulting in the immediate `SIGSEGV` crash.
4. Additionally, the test verifications (the `verify` lambdas) hardcoded `getHwAgentTestClient(SwitchID(0))`, which fetched the wrong or invalid hardware client when the test target was actually `SwitchID(1)`.

# Solution
1. Dynamic Parameter Resolution (`std::optional<SwitchID>`):
   We changed the default parameters of the helper methods from `SwitchID switchID = SwitchID(0)` to `std::optional<SwitchID> switchID = std::nullopt`. 
   Within each helper implementation, a local variable `SwitchID currentSwitchId` is defined, resolving `std::nullopt` safely to `getCurrentSwitchIdForTesting()` at runtime:
```
switchID currentSwitchId = switchID.value_or(getCurrentSwitchIdForTesting());
```

2. Active NPU Client Binding:
   We updated all hardcoded `getHwAgentTestClient(SwitchID(0))` calls in both `aclVerifyHelper` and the individual test cases (`AclIp4TcpQualifiers`, `AclIp6TcpQualifiers`, `AclIcmp4Qualifiers`, etc.) to use `getHwAgentTestClient(getCurrentSwitchIdForTesting())`. This guarantees that assertions query the exact hardware agent corresponding to the switch under test.

# Test Plan
Verified that all 5 ACL qualifier test cases pass under both `npu0` and `npu1` :
```
[root@localhost log]# grep " OK " AgentTxNpu[01]/multi_switch_agent-*.log
AgentTxNpu0/multi_switch_agent-AgentHwAclQualifierTest.AclIcmp4Qualifiers-20260623_114648.log:[       OK ] AgentHwAclQualifierTest.AclIcmp4Qualifiers (47411 ms)
AgentTxNpu0/multi_switch_agent-AgentHwAclQualifierTest.AclIcmp6Qualifiers-20260623_114742.log:[       OK ] AgentHwAclQualifierTest.AclIcmp6Qualifiers (47435 ms)
AgentTxNpu0/multi_switch_agent-AgentHwAclQualifierTest.AclIp4TcpQualifiers-20260623_114458.log:[       OK ] AgentHwAclQualifierTest.AclIp4TcpQualifiers (47556 ms)
AgentTxNpu0/multi_switch_agent-AgentHwAclQualifierTest.AclIp6TcpQualifiers-20260623_114553.log:[       OK ] AgentHwAclQualifierTest.AclIp6TcpQualifiers (47311 ms)
AgentTxNpu0/multi_switch_agent-AgentHwAclQualifierTest.AclModifyQualifier-20260623_114836.log:[       OK ] AgentHwAclQualifierTest.AclModifyQualifier (47483 ms)
AgentTxNpu1/multi_switch_agent-AgentHwAclQualifierTest.AclIcmp4Qualifiers-20260623_114203.log:[       OK ] AgentHwAclQualifierTest.AclIcmp4Qualifiers (50952 ms)
AgentTxNpu1/multi_switch_agent-AgentHwAclQualifierTest.AclIcmp6Qualifiers-20260623_114301.log:[       OK ] AgentHwAclQualifierTest.AclIcmp6Qualifiers (50996 ms)
AgentTxNpu1/multi_switch_agent-AgentHwAclQualifierTest.AclIp4TcpQualifiers-20260623_114008.log:[       OK ] AgentHwAclQualifierTest.AclIp4TcpQualifiers (49919 ms)
AgentTxNpu1/multi_switch_agent-AgentHwAclQualifierTest.AclIp6TcpQualifiers-20260623_114105.log:[       OK ] AgentHwAclQualifierTest.AclIp6TcpQualifiers (51174 ms)
AgentTxNpu1/multi_switch_agent-AgentHwAclQualifierTest.AclModifyQualifier-20260623_114359.log:[       OK ] AgentHwAclQualifierTest.AclModifyQualifier (52282 ms)

```

