### PR TITLE
[Celestica] Ladakh800bcls: Agent Test: Fix AgentTrunkLoadBalancerTests no used vlan create route interface fail in warmboot

### DIFF
--- a/fboss/agent/test/TrunkUtils.cpp
+++ b/fboss/agent/test/TrunkUtils.cpp
@@ -51,15 +51,51 @@ void addAggPort(
     aggPort.memberPorts()->push_back(makePortMember(port, rate));
   }
   config->aggregatePorts()->push_back(aggPort);
-  // Set VLAN for all members to be the same
+
   std::set<uint32_t> memberPorts(ports.begin(), ports.end());
   std::optional<int32_t> aggVlan;
+  std::set<int32_t> memberOldVlans;
+
   for (auto& vlanPort : *config->vlanPorts()) {
     if (memberPorts.contains(vlanPort.logicalPort().value())) {
+      int32_t oldVlan = vlanPort.vlanID().value();
+      memberOldVlans.insert(oldVlan);
       if (!aggVlan) {
-        aggVlan = vlanPort.vlanID().value();
+        aggVlan = oldVlan;
       }
       vlanPort.vlanID() = *aggVlan;
+    }
+  }
+
+  if (aggVlan.has_value()) {
+    std::set<int32_t> stillReferenced;
+    for (const auto& vlanPort : *config->vlanPorts()) {
+      stillReferenced.insert(vlanPort.vlanID().value());
+    }
+
+    for (auto oldVlan : memberOldVlans) {
+      if (oldVlan == *aggVlan || stillReferenced.contains(oldVlan)) {
+        continue;
+      }
+
+      auto& vlans = *config->vlans();
+      vlans.erase(
+          std::remove_if(
+              vlans.begin(),
+              vlans.end(),
+              [&](const auto& v) { return v.id().value() == oldVlan; }),
+          vlans.end());
+
+      auto& intfs = *config->interfaces();
+      intfs.erase(
+          std::remove_if(
+              intfs.begin(),
+              intfs.end(),
+              [&](const auto& i) {
+                return i.type().value() == cfg::InterfaceType::VLAN &&
+                    i.vlanID().value() == oldVlan;
+              }),
+          intfs.end());
     }
   }
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed


# Summary

 Issue Summary

  On multi-NPU hardware platforms, the AgentTrunkLoadBalancerTest suite was experiencing a fatal warmboot failure, The failure manifested as a no sai vlan for VlanID 2001 error



  Root Cause Analysis

after debugging ,
1: I found in AgentTrunkLoadBalancerTests config call onePortPerInterfaceConfig
2: then addAggPort 3 ports, before that logical port 1(vlan2000) 2(2001) 3(2002), then changed to
port 1(vlan2000) 2(2000) 3(2000), vlan/vlaninterface 2001 2002 empty member ports
3: then new config goto ApplyThriftConfig.cpp new_->resetVlans(
toMultiSwitchMap<MultiSwitchVlanMap>(newVlans, scopeResolver_));
const HwSwitchMatcher SwitchIdScopeResolver::scope(
    const std::shared_ptr<Vlan>& vlan)
