### PR TITLE
[meta] use own io_uring executor instead of setUseDefaultIoUringExecutor (#1331)

### DIFF
--- a/fboss/cli/fboss2/test/BUCK
+++ b/fboss/cli/fboss2/test/BUCK
@@ -258,9 +258,14 @@ cpp_binary(
     deps = [
         "//fboss/agent/if:ctrl-cpp2-services",
         "//fboss/lib:thrift_service_utils_oss",  # @manual
+        "//folly/executors:io_thread_pool_executor",
+        "//folly/executors/thread_factory:named_thread_factory",
         "//folly/init:init",
         "//folly/io/async:async_base",
         "//folly/io/async:epoll",
+        "//folly/io/async:event_base_manager",
+        "//folly/io/async:io_uring_backend",
+        "//folly/system:hardware_concurrency",
         "//thrift/lib/cpp2:server",
         "//thrift/lib/cpp2/async:rocket_client_channel",
         "//thrift/lib/cpp2/util:util",

--- a/fboss/cli/fboss2/test/thrift_latency_test.cpp
+++ b/fboss/cli/fboss2/test/thrift_latency_test.cpp
@@ -21,9 +21,15 @@
 #include <numeric>
 #include <vector>
 
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <folly/init/Init.h>
 #include <folly/io/async/Epoll.h>
 #include <folly/io/async/EventBase.h>
+#include <folly/io/async/EventBaseManager.h>
+#include <folly/io/async/IoUringBackend.h>
+#include <folly/io/async/IoUringOptions.h>
+#include <folly/system/HardwareConcurrency.h>
 #include <thrift/lib/cpp2/async/RocketClientChannel.h>
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 #include <thrift/lib/cpp2/util/ScopedServerInterfaceThread.h>
@@ -197,12 +203,39 @@ int main(int argc, char** argv) {
   // Test 3: IoUring backend
   printSeparator();
   std::cout << "[3/3] Testing IoUring backend..." << std::endl;
+#if FOLLY_HAS_LIBURING
   auto iouringResult = runBackendTest("IoUring", [](ThriftServer& server) {
     server.setPreferIoUring(true);
-    server.setUseDefaultIoUringExecutor(true);
+    static folly::EventBaseManager ioUringEbm(
+        folly::EventBase::Options().setBackendFactory(
+            []() -> std::unique_ptr<folly::EventBaseBackendBase> {
+              folly::IoUringOptions options;
+              options.setRegisterRingFd(true)
+                  .setInitialProvidedBuffers(2048, 2000)
+                  .setUseRegisteredFds(2048)
+                  .setDeferTaskRun(true)
+                  .setCapacity(512);
+              return std::make_unique<folly::IoUringBackend>(
+                  std::move(options));
+            }));
+    server.setIOThreadPool(
+        std::make_shared<folly::IOThreadPoolExecutor>(
+            folly::available_concurrency(),
+            std::make_shared<folly::NamedThreadFactory>("ThriftIO"),
+            &ioUringEbm,
+            folly::IOThreadPoolExecutor::Options().setEnableThreadIdCollection(
+                true)));
   });
   printResult(iouringResult);
   results.push_back(iouringResult);
+#else
+  std::cout << "  SKIPPED - liburing not available" << std::endl;
+  BackendResult iouringSkipped;
+  iouringSkipped.name = "IoUring";
+  iouringSkipped.success = false;
+  iouringSkipped.errorMsg = "liburing not available";
+  results.push_back(iouringSkipped);
+#endif
 
   // Print summary
   printSeparator();


### PR DESCRIPTION
Summary:

**WHAT**

The fboss2 `thrift_latency_test` IoUring backend benchmark builds and owns its io_uring `IOThreadPoolExecutor` instead of `setUseDefaultIoUringExecutor(true)`.

**WHY**

That setter is removed in the next diff up the stack; migrating the benchmark off it first keeps the stack landable in order. Guarded by `#if FOLLY_HAS_LIBURING` for the OSS/CMake build path following the example of the epoll test right above the uring test.

Differential Revision: D109085895


