### PR TITLE
[Accton][wedge800cact] Fix warmboot VerifyHostToQueueMappingClassID failure

### DIFF
--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -1649,6 +1649,20 @@ void SwSwitch::initialConfigApplied(
   sendNeighborSolicitationForConfiguredInterfaces("warm boot");
   sendArpRequestForConfiguredInterfaces("warm boot");
 
+  // After warmboot completes, immediately synchronize hardware stats to
+  // software cache (hwSwitchStats_). This ensures that tests reading stats
+  // immediately after warmboot get correct values instead of stale cached
+  // data. The background stats thread normally updates cache every 1 second,
+  // but tests may read stats within milliseconds of warmboot completing.
+
+  try {
+    XLOG(DBG2) << "Warm boot: synchronizing hardware stats to software cache";
+    updateStats();
+    XLOG(DBG2) << "Warm boot: stats synchronization completed";
+  } catch (const std::exception& ex) {
+    XLOG(ERR) << "Warm boot: stats synchronization failed: " << ex.what();
+  }
+
   if (flags_ & SwitchFlags::PUBLISH_STATS) {
     stats()->switchConfiguredMs(
         duration_cast<std::chrono::milliseconds>(

--- a/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
@@ -47,6 +47,8 @@ class AgentQueuePerHostL2Test : public AgentHwTest {
     auto ttlCounterName = utility::getQueuePerHostTtlCounterName();
 
     auto statBefore = utility::getAclInOutPackets(getSw(), ttlCounterName);
+    XLOG(DBG2) << "ACL counter '" << ttlCounterName
+               << "' statBefore = " << statBefore;
 
     std::map<int, int64_t> beforeQueueOutPkts;
     for (const auto& queueId : utility::kQueuePerhostQueueIds()) {
@@ -132,6 +134,10 @@ class AgentQueuePerHostL2Test : public AgentHwTest {
         auto statAfter =
             utility::getAclInOutPackets(this->getSw(), ttlCounterName);
 
+        XLOG(DBG2) << "ACL counter '" << ttlCounterName
+                   << "' statBefore = " << statBefore
+                   << ", statAfter = " << statAfter
+                   << ", delta = " << (statAfter - statBefore);
         /*
          * counts ttl >= 128 packet only
          * but L2 traffic (so TTL is not decremented, and thus looped back


### PR DESCRIPTION
Regarding the T1 warmboot.AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID failure: the issue is a warmboot stats race condition.
The test gets stale cached ACL stats within milliseconds of warmboot completing because the background stats thread updates them only every 1 second.

Solution:
Explicitly call updateStats() in SwSwitch::initialConfigApplied() after warmboot completes to immediately sync hardware stats to the software cache.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run --files fboss/agent/SwSwitch.cpp fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp`

# Summary
After warmboot, tests immediately reading stats would get stale cached values because the background thread updates only every 1s.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan
Test command:
`for i in {1..10}; do echo "=== run $i attempts ==="; time ./bin/run_test.py sai_agent --agent-run-mode mono --filter=AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID --skip-known-bad-tests "leaba/25.11.4210/25.11.4210/graphene202x" --enable-production-features g202x --config  /opt/fboss/share/hw_test_configs/wedge800cact.agent.materialized_JSON --fruid-path /home/Go_FBOSS_Test/W800CA-Fix/./fboss-configs/fboss/oss/scripts/run_configs/fruid.json --mgmt-if eth0 --platform_mapping_override_path /home/Go_FBOSS_Test/W800CA-Fix/./fboss-configs/fboss/lib/platform_mapping_v2/generated_platform_mappings/wedge800cact_platform_mapping-2026-0418-v0.7-honglim_20260409-del_pie.json  2>&1 | tee 463e_W800CACT_VerifyHostToQueueMappingClassID_DUT35_DVT1_v5_$(date '+%Y-%m-%d-%H:%M')_$i.log; done`

The test consistently passes for 10 consecutive runs.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
