### PR TITLE
[Nexthop][fboss2-dev] BGP-aware fboss2 config session (ConfigSession infra)

### DIFF
--- a/cmake/CliFboss2.cmake
+++ b/cmake/CliFboss2.cmake
@@ -1075,6 +1075,7 @@ target_link_libraries(fboss2_config_lib
   agent_dir_util
   common_file_utils
   switch_config_cpp2
+  bgp_config_cpp2
   switchinfo_utils
   platform_mapping
   Folly::folly

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -1329,6 +1329,7 @@ cpp_library(
         ":cmd-handler",
         ":fboss2-lib",
         "//common/network/if:if-cpp2-types",
+        "//configerator/structs/neteng/fboss/bgp:bgp_config-cpp2-types",
         "//fboss/agent:agent_config-cpp2-types",
         "//fboss/agent:fboss-types",
         "//fboss/agent:platform_config-cpp2-types",

--- a/fboss/cli/fboss2/cli_metadata.thrift
+++ b/fboss/cli/fboss2/cli_metadata.thrift
@@ -19,13 +19,13 @@ enum ConfigActionLevel {
   HITLESS = 0, // Can be applied with reloadConfig() - default
   AGENT_WARMBOOT = 1, // Requires agent warmboot restart
   AGENT_COLDBOOT = 2, // Requires agent coldboot restart (clears ASIC state)
-  BGP_RESTART = 3, // Requires a restart of the bgp_pp (BGP++) service
+  BGP_RESTART = 3, // Requires a restart of the bgpd (BGP++) service
 }
 
 // Identifier for different services that can be configured
 enum ServiceType {
   AGENT = 1,
-  BGP = 2, // The bgp_pp (BGP++) routing daemon
+  BGP = 2, // The bgpd (BGP++) routing daemon
 }
 
 // Metadata stored alongside the session configuration file.

--- a/fboss/cli/fboss2/cli_metadata.thrift
+++ b/fboss/cli/fboss2/cli_metadata.thrift
@@ -19,11 +19,13 @@ enum ConfigActionLevel {
   HITLESS = 0, // Can be applied with reloadConfig() - default
   AGENT_WARMBOOT = 1, // Requires agent warmboot restart
   AGENT_COLDBOOT = 2, // Requires agent coldboot restart (clears ASIC state)
+  BGP_RESTART = 3, // Requires a restart of the bgp_pp (BGP++) service
 }
 
 // Identifier for different services that can be configured
 enum ServiceType {
   AGENT = 1,
+  BGP = 2, // The bgp_pp (BGP++) routing daemon
 }
 
 // Metadata stored alongside the session configuration file.

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionClear.cpp
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionClear.cpp
@@ -28,10 +28,12 @@ CmdConfigSessionClearTraits::RetType CmdConfigSessionClear::queryClient(
   // getInstance(), which would create a session if one doesn't exist
   std::string sessionConfigPath = ConfigSession::getSessionConfigPathStatic();
   std::string metadataPath = ConfigSession::getSessionMetadataPathStatic();
+  std::string bgpConfigPath = ConfigSession::getBgpSessionConfigPathStatic();
 
   std::error_code ec;
   bool removedConfig = false;
   bool removedMetadata = false;
+  bool removedBgpConfig = false;
 
   // Remove session config file (~/.fboss2/agent.conf)
   if (fs::exists(sessionConfigPath)) {
@@ -60,7 +62,23 @@ CmdConfigSessionClearTraits::RetType CmdConfigSessionClear::queryClient(
     removedMetadata = true;
   }
 
-  if (removedConfig || removedMetadata) {
+  // Remove staged BGP config file (~/.fboss2/bgp_config.json). BGP global edits
+  // are staged here (alongside any peer edits from BgpConfigSession), so a
+  // BGP-only session must be cleared too.
+  if (fs::exists(bgpConfigPath)) {
+    ec.clear();
+    fs::remove(bgpConfigPath, ec);
+    if (ec) {
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to remove BGP session config file {}: {}",
+              bgpConfigPath,
+              ec.message()));
+    }
+    removedBgpConfig = true;
+  }
+
+  if (removedConfig || removedMetadata || removedBgpConfig) {
     return "Config session cleared successfully.";
   }
   return "No config session exists. Nothing to clear.";

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionCommit.cpp
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionCommit.cpp
@@ -23,7 +23,7 @@ CmdConfigSessionCommitTraits::RetType CmdConfigSessionCommit::queryClient(
     const HostInfo& hostInfo) {
   auto& session = ConfigSession::getInstance();
 
-  if (!session.sessionExists()) {
+  if (!session.hasActiveSession()) {
     return "No config session exists. Make a config change first.";
   }
 
@@ -57,6 +57,11 @@ CmdConfigSessionCommitTraits::RetType CmdConfigSessionCommit::queryClient(
         for (const auto& serviceName : serviceNamesList) {
           restartedServices.push_back(
               fmt::format("{} (warmboot)", serviceName));
+        }
+        break;
+      case cli::ConfigActionLevel::BGP_RESTART:
+        for (const auto& serviceName : serviceNamesList) {
+          restartedServices.push_back(fmt::format("{} (restart)", serviceName));
         }
         break;
       case cli::ConfigActionLevel::HITLESS:

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.cpp
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.cpp
@@ -17,11 +17,13 @@
 #include "fboss/cli/fboss2/utils/CmdUtils.h"
 #include "fboss/cli/fboss2/utils/HostInfo.h"
 
+#include <fmt/format.h>
 #include <folly/FileUtil.h>
 #include <folly/Subprocess.h>
 #include <unistd.h>
 #include <cstdlib>
 #include <exception>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -32,27 +34,68 @@ namespace facebook::fboss {
 
 namespace {
 
-// Helper function to get config content from a revision specifier
-// Returns the content and a label for the revision
+// Git-relative paths of the two config files tracked in the /etc/coop repo.
+constexpr auto kAgentGitRelPath = "cli/agent.conf";
+constexpr auto kBgpGitRelPath = "bgpcpp/bgpcpp.conf";
+
+// A diffable config domain. The agent config and the BGP config are tracked in
+// the same /etc/coop git repo but live in different files; `config session
+// diff` shows whichever domain(s) are staged/relevant.
+struct DiffDomain {
+  std::string name; // "Agent" / "BGP" (section header when >1 domain shown)
+  std::string gitRelPath; // path in the git repo (e.g. cli/agent.conf)
+  std::string systemPath; // current live file
+  std::string sessionPath; // staged session file (~/.fboss2/...)
+  bool staged; // a session edit is staged for this domain
+};
+
+std::vector<DiffDomain> allDomains(ConfigSession& session) {
+  return {
+      DiffDomain{
+          "Agent",
+          kAgentGitRelPath,
+          session.getSystemConfigPath(),
+          session.getSessionConfigPath(),
+          session.sessionExists()},
+      DiffDomain{
+          "BGP",
+          kBgpGitRelPath,
+          session.getBgpSystemConfigPath(),
+          session.getBgpSessionConfigPath(),
+          session.bgpSessionExists()},
+  };
+}
+
+// Read a file, returning empty content (not an error) when it doesn't exist.
+std::string readFileOrEmpty(const std::string& path) {
+  std::string content;
+  folly::readFile(path.c_str(), content);
+  return content;
+}
+
+// Get config content from a revision specifier for a specific domain file.
+// "current" reads the live system file. A path absent at the given revision
+// (e.g. a commit predating BGP config) is treated as empty content.
 std::pair<std::string, std::string> getRevisionContent(
     const std::string& revision,
-    ConfigSession& session) {
-  auto& git = session.getGit();
-  std::string cliConfigPath = session.getCliConfigPath();
-
+    const DiffDomain& domain,
+    Git& git) {
   if (revision == "current") {
-    // Read the current live config (via the symlink or directly from cli path)
-    std::string content;
-    if (!folly::readFile(cliConfigPath.c_str(), content)) {
-      throw std::runtime_error(
-          "Failed to read current config from " + cliConfigPath);
-    }
-    return {content, "current live config"};
+    return {readFileOrEmpty(domain.systemPath), "current live config"};
   }
-
-  // Resolve the commit SHA and get the content from Git
   std::string resolvedSha = git.resolveRef(revision);
-  std::string content = git.fileAtRevision(resolvedSha, "cli/agent.conf");
+  // Verify the revision is real before treating a missing domain path as empty.
+  // cli/agent.conf is present in every commit (including the initial one), so a
+  // genuinely invalid revision throws here and propagates; only a path absent
+  // at an otherwise-valid revision (e.g. bgpcpp.conf before BGP existed) is
+  // treated as empty.
+  git.fileAtRevision(resolvedSha, kAgentGitRelPath);
+  std::string content;
+  try {
+    content = git.fileAtRevision(resolvedSha, domain.gitRelPath);
+  } catch (const std::exception&) {
+    content = "";
+  }
   return {content, Git::shortSha1(revision)};
 }
 
@@ -116,64 +159,108 @@ std::string executeDiff(
   }
 }
 
+// Append a (optionally headered) diff section to the combined output.
+void appendSection(
+    std::string& out,
+    const std::string& name,
+    const std::string& body,
+    bool withHeader) {
+  if (withHeader) {
+    if (!out.empty()) {
+      out += "\n";
+    }
+    out += fmt::format("===== {} config =====\n", name);
+  }
+  out += body;
+  if (!body.empty() && body.back() != '\n') {
+    out += "\n";
+  }
+}
+
 } // namespace
 
 CmdConfigSessionDiffTraits::RetType CmdConfigSessionDiff::queryClient(
     const HostInfo& /* hostInfo */,
     const utils::RevisionList& revisions) {
   auto& session = ConfigSession::getInstance();
+  auto& git = session.getGit();
+  auto domains = allDomains(session);
 
-  std::string systemConfigPath = session.getSystemConfigPath();
-  std::string sessionConfigPath = session.getSessionConfigPath();
+  // Modes 1 and 2 both diff each staged domain's session file against some
+  // "base" (current live config for mode 1; a revision for mode 2). The only
+  // difference is how the base content+label is obtained, so share the loop.
+  auto diffStagedDomains =
+      [&](const std::function<std::pair<std::string, std::string>(
+              const DiffDomain&)>& getBase) {
+        int stagedCount = 0;
+        for (const auto& d : domains) {
+          stagedCount += d.staged ? 1 : 0;
+        }
+        std::string out;
+        for (const auto& d : domains) {
+          if (!d.staged) {
+            continue;
+          }
+          auto [baseContent, baseLabel] = getBase(d);
+          std::string sessionContent;
+          if (!folly::readFile(d.sessionPath.c_str(), sessionContent)) {
+            throw std::runtime_error(
+                "Failed to read session config from " + d.sessionPath);
+          }
+          appendSection(
+              out,
+              d.name,
+              executeDiff(
+                  baseContent, sessionContent, baseLabel, "session config"),
+              stagedCount > 1);
+        }
+        return out;
+      };
 
-  // Mode 1: No arguments - diff session vs current live config
+  // Mode 1: No arguments - diff each staged domain's session vs current live.
   if (revisions.empty()) {
-    if (!session.sessionExists()) {
+    if (!session.hasActiveSession()) {
       return "No config session exists. Make a config change first.";
     }
-
-    std::string currentContent;
-    if (!folly::readFile(systemConfigPath.c_str(), currentContent)) {
-      throw std::runtime_error(
-          "Failed to read current config from " + systemConfigPath);
-    }
-
-    std::string sessionContent;
-    if (!folly::readFile(sessionConfigPath.c_str(), sessionContent)) {
-      throw std::runtime_error(
-          "Failed to read session config from " + sessionConfigPath);
-    }
-
-    return executeDiff(
-        currentContent,
-        sessionContent,
-        "current live config",
-        "session config");
+    return diffStagedDomains([&](const DiffDomain& d) {
+      return std::make_pair(
+          readFileOrEmpty(d.systemPath), std::string("current live config"));
+    });
   }
 
-  // Mode 2: One argument - diff session vs specified revision
+  // Mode 2: One argument - diff each staged domain's session vs a revision.
   if (revisions.size() == 1) {
-    if (!session.sessionExists()) {
+    if (!session.hasActiveSession()) {
       return "No config session exists. Make a config change first.";
     }
-
-    auto [revContent, revLabel] = getRevisionContent(revisions[0], session);
-
-    std::string sessionContent;
-    if (!folly::readFile(sessionConfigPath.c_str(), sessionContent)) {
-      throw std::runtime_error(
-          "Failed to read session config from " + sessionConfigPath);
-    }
-
-    return executeDiff(revContent, sessionContent, revLabel, "session config");
+    return diffStagedDomains([&](const DiffDomain& d) {
+      return getRevisionContent(revisions[0], d, git);
+    });
   }
 
-  // Mode 3: Two arguments - diff between two revisions
+  // Mode 3: Two arguments - diff between two revisions for each domain that
+  // has content at either revision.
   if (revisions.size() == 2) {
-    auto [content1, label1] = getRevisionContent(revisions[0], session);
-    auto [content2, label2] = getRevisionContent(revisions[1], session);
-
-    return executeDiff(content1, content2, label1, label2);
+    // Pre-compute each domain's rendered diff section so headers are only added
+    // when more than one domain is shown.
+    std::vector<std::pair<std::string, std::string>> sections; // {name, body}
+    for (const auto& d : domains) {
+      auto [c1, l1] = getRevisionContent(revisions[0], d, git);
+      auto [c2, l2] = getRevisionContent(revisions[1], d, git);
+      if (c1.empty() && c2.empty()) {
+        continue; // domain absent at both revisions
+      }
+      sections.emplace_back(d.name, executeDiff(c1, c2, l1, l2));
+    }
+    if (sections.empty()) {
+      return "No config found at the given revisions.";
+    }
+    std::string out;
+    const bool multi = sections.size() > 1;
+    for (const auto& [name, body] : sections) {
+      appendSection(out, name, body, multi);
+    }
+    return out;
   }
 
   // More than 2 arguments is an error

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -592,7 +592,7 @@ void ConfigSession::saveBgpConfig() {
 
   // Serialize the entire typed config (round-tripped through parse so integer
   // map keys become string keys, mirroring saveConfig() for the agent).
-  std::string json =
+  auto json =
       apache::thrift::SimpleJSONSerializer::serialize<std::string>(bgpConfig_);
   std::string prettyJson = folly::toPrettyJson(folly::parseJson(json));
   folly::writeFileAtomic(

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -356,6 +357,22 @@ std::string ConfigSession::getSessionMetadataPathStatic() {
   return getSessionDir() + "/cli_metadata.json";
 }
 
+std::string ConfigSession::getBgpSessionConfigPathStatic() {
+  return getSessionDir() + "/bgp_config.json";
+}
+
+std::string ConfigSession::fileAtRevisionOrEmpty(
+    const std::string& revision,
+    const std::string& gitRelPath) const {
+  try {
+    return git_->fileAtRevision(revision, gitRelPath);
+  } catch (const std::exception&) {
+    // The path did not exist at that revision (e.g. a commit predating BGP
+    // config). Treat as empty.
+    return "";
+  }
+}
+
 std::string ConfigSession::getSessionConfigPath() const {
   return sessionConfigDir_ + "/agent.conf";
 }
@@ -374,6 +391,14 @@ std::string ConfigSession::getCliConfigPath() const {
 
 bool ConfigSession::sessionExists() const {
   return fs::exists(getSessionConfigPath());
+}
+
+bool ConfigSession::hasActiveSession() const {
+  // An agent config session (agent.conf) OR a protocol session staged outside
+  // agent.conf. BGP is the latter: a staged ~/.fboss2/bgp_config.json (written
+  // by either the typed global config here or BgpConfigSession's peer edits)
+  // with a recorded BGP_RESTART action, but never touching agent.conf.
+  return sessionExists() || bgpSessionExists();
 }
 
 cfg::AgentConfig& ConfigSession::getAgentConfig() {
@@ -464,6 +489,115 @@ void ConfigSession::saveConfig(
 
 void ConfigSession::saveConfig() {
   saveConfig(cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+}
+
+void ConfigSession::recordServiceAction(
+    cli::ServiceType service,
+    cli::ConfigActionLevel actionLevel) {
+  // Record the command from /proc/self/cmdline so it shows up in this
+  // session's command history, exactly like saveConfig() does. Config for
+  // this service lives in a separate file (e.g. ~/.fboss2/bgp_config.json),
+  // so we deliberately do NOT touch the agent config here.
+  std::string rawCmd = readCommandLineFromProc();
+  auto pos = rawCmd.find("config ");
+  if (pos != std::string::npos) {
+    std::string cmd = rawCmd.substr(pos);
+    if (commands_.empty() || commands_.back() != cmd) {
+      commands_.push_back(cmd);
+    }
+  }
+
+  // Update and persist the required action level for this service.
+  updateRequiredAction(service, actionLevel);
+  saveMetadata();
+}
+
+std::string ConfigSession::getBgpSessionConfigPath() const {
+  return sessionConfigDir_ + "/bgp_config.json";
+}
+
+std::string ConfigSession::getBgpSystemConfigDir() const {
+  return systemConfigDir_ + "/bgpcpp";
+}
+
+std::string ConfigSession::getBgpSystemConfigPath() const {
+  return getBgpSystemConfigDir() + "/bgpcpp.conf";
+}
+
+bool ConfigSession::bgpSessionExists() const {
+  return fs::exists(getBgpSessionConfigPath());
+}
+
+void ConfigSession::loadBgpConfig() {
+  if (bgpConfigLoaded_) {
+    return;
+  }
+
+  // Prefer staged edits; otherwise seed from the running bgp_pp config; else
+  // schema defaults. A read failure on a file that exists is logged (not
+  // silently treated as "no config") so a permission/IO error doesn't
+  // masquerade as a fresh session.
+  std::string content;
+  std::string sessionPath = getBgpSessionConfigPath();
+  std::string systemPath = getBgpSystemConfigPath();
+  if (fs::exists(sessionPath)) {
+    if (!folly::readFile(sessionPath.c_str(), content)) {
+      LOG(WARNING) << "Failed to read staged BGP config " << sessionPath
+                   << "; starting from defaults";
+    }
+  } else if (fs::exists(systemPath)) {
+    if (!folly::readFile(systemPath.c_str(), content)) {
+      LOG(WARNING) << "Failed to read system BGP config " << systemPath
+                   << "; starting from defaults";
+    }
+  }
+
+  bgpConfig_ = bgp::thrift::BgpConfig();
+  if (!content.empty()) {
+    try {
+      apache::thrift::SimpleJSONSerializer::deserialize<bgp::thrift::BgpConfig>(
+          content, bgpConfig_);
+    } catch (const std::exception& ex) {
+      LOG(WARNING) << "Failed to parse BGP config, starting from defaults: "
+                   << ex.what();
+      bgpConfig_ = bgp::thrift::BgpConfig();
+    }
+  }
+  bgpConfigLoaded_ = true;
+}
+
+bgp::thrift::BgpConfig& ConfigSession::getBgpConfig() {
+  if (!bgpConfigLoaded_) {
+    loadBgpConfig();
+  }
+  return bgpConfig_;
+}
+
+const bgp::thrift::BgpConfig& ConfigSession::getBgpConfig() const {
+  if (!bgpConfigLoaded_) {
+    throw std::runtime_error(
+        "BGP config not loaded yet. Call getBgpConfig() (non-const) first.");
+  }
+  return bgpConfig_;
+}
+
+void ConfigSession::saveBgpConfig() {
+  if (!bgpConfigLoaded_) {
+    loadBgpConfig();
+  }
+
+  // Serialize the entire typed config (round-tripped through parse so integer
+  // map keys become string keys, mirroring saveConfig() for the agent).
+  std::string json =
+      apache::thrift::SimpleJSONSerializer::serialize<std::string>(bgpConfig_);
+  std::string prettyJson = folly::toPrettyJson(folly::parseJson(json));
+  folly::writeFileAtomic(
+      getBgpSessionConfigPath(), prettyJson, 0644, folly::SyncType::WITH_SYNC);
+
+  // Record the command (mirrors saveConfig) and that bgp_pp must be restarted
+  // for this change to take effect on a subsequent `config session commit`.
+  recordServiceAction(
+      cli::ServiceType::BGP, cli::ConfigActionLevel::BGP_RESTART);
 }
 
 Git& ConfigSession::getGit() {
@@ -625,6 +759,7 @@ ConfigSession::applyServiceActions(
     switch (level) {
       case cli::ConfigActionLevel::AGENT_COLDBOOT:
       case cli::ConfigActionLevel::AGENT_WARMBOOT:
+      case cli::ConfigActionLevel::BGP_RESTART:
         serviceNames[service] =
             fbossServiceUtil_->restartService(service, level);
         break;
@@ -665,7 +800,12 @@ void ConfigSession::loadConfig() {
 
 void ConfigSession::initializeSession() {
   initializeGit();
-  if (!sessionExists()) {
+  // Resume an existing session if EITHER an agent (agent.conf) or a BGP
+  // (bgp_config.json) session is staged. Keying only on the agent session file
+  // would misdetect a BGP-only session as fresh and clear its recorded
+  // BGP_RESTART action on the next (separate-process) CLI invocation,
+  // silently dropping the staged change at commit time.
+  if (!hasActiveSession()) {
     // Starting a new session - reset all state to ensure we don't carry over
     // stale data from a previous session (e.g., if the singleton persisted
     // in memory but the session files were deleted).
@@ -729,8 +869,30 @@ void ConfigSession::initializeGit() {
           cliConfigPath, seedContent, 0644, folly::SyncType::WITH_SYNC);
     }
 
+    // Seed an empty metadata file and include it in the initial commit so the
+    // baseline shows up in `git log -- cli/cli_metadata.json`. No-arg
+    // rollback() walks metadata history (so BGP-only commits, which never touch
+    // agent.conf, are reachable); without the baseline in that history, rolling
+    // back to the very first commit would fail with "no previous revision".
+    std::string initialMetadataPath = getSystemMetadataPath();
+    if (!fs::exists(initialMetadataPath)) {
+      folly::writeFileAtomic(
+          initialMetadataPath, "{}", 0644, folly::SyncType::WITH_SYNC);
+    }
+
+    // Seed the running bgp_pp config into the baseline commit too. Without it,
+    // the first revision has no BGP snapshot, so a rollback to it would read
+    // the empty target as "BGP never existed" and DELETE the running
+    // bgpcpp.conf.
+    std::vector<std::string> initialFiles = {
+        cliConfigPath, initialMetadataPath};
+    std::string bgpSystemPath = getBgpSystemConfigPath();
+    if (fs::exists(bgpSystemPath)) {
+      initialFiles.push_back(bgpSystemPath);
+    }
+
     try {
-      git_->commit({cliConfigPath}, "Initial commit", username_, "");
+      git_->commit(initialFiles, "Initial commit", username_, "");
     } catch (const std::exception&) {
       // Another process may have raced us to the initial commit.
       // If commits now exist, swallow the error; otherwise re-throw.
@@ -758,10 +920,18 @@ void ConfigSession::copySystemConfigToSession() const {
 }
 
 ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
-  if (!sessionExists()) {
+  // A BGP-only session stages bgp_config.json but never agent.conf, so the
+  // agent-config file operations below are guarded on hasAgentSession.
+  const bool hasAgentSession = sessionExists();
+  if (!hasActiveSession()) {
     throw std::runtime_error(
         "No config session exists. Make a config change first.");
   }
+
+  // A BGP-only session never ran initializeSession(), so ensure the /etc/coop
+  // git repo and its initial commit exist before we commit into it. Idempotent
+  // for agent sessions, which initialized git when the session started.
+  initializeGit();
 
   // Check if someone else committed changes while this session was in progress
   std::string currentHead = git_->getHead();
@@ -784,25 +954,70 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
 
   ensureDirectoryExists(cliConfigDir);
 
-  // Read the session config content
+  // Read the staged agent config (only present for an agent config session; a
+  // BGP-only session never writes agent.conf). oldConfigData is read for
+  // rollback if needed.
   std::string sessionConfigData;
-  if (!folly::readFile(sessionConfigPath.c_str(), sessionConfigData)) {
-    throw std::runtime_error(
-        fmt::format(
-            "Failed to read session config from {}", sessionConfigPath));
-  }
-
-  // Read the old config for rollback if needed
   std::string oldConfigData;
-  if (fs::exists(cliConfigPath)) {
-    if (!folly::readFile(cliConfigPath.c_str(), oldConfigData)) {
+  if (hasAgentSession) {
+    if (!folly::readFile(sessionConfigPath.c_str(), sessionConfigData)) {
       throw std::runtime_error(
-          fmt::format("Failed to read CLI config from {}", cliConfigPath));
+          fmt::format(
+              "Failed to read session config from {}", sessionConfigPath));
+    }
+    if (fs::exists(cliConfigPath)) {
+      if (!folly::readFile(cliConfigPath.c_str(), oldConfigData)) {
+        throw std::runtime_error(
+            fmt::format("Failed to read CLI config from {}", cliConfigPath));
+      }
     }
   }
 
-  // Early return if there are no changes to commit
-  if (sessionConfigData == oldConfigData && requiredActions_.empty()) {
+  // Capture the running BGP system config up front: it tells us whether the
+  // staged BGP config actually changed (so we can skip a needless bgp_pp
+  // restart) and is the snapshot we restore if the commit fails partway.
+  const std::string bgpSystemPath = getBgpSystemConfigPath();
+  const bool bgpSystemConfigExisted = fs::exists(bgpSystemPath);
+  std::string bgpOldData;
+  if (bgpSystemConfigExisted) {
+    // Check the read: a silently-failed read would leave bgpOldData empty and
+    // make the restore-on-failure path below write an empty bgpcpp.conf,
+    // corrupting the running config (mirrors the guard in rollback()).
+    if (!folly::readFile(bgpSystemPath.c_str(), bgpOldData)) {
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to read current BGP config from {}", bgpSystemPath));
+    }
+  }
+
+  // saveBgpConfig() records BGP_RESTART unconditionally, so re-committing an
+  // unchanged BGP config would otherwise still bounce bgp_pp (a disruptive,
+  // traffic-affecting restart for no effective change). Treat BGP as changed
+  // only when the staged config differs from what is running.
+  bool bgpConfigChanged = false;
+  if (requiredActions_.count(cli::ServiceType::BGP) > 0 && bgpSessionExists()) {
+    std::string stagedBgpData;
+    if (!folly::readFile(getBgpSessionConfigPath().c_str(), stagedBgpData)) {
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to read staged BGP config from {}",
+              getBgpSessionConfigPath()));
+    }
+    bgpConfigChanged = (stagedBgpData != bgpOldData);
+  }
+
+  // Copy requiredActions_ before we reset it (returned in CommitResult) and
+  // drop BGP when the BGP config is unchanged, so an unchanged BGP commit
+  // neither promotes the config nor restarts bgp_pp.
+  auto actions = requiredActions_;
+  if (!bgpConfigChanged) {
+    actions.erase(cli::ServiceType::BGP);
+  }
+
+  // Early return if there are no changes to commit.
+  const bool agentConfigChanged =
+      hasAgentSession && sessionConfigData != oldConfigData;
+  if (!agentConfigChanged && actions.empty()) {
     return CommitResult{"", {}, {}};
   }
 
@@ -834,34 +1049,72 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
             "Failed to copy metadata to {}: {}", targetMetadataPath, e.what()));
   }
 
-  // Atomically write the session config to the CLI config path
-  folly::writeFileAtomic(
-      cliConfigPath, sessionConfigData, 0644, folly::SyncType::WITH_SYNC);
+  // Files to include in the git commit. The metadata file is always part of a
+  // commit; agent.conf and its symlink are added only when an agent config
+  // session was staged. BGP config (if staged this session) is added below; it
+  // lives under /etc/coop/bgpcpp/ so it's versioned by this same /etc/coop
+  // repo.
+  std::vector<std::string> commitFiles = {targetMetadataPath};
 
-  // Ensure the system config symlink points to the CLI config
-  atomicSymlinkUpdate(systemConfigPath, "cli/agent.conf");
+  if (hasAgentSession) {
+    // Atomically write the session config to the CLI config path
+    folly::writeFileAtomic(
+        cliConfigPath, sessionConfigData, 0644, folly::SyncType::WITH_SYNC);
 
-  // Apply the config based on the required action levels for each service
-  // Copy requiredActions_ before we reset it - this will be returned in
-  // CommitResult
-  auto actions = requiredActions_;
+    // Ensure the system config symlink points to the CLI config
+    atomicSymlinkUpdate(systemConfigPath, "cli/agent.conf");
+
+    commitFiles.push_back(cliConfigPath);
+    commitFiles.push_back(systemConfigPath);
+  }
 
   // Apply the config based on the required action level
   std::string commitSha;
   std::map<cli::ServiceType, std::vector<std::string>> serviceNames;
+
+  // stagingBgp reflects the trimmed action set: false when the BGP config was
+  // unchanged, so we neither promote bgpcpp.conf nor restart bgp_pp below. The
+  // prior BGP config (bgpOldData / bgpSystemConfigExisted, captured above) is
+  // the snapshot restored if the commit fails partway.
+  const bool stagingBgp = actions.count(cli::ServiceType::BGP) > 0;
+  std::string bgpConfPath;
+
   try {
+    // If this session staged BGP config changes, promote the staged
+    // bgp_config.json to /etc/coop/bgpcpp/bgpcpp.conf BEFORE bgp_pp is
+    // restarted below, so the restart picks up the new config. The promoted
+    // file is committed as part of this commit's git operation. The staged
+    // session file is left in place until the whole commit succeeds, so a
+    // failure here can be rolled back and retried.
+    if (stagingBgp && bgpSessionExists()) {
+      std::string staged;
+      if (!folly::readFile(getBgpSessionConfigPath().c_str(), staged)) {
+        throw std::runtime_error(
+            fmt::format(
+                "Failed to read staged BGP config from {}",
+                getBgpSessionConfigPath()));
+      }
+      ensureDirectoryExists(getBgpSystemConfigDir());
+      folly::writeFileAtomic(
+          getBgpSystemConfigPath(), staged, 0644, folly::SyncType::WITH_SYNC);
+      bgpConfPath = getBgpSystemConfigPath();
+      commitFiles.push_back(bgpConfPath);
+    } else if (bgpSystemConfigExisted) {
+      // Agent-only commit: still track the running bgp_pp config so a later
+      // rollback has a snapshot to restore instead of wiping it. No restart —
+      // the file is already the running config.
+      commitFiles.push_back(bgpSystemPath);
+    }
+
     serviceNames = applyServiceActions(actions, hostInfo);
 
     // Create a Git commit with all changed files:
     // - cli/agent.conf (the config file)
     // - cli/cli_metadata.json (the metadata file)
     // - agent.conf (the symlink, in case it was updated)
+    // - bgpcpp/bgpcpp.conf (the bgp config, if staged this session)
     std::string commitMessage = fmt::format("Config commit by {}", username_);
-    commitSha = git_->commit(
-        {cliConfigPath, targetMetadataPath, systemConfigPath},
-        commitMessage,
-        username_,
-        "");
+    commitSha = git_->commit(commitFiles, commitMessage, username_, "");
     LOG(INFO) << "Config committed as " << Git::shortSha1(commitSha);
   } catch (const std::exception& ex) {
     // Rollback: restore the old config, then re-apply actions
@@ -870,6 +1123,18 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
       if (!oldConfigData.empty()) {
         folly::writeFileAtomic(
             cliConfigPath, oldConfigData, 0644, folly::SyncType::WITH_SYNC);
+      }
+      // Restore the BGP system config to its pre-commit state. The staged
+      // session file is left intact, so the user can retry after the failure
+      // is resolved.
+      if (stagingBgp && !bgpConfPath.empty()) {
+        if (bgpSystemConfigExisted) {
+          folly::writeFileAtomic(
+              bgpConfPath, bgpOldData, 0644, folly::SyncType::WITH_SYNC);
+        } else {
+          std::error_code rmEc;
+          fs::remove(bgpConfPath, rmEc);
+        }
       }
       applyServiceActions(actions, hostInfo);
     } catch (const std::exception& rollbackEx) {
@@ -886,15 +1151,26 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
             ex.what()));
   }
 
-  // Only remove the session config after everything succeeded
-  std::error_code ec;
-  fs::remove(sessionConfigPath, ec);
-  if (ec) {
-    // Log warning but don't fail - the commit succeeded
-    LOG(WARNING) << fmt::format(
-        "Failed to remove session config {}: {}",
-        sessionConfigPath,
-        ec.message());
+  // Now that the commit has fully succeeded, clear the staged BGP session file
+  // (it was deliberately left in place for rollback). Force a re-seed from the
+  // newly promoted system config on next access.
+  if (stagingBgp) {
+    std::error_code rmEc;
+    fs::remove(getBgpSessionConfigPath(), rmEc);
+    bgpConfigLoaded_ = false;
+  }
+
+  // Only remove the agent session config after everything succeeded.
+  if (hasAgentSession) {
+    std::error_code ec;
+    fs::remove(sessionConfigPath, ec);
+    if (ec) {
+      // Log warning but don't fail - the commit succeeded
+      LOG(WARNING) << fmt::format(
+          "Failed to remove session config {}: {}",
+          sessionConfigPath,
+          ec.message());
+    }
   }
 
   // Reset action level for all services after successful commit
@@ -909,7 +1185,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
 }
 
 void ConfigSession::rebase() {
-  if (!sessionExists()) {
+  if (!hasActiveSession()) {
     throw std::runtime_error(
         "No config session exists. Make a config change first.");
   }
@@ -922,33 +1198,46 @@ void ConfigSession::rebase() {
         "No rebase needed: session is already based on the current HEAD.");
   }
 
-  // Get the three versions of the config:
-  // 1. Base config (what the session was originally based on)
-  // 2. Current HEAD config (what someone else committed)
-  // 3. Session config (user's changes)
-  std::string cliConfigRelPath = "cli/agent.conf";
-  std::string baseConfig = git_->fileAtRevision(base_, cliConfigRelPath);
-  std::string headConfig = git_->fileAtRevision(currentHead, cliConfigRelPath);
-
-  std::string sessionConfigPath = getSessionConfigPath();
-  std::string sessionConfig;
-  if (!folly::readFile(sessionConfigPath.c_str(), sessionConfig)) {
-    throw std::runtime_error(
-        fmt::format(
-            "Failed to read session config from {}", sessionConfigPath));
-  }
-
-  // Parse all three as JSON
-  folly::dynamic baseJson = folly::parseJson(baseConfig);
-  folly::dynamic headJson = folly::parseJson(headConfig);
-  folly::dynamic sessionJson = folly::parseJson(sessionConfig);
-
-  // Perform a 3-way merge
-  // For each key in session that differs from base, apply to head
-  // If head also changed the same key differently, that's a conflict
   std::vector<std::string> conflicts;
-  folly::dynamic mergedJson =
-      threeWayMerge(baseJson, headJson, sessionJson, "", conflicts);
+
+  // 3-way merge a single staged file against the base/head revisions of its
+  // git-tracked counterpart. Returns the merged pretty JSON, or nullopt if the
+  // domain is not staged this session. A missing file at a revision (e.g. a
+  // commit predating BGP config) is treated as an empty object.
+  auto mergeStaged =
+      [&](const std::string& gitRelPath,
+          const std::string& sessionPath) -> std::optional<std::string> {
+    if (!fs::exists(sessionPath)) {
+      return std::nullopt;
+    }
+    std::string sessionConfig;
+    if (!folly::readFile(sessionPath.c_str(), sessionConfig)) {
+      throw std::runtime_error(
+          fmt::format("Failed to read session config from {}", sessionPath));
+    }
+    std::string baseConfig = fileAtRevisionOrEmpty(base_, gitRelPath);
+    std::string headConfig = fileAtRevisionOrEmpty(currentHead, gitRelPath);
+    // A missing file at a revision is treated as an empty object.
+    folly::dynamic baseJson = folly::dynamic::object;
+    if (!baseConfig.empty()) {
+      baseJson = folly::parseJson(baseConfig);
+    }
+    folly::dynamic headJson = folly::dynamic::object;
+    if (!headConfig.empty()) {
+      headJson = folly::parseJson(headConfig);
+    }
+    folly::dynamic sessionJson = folly::parseJson(sessionConfig);
+    folly::dynamic merged =
+        threeWayMerge(baseJson, headJson, sessionJson, "", conflicts);
+    return folly::toPrettyJson(merged);
+  };
+
+  // Merge each staged domain. Conflicts from both are aggregated so the user
+  // sees every conflicting path at once.
+  std::optional<std::string> agentMerged =
+      mergeStaged("cli/agent.conf", getSessionConfigPath());
+  std::optional<std::string> bgpMerged =
+      mergeStaged(kBgpGitRelPath, getBgpSessionConfigPath());
 
   if (!conflicts.empty()) {
     std::string conflictList;
@@ -961,22 +1250,39 @@ void ConfigSession::rebase() {
             conflictList));
   }
 
-  // Write the merged config to the session file
-  std::string mergedConfigStr = folly::toPrettyJson(mergedJson);
-  folly::writeFileAtomic(
-      sessionConfigPath, mergedConfigStr, 0644, folly::SyncType::WITH_SYNC);
+  // Write the merged config(s) back to the session file(s).
+  if (agentMerged) {
+    folly::writeFileAtomic(
+        getSessionConfigPath(), *agentMerged, 0644, folly::SyncType::WITH_SYNC);
+  }
+  if (bgpMerged) {
+    folly::writeFileAtomic(
+        getBgpSessionConfigPath(),
+        *bgpMerged,
+        0644,
+        folly::SyncType::WITH_SYNC);
+  }
 
-  // Update the base to current HEAD
+  // Update the base to current HEAD (single repo, shared across domains).
   base_ = currentHead;
   saveMetadata();
 
-  // Reload the config into memory
-  loadConfig();
+  // Reload in-memory state for whichever domains were rebased.
+  if (agentMerged) {
+    loadConfig();
+  }
+  if (bgpMerged) {
+    bgpConfigLoaded_ = false;
+  }
 }
 
 std::string ConfigSession::rollback(const HostInfo& hostInfo) {
-  // Get the commit history to find the previous commit
-  auto commits = git_->log(getCliConfigPath(), 2);
+  // Find the previous commit using the metadata file's history. The metadata
+  // (cli/cli_metadata.json) is committed by every config commit -- agent OR
+  // BGP -- whereas cli/agent.conf is unchanged by a BGP-only commit. Logging
+  // the metadata path therefore includes BGP-only commits, so no-arg rollback
+  // doesn't silently skip them.
+  auto commits = git_->log(getSystemMetadataPath(), 2);
   if (commits.size() < 2) {
     throw std::runtime_error(
         "Cannot rollback: no previous revision available in Git history");
@@ -1006,6 +1312,11 @@ std::string ConfigSession::rollback(
       git_->fileAtRevision(resolvedSha, "cli/cli_metadata.json");
   std::string metadataPath = fmt::format("{}/cli_metadata.json", cliConfigDir);
 
+  // Target BGP config at that revision ("" if the commit predates BGP config).
+  std::string bgpSystemPath = getBgpSystemConfigPath();
+  std::string targetBgpData =
+      fileAtRevisionOrEmpty(resolvedSha, kBgpGitRelPath);
+
   // Read the current config for rollback if needed
   std::string oldConfigData;
   if (fs::exists(cliConfigPath)) {
@@ -1021,38 +1332,90 @@ std::string ConfigSession::rollback(
           fmt::format("Failed to read current metadata from {}", metadataPath));
     }
   }
+  std::string oldBgpData;
+  const bool bgpSystemExisted = fs::exists(bgpSystemPath);
+  if (bgpSystemExisted) {
+    if (!folly::readFile(bgpSystemPath.c_str(), oldBgpData)) {
+      // Don't proceed: a failed read here would make the restore-on-failure
+      // path below write an empty bgpcpp.conf, corrupting the running config.
+      throw std::runtime_error(
+          fmt::format(
+              "Failed to read current BGP config from {}", bgpSystemPath));
+    }
+  }
 
-  // Atomically write the target config and metadata to the CLI directory
-  folly::writeFileAtomic(
-      cliConfigPath, targetConfigData, 0644, folly::SyncType::WITH_SYNC);
+  // Only act on a service whose config actually changes in this rollback. A
+  // BGP-only commit leaves cli/agent.conf identical, and vice versa.
+  const bool agentChanged = targetConfigData != oldConfigData;
+  const bool bgpChanged = targetBgpData != oldBgpData;
+
+  // Always restore the metadata (it records the new rollback base). Only
+  // rewrite the agent config + symlink when it actually changed, to avoid
+  // needless writes and symlink churn on a BGP-only rollback.
   folly::writeFileAtomic(
       metadataPath, targetMetadataData, 0644, folly::SyncType::WITH_SYNC);
+  if (agentChanged) {
+    folly::writeFileAtomic(
+        cliConfigPath, targetConfigData, 0644, folly::SyncType::WITH_SYNC);
+    atomicSymlinkUpdate(systemConfigPath, "cli/agent.conf");
+  }
 
-  // Ensure the system config symlink points to the CLI config
-  atomicSymlinkUpdate(systemConfigPath, "cli/agent.conf");
+  // Promote the target BGP config (if it changed) so bgp_pp picks it up when
+  // restarted below. An empty target means BGP didn't exist at that revision,
+  // so remove the running config file.
+  if (bgpChanged) {
+    if (!targetBgpData.empty()) {
+      ensureDirectoryExists(getBgpSystemConfigDir());
+      folly::writeFileAtomic(
+          bgpSystemPath, targetBgpData, 0644, folly::SyncType::WITH_SYNC);
+    } else if (bgpSystemExisted) {
+      std::error_code rmEc;
+      fs::remove(bgpSystemPath, rmEc);
+      if (rmEc) {
+        throw std::runtime_error(
+            fmt::format(
+                "Failed to remove BGP config {} while rolling back to a "
+                "pre-BGP revision: {}",
+                bgpSystemPath,
+                rmEc.message()));
+      }
+    }
+  }
 
-  // Reload the config - if this fails, restore the old config and metadata
-  // TODO: look at all the metadata files in the revision range and
-  // decide whether or not we need to restart the agent based on the highest
-  // action level in that range.
+  // Apply the rolled-back config - if this fails, restore prior state.
   std::string newCommitSha;
   try {
-    auto client =
-        utils::createClient<apache::thrift::Client<facebook::fboss::FbossCtrl>>(
-            hostInfo);
-    client->sync_reloadConfig();
+    // Reload the agent only if its config changed.
+    if (agentChanged) {
+      auto client = utils::createClient<
+          apache::thrift::Client<facebook::fboss::FbossCtrl>>(hostInfo);
+      client->sync_reloadConfig();
+    }
+    // Restart bgp_pp only if its config changed.
+    if (bgpChanged) {
+      ensureFbossServiceUtil(hostInfo);
+      fbossServiceUtil_->restartService(
+          cli::ServiceType::BGP, cli::ConfigActionLevel::BGP_RESTART);
+    }
 
-    // Create a Git commit for the rollback with all relevant files
+    // Create a Git commit for the rollback. Metadata always changes; the agent
+    // config + symlink are included only when they were actually rewritten
+    // above (a BGP-only rollback leaves them untouched, so committing them
+    // could capture unrelated on-disk drift into the rollback commit).
+    std::vector<std::string> rollbackFiles = {metadataPath};
+    if (agentChanged) {
+      rollbackFiles.push_back(cliConfigPath);
+      rollbackFiles.push_back(systemConfigPath);
+    }
+    if (bgpChanged && !targetBgpData.empty()) {
+      rollbackFiles.push_back(bgpSystemPath);
+    }
     std::string commitMessage = fmt::format(
         "Rollback to {} by {}", Git::shortSha1(resolvedSha), username_);
-    newCommitSha = git_->commit(
-        {cliConfigPath, metadataPath, systemConfigPath},
-        commitMessage,
-        username_,
-        "");
+    newCommitSha = git_->commit(rollbackFiles, commitMessage, username_, "");
     LOG(INFO) << "Rollback committed as " << Git::shortSha1(newCommitSha);
   } catch (const std::exception& ex) {
-    // Rollback: restore the old config and metadata
+    // Rollback: restore the old config, metadata, and BGP config.
     try {
       if (!oldConfigData.empty()) {
         folly::writeFileAtomic(
@@ -1061,6 +1424,15 @@ std::string ConfigSession::rollback(
       if (!oldMetadataData.empty()) {
         folly::writeFileAtomic(
             metadataPath, oldMetadataData, 0644, folly::SyncType::WITH_SYNC);
+      }
+      if (bgpChanged) {
+        if (bgpSystemExisted) {
+          folly::writeFileAtomic(
+              bgpSystemPath, oldBgpData, 0644, folly::SyncType::WITH_SYNC);
+        } else {
+          std::error_code rmEc;
+          fs::remove(bgpSystemPath, rmEc);
+        }
       }
     } catch (const std::exception& rollbackEx) {
       // If rollback also fails, include both errors in the message
@@ -1076,25 +1448,44 @@ std::string ConfigSession::rollback(
             ex.what()));
   }
 
+  // The on-disk config changed underneath any cached in-memory state; force a
+  // reload on next access regardless of whether the session is clean.
+  configLoaded_ = false;
+  bgpConfigLoaded_ = false;
+
   // Update the session state after rollback
   // Check if the current session is clean (no pending changes)
   if (commands_.empty()) {
-    // Session is clean - update base to the new rollback commit and sync the
-    // session config to match the rolled-back configuration
+    // Session is clean - update base to the new rollback commit and sync any
+    // active session config to match the rolled-back configuration.
     base_ = newCommitSha;
 
-    // Copy the rolled-back config to the session config
-    folly::writeFileAtomic(
-        getSessionConfigPath(),
-        targetConfigData,
-        0644,
-        folly::SyncType::WITH_SYNC);
+    // Only re-seed a session file that already exists, and seed each domain
+    // from its own rolled-back data. Unconditionally writing the agent session
+    // file would materialize a phantom agent session after a BGP-only rollback
+    // (and leave the BGP session file stale); keep the two domains symmetric.
+    if (sessionExists()) {
+      folly::writeFileAtomic(
+          getSessionConfigPath(),
+          targetConfigData,
+          0644,
+          folly::SyncType::WITH_SYNC);
+    }
+    if (bgpSessionExists()) {
+      if (!targetBgpData.empty()) {
+        folly::writeFileAtomic(
+            getBgpSessionConfigPath(),
+            targetBgpData,
+            0644,
+            folly::SyncType::WITH_SYNC);
+      } else {
+        std::error_code rmEc;
+        fs::remove(getBgpSessionConfigPath(), rmEc);
+      }
+    }
 
     // Save the updated metadata (with new base)
     saveMetadata();
-
-    // Force config reload from session config on next access
-    configLoaded_ = false;
 
     LOG(INFO) << "Session updated to rollback commit "
               << Git::shortSha1(newCommitSha);

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -524,6 +524,10 @@ std::string ConfigSession::getBgpSystemConfigPath() const {
   return getBgpSystemConfigDir() + "/bgpcpp.conf";
 }
 
+std::string ConfigSession::getBgpSystemConfigLinkPath() const {
+  return systemConfigDir_ + "/bgpcpp.conf";
+}
+
 bool ConfigSession::bgpSessionExists() const {
   return fs::exists(getBgpSessionConfigPath());
 }
@@ -1099,6 +1103,13 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
           getBgpSystemConfigPath(), staged, 0644, folly::SyncType::WITH_SYNC);
       bgpConfPath = getBgpSystemConfigPath();
       commitFiles.push_back(bgpConfPath);
+      // Keep the daemon-facing path (/etc/coop/bgpcpp.conf) a symlink into the
+      // CLI-managed bgpcpp/ subdir, mirroring agent.conf -> cli/agent.conf.
+      // bgpd reads its provisioned --config /etc/coop/bgpcpp.conf and follows
+      // the symlink, so no per-device systemd --config override is needed. The
+      // symlink is git-tracked alongside the config so a rollback restores it.
+      atomicSymlinkUpdate(getBgpSystemConfigLinkPath(), kBgpGitRelPath);
+      commitFiles.push_back(getBgpSystemConfigLinkPath());
     } else if (bgpSystemConfigExisted) {
       // Agent-only commit: still track the running bgpd config so a later
       // rollback has a snapshot to restore instead of wiping it. No restart —

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -533,7 +533,7 @@ void ConfigSession::loadBgpConfig() {
     return;
   }
 
-  // Prefer staged edits; otherwise seed from the running bgp_pp config; else
+  // Prefer staged edits; otherwise seed from the running bgpd config; else
   // schema defaults. A read failure on a file that exists is logged (not
   // silently treated as "no config") so a permission/IO error doesn't
   // masquerade as a fresh session.
@@ -594,7 +594,7 @@ void ConfigSession::saveBgpConfig() {
   folly::writeFileAtomic(
       getBgpSessionConfigPath(), prettyJson, 0644, folly::SyncType::WITH_SYNC);
 
-  // Record the command (mirrors saveConfig) and that bgp_pp must be restarted
+  // Record the command (mirrors saveConfig) and that bgpd must be restarted
   // for this change to take effect on a subsequent `config session commit`.
   recordServiceAction(
       cli::ServiceType::BGP, cli::ConfigActionLevel::BGP_RESTART);
@@ -880,7 +880,7 @@ void ConfigSession::initializeGit() {
           initialMetadataPath, "{}", 0644, folly::SyncType::WITH_SYNC);
     }
 
-    // Seed the running bgp_pp config into the baseline commit too. Without it,
+    // Seed the running bgpd config into the baseline commit too. Without it,
     // the first revision has no BGP snapshot, so a rollback to it would read
     // the empty target as "BGP never existed" and DELETE the running
     // bgpcpp.conf.
@@ -974,7 +974,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
   }
 
   // Capture the running BGP system config up front: it tells us whether the
-  // staged BGP config actually changed (so we can skip a needless bgp_pp
+  // staged BGP config actually changed (so we can skip a needless bgpd
   // restart) and is the snapshot we restore if the commit fails partway.
   const std::string bgpSystemPath = getBgpSystemConfigPath();
   const bool bgpSystemConfigExisted = fs::exists(bgpSystemPath);
@@ -991,7 +991,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
   }
 
   // saveBgpConfig() records BGP_RESTART unconditionally, so re-committing an
-  // unchanged BGP config would otherwise still bounce bgp_pp (a disruptive,
+  // unchanged BGP config would otherwise still bounce bgpd (a disruptive,
   // traffic-affecting restart for no effective change). Treat BGP as changed
   // only when the staged config differs from what is running.
   bool bgpConfigChanged = false;
@@ -1008,7 +1008,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
 
   // Copy requiredActions_ before we reset it (returned in CommitResult) and
   // drop BGP when the BGP config is unchanged, so an unchanged BGP commit
-  // neither promotes the config nor restarts bgp_pp.
+  // neither promotes the config nor restarts bgpd.
   auto actions = requiredActions_;
   if (!bgpConfigChanged) {
     actions.erase(cli::ServiceType::BGP);
@@ -1073,7 +1073,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
   std::map<cli::ServiceType, std::vector<std::string>> serviceNames;
 
   // stagingBgp reflects the trimmed action set: false when the BGP config was
-  // unchanged, so we neither promote bgpcpp.conf nor restart bgp_pp below. The
+  // unchanged, so we neither promote bgpcpp.conf nor restart bgpd below. The
   // prior BGP config (bgpOldData / bgpSystemConfigExisted, captured above) is
   // the snapshot restored if the commit fails partway.
   const bool stagingBgp = actions.count(cli::ServiceType::BGP) > 0;
@@ -1081,7 +1081,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
 
   try {
     // If this session staged BGP config changes, promote the staged
-    // bgp_config.json to /etc/coop/bgpcpp/bgpcpp.conf BEFORE bgp_pp is
+    // bgp_config.json to /etc/coop/bgpcpp/bgpcpp.conf BEFORE bgpd is
     // restarted below, so the restart picks up the new config. The promoted
     // file is committed as part of this commit's git operation. The staged
     // session file is left in place until the whole commit succeeds, so a
@@ -1100,7 +1100,7 @@ ConfigSession::CommitResult ConfigSession::commit(const HostInfo& hostInfo) {
       bgpConfPath = getBgpSystemConfigPath();
       commitFiles.push_back(bgpConfPath);
     } else if (bgpSystemConfigExisted) {
-      // Agent-only commit: still track the running bgp_pp config so a later
+      // Agent-only commit: still track the running bgpd config so a later
       // rollback has a snapshot to restore instead of wiping it. No restart —
       // the file is already the running config.
       commitFiles.push_back(bgpSystemPath);
@@ -1360,7 +1360,7 @@ std::string ConfigSession::rollback(
     atomicSymlinkUpdate(systemConfigPath, "cli/agent.conf");
   }
 
-  // Promote the target BGP config (if it changed) so bgp_pp picks it up when
+  // Promote the target BGP config (if it changed) so bgpd picks it up when
   // restarted below. An empty target means BGP didn't exist at that revision,
   // so remove the running config file.
   if (bgpChanged) {
@@ -1391,7 +1391,7 @@ std::string ConfigSession::rollback(
           apache::thrift::Client<facebook::fboss::FbossCtrl>>(hostInfo);
       client->sync_reloadConfig();
     }
-    // Restart bgp_pp only if its config changed.
+    // Restart bgpd only if its config changed.
     if (bgpChanged) {
       ensureFbossServiceUtil(hostInfo);
       fbossServiceUtil_->restartService(

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <neteng/fboss/bgp/public_tld/configerator/structs/neteng/fboss/bgp/gen-cpp2/bgp_config_types.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -102,6 +103,9 @@ class ConfigSession {
   static std::string getSessionDir();
   static std::string getSessionConfigPathStatic();
   static std::string getSessionMetadataPathStatic();
+  // ~/.fboss2/bgp_config.json — staged BGP edits (used by `config session
+  // clear` without instantiating a session).
+  static std::string getBgpSessionConfigPathStatic();
 
   // Get the path to the session config file (~/.fboss2/agent.conf)
   std::string getSessionConfigPath() const;
@@ -145,8 +149,15 @@ class ConfigSession {
   std::string rollback(const HostInfo& hostInfo);
   std::string rollback(const HostInfo& hostInfo, const std::string& commitSha);
 
-  // Check if a session exists
+  // Check if an agent config session exists (~/.fboss2/agent.conf staged).
   bool sessionExists() const;
+
+  // Check if any committable session is staged: either an agent config session
+  // (agent.conf) or a protocol session persisted outside agent.conf (e.g. a
+  // BGP++ session at ~/.fboss2/bgp_config.json recorded via
+  // recordServiceAction()). The commit path uses this rather than
+  // sessionExists() so a BGP-only change can be committed.
+  bool hasActiveSession() const;
 
   // Get the parsed agent configuration
   cfg::AgentConfig& getAgentConfig();
@@ -168,6 +179,43 @@ class ConfigSession {
   void saveConfig(cli::ServiceType service, cli::ConfigActionLevel actionLevel);
   // Save the configuration for AGENT service with HITLESS action level.
   void saveConfig();
+
+  // Record that a service requires an action for a config change that is
+  // persisted OUTSIDE the agent config file (e.g. BGP++ writes its own
+  // ~/.fboss2/bgp_config.json). This updates the action level for the service
+  // in the shared session metadata and persists it, WITHOUT rewriting
+  // agent.conf. A subsequent `config session commit` then applies the recorded
+  // action (e.g. restart bgp_pp).
+  void recordServiceAction(
+      cli::ServiceType service,
+      cli::ConfigActionLevel actionLevel);
+
+  // ==================== BGP configuration ====================
+  // ConfigSession owns the BGP config as a typed bgp::thrift::BgpConfig,
+  // exactly the way it owns cfg::AgentConfig for the agent. It is BGP-*aware*
+  // but agnostic about the config's internal structure: getBgpConfig() exposes
+  // the WHOLE typed config (router_id, ASNs, peers, peer_groups, networks, ...)
+  // and commands mutate whichever typed fields they need -- mirroring how
+  // interface commands mutate getAgentConfig().sw()->ports(). ConfigSession has
+  // no notion of "global" vs "peer" vs "peer-group".
+
+  // Typed, mutable view of the entire BGP config. Lazily seeded from the staged
+  // ~/.fboss2/bgp_config.json, else the running /etc/coop/bgpcpp/bgpcpp.conf,
+  // else schema defaults. Mirrors getAgentConfig().
+  bgp::thrift::BgpConfig& getBgpConfig();
+  const bgp::thrift::BgpConfig& getBgpConfig() const;
+
+  // Persist the typed BGP config back to ~/.fboss2/bgp_config.json and record
+  // that bgp_pp must be restarted for this change to take effect on a
+  // subsequent `config session commit`. Mirrors saveConfig() for the agent.
+  void saveBgpConfig();
+
+  // ~/.fboss2/bgp_config.json (staged BGP edits)
+  std::string getBgpSessionConfigPath() const;
+  // /etc/coop/bgpcpp/bgpcpp.conf (config read by the bgp_pp daemon)
+  std::string getBgpSystemConfigPath() const;
+  // Whether a BGP session is staged (~/.fboss2/bgp_config.json exists)
+  bool bgpSessionExists() const;
 
   // Get the Git instance for this config session
   // Used to access the Git repository for history, rollback, etc.
@@ -238,6 +286,26 @@ class ConfigSession {
   cfg::AgentConfig agentConfig_;
   std::unique_ptr<utils::PortMap> portMap_;
   bool configLoaded_ = false;
+
+  // Typed view of the entire BGP config (lazily loaded), mirroring
+  // agentConfig_.
+  bgp::thrift::BgpConfig bgpConfig_;
+  bool bgpConfigLoaded_ = false;
+
+  // /etc/coop/bgpcpp (directory holding the bgp_pp daemon's config)
+  std::string getBgpSystemConfigDir() const;
+  // Lazily seed bgpConfig_ from disk (staged file, else running config, else
+  // defaults). Mirrors loadConfig() for the agent.
+  void loadBgpConfig();
+
+  // git relative path of the bgp_pp config tracked in the /etc/coop repo.
+  static constexpr auto kBgpGitRelPath = "bgpcpp/bgpcpp.conf";
+  // Like Git::fileAtRevision but returns "" instead of throwing when the path
+  // does not exist at that revision (e.g. a pre-BGP commit). Used by
+  // rebase/rollback/diff so a missing bgpcpp.conf is treated as empty.
+  std::string fileAtRevisionOrEmpty(
+      const std::string& revision,
+      const std::string& gitRelPath) const;
 
   // Track the highest action level required for pending config changes per
   // service. Persisted to disk so it survives across CLI invocations within a

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -185,7 +185,7 @@ class ConfigSession {
   // ~/.fboss2/bgp_config.json). This updates the action level for the service
   // in the shared session metadata and persists it, WITHOUT rewriting
   // agent.conf. A subsequent `config session commit` then applies the recorded
-  // action (e.g. restart bgp_pp).
+  // action (e.g. restart bgpd).
   void recordServiceAction(
       cli::ServiceType service,
       cli::ConfigActionLevel actionLevel);
@@ -206,13 +206,13 @@ class ConfigSession {
   const bgp::thrift::BgpConfig& getBgpConfig() const;
 
   // Persist the typed BGP config back to ~/.fboss2/bgp_config.json and record
-  // that bgp_pp must be restarted for this change to take effect on a
+  // that bgpd must be restarted for this change to take effect on a
   // subsequent `config session commit`. Mirrors saveConfig() for the agent.
   void saveBgpConfig();
 
   // ~/.fboss2/bgp_config.json (staged BGP edits)
   std::string getBgpSessionConfigPath() const;
-  // /etc/coop/bgpcpp/bgpcpp.conf (config read by the bgp_pp daemon)
+  // /etc/coop/bgpcpp/bgpcpp.conf (config read by the bgpd daemon)
   std::string getBgpSystemConfigPath() const;
   // Whether a BGP session is staged (~/.fboss2/bgp_config.json exists)
   bool bgpSessionExists() const;
@@ -292,13 +292,13 @@ class ConfigSession {
   bgp::thrift::BgpConfig bgpConfig_;
   bool bgpConfigLoaded_ = false;
 
-  // /etc/coop/bgpcpp (directory holding the bgp_pp daemon's config)
+  // /etc/coop/bgpcpp (directory holding the bgpd daemon's config)
   std::string getBgpSystemConfigDir() const;
   // Lazily seed bgpConfig_ from disk (staged file, else running config, else
   // defaults). Mirrors loadConfig() for the agent.
   void loadBgpConfig();
 
-  // git relative path of the bgp_pp config tracked in the /etc/coop repo.
+  // git relative path of the bgpd config tracked in the /etc/coop repo.
   static constexpr auto kBgpGitRelPath = "bgpcpp/bgpcpp.conf";
   // Like Git::fileAtRevision but returns "" instead of throwing when the path
   // does not exist at that revision (e.g. a pre-BGP commit). Used by

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -294,6 +294,11 @@ class ConfigSession {
 
   // /etc/coop/bgpcpp (directory holding the bgpd daemon's config)
   std::string getBgpSystemConfigDir() const;
+  // /etc/coop/bgpcpp.conf — the stable path the bgpd daemon is configured to
+  // read (--config). commit() keeps it as a symlink into the CLI-managed
+  // bgpcpp/ subdir (kBgpGitRelPath), mirroring how agent.conf symlinks to
+  // cli/agent.conf, so the daemon needs no per-device --config override.
+  std::string getBgpSystemConfigLinkPath() const;
   // Lazily seed bgpConfig_ from disk (staged file, else running config, else
   // defaults). Mirrors loadConfig() for the agent.
   void loadBgpConfig();

--- a/fboss/cli/fboss2/session/FbossServiceUtil.cpp
+++ b/fboss/cli/fboss2/session/FbossServiceUtil.cpp
@@ -25,6 +25,7 @@ namespace {
 constexpr std::string_view kWedgeAgent = "wedge_agent";
 constexpr std::string_view kSwAgent = "fboss_sw_agent";
 constexpr std::string_view kHwAgentPrefix = "fboss_hw_agent@";
+constexpr std::string_view kBgpPp = "bgp_pp";
 } // namespace
 
 namespace facebook::fboss {
@@ -48,6 +49,8 @@ std::string FbossServiceUtil::getServiceName(cli::ServiceType service) {
   switch (service) {
     case cli::ServiceType::AGENT:
       return std::string(kWedgeAgent);
+    case cli::ServiceType::BGP:
+      return std::string(kBgpPp);
   }
   throw std::runtime_error("Unknown service type");
 }
@@ -128,6 +131,9 @@ std::vector<std::string> FbossServiceUtil::getServicesToRestart(
       }
       return services;
     }
+    case cli::ServiceType::BGP:
+      // BGP++ is a single, mode-independent service.
+      return {std::string(kBgpPp)};
   }
   throw std::runtime_error("Unknown service type");
 }
@@ -151,7 +157,11 @@ std::vector<std::string> FbossServiceUtil::reloadConfig(
       reloadedServices.emplace_back(serviceName);
       break;
     }
-      // TODO: Add cases for future services (e.g., BGP)
+    case cli::ServiceType::BGP:
+      // bgp_pp has no hitless reloadConfig() RPC; config changes are applied by
+      // restarting the service (BGP_RESTART), so this path is never taken.
+      throw std::runtime_error(
+          "bgp_pp does not support config reload; it must be restarted");
   }
   return reloadedServices;
 }
@@ -159,14 +169,30 @@ std::vector<std::string> FbossServiceUtil::reloadConfig(
 std::vector<std::string> FbossServiceUtil::restartService(
     cli::ServiceType service,
     cli::ConfigActionLevel level) {
-  std::string restartType = (level == cli::ConfigActionLevel::AGENT_COLDBOOT)
-      ? "coldboot"
-      : "warmboot";
+  std::string restartType;
+  switch (level) {
+    case cli::ConfigActionLevel::AGENT_COLDBOOT:
+      restartType = "coldboot";
+      break;
+    case cli::ConfigActionLevel::AGENT_WARMBOOT:
+      restartType = "warmboot";
+      break;
+    case cli::ConfigActionLevel::BGP_RESTART:
+      restartType = "restart";
+      break;
+    case cli::ConfigActionLevel::HITLESS:
+      // Not expected: HITLESS is applied via reloadConfig(), not restart.
+      restartType = "reload";
+      break;
+  }
 
   auto services = getServicesToRestart(service);
 
-  LOG(INFO) << "Restarting agents (" << restartType << ")...";
+  LOG(INFO) << "Restarting " << getServiceName(service) << " (" << restartType
+            << ")...";
 
+  // Only AGENT_COLDBOOT needs the coldboot marker file; every other level is a
+  // plain restart-and-wait.
   if (level == cli::ConfigActionLevel::AGENT_COLDBOOT) {
     performColdboot(services);
   } else {

--- a/fboss/cli/fboss2/session/FbossServiceUtil.cpp
+++ b/fboss/cli/fboss2/session/FbossServiceUtil.cpp
@@ -25,7 +25,7 @@ namespace {
 constexpr std::string_view kWedgeAgent = "wedge_agent";
 constexpr std::string_view kSwAgent = "fboss_sw_agent";
 constexpr std::string_view kHwAgentPrefix = "fboss_hw_agent@";
-constexpr std::string_view kBgpPp = "bgp_pp";
+constexpr std::string_view kBgpd = "bgpd";
 } // namespace
 
 namespace facebook::fboss {
@@ -50,7 +50,7 @@ std::string FbossServiceUtil::getServiceName(cli::ServiceType service) {
     case cli::ServiceType::AGENT:
       return std::string(kWedgeAgent);
     case cli::ServiceType::BGP:
-      return std::string(kBgpPp);
+      return std::string(kBgpd);
   }
   throw std::runtime_error("Unknown service type");
 }
@@ -133,7 +133,7 @@ std::vector<std::string> FbossServiceUtil::getServicesToRestart(
     }
     case cli::ServiceType::BGP:
       // BGP++ is a single, mode-independent service.
-      return {std::string(kBgpPp)};
+      return {std::string(kBgpd)};
   }
   throw std::runtime_error("Unknown service type");
 }
@@ -158,10 +158,10 @@ std::vector<std::string> FbossServiceUtil::reloadConfig(
       break;
     }
     case cli::ServiceType::BGP:
-      // bgp_pp has no hitless reloadConfig() RPC; config changes are applied by
+      // bgpd has no hitless reloadConfig() RPC; config changes are applied by
       // restarting the service (BGP_RESTART), so this path is never taken.
       throw std::runtime_error(
-          "bgp_pp does not support config reload; it must be restarted");
+          "bgpd does not support config reload; it must be restarted");
   }
   return reloadedServices;
 }

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionDiffTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionDiffTest.cpp
@@ -6,7 +6,11 @@
 #include <filesystem>
 
 #include "fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/utils/CmdUtils.h"
+
+#include <string>
+#include <vector>
 
 using namespace ::testing;
 
@@ -311,6 +315,25 @@ TEST_F(CmdConfigSessionDiffTestFixture, printOutputNoDifferences) {
   std::string output = buffer.str();
 
   EXPECT_NE(output.find("No differences"), std::string::npos);
+}
+
+TEST_F(CmdConfigSessionDiffTestFixture, diffBgpSession) {
+  setupTestableConfigSession();
+  // Remove the agent session so only a BGP session is staged.
+  std::filesystem::remove(getSessionConfigPath());
+
+  auto& session = ConfigSession::getInstance();
+  session.getBgpConfig().router_id() = "9.9.9.9";
+  session.saveBgpConfig();
+
+  auto cmd = CmdConfigSessionDiff();
+  utils::RevisionList emptyRevisions(std::vector<std::string>{});
+  auto result = cmd.queryClient(localhost(), emptyRevisions);
+
+  // A BGP-only session must be visible (not gated out as "no session"), and
+  // the staged router_id must show up in the diff.
+  EXPECT_EQ(result.find("No config session exists"), std::string::npos);
+  EXPECT_NE(result.find("9.9.9.9"), std::string::npos);
 }
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
@@ -9,12 +9,14 @@
 #include <folly/json/json.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <unistd.h>
 #include <filesystem>
 #include <fstream>
 #include <stdexcept>
 #include <string>
 
 #include "fboss/cli/fboss2/test/TestableConfigSession.h"
+#include "fboss/cli/fboss2/test/config/MockSystemdInterface.h"
 
 namespace fs = std::filesystem;
 
@@ -187,7 +189,7 @@ TEST_F(ConfigSessionTestFixture, sessionCommit) {
 
     // Verify metadata file was also committed to git
     auto metadataCommits = git.log(targetMetadata.string());
-    EXPECT_EQ(metadataCommits.size(), 2); // 2 commits
+    EXPECT_EQ(metadataCommits.size(), 3); // Initial baseline + 2 commits
   }
 }
 
@@ -501,7 +503,8 @@ TEST_F(ConfigSessionTestFixture, rollbackToSpecificCommit) {
 
     // Verify metadata file history
     auto metadataCommits = git.log(metadataPath.string());
-    EXPECT_EQ(metadataCommits.size(), 3); // 2 commits + rollback
+    EXPECT_EQ(
+        metadataCommits.size(), 4); // Initial baseline + 2 commits + rollback
   }
 }
 
@@ -1272,6 +1275,322 @@ TEST_F(ConfigSessionTestFixture, commitTwiceSecondIsEmpty) {
     // Verify the result indicates no commit was made
     EXPECT_TRUE(result.commitSha.empty());
     EXPECT_TRUE(result.actions.empty());
+  }
+}
+
+// Editing one part of the typed BGP config (e.g. a top-level field) and saving
+// must round-trip the WHOLE config, so peers/peer-groups already staged in the
+// file survive. ConfigSession owns the entire typed bgp::thrift::BgpConfig and
+// is agnostic about which section a command touches.
+TEST_F(ConfigSessionTestFixture, bgpConfigEditPreservesOtherSections) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  TestableConfigSession session(
+      sessionDir.string(), (getTestEtcDir() / "coop").string());
+
+  // Stage a config that already has peers/peer-groups (as another command would
+  // have done via the same typed config).
+  fs::path bgpPath = sessionDir / "bgp_config.json";
+  folly::dynamic staged = folly::dynamic::object(
+      "peers",
+      folly::dynamic::array(
+          folly::dynamic::object("peer_addr", "2401:db00::1")(
+              "is_passive", true)))(
+      "peer_groups",
+      folly::dynamic::array(folly::dynamic::object("name", "RACK")));
+  ASSERT_TRUE(folly::writeFile(folly::toPrettyJson(staged), bgpPath.c_str()));
+
+  // Edit a top-level field via the typed API and persist.
+  auto& bgp = session.getBgpConfig();
+  bgp.router_id() = "10.0.0.1";
+  bgp.count_confeds_in_as_path_len() = true;
+  session.setCommandLine(
+      "fboss2-dev config protocol bgp global router-id 10.0.0.1");
+  session.saveBgpConfig();
+
+  // The saved file carries the edited fields AND the untouched peers/groups.
+  std::string content;
+  ASSERT_TRUE(folly::readFile(bgpPath.c_str(), content));
+  auto saved = folly::parseJson(content);
+
+  EXPECT_EQ(saved["router_id"].asString(), "10.0.0.1");
+  ASSERT_TRUE(saved.count("count_confeds_in_as_path_len"));
+  EXPECT_TRUE(saved["count_confeds_in_as_path_len"].asBool());
+
+  ASSERT_TRUE(saved.count("peers"));
+  ASSERT_EQ(saved["peers"].size(), 1);
+  EXPECT_EQ(saved["peers"][0]["peer_addr"].asString(), "2401:db00::1");
+  EXPECT_TRUE(saved["peers"][0]["is_passive"].asBool());
+
+  ASSERT_TRUE(saved.count("peer_groups"));
+  ASSERT_EQ(saved["peer_groups"].size(), 1);
+  EXPECT_EQ(saved["peer_groups"][0]["name"].asString(), "RACK");
+
+  // A BGP restart must be recorded so `config session commit` applies it.
+  EXPECT_EQ(
+      session.getRequiredAction(cli::ServiceType::BGP),
+      cli::ConfigActionLevel::BGP_RESTART);
+}
+
+// A staged BGP edit persists to disk and is seeded back by a fresh session via
+// the typed view.
+TEST_F(ConfigSessionTestFixture, bgpConfigEditPersistsAndSeeds) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  fs::path bgpPath = sessionDir / "bgp_config.json";
+  {
+    TestableConfigSession session(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    auto& bgp = session.getBgpConfig();
+    bgp.local_as_4_byte() = 65001;
+    session.setCommandLine(
+        "fboss2-dev config protocol bgp global local-asn 65001");
+    session.saveBgpConfig();
+  }
+  ASSERT_TRUE(fs::exists(bgpPath));
+
+  {
+    TestableConfigSession session(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    auto& bgp = session.getBgpConfig();
+    ASSERT_TRUE(bgp.local_as_4_byte().has_value());
+    EXPECT_EQ(*bgp.local_as_4_byte(), 65001);
+  }
+}
+
+// A BGP-only session must be rebaseable when another commit advances HEAD; the
+// staged BGP global edit is preserved (merged against an unchanged bgpcpp.conf)
+// and the agent change committed by the other user is folded in.
+TEST_F(ConfigSessionTestFixture, rebaseBgpSession) {
+  fs::path sessionDir1 = getTestHomeDir() / ".fboss2_user1";
+  fs::path sessionDir2 = getTestHomeDir() / ".fboss2_user2";
+
+  setupMockedAgentServer();
+  // Only user1's agent commit reloads the agent; rebase does not.
+  EXPECT_CALL(getMockAgent(), reloadConfig()).Times(1);
+
+  TestableConfigSession session1(
+      sessionDir1.string(), (getTestEtcDir() / "coop").string());
+  TestableConfigSession session2(
+      sessionDir2.string(), (getTestEtcDir() / "coop").string());
+
+  // user1 commits an agent change -> HEAD advances, session2's base goes stale.
+  (*session1.getAgentConfig().sw()->ports())[0].description() = "User1 change";
+  session1.setCommandLine("config interface eth1/1/1 description User1");
+  session1.saveConfig(cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+  EXPECT_FALSE(session1.commit(localhost()).commitSha.empty());
+
+  // user2 stages a BGP change.
+  session2.getBgpConfig().router_id() = "7.7.7.7";
+  session2.setCommandLine("config protocol bgp global router-id 7.7.7.7");
+  session2.saveBgpConfig();
+
+  // Committing fails (stale base); rebase resolves it without conflicts.
+  EXPECT_THROW(session2.commit(localhost()), std::runtime_error);
+  EXPECT_NO_THROW(session2.rebase());
+
+  // The staged BGP value survives the rebase...
+  std::string bgp;
+  ASSERT_TRUE(
+      folly::readFile((sessionDir2 / "bgp_config.json").string().c_str(), bgp));
+  EXPECT_THAT(bgp, ::testing::HasSubstr("7.7.7.7"));
+  // ...and user1's agent change was folded into session2's agent config.
+  std::string agent;
+  ASSERT_TRUE(
+      folly::readFile((sessionDir2 / "agent.conf").string().c_str(), agent));
+  EXPECT_THAT(agent, ::testing::HasSubstr("User1 change"));
+}
+
+// Rolling back to an earlier commit must restore the BGP system config and
+// restart bgp_pp (not just the agent config).
+TEST_F(ConfigSessionTestFixture, rollbackBgpConfig) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  fs::path bgpSys = getTestEtcDir() / "coop" / "bgpcpp" / "bgpcpp.conf";
+
+  auto makeSession = [&]() {
+    auto s = std::make_unique<TestableConfigSession>(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    // BGP commits/rollback restart bgp_pp via systemd; mock it out.
+    s->setMockSystemdFactory([] {
+      return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
+    });
+    return s;
+  };
+
+  std::string sha1;
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "1.1.1.1";
+    s->setCommandLine("config protocol bgp global router-id 1.1.1.1");
+    s->saveBgpConfig();
+    sha1 = s->commit(localhost()).commitSha;
+    ASSERT_FALSE(sha1.empty());
+  }
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "2.2.2.2";
+    s->setCommandLine("config protocol bgp global router-id 2.2.2.2");
+    s->saveBgpConfig();
+    ASSERT_FALSE(s->commit(localhost()).commitSha.empty());
+  }
+
+  // System BGP config now reflects the latest commit.
+  std::string content;
+  ASSERT_TRUE(folly::readFile(bgpSys.string().c_str(), content));
+  EXPECT_THAT(content, ::testing::HasSubstr("2.2.2.2"));
+
+  // Roll back to the first commit -> BGP config restored to 1.1.1.1.
+  {
+    auto s = makeSession();
+    std::string rb = s->rollback(localhost(), sha1);
+    EXPECT_FALSE(rb.empty());
+  }
+  ASSERT_TRUE(folly::readFile(bgpSys.string().c_str(), content));
+  EXPECT_THAT(content, ::testing::HasSubstr("1.1.1.1"));
+  EXPECT_THAT(content, ::testing::Not(::testing::HasSubstr("2.2.2.2")));
+}
+
+// Re-committing a BGP config that is byte-identical to the running
+// /etc/coop/bgpcpp/bgpcpp.conf must be a no-op: no git commit and (crucially)
+// no disruptive bgp_pp restart. saveBgpConfig() records BGP_RESTART
+// unconditionally, so commit() compares staged vs running content.
+TEST_F(ConfigSessionTestFixture, commitUnchangedBgpConfigIsNoOp) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  auto makeSession = [&]() {
+    auto s = std::make_unique<TestableConfigSession>(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    s->setMockSystemdFactory([] {
+      return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
+    });
+    return s;
+  };
+
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "1.1.1.1";
+    s->setCommandLine("config protocol bgp global router-id 1.1.1.1");
+    s->saveBgpConfig();
+    ASSERT_FALSE(s->commit(localhost()).commitSha.empty());
+  }
+  // Stage the SAME value again and commit -> no-op (empty commitSha, so no git
+  // revision and no bgp_pp restart).
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "1.1.1.1";
+    s->setCommandLine("config protocol bgp global router-id 1.1.1.1");
+    s->saveBgpConfig();
+    auto result = s->commit(localhost());
+    EXPECT_TRUE(result.commitSha.empty())
+        << "committing an unchanged BGP config should be a no-op (no restart)";
+    EXPECT_EQ(result.actions.count(cli::ServiceType::BGP), 0u)
+        << "unchanged BGP config must not apply BGP_RESTART";
+  }
+}
+
+// commit() must abort if it cannot read the running bgpcpp.conf, instead of
+// silently proceeding with an empty snapshot (which a later failed-commit
+// rollback would write back, corrupting the running config). Mirrors the guard
+// rollback() already has.
+TEST_F(ConfigSessionTestFixture, commitThrowsWhenRunningBgpConfigUnreadable) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  fs::path bgpSys = getTestEtcDir() / "coop" / "bgpcpp" / "bgpcpp.conf";
+  auto makeSession = [&]() {
+    auto s = std::make_unique<TestableConfigSession>(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    s->setMockSystemdFactory([] {
+      return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
+    });
+    return s;
+  };
+
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "1.1.1.1";
+    s->setCommandLine("config protocol bgp global router-id 1.1.1.1");
+    s->saveBgpConfig();
+    ASSERT_FALSE(s->commit(localhost()).commitSha.empty());
+  }
+  ASSERT_TRUE(fs::exists(bgpSys));
+
+  // Make the running config unreadable; running as a non-root user this makes
+  // folly::readFile fail. (Skip the assertion if we happen to run as root,
+  // where permission bits are bypassed.)
+  fs::permissions(bgpSys, fs::perms::none);
+  if (::geteuid() != 0) {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "2.2.2.2";
+    s->setCommandLine("config protocol bgp global router-id 2.2.2.2");
+    s->saveBgpConfig();
+    EXPECT_THROW(s->commit(localhost()), std::runtime_error);
+  }
+  // Restore perms so fixture teardown can remove the temp tree.
+  fs::permissions(bgpSys, fs::perms::owner_all);
+}
+
+// A BGP-only session (bgp_config.json + metadata present, agent.conf session
+// file absent) must RESUME on the next CLI invocation, not be misdetected as
+// fresh -- otherwise requiredActions_ (BGP_RESTART) is cleared and the
+// staged change is silently dropped at commit time.
+TEST_F(ConfigSessionTestFixture, bgpOnlySessionResumesAcrossInvocations) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  fs::path agentSess = sessionDir / "agent.conf";
+  fs::path bgpSess = sessionDir / "bgp_config.json";
+  auto makeSession = [&]() {
+    auto s = std::make_unique<TestableConfigSession>(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    s->setMockSystemdFactory([] {
+      return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
+    });
+    return s;
+  };
+
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "9.9.9.9";
+    s->setCommandLine("config protocol bgp global router-id 9.9.9.9");
+    s->saveBgpConfig();
+  }
+  // Simulate a pure BGP-only session: drop the agent session file that the
+  // first construction seeded, leaving only the staged BGP config + metadata.
+  fs::remove(agentSess);
+  ASSERT_TRUE(fs::exists(bgpSess));
+  ASSERT_FALSE(fs::exists(agentSess));
+
+  // The next invocation must resume and still commit the staged BGP change.
+  {
+    auto s = makeSession();
+    auto result = s->commit(localhost());
+    EXPECT_FALSE(result.commitSha.empty())
+        << "BGP-only session must resume, not be wiped as a fresh session";
+  }
+}
+
+// No-arg rollback() walks cli/cli_metadata.json history so BGP-only commits are
+// reachable. The initial baseline commit must therefore also touch metadata, or
+// rolling back to the baseline (after exactly one real commit) fails.
+TEST_F(ConfigSessionTestFixture, noArgRollbackReachesBaseline) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+  auto makeSession = [&]() {
+    auto s = std::make_unique<TestableConfigSession>(
+        sessionDir.string(), (getTestEtcDir() / "coop").string());
+    s->setMockSystemdFactory([] {
+      return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
+    });
+    return s;
+  };
+
+  {
+    auto s = makeSession();
+    s->getBgpConfig().router_id() = "1.1.1.1";
+    s->setCommandLine("config protocol bgp global router-id 1.1.1.1");
+    s->saveBgpConfig();
+    ASSERT_FALSE(s->commit(localhost()).commitSha.empty());
+  }
+  // Exactly one real commit sits on top of the baseline; no-arg rollback must
+  // still reach the baseline (it appears in metadata history now).
+  {
+    auto s = makeSession();
+    std::string rb;
+    EXPECT_NO_THROW(rb = s->rollback(localhost()));
+    EXPECT_FALSE(rb.empty());
   }
 }
 

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
@@ -1400,7 +1400,7 @@ TEST_F(ConfigSessionTestFixture, rebaseBgpSession) {
 }
 
 // Rolling back to an earlier commit must restore the BGP system config and
-// restart bgp_pp (not just the agent config).
+// restart bgpd (not just the agent config).
 TEST_F(ConfigSessionTestFixture, rollbackBgpConfig) {
   fs::path sessionDir = getTestHomeDir() / ".fboss2";
   fs::path bgpSys = getTestEtcDir() / "coop" / "bgpcpp" / "bgpcpp.conf";
@@ -1408,7 +1408,7 @@ TEST_F(ConfigSessionTestFixture, rollbackBgpConfig) {
   auto makeSession = [&]() {
     auto s = std::make_unique<TestableConfigSession>(
         sessionDir.string(), (getTestEtcDir() / "coop").string());
-    // BGP commits/rollback restart bgp_pp via systemd; mock it out.
+    // BGP commits/rollback restart bgpd via systemd; mock it out.
     s->setMockSystemdFactory([] {
       return std::make_unique<::testing::NiceMock<MockSystemdInterface>>();
     });
@@ -1450,7 +1450,7 @@ TEST_F(ConfigSessionTestFixture, rollbackBgpConfig) {
 
 // Re-committing a BGP config that is byte-identical to the running
 // /etc/coop/bgpcpp/bgpcpp.conf must be a no-op: no git commit and (crucially)
-// no disruptive bgp_pp restart. saveBgpConfig() records BGP_RESTART
+// no disruptive bgpd restart. saveBgpConfig() records BGP_RESTART
 // unconditionally, so commit() compares staged vs running content.
 TEST_F(ConfigSessionTestFixture, commitUnchangedBgpConfigIsNoOp) {
   fs::path sessionDir = getTestHomeDir() / ".fboss2";
@@ -1471,7 +1471,7 @@ TEST_F(ConfigSessionTestFixture, commitUnchangedBgpConfigIsNoOp) {
     ASSERT_FALSE(s->commit(localhost()).commitSha.empty());
   }
   // Stage the SAME value again and commit -> no-op (empty commitSha, so no git
-  // revision and no bgp_pp restart).
+  // revision and no bgpd restart).
   {
     auto s = makeSession();
     s->getBgpConfig().router_id() = "1.1.1.1";

--- a/fboss/cli/fboss2/test/config/CmdConfigTestBase.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigTestBase.cpp
@@ -2,7 +2,7 @@
 
 #include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
 
-#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <fmt/format.h>
 #include <fstream>
 
@@ -52,9 +52,15 @@ CmdConfigTestBase::CmdConfigTestBase(
   // Create session config path
   sessionConfigPath_ = testHomeDir_ / ".fboss2" / "agent.conf";
 
-  // Initialize Git repository and create initial commit
+  // Initialize Git repository and create initial commit. Mirror
+  // ConfigSession::initializeGit(): the baseline commit also touches
+  // cli/cli_metadata.json so it shows up in `git log -- cli/cli_metadata.json`,
+  // which no-arg rollback() walks (so the baseline is reachable after the very
+  // first real commit).
+  std::filesystem::path metadataPath = cliConfigDir_ / "cli_metadata.json";
+  createTestConfig(metadataPath, "{}");
   git_.init();
-  git_.commit({"cli/agent.conf"}, "Initial commit");
+  git_.commit({"cli/agent.conf", "cli/cli_metadata.json"}, "Initial commit");
 }
 
 void CmdConfigTestBase::SetUp() {


### PR DESCRIPTION
## Summary

Make the fboss2 `ConfigSession` and `config session` lifecycle BGP-aware. This
is the base for the `config protocol bgp` commands, which build on top (see the
stacked PR).

- `ConfigSession` owns the BGP config as a typed `bgp::thrift::BgpConfig`,
  exactly the way it owns `cfg::AgentConfig` for the agent.
  `getBgpConfig()`/`saveBgpConfig()` expose the whole typed config and stage it
  to `~/.fboss2/bgp_config.json`. `ConfigSession` is BGP-aware but agnostic
  about the config's internal structure: a command mutates whichever typed
  fields it needs, mirroring how interface commands mutate
  `getAgentConfig().sw()->ports()`. The whole config round-trips through the
  typed struct, so no surgical merge / preserve-list is needed.
- `commit()` promotes `bgp_config.json` to `/etc/coop/bgpcpp/bgpcpp.conf`,
  restarts `bgp_pp`, and versions it in the same `/etc/coop` git repo as
  `agent.conf`.
- `config session clear/diff/rebase/rollback` are BGP-aware: clear removes a
  staged BGP session, diff shows staged BGP changes, rebase 3-way-merges
  `bgpcpp.conf`, rollback restores `bgpcpp.conf` + restarts `bgp_pp` (using
  metadata history so BGP-only commits are reachable).
- `FbossServiceUtil` + `cli_metadata` gain the `bgp_pp` (`BGP`)
  service/action; the config lib gains the `bgp_config` cpp2 dependency.

## Test Plan

- `fboss/cli/fboss2/test/config:cmd_config_test` — 455 tests pass
  (the BGP-session unit tests for the fixes below land in this PR).
- `//fboss/cli/...` builds on top of `upstream/main`.
- End-to-end coverage of the BGP session lifecycle on a live `bgp_pp` runs as
  `ConfigBgpSessionTest`, which is added in the stacked PR (the integration
  harness ships with the `config protocol bgp` commands) — 6/6 pass there.


