### PR TITLE
Fix MoD ingress-port check on XGS (hw logical port)

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.cpp
@@ -6,8 +6,8 @@
 
 #include <folly/ScopeGuard.h>
 
-#include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/FbossError.h"
+#include "fboss/agent/SwSwitch.h"
 #include "fboss/agent/TxPacket.h"
 #include "fboss/agent/packet/PktUtil.h"
 #include "fboss/agent/test/TestUtils.h"
@@ -176,7 +176,20 @@ void AgentMirrorOnDropStatelessTest::validateMirrorOnDropPacket(
   EXPECT_EQ(fields.outerDstIp, kCollectorIp_);
   EXPECT_EQ(fields.outerSrcPort, static_cast<uint16_t>(kMirrorSrcPort));
   EXPECT_EQ(fields.outerDstPort, static_cast<uint16_t>(kMirrorDstPort));
-  EXPECT_EQ(fields.ingressPort, static_cast<uint16_t>(injectionPortId));
+  // Some ASICs report the hardware logical port id (not the FBOSS PortID) in
+  // the MoD packet; translate the injection PortID to match. The mapping comes
+  // from port stats, which lag a warm boot, so retry until it's populated.
+  auto expectedIngressPort = static_cast<uint16_t>(injectionPortId);
+  if (impl()->ingressPortIsHwLogicalPort()) {
+    std::optional<uint32_t> hwLogicalPortId;
+    WITH_RETRIES({
+      hwLogicalPortId = getSw()->getHwLogicalPortId(injectionPortId);
+      EXPECT_EVENTUALLY_TRUE(hwLogicalPortId.has_value());
+    });
+    ASSERT_TRUE(hwLogicalPortId.has_value());
+    expectedIngressPort = static_cast<uint16_t>(*hwLogicalPortId);
+  }
+  EXPECT_EQ(fields.ingressPort, expectedIngressPort);
   EXPECT_EQ(fields.dropReasonIngress, expectedReasons.ingressDropReason);
   EXPECT_EQ(fields.dropReasonEgress, expectedReasons.egressDropReason);
   EXPECT_EQ(fields.innerSrcIp, expectedInnerSrcIp.value_or(kPacketSrcIp_));

--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.h
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include <folly/IPAddress.h>
+#include <folly/IPAddressV6.h>
 #include <folly/MacAddress.h>
 #include <folly/io/IOBuf.h>
 
@@ -79,6 +79,11 @@ class MirrorOnDropImpl {
   // Check ASIC-specific wire-format invariants
   // (e.g., IPFIX version for XGS).
   virtual void verifyInvariants(const folly::IOBuf* buf) const = 0;
+
+  // True if the MoD packet's ingress-port field carries the hardware logical
+  // port id rather than the FBOSS PortID, so the framework translates the
+  // injection PortID via SwSwitch::getHwLogicalPortId before comparing.
+  virtual bool ingressPortIsHwLogicalPort() const = 0;
 
   // ASIC-specific raw drop-reason code for each category. The framework
   // packs these into the ingress-vs-egress slot expected by the wire format.

--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropTajoImpl.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropTajoImpl.cpp
@@ -164,6 +164,12 @@ void TajoMirrorOnDropImpl::verifyInvariants(const folly::IOBuf* buf) const {
   EXPECT_EQ(parsed.puntHeader.reserved2, 0x0000);
 }
 
+bool TajoMirrorOnDropImpl::ingressPortIsHwLogicalPort() const {
+  // The Tajo punt header's ingress-port encoding has not been characterized
+  // against hardware; keep comparing against the FBOSS PortID as before.
+  return false;
+}
+
 uint16_t TajoMirrorOnDropImpl::getDefaultRouteDropReason() const {
   return kTajoDropReasonDefaultRoute;
 }

--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropTajoImpl.h
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropTajoImpl.h
@@ -28,6 +28,8 @@ class TajoMirrorOnDropImpl : public MirrorOnDropImpl {
 
   void verifyInvariants(const folly::IOBuf* buf) const override;
 
+  bool ingressPortIsHwLogicalPort() const override;
+
   uint16_t getDefaultRouteDropReason() const override;
   uint16_t getAclDropReason() const override;
   uint16_t getMmuDropReason() const override;

--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropXgsImpl.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropXgsImpl.cpp
@@ -116,6 +116,12 @@ void XgsMirrorOnDropImpl::verifyInvariants(const folly::IOBuf* buf) const {
       psamp::XGS_PSAMP_VAR_LEN_INDICATOR);
 }
 
+bool XgsMirrorOnDropImpl::ingressPortIsHwLogicalPort() const {
+  // XGS PSAMP carries the Broadcom hardware logical port id, not the FBOSS
+  // logical PortID.
+  return true;
+}
+
 uint16_t XgsMirrorOnDropImpl::getDefaultRouteDropReason() const {
   return kBcmDropReasonL3DstDiscard;
 }

--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropXgsImpl.h
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropXgsImpl.h
@@ -27,6 +27,8 @@ class XgsMirrorOnDropImpl : public MirrorOnDropImpl {
 
   void verifyInvariants(const folly::IOBuf* buf) const override;
 
+  bool ingressPortIsHwLogicalPort() const override;
+
   uint16_t getDefaultRouteDropReason() const override;
   uint16_t getAclDropReason() const override;
   uint16_t getMmuDropReason() const override;


### PR DESCRIPTION
## Summary

`AgentMirrorOnDropStatelessTest.DefaultRouteDrop` and `.AclDrop` fail on NH-4010-F (Tomahawk5 / XGS), on cold and warm boot. `validateMirrorOnDropPacket` asserts that the MoD packet's ingress-port equals the FBOSS logical `PortID`. On XGS the PSAMP `ingressPort` field actually carries the Broadcom **hardware logical port id** (the low bits of the SAI port object id), which is a different numbering from the FBOSS `PortID`.

The failure shows up where the injection port's `PortID` differs from its hardware logical port. On NH-4010-F the first interface port maps `PortID 1 → hw logical port 3`, so the assertion sees `3 vs 1`. Platforms where the two happen to coincide for the injection port pass the old assertion only by coincidence, so `ingressPort == PortID` was silently fragile.

## Fix

Add a per-ASIC `ingressPortIsHwLogicalPort()` to the `MirrorOnDropImpl` strategy:

- **XGS** returns `true` → `validateMirrorOnDropPacket` translates the injection `PortID` via `SwSwitch::getHwLogicalPortId()` before comparing. The lookup is wrapped in `WITH_RETRIES` because the stats-backed mapping can lag a warm boot.
- **Tajo** returns `false` → unchanged; its punt-header ingress-port encoding hasn't been characterized against hardware yet.

On platforms where `PortID == hwLogicalPort` this returns the same value the old check used (no behavior change); where they differ it returns the real hardware port that the MoD packet carries. This mirrors the translation the DNX path already performs via its source-system-port aggregate.

## Test Plan

On NH-4010-F (Tomahawk5), `AgentMirrorOnDropStatelessTest.DefaultRouteDrop` and `.AclDrop` now pass on both cold and warm boot (previously failed warm boot with `ingressPort 3 vs 1`).
