### PR TITLE
[meta] rename setPreferIoUring to setPreferAsyncIoUringSocket (#1329)

### DIFF
--- a/fboss/cli/fboss2/test/thrift_latency_test.cpp
+++ b/fboss/cli/fboss2/test/thrift_latency_test.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv) {
   std::cout << "[3/3] Testing IoUring backend..." << std::endl;
 #if FOLLY_HAS_LIBURING
   auto iouringResult = runBackendTest("IoUring", [](ThriftServer& server) {
-    server.setPreferIoUring(true);
+    server.setPreferAsyncIoUringSocket(true);
     static folly::EventBaseManager ioUringEbm(
         folly::EventBase::Options().setBackendFactory(
             []() -> std::unique_ptr<folly::EventBaseBackendBase> {


### PR DESCRIPTION
Summary:

renaming this setter to better indicate it's intention and side-effects.

Differential Revision: D109081575