if (vlan->getPortsInfo().empty())  
// Return the first switchId.
// TODO: Remove this after scope resolution is updated to return single
// switchId based on virtual interface and switchId configuration.
return HwSwitchMatcher(
std::unordered_set<SwitchID>(
{*allSwitchMatcher().switchIds().begin()}));
debug log : SwitchIdScopeResolver.cpp:253] willtest Vlan 2001 has no ports, scoping to first switch ID: 1
4: since vlan 2001 scope to switch id 1, when thrift config send to agent , delta will remove vlan 2001,
5: after cold boot test, then enter warmboot restoring the environment , in high level config there are vlan 2001, but in agent sai , there is no vlan sai 2001 handler, so this case fail on npu0 warmboot,
why this case issue doesn't happen on other cases which call addAggPort , Because several conditions need to be met. (onePortPerInterfaceConfig ,addAggPort more then one ports) trunk/LAG/SRv6/MPLS/MAC/copp tests they do not.
 
 Solution Implemented

 In void addAggPort(

When adding a port to agg, check which vlan it is previously part of another vlan and if that vlan does not have any remaining ports, then delete the vlan from the config


# Test Plan

test addaggport related test cases

npu0.warm_boot.AgentCoppTest/0.LocalDstIpBgpPortToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.LocalDstIpNonBgpPortToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.Ipv6LinkLocalMcastToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.Ipv6LinkLocalMcastTxFromCpu,OK,
npu0.warm_boot.AgentCoppTest/0.Ipv6LinkLocalUcastToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.SlowProtocolsMacToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.CpuPortIpv6LinkLocalUcastIp,OK,
npu0.warm_boot.AgentCoppTest/0.Ipv6LinkLocalMcastNetworkControlDscpToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.ArpRequestAndReplyToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.NdpSolicitationToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.NdpSolicitNeighbor,OK,
npu0.warm_boot.AgentCoppTest/0.NdpAdvertisementToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.UnresolvedRoutesToLowPriQueue,OK,
npu0.warm_boot.AgentCoppTest/0.JumboFramesToQueues,OK,
npu0.warm_boot.AgentCoppTest/0.LldpProtocolToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.Ttl1PacketToLowPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.DHCPv6SolicitToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/0.DHCPv6AdvertiseToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.LocalDstIpBgpPortToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.LocalDstIpNonBgpPortToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.Ipv6LinkLocalMcastToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.Ipv6LinkLocalMcastTxFromCpu,OK,
npu0.warm_boot.AgentCoppTest/1.Ipv6LinkLocalUcastToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.SlowProtocolsMacToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.CpuPortIpv6LinkLocalUcastIp,OK,
npu0.warm_boot.AgentCoppTest/1.Ipv6LinkLocalMcastNetworkControlDscpToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.ArpRequestAndReplyToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.NdpSolicitationToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.NdpSolicitNeighbor,OK,
npu0.warm_boot.AgentCoppTest/1.NdpAdvertisementToHighPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.UnresolvedRoutesToLowPriQueue,OK,
npu0.warm_boot.AgentCoppTest/1.JumboFramesToQueues,OK,
npu0.warm_boot.AgentCoppTest/1.LldpProtocolToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.Ttl1PacketToLowPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.DHCPv6SolicitToMidPriQ,OK,
npu0.warm_boot.AgentCoppTest/1.DHCPv6AdvertiseToMidPriQ,OK,
npu0.warm_boot.AgentCoppEapolTest/0.EapolToHighPriQ,OK,
npu0.warm_boot.AgentCoppEapolTest/1.EapolToHighPriQ,OK,
npu0.warm_boot.AgentEcmpTestWithWBWrites.L2ResolveOneNhopThenLinkDownThenUp,OK,
npu0.warm_boot.AgentEcmpTest.ecmpToDropToEcmp,OK,
npu0.warm_boot.AgentEcmpTest.L2ResolveOneNhopThenLinkDownThenUpThenL2ResolveNhop,OK,
npu0.warm_boot.AgentEcmpTest.L2UnresolvedNhopsECMPInHWEmpty,OK,
npu0.warm_boot.AgentEcmpNeighborTest.ResolvePendingResolveNexthop,OK,
npu0.warm_boot.AgentLinkLocalForwardingTest.EcmpLinkLocalNexthopsLoadBalanced,OK,
npu0.warm_boot.AgentMacLearningAndMyStationInteractionTestHw.verifyInteractionHwMacLearning,OK,
npu0.warm_boot.AgentMacLearningAndMyStationInteractionTestSw.verifyInteractionSwMacLearning,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifySwLearningForPort,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifySwLearningForPortNoCycle,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifySwLearningForTrunk,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifySwAgingForPort,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifySwAgingForTrunk,OK,
npu0.warm_boot.AgentMacSwLearningModeTest.VerifyCallbacksOnMacEntryChange,OK,
npu0.warm_boot.AgentMacLearningStaticConfigTest.VerifyStaticMacEntriesFromConfig,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/0.learnMacAndProgramNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/0.learnMacProgramNeighborsAndAgeMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/0.learnMacProgramNeighborsAndUpdateMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/0.flapMacAndNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/0.learnMacLinkDownNeighborResolve,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.learnMacAndProgramNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndAgeMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndUpdateMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.flapMacAndNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.learnMacProgramNeighborsAndMove,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/1.learnMacLinkDownNeighborResolve,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacAndProgramNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacProgramNeighborsAndAgeMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacProgramNeighborsAndUpdateMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/2.flapMacAndNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacLinkDownNeighborResolve,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacAndProgramNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndAgeMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndUpdateMac,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.flapMacAndNeighbors,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndMove,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacLinkDownNeighborResolve,OK,
npu0.warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacLinkDownNeighborResolve,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X3WideTrunksCpuTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X2WideTrunksCpuTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksFrontPanelTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksFrontPanelTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X3WideTrunksCpuTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X2WideTrunksCpuTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksFrontPanelTraffic,OK,
npu0.warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksFrontPanelTraffic,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpSpillover,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpDecompress,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollback,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollbackPartial,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpReplay,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpBackupUpdateOverWB,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyDynamicPrefixUpdate,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifySpilloverPrefixUpdate,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifySpilloverPrefixReclaimOnRouteDelete,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifySpilloverPrefixChangeToPrimaryGroupNhops,OK,
npu0.warm_boot.AgentEcmpSpilloverTest.VerifyEcmpDecompressByPrefixCount,OK,



# AI skill code check


<img width="1275" height="543" alt="image" src="https://github.com/user-attachments/assets/e1584672-cce3-464b-8222-98a38c1138b2" />




