### PR TITLE
[Nexthop][PlatformManager][M4062NHP] Support AMD CPU i2c buses C and D

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -367,10 +367,11 @@ bool ConfigValidator::isValidI2cAdaptersFromCpu(
   std::set<std::string> seen;
   for (const auto& name : i2cAdaptersFromCpu) {
     if (re2::RE2::FullMatch(name, kCpuBusNameRegex)) {
-      if (name != "CPU_BUS@0" && name != "CPU_BUS@1") {
+      static const re2::RE2 kSupportedCpuBusNameRegex{"CPU_BUS@[0-3]"};
+      if (!re2::RE2::FullMatch(name, kSupportedCpuBusNameRegex)) {
         XLOG(ERR) << fmt::format(
             "Invalid virtual bus name '{}'. "
-            "Only CPU_BUS@0 and CPU_BUS@1 are supported",
+            "Only CPU_BUS@0 through CPU_BUS@3 are supported",
             name);
         return false;
       }

--- a/fboss/platform/platform_manager/I2cExplorer.cpp
+++ b/fboss/platform/platform_manager/I2cExplorer.cpp
@@ -179,8 +179,13 @@ std::map<std::string, uint16_t> I2cExplorer::resolveAmdCpuBusNums(
 std::map<std::string, uint16_t> I2cExplorer::resolveIntelCpuBusNums(
     const std::vector<std::string>& i2cAdaptersFromCpu) {
   // One SMBus I801 adapter per unit — only CPU_BUS@0 is valid.
-  CHECK_EQ(i2cAdaptersFromCpu.size(), 1)
-      << "resolveIntelCpuBusNums only supports a single CPU_BUS@0 entry";
+  if (i2cAdaptersFromCpu.size() != 1 || i2cAdaptersFromCpu[0] != "CPU_BUS@0") {
+    throw std::runtime_error(
+        fmt::format(
+            "Invalid i2cAdaptersFromCpu configuration for Intel CPU. "
+            "Expected a single 'CPU_BUS@0' entry, got: {}",
+            folly::join(", ", i2cAdaptersFromCpu)));
+  }
 
   const auto& name = i2cAdaptersFromCpu[0];
 

--- a/fboss/platform/platform_manager/I2cExplorer.cpp
+++ b/fboss/platform/platform_manager/I2cExplorer.cpp
@@ -26,6 +26,8 @@ constexpr auto kCpuI2cBusNumsWaitSecs = 1;
 const std::map<std::string, int> kAmdAcpiPathToBusIndex = {
     {R"(\_SB_.I2CA)", 1},
     {R"(\_SB_.I2CB)", 0},
+    {R"(\_SB_.I2CC)", 2},
+    {R"(\_SB_.I2CD)", 3},
 };
 
 std::string getI2cAdapterName(const fs::path& busPath) {

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -824,7 +824,8 @@ struct PlatformConfig {
   //          name.  Only CPU_BUS@0 is supported today.
   //        - AMD: identifies DesignWare I2C buses via ACPI
   //          firmware_node/path under /sys/devices/platform/AMDI0010:*.
-  //          CPU_BUS@0 maps to \_SB_.I2CB, CPU_BUS@1 to \_SB_.I2CA.
+  //          CPU_BUS@0 maps to \_SB_.I2CB, CPU_BUS@1 to \_SB_.I2CA,
+  //          CPU_BUS@2 to \_SB_.I2CC, CPU_BUS@3 to \_SB_.I2CD.
   //  (b) Exact adapter name matching /sys/bus/i2c/devices/i2c-N/name
   //      (e.g. "SMBus I801 adapter at 5000").
   // All entries in a single config must use the same style.

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -117,17 +117,18 @@ TEST(ConfigValidatorTest, I2cAdaptersFromCpuValidation) {
   // CPU_BUS@1 — valid (AMD second bus)
   EXPECT_TRUE(ConfigValidator().isValidI2cAdaptersFromCpu({"CPU_BUS@1"}));
 
-  // CPU_BUS@0 + CPU_BUS@1 — valid (AMD two-bus config)
+  // CPU_BUS@0 through CPU_BUS@3 — valid (AMD four-bus config)
   EXPECT_TRUE(
-      ConfigValidator().isValidI2cAdaptersFromCpu({"CPU_BUS@0", "CPU_BUS@1"}));
+      ConfigValidator().isValidI2cAdaptersFromCpu(
+          {"CPU_BUS@0", "CPU_BUS@1", "CPU_BUS@2", "CPU_BUS@3"}));
 
   // Exact names only — valid
   EXPECT_TRUE(
       ConfigValidator().isValidI2cAdaptersFromCpu(
           {"SMBus I801 adapter at 5000"}));
 
-  // CPU_BUS@2 — invalid (only @0 and @1 supported)
-  EXPECT_FALSE(ConfigValidator().isValidI2cAdaptersFromCpu({"CPU_BUS@2"}));
+  // CPU_BUS@4 — invalid (only @0 through @3 supported)
+  EXPECT_FALSE(ConfigValidator().isValidI2cAdaptersFromCpu({"CPU_BUS@4"}));
 
   // Duplicate CPU_BUS@0 — invalid
   EXPECT_FALSE(

--- a/fboss/platform/platform_manager/tests/I2cExplorerTest.cpp
+++ b/fboss/platform/platform_manager/tests/I2cExplorerTest.cpp
@@ -113,3 +113,18 @@ TEST(I2cExplorerTest, I2cAddr) {
   EXPECT_NO_THROW(I2cAddr("0x0f"));
   EXPECT_NO_THROW(I2cAddr("0xaf"));
 }
+
+TEST(I2cExplorerTest, IntelCpuBusConfigValidation) {
+  I2cExplorer explorer;
+
+  // Multiple virtual CPU buses are not supported on Intel.
+  EXPECT_THROW(
+      explorer.resolveIntelCpuBusNums({"CPU_BUS@0", "CPU_BUS@1"}),
+      std::runtime_error);
+
+  // Single unsupported CPU_BUS index is rejected.
+  EXPECT_THROW(
+      explorer.resolveIntelCpuBusNums({"CPU_BUS@1"}), std::runtime_error);
+  EXPECT_THROW(
+      explorer.resolveIntelCpuBusNums({"CPU_BUS@2"}), std::runtime_error);
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Map the AMD i2c controllers I2CC and I2CD to CPU_BUS@2 and CPU_BUS@3 in I2cExplorer (index-aligned to the AMD i2c[N] controllers; the legacy I2CA/I2CB mapping is unchanged), and widen ConfigValidator to accept CPU_BUS@0 through CPU_BUS@3 in i2cAdaptersFromCpu. This lets a platform_manager.json model devices on the third and fourth CPU-direct i2c buses.

# Test Plan

Running the config_validator_test which now verifies CPU_BUS@[0-3] are valid while anything past that index is invalid.