### PR TITLE
[Celestica] Leh800bcls: Resolve multi-switch empty fb303 counters in IS_OSS Split Agent mode

### DIFF
--- a/fboss/agent/hw/test/BUCK
+++ b/fboss/agent/hw/test/BUCK
@@ -759,6 +759,8 @@ cpp_library(
     ],
     exported_deps = [
         ":hw_test_thrift_handler_h",
+        "//fb303:service_data",
+        "//fb303:thread_cached_service_data",
         "//folly:synchronized",
         "//folly/logging:log_handler",
         "//folly/logging:logging",

--- a/fboss/agent/hw/test/HwTestLogCaptureThriftHandler.cpp
+++ b/fboss/agent/hw/test/HwTestLogCaptureThriftHandler.cpp
@@ -2,6 +2,8 @@
 
 #include "fboss/agent/hw/test/HwTestThriftHandler.h"
 
+#include <fb303/ServiceData.h>
+#include <fb303/ThreadCachedServiceData.h>
 #include <folly/Synchronized.h>
 #include <folly/logging/LogHandler.h>
 #include <folly/logging/LogHandlerConfig.h>
@@ -85,6 +87,18 @@ void HwTestThriftHandler::getMatchingLogMessages(
     return;
   }
   out = static_cast<CaptureLogHandler*>(handler.get())->matching(*substring);
+}
+
+void HwTestThriftHandler::getFb303RegexCounters(
+    std::map<std::string, int64_t>& counters,
+    std::unique_ptr<std::string> regex) {
+  facebook::fb303::ThreadCachedServiceData::get()->publishStats();
+  counters = facebook::fb303::fbData->getRegexCounters(*regex);
+}
+
+int64_t HwTestThriftHandler::getFb303Counter(std::unique_ptr<std::string> key) {
+  facebook::fb303::ThreadCachedServiceData::get()->publishStats();
+  return facebook::fb303::fbData->getCounterIfExists(*key).value_or(0);
 }
 
 } // namespace utility

--- a/fboss/agent/hw/test/HwTestThriftHandler.h
+++ b/fboss/agent/hw/test/HwTestThriftHandler.h
@@ -258,6 +258,12 @@ class HwTestThriftHandler : public AgentHwTestCtrlSvIf {
       std::vector<std::string>& out,
       std::unique_ptr<std::string> substring) override;
 
+  void getFb303RegexCounters(
+      std::map<std::string, int64_t>& counters,
+      std::unique_ptr<std::string> regex) override;
+
+  int64_t getFb303Counter(std::unique_ptr<std::string> key) override;
+
  private:
   HwSwitch* hwSwitch_;
   // Captures log messages in this process for tests to read over RPC.

--- a/fboss/agent/if/agent_hw_test_ctrl.thrift
+++ b/fboss/agent/if/agent_hw_test_ctrl.thrift
@@ -240,4 +240,8 @@ service AgentHwTestCtrl {
   // installLogCapture() must be called before the log is emitted.
   void installLogCapture();
   list<string> getMatchingLogMessages(1: string substring);
+
+  // fb303 cross-process utils for multi-switch testing
+  map<string, i64> getFb303RegexCounters(1: string regex);
+  i64 getFb303Counter(1: string key);
 }

--- a/fboss/agent/test/AgentEnsemble.cpp
+++ b/fboss/agent/test/AgentEnsemble.cpp
@@ -881,8 +881,8 @@ std::map<std::string, int64_t> AgentEnsemble::getFb303CountersByRegex(
       client->getChannelShared()};
   monitoringClient.sync_getRegexCounters(counters, regex);
 #else
-  // TODO: This needs to be updated to support multi-switch.
-  counters = facebook::fb303::fbData->getRegexCounters(regex);
+  auto switchID = scopeResolver().scope(portId).switchId();
+  counters = queryHwAgentFb303RegexCounters(switchID, regex);
 #endif
   return counters;
 }
@@ -908,8 +908,7 @@ int64_t AgentEnsemble::getFb303Counter(
       client->getChannelShared()};
   counter = monitoringClient.sync_getCounter(key);
 #else
-  // TODO: This needs to be updated to support multi-switch.
-  counter = facebook::fb303::fbData->getCounter(key);
+  counter = queryHwAgentFb303Counter(switchID, key);
 #endif
   return counter;
 }
@@ -959,10 +958,49 @@ std::map<std::string, int64_t> AgentEnsemble::getFb303RegexCounters(
       client->getChannelShared()};
   monitoringClient.sync_getRegexCounters(counters, regex);
 #else
-  // TODO: This needs to be updated to support multi-switch.
-  counters = facebook::fb303::fbData->getRegexCounters(regex);
+  counters = queryHwAgentFb303RegexCounters(switchID, regex);
 #endif
   return counters;
+}
+
+std::map<std::string, int64_t> AgentEnsemble::queryHwAgentFb303RegexCounters(
+    const SwitchID& switchID,
+    const std::string& regex) {
+  std::map<std::string, int64_t> counters;
+  if (!getSw()->isRunModeMultiSwitch()) {
+    counters = facebook::fb303::fbData->getRegexCounters(regex);
+  } else {
+    try {
+      auto hwTestClient = getHwAgentTestClient(switchID);
+      hwTestClient->sync_getFb303RegexCounters(counters, regex);
+    } catch (const std::exception& ex) {
+      XLOG(ERR)
+          << "Failed to fetch remote fb303 counters via HwTestCtrl for switch "
+          << switchID << ": " << ex.what();
+      throw;
+    }
+  }
+  return counters;
+}
+
+int64_t AgentEnsemble::queryHwAgentFb303Counter(
+    const SwitchID& switchID,
+    const std::string& key) {
+  int64_t counter{0};
+  if (!getSw()->isRunModeMultiSwitch()) {
+    counter = facebook::fb303::fbData->getCounter(key);
+  } else {
+    try {
+      auto hwTestClient = getHwAgentTestClient(switchID);
+      counter = hwTestClient->sync_getFb303Counter(key);
+    } catch (const std::exception& ex) {
+      XLOG(ERR)
+          << "Failed to fetch remote fb303 counter via HwTestCtrl for switch "
+          << switchID << ": " << ex.what();
+      throw;
+    }
+  }
+  return counter;
 }
 
 std::string AgentEnsemble::getHwDebugDump() {

--- a/fboss/agent/test/AgentEnsemble.h
+++ b/fboss/agent/test/AgentEnsemble.h
@@ -405,6 +405,13 @@ class AgentEnsemble : public TestEnsembleIf {
   void overrideConfigFlag(const std::string& fileName);
   void dumpConfigForHwAgent(AgentConfig* agentConf);
 
+  std::map<std::string, int64_t> queryHwAgentFb303RegexCounters(
+      const SwitchID& switchId,
+      const std::string& regex);
+  int64_t queryHwAgentFb303Counter(
+      const SwitchID& switchId,
+      const std::string& key);
+
   void writeConfig(const cfg::SwitchConfig& config);
   void writeConfig(const cfg::AgentConfig& config);
   bool waitForRateOnPort(


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
The agent test case verifyBufferPoolWatermarks, verifyIngressPriorityGroupWatermarks, and PfcWatchdogDetection tests all failed on both npu0 and npu1 on the leh800bcls.
- AgentTrafficPfcGenTest.verifyBufferPoolWatermarks
```
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp:168: Failure
Expected: (globalHeadroomWatermark) > (0), actual: 0 vs 0

/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp:170: Failure
Expected: (globalSharedWatermark) > (0), actual: 0 vs 0
```
- AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks
```
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp:200: Failure
Expected equality of these values:
  counters.size()
    Which is: 0
  numKeys
    Which is: 2

/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp:206: Failure
Expected: (totalWatermark) > (0), actual: 0 vs 0
```
- AgentTrafficPfcWatchdogTest.PfcWatchdogDetection
```
unknown file: Failure
C++ exception with description "no such counter "switch.0.pfc_deadlock_detection_count.sum"" thrown in the test body.
```

# Root Cause
 In Split Agent mode, the test main thread runs in the software agent process (multi_switch_agent), while physical metrics are published strictly inside the local facebook::fb303::fbData singleton of the isolated hardware agent process (fboss_hw_agent-sai_impl).

 In IS_OSS open-source builds, the Monitor client classes are completely excluded from compilation, forcing **AgentEnsemble.cpp** to execute the legacy fallback:
```
#ifndef IS_OSS
...  monitoringClient.sync_getRegexCounters ...
#else
  // TODO: This needs to be updated to support multi-switch.
  counters = facebook::fb303::fbData->getRegexCounters(regex);
#endif
```
 This causes the test process to query its own local blank fbData instead of the switch under test. The local fbData in the test process is empty, causing watermark regex matches to return empty maps, and exact-key queries (such as watchdog deadlock detection counters) to throw C++ std::invalid_argument exceptions, crashing the test body.

# Solution
  1. Protocol Extension (agent_hw_test_ctrl.thrift):
    Added getFb303RegexCounters and getFb303Counter APIs to AgentHwTestCtrl.
  2. Server Implementation (HwTestThriftHandler.h):
    Implemented these overrides inline. To eliminate microsecond timing gaps, we manually trigger an in-band cache flush before returning the counters, using safe getCounterIfExists to prevent exceptions:
```
void getFb303RegexCounters(counters, regex) override {
  facebook::fb303::ThreadCachedServiceData::get()->publishStats(); // Force flush
  counters = facebook::fb303::fbData->getRegexCounters(*regex);
}
```
  3. Ensemble Pull & Mode Duality (AgentEnsemble.cpp):
    Refactored #else // IS_OSS branches. If !isRunModeMultiSwitch() (Monolithic mode), we directly read local fbData to completely avoid false-positive warning logs and connection attempts on monolithic platforms. If in multi-switch mode, we remotely query the hardware agent via getHwAgentTestClient(switchID).

# Test Plan
Verified test case verifyBufferPoolWatermarks, verifyIngressPriorityGroupWatermarks, and PfcWatchdogDetection passed on npu0 and npu1.
```
[root@localhost log]# grep " OK " AgentTxNpu[10]/mu*.log
AgentTxNpu0/multi_switch_agent-AgentTrafficPfcGenTest.verifyBufferPoolWatermarks-20260626_130335.log:[       OK ] AgentTrafficPfcGenTest.verifyBufferPoolWatermarks (65648 ms)
AgentTxNpu0/multi_switch_agent-AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks-20260626_130447.log:[       OK ] AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks (65813 ms)
AgentTxNpu0/multi_switch_agent-AgentTrafficPfcWatchdogTest.PfcWatchdogDetection-20260626_130600.log:[       OK ] AgentTrafficPfcWatchdogTest.PfcWatchdogDetection (70769 ms)
AgentTxNpu1/multi_switch_agent-AgentTrafficPfcGenTest.verifyBufferPoolWatermarks-20260626_125951.log:[       OK ] AgentTrafficPfcGenTest.verifyBufferPoolWatermarks (65464 ms)
AgentTxNpu1/multi_switch_agent-AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks-20260626_130103.log:[       OK ] AgentTrafficPfcGenTest.verifyIngressPriorityGroupWatermarks (66169 ms)
AgentTxNpu1/multi_switch_agent-AgentTrafficPfcWatchdogTest.PfcWatchdogDetection-20260626_130217.log:[       OK ] AgentTrafficPfcWatchdogTest.PfcWatchdogDetection (70933 ms)

```