### PR TITLE
[Celestica] Tahansb: fan_service: Fixing OTP issues by optimizing the OTP algorithm

### DIFF
--- a/fboss/platform/configs/tahansb800bc/fan_service.json
+++ b/fboss/platform/configs/tahansb800bc/fan_service.json
@@ -20,8 +20,8 @@
     "conditions": [
       {
         "sensorName": "SMB_U2_TH6_TEMP",
-        "overtempThreshold": 120,
-        "slidingWindowSize": 10
+        "overtempThreshold": 103,
+        "slidingWindowSize": 2
       }
     ]
   },

--- a/fboss/platform/fan_service/OvertempCondition.cpp
+++ b/fboss/platform/fan_service/OvertempCondition.cpp
@@ -76,16 +76,22 @@ bool OvertempCondition::checkIfOvertemp() {
   for (auto overtempItem = entries.begin(); overtempItem != entries.end();
        overtempItem++) {
     auto& entry = overtempItem->second;
-    if (entry.length == 0) {
+    if (entry.length < entry.slidingWindowSize) {
       return false;
     }
-    float movingAverage = entry.sumTotal / entry.length;
-    if (movingAverage > entry.overtempThreshold) {
+    bool isOvertemp = true;
+    for (auto sensorRead : entry.sensorReads) {
+      if (sensorRead <= entry.overtempThreshold) {
+        isOvertemp = false;
+        break;
+      }
+    }
+    if (isOvertemp) {
       XLOG(ERR) << fmt::format(
-          "Overtemp condition detected for sensor:{} value:{}, entry_count:{}",
+          "Overtemp condition detected for sensor:{} threshold:{}, window_size:{}",
           entry.sensorName,
-          movingAverage,
-          entry.length);
+          entry.overtempThreshold,
+          entry.slidingWindowSize);
       overtempCount++;
     }
   }

--- a/fboss/platform/fan_service/tests/OvertempTests.cpp
+++ b/fboss/platform/fan_service/tests/OvertempTests.cpp
@@ -14,7 +14,7 @@ TEST(OvertempConditionTest, Basic) {
 
   overtempCondition.setNumOvertempSensorForShutdown(1);
   overtempCondition.addSensorForTracking("TimmyHick9_Core_Temp", 102.84, 1);
-  overtempCondition.addSensorForTracking("OSFP3200_Port1_Core_Temp", 70.1, 1);
+  overtempCondition.addSensorForTracking("OSFP3200_Port1_Core_Temp", 70.1, 2);
 
   // Make sure the registered sensors are tracked.
   EXPECT_TRUE(overtempCondition.isTracked("TimmyHick9_Core_Temp"));
@@ -27,7 +27,11 @@ TEST(OvertempConditionTest, Basic) {
   EXPECT_FALSE(overtempCondition.checkIfOvertemp());
 
   overtempCondition.processSensorData("OSFP3200_Port1_Core_Temp", 70.2);
-  // Make sure there is no false negative
+  // The first overtemp read should not trigger shutdown when window size is 2.
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("OSFP3200_Port1_Core_Temp", 70.3);
+  // Make sure there is no false negative after two consecutive overtemp reads.
   EXPECT_TRUE(overtempCondition.checkIfOvertemp());
 }
 
@@ -62,9 +66,58 @@ TEST(OvertempConditionTest, SlidingWindow) {
   overtempCondition.processSensorData("Zinclake_Hotswap_Temp", 84.3);
   EXPECT_FALSE(overtempCondition.checkIfOvertemp());
 
-  // Overtemp condition should be met after this
+  // Only one sensor is showing overtemp. No shutdown should be triggered.
   overtempCondition.processSensorData("Spooktrim7_Core_Temp", 110.2);
   overtempCondition.processSensorData("Retimer_Port1_Temp", 79.1);
   overtempCondition.processSensorData("Zinclake_Hotswap_Temp", 120.1);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("Spooktrim7_Core_Temp", 111.2);
+  overtempCondition.processSensorData("Retimer_Port1_Temp", 79.1);
+  overtempCondition.processSensorData("Zinclake_Hotswap_Temp", 121.1);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("Spooktrim7_Core_Temp", 111.2);
+  overtempCondition.processSensorData("Retimer_Port1_Temp", 79.1);
+  overtempCondition.processSensorData("Zinclake_Hotswap_Temp", 121.1);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  // Overtemp condition should be met after each sensor's window is overtemp.
+  overtempCondition.processSensorData("Spooktrim7_Core_Temp", 111.2);
+  overtempCondition.processSensorData("Retimer_Port1_Temp", 79.1);
+  overtempCondition.processSensorData("Zinclake_Hotswap_Temp", 121.1);
+  EXPECT_TRUE(overtempCondition.checkIfOvertemp());
+}
+
+TEST(OvertempConditionTest, SingleHugeSpikeDoesNotTriggerShutdown) {
+  OvertempCondition overtempCondition;
+  overtempCondition.setNumOvertempSensorForShutdown(1);
+  overtempCondition.addSensorForTracking("TimmyHick9_Core_Temp", 102.84, 2);
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 70.4);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 10000.0);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 70.5);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+}
+
+TEST(OvertempConditionTest, BelowThresholdReadResetsWindow) {
+  OvertempCondition overtempCondition;
+  overtempCondition.setNumOvertempSensorForShutdown(1);
+  overtempCondition.addSensorForTracking("TimmyHick9_Core_Temp", 102.84, 2);
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 103.0);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 70.5);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 103.1);
+  EXPECT_FALSE(overtempCondition.checkIfOvertemp());
+
+  overtempCondition.processSensorData("TimmyHick9_Core_Temp", 103.2);
   EXPECT_TRUE(overtempCondition.checkIfOvertemp());
 }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="484" height="146" alt="image" src="https://github.com/user-attachments/assets/cf2ea974-bd8f-43d9-a793-7dee5a7027c2" />

# Summary

Meta reported a TH6 PCIe link issue, which, after debugging, was found to be caused by an SW OTP. It appears that during the TH6 SDK/agent initialization process, the TH6_TEMP sensor reads an abnormal, untrustworthy temperature jump. This anomalous reading value should not be used to trigger OTP. 
The OTP algorithm has been optimized. The previous algorithm, which calculated the average of _windowsize_ TH6 temperature samples to determine OTP, was a bit unreasonable. When an abnormally high temperature value is read within the window size, the calculated average will still remain high enough to exceed the overtemp threshold. It has been replaced with an algorithm that requires the TH6 temperature to exceed the overtempThreshold for _windowsize_ consecutive samples before triggering OTP.

# Test Plan

Continuously execute the agent initialization stress test while simultaneously running platform_manager, sensor_service, and fan_service.
Our SVT team has been running the stress test continuously for a week, and the issue has not been reproduced.