### PR TITLE
[Nexthop][m4062nhp] Add bsp_tests config

### DIFF
--- a/fboss/platform/config_lib/ConfigLibTest.cpp
+++ b/fboss/platform/config_lib/ConfigLibTest.cpp
@@ -83,6 +83,7 @@ TEST(ConfigLibTest, Basic) {
   // BspTests Configs
   EXPECT_NO_THROW(ConfigLib().getBspTestConfig(kMeru800bfa));
   EXPECT_NO_THROW(ConfigLib().getBspTestConfig(kBlackwolf800banw));
+  EXPECT_NO_THROW(ConfigLib().getBspTestConfig(kM4062nhp));
   EXPECT_THROW(
       ConfigLib().getBspTestConfig(kNonExistentPlatform), std::out_of_range);
 

--- a/fboss/platform/configs/m4062nhp/bsp_tests.json
+++ b/fboss/platform/configs/m4062nhp/bsp_tests.json
@@ -1,0 +1,89 @@
+{
+  "testData": {
+    "SCM.DPM": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x98",
+            "expected": "0x22"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "vout1",
+          "vout2",
+          "vout3",
+          "vout4",
+          "vout5",
+          "vout6",
+          "vout7",
+          "vout8",
+          "vout9",
+          "vout10",
+          "vout11",
+          "vout12",
+          "vout13",
+          "vout14",
+          "vout15",
+          "vout16",
+          "vout17"
+        ]
+      }
+    },
+    "SCM.DPM_2": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0x98",
+            "expected": "0x22"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "vout1",
+          "vout2",
+          "vout3",
+          "vout4",
+          "vout5",
+          "vout6",
+          "vout7",
+          "vout8",
+          "vout9",
+          "vout10",
+          "vout11",
+          "vout12",
+          "vout13",
+          "vout14",
+          "vout15",
+          "vout16",
+          "vout17"
+        ]
+      }
+    },
+    "SMB.SWITCH_CARD_TEMP_SENSOR": {
+      "i2cTestData": {
+        "i2cGetData": [
+          {
+            "reg": "0xfe",
+            "expected": "0x54"
+          },
+          {
+            "reg": "0xff",
+            "expected": "0x14"
+          }
+        ]
+      },
+      "hwmonTestData": {
+        "expectedFeatures": [
+          "temp1",
+          "temp2",
+          "temp3",
+          "temp4",
+          "temp5"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Add a bsp_tests.json for the m4062nhp platform and load it in the config_lib BspTests coverage. The config describes the two ADM1266 power-sequencers (SCM.DPM / SCM.DPM_2: vout1..vout17 hwmon features and the PMBus revision register) and the TMP464 switch-card temp sensor (SMB.SWITCH_CARD_TEMP_SENSOR: temp1..temp5 hwmon features and the manufacturer/device ID registers).

Requires #1332 for the platform manager support.

# Test Plan
Exercise it from ConfigLibTest to verify the file in a config-load test.