### PR TITLE
[Celestica] Leh800bcls: Make getSubsidiaryPorts multi-NPU aware in AgentFlowletWideArsSwitchingTest

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentFlowletSwitchingTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentFlowletSwitchingTests.cpp
@@ -798,6 +798,7 @@ class AgentFlowletWideArsSwitchingTest : public AgentFlowletSwitchingTest {
     const auto& platformPorts =
         ensemble.getSw()->getPlatformMapping()->getPlatformPorts();
     std::vector<PortID> ports;
+    const SwitchID currentSwitchId = getCurrentSwitchIdForTesting();
     for (const auto& [controllingPort, subPorts] : portsByControllingPort) {
       if (ports.size() >= kWideEcmpWidth) {
         break;
@@ -806,6 +807,10 @@ class AgentFlowletWideArsSwitchingTest : public AgentFlowletSwitchingTest {
       if (ctrlIt == platformPorts.end() ||
           *ctrlIt->second.mapping()->portType() !=
               cfg::PortType::INTERFACE_PORT) {
+        continue;
+      }
+      if (ensemble.scopeResolver().scope(PortID(controllingPort)).switchId() !=
+          currentSwitchId) {
         continue;
       }
       for (auto subPort : subPorts) {
@@ -818,6 +823,7 @@ class AgentFlowletWideArsSwitchingTest : public AgentFlowletSwitchingTest {
         ports.push_back(subPort);
       }
     }
+    CHECK_GE(ports.size(), kWideEcmpWidth);
     return ports;
   }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
[INFO] Stashing unstaged files to /work/home/gangtao/.cache/pre-commit/patch1782307946-1174304.
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
When running the agent test cases on NPU 1, the following error occurs:
```
unknown file: Failure
C++ exception with description "Could not find a nhop for: PhysicalPort-1" thrown in the test body.
```

# Root Cause
In Split Agent mode, NPU1's active configuration only loads ports belonging to Switch1. However, the test utility `getSubsidiaryPorts()` was query-blind and fetched the platform-level port list (which includes NPU0 ports).
Since NPU0 ports are sorted first, it returned `PhysicalPort-1` (Switch0 port) for Switch1's test runner, triggering a catastrophic exception inside `EcmpSetupTargetedPorts`.

# Solution
Refactored `getSubsidiaryPorts()` in `AgentFlowletSwitchingTests.cpp` to filter the platform-mapped controlling ports dynamically using `getCurrentSwitchIdForTesting()`. This guarantees that each NPU only configures and verifies its own local interfaces and ports.

# Test Plan
Verified that below test cases pass under both npu0 and npu1:
```
[root@localhost log]# grep " OK " TCNpu[01]_AgentFlowletWideArsSwitchingTest.VerifyEcmp/mu*.log
TCNpu0_AgentFlowletWideArsSwitchingTest.VerifyEcmp/multi_switch_agent-AgentFlowletWideArsSwitchingTest.VerifyEcmp-20260624_132951.log:[       OK ] AgentFlowletWideArsSwitchingTest.VerifyEcmp (230366 ms)
TCNpu1_AgentFlowletWideArsSwitchingTest.VerifyEcmp/multi_switch_agent-AgentFlowletWideArsSwitchingTest.VerifyEcmp-20260624_132546.log:[       OK ] AgentFlowletWideArsSwitchingTest.VerifyEcmp (231648 ms)
[root@localhost log]#

```