### PR TITLE
[Nexthop] support for WEDGE800BNHP agent/qsfp services

### DIFF
--- a/fboss/agent/platforms/common/PlatformMappingUtils.cpp
+++ b/fboss/agent/platforms/common/PlatformMappingUtils.cpp
@@ -191,6 +191,7 @@ std::unique_ptr<PlatformMapping> initPlatformMapping(PlatformType type) {
           ? std::make_unique<Icecube800banwPlatformMapping>()
           : std::make_unique<Icecube800banwPlatformMapping>(platformMappingStr);
     case PlatformType::PLATFORM_WEDGE800BACT:
+    case PlatformType::PLATFORM_WEDGE800BNHP:
       return platformMappingStr.empty()
           ? std::make_unique<Wedge800BACTPlatformMapping>()
           : std::make_unique<Wedge800BACTPlatformMapping>(platformMappingStr);

--- a/fboss/agent/platforms/sai/SaiPlatform.cpp
+++ b/fboss/agent/platforms/sai/SaiPlatform.cpp
@@ -422,7 +422,9 @@ void SaiPlatform::initPorts() {
       saiPort = std::make_unique<SaiBcmLadakh800bclsPlatformPort>(portId, this);
     } else if (platformMode == PlatformType::PLATFORM_LEH800BCLS) {
       saiPort = std::make_unique<SaiBcmLeh800bclsPlatformPort>(portId, this);
-    } else if (platformMode == PlatformType::PLATFORM_WEDGE800BACT) {
+    } else if (
+        platformMode == PlatformType::PLATFORM_WEDGE800BACT ||
+        platformMode == PlatformType::PLATFORM_WEDGE800BNHP) {
       saiPort = std::make_unique<SaiBcmWedge800BACTPlatformPort>(portId, this);
     } else if (platformMode == PlatformType::PLATFORM_WEDGE800CACT) {
       saiPort = std::make_unique<SaiWedge800CACTPlatformPort>(portId, this);

--- a/fboss/agent/platforms/sai/SaiPlatformInit.cpp
+++ b/fboss/agent/platforms/sai/SaiPlatformInit.cpp
@@ -243,7 +243,9 @@ std::unique_ptr<SaiPlatform> chooseSaiPlatform(
   } else if (productInfo->getType() == PlatformType::PLATFORM_LEH800BCLS) {
     return std::make_unique<SaiBcmLeh800bclsPlatform>(
         std::move(productInfo), localMac, platformMappingStr);
-  } else if (productInfo->getType() == PlatformType::PLATFORM_WEDGE800BACT) {
+  } else if (
+      productInfo->getType() == PlatformType::PLATFORM_WEDGE800BACT ||
+      productInfo->getType() == PlatformType::PLATFORM_WEDGE800BNHP) {
     return std::make_unique<SaiBcmWedge800BACTPlatform>(
         std::move(productInfo), localMac, platformMappingStr);
   } else if (productInfo->getType() == PlatformType::PLATFORM_WEDGE800CACT) {

--- a/fboss/led_service/LedManagerInit.cpp
+++ b/fboss/led_service/LedManagerInit.cpp
@@ -81,7 +81,9 @@ std::unique_ptr<LedManager> createLedManager() {
     return std::make_unique<Icetea800bcLedManager>();
   } else if (mode == PlatformType::PLATFORM_TAHANSB800BC) {
     return std::make_unique<Tahansb800bcLedManager>();
-  } else if (mode == PlatformType::PLATFORM_WEDGE800BACT) {
+  } else if (
+      mode == PlatformType::PLATFORM_WEDGE800BACT ||
+      mode == PlatformType::PLATFORM_WEDGE800BNHP) {
     return std::make_unique<Wedge800BACTLedManager>();
   } else if (mode == PlatformType::PLATFORM_WEDGE800CACT) {
     return std::make_unique<Wedge800CACTLedManager>();

--- a/fboss/lib/bsp/bspmapping/Main.cpp
+++ b/fboss/lib/bsp/bspmapping/Main.cpp
@@ -47,6 +47,8 @@ const std::map<PlatformType, folly::StringPiece> kHardwareNameMap = {
      kPortMappingTahansb800bcCsv},
     {facebook::fboss::PlatformType::PLATFORM_WEDGE800BACT,
      kPortMappingWedge800BACTCsv},
+    {facebook::fboss::PlatformType::PLATFORM_WEDGE800BNHP,
+     kPortMappingWedge800BACTCsv},
     {facebook::fboss::PlatformType::PLATFORM_WEDGE800CACT,
      kPortMappingWedge800CACTCsv},
     {facebook::fboss::PlatformType::PLATFORM_LADAKH800BCLS,

--- a/fboss/lib/bsp/bspmapping/test/ParserTest.cpp
+++ b/fboss/lib/bsp/bspmapping/test/ParserTest.cpp
@@ -66,6 +66,10 @@ TEST(ParserTest, GetNameForTests) {
       "wedge800bact");
   EXPECT_EQ(
       facebook::fboss::Parser::getNameFor(
+          facebook::fboss::PlatformType::PLATFORM_WEDGE800BNHP),
+      "wedge800bnhp");
+  EXPECT_EQ(
+      facebook::fboss::Parser::getNameFor(
           facebook::fboss::PlatformType::PLATFORM_WEDGE800CACT),
       "wedge800cact");
   EXPECT_EQ(

--- a/fboss/lib/if/fboss_common.thrift
+++ b/fboss/lib/if/fboss_common.thrift
@@ -64,6 +64,7 @@ enum PlatformType {
   PLATFORM_SAINTPAUL = 51,
   PLATFORM_LEH800BCLS = 52,
   PLATFORM_M4062NHP = 53,
+  PLATFORM_WEDGE800BNHP = 54,
   PLATFORM_UNKNOWN = 1000, # Placeholder for unknown platform type
 }
 

--- a/fboss/lib/platforms/PlatformMode.h
+++ b/fboss/lib/platforms/PlatformMode.h
@@ -126,6 +126,8 @@ inline std::string toString(PlatformType mode) {
       return "MERU400BFU";
     case PlatformType::PLATFORM_MERU400BIA_DEPRECATED:
       return "MERU400BIA";
+    case PlatformType::PLATFORM_WEDGE800BNHP:
+      return "WEDGE800BNHP";
     case PlatformType::PLATFORM_UNKNOWN:
       return "UNKNOWN";
   }

--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -100,6 +100,10 @@ void PlatformProductInfo::initMode() {
         modelName.find("WEDGE800BACT") == 0) {
       type_ = PlatformType::PLATFORM_WEDGE800BACT;
     } else if (
+        modelName.find("Wedge800BNHP") == 0 ||
+        modelName.find("WEDGE800BNHP") == 0) {
+      type_ = PlatformType::PLATFORM_WEDGE800BNHP;
+    } else if (
         modelName.find("Wedge800CACT") == 0 ||
         modelName.find("WEDGE800CACT") == 0) {
       type_ = PlatformType::PLATFORM_WEDGE800CACT;
@@ -335,6 +339,8 @@ void PlatformProductInfo::initMode() {
       type_ = PlatformType::PLATFORM_SAINTPAUL;
     } else if (FLAGS_mode == "m4062nhp") {
       type_ = PlatformType::PLATFORM_M4062NHP;
+    } else if (FLAGS_mode == "wedge800bnhp") {
+      type_ = PlatformType::PLATFORM_WEDGE800BNHP;
     } else {
       throw std::runtime_error("invalid mode " + FLAGS_mode);
     }

--- a/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
+++ b/fboss/qsfp_service/platforms/wedge/WedgeManagerInit.cpp
@@ -172,6 +172,7 @@ std::unique_ptr<WedgeManager> createWedgeManager(
           PlatformType::PLATFORM_TAHANSB800BC>(
           platformMapping, qsfpServiceThreads);
     case PlatformType::PLATFORM_WEDGE800BACT:
+    case PlatformType::PLATFORM_WEDGE800BNHP:
       return createBspWedgeManager<
           Wedge800BACTBspPlatformMapping,
           PlatformType::PLATFORM_WEDGE800BACT>(

--- a/fboss/util/wedge_qsfp_util.cpp
+++ b/fboss/util/wedge_qsfp_util.cpp
@@ -4747,7 +4747,8 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
                                  .get();
       auto ioBus = std::make_unique<BspIOBus>(systemContainer);
       return std::make_pair(std::move(ioBus), 0);
-    } else if (FLAGS_platform == "wedge800bact") {
+    } else if (
+        FLAGS_platform == "wedge800bact" || FLAGS_platform == "wedge800bnhp") {
       auto systemContainer = BspGenericSystemContainer<
                                  Wedge800BACTBspPlatformMapping>::getInstance()
                                  .get();
@@ -4862,7 +4863,9 @@ std::pair<std::unique_ptr<TransceiverI2CApi>, int> getTransceiverAPI() {
             .get();
     auto ioBus = std::make_unique<BspIOBus>(systemContainer);
     return std::make_pair(std::move(ioBus), 0);
-  } else if (mode == PlatformType::PLATFORM_WEDGE800BACT) {
+  } else if (
+      mode == PlatformType::PLATFORM_WEDGE800BACT ||
+      mode == PlatformType::PLATFORM_WEDGE800BNHP) {
     auto systemContainer =
         BspGenericSystemContainer<Wedge800BACTBspPlatformMapping>::getInstance()
             .get();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Adds WEDGE800BNHP, while leveraging WEDGE800BACT code:
- Defines `PLATFORM_WEDGE800BNHP = 54` in `fboss_common.thrift`
- `PlatformMappingUtils.cpp`: fall-through `PLATFORM_WEDGE800BNHP` into `PLATFORM_WEDGE800BACT`
- Wires BNHP into agent (`SaiPlatform`, `SaiPlatformInit`), `qsfp_service`, `led_service`, BSP mapping, `PlatformProductInfo`, and `wedge_qsfp_util`

# Test Plan
WEDGE800BNHP should work similarly to WEDGE800BACT.
