### PR TITLE
[Celestica] Leh800bcls: Support NPU-specific yamlConfig to allow differing polarity settings on multi-NPU platforms

### DIFF
--- a/fboss/agent/platforms/sai/SaiBcmPlatform.cpp
+++ b/fboss/agent/platforms/sai/SaiBcmPlatform.cpp
@@ -25,17 +25,48 @@ std::string SaiBcmPlatform::getHwConfig() {
   if (getAsic()->isSupported(HwAsic::Feature::HSDK)) {
     std::string yamlConfig;
     try {
-      yamlConfig = config()
-                       ->thrift.platform()
-                       ->chip()
-                       ->get_asicConfig()
-                       .common()
-                       ->get_yamlConfig();
-    } catch (const std::exception&) {
+      auto asicConfig = config()->thrift.platform()->chip()->get_asicConfig();
+      try {
+        if (asicConfig.npuEntries()) {
+          int16_t switchIndex = getAsic()->getSwitchIndex();
+          XLOG(INFO)
+              << "Loading HSDK config: found npuEntries, current switchIndex="
+              << switchIndex;
+          auto& npuEntries = asicConfig.npuEntries().value();
+          auto npuEntry = npuEntries.find(switchIndex);
+          if ((npuEntry != npuEntries.end()) &&
+              (npuEntry->second.getType() ==
+               cfg::AsicConfigEntry::Type::yamlConfig)) {
+            XLOG(INFO) << "Loading NPU-specific yamlConfig for switchIndex="
+                       << switchIndex;
+            yamlConfig = npuEntry->second.get_yamlConfig();
+          } else {
+            XLOG(INFO) << "No NPU-specific yamlConfig found for switchIndex="
+                       << switchIndex << ", falling back to common config";
+          }
+        }
+      } catch (const std::exception& e) {
+        XLOG(WARN) << "Failed to read NPU-specific config: " << e.what()
+                   << ", falling back to common config";
+      }
+      if (yamlConfig.empty()) {
+        if (asicConfig.common()->getType() ==
+            cfg::AsicConfigEntry::Type::yamlConfig) {
+          yamlConfig = asicConfig.common()->get_yamlConfig();
+        } else {
+          XLOG(INFO) << "No common HSDK yamlConfig found";
+        }
+      }
+      if (yamlConfig.empty()) {
+        throw FbossError("No HSDK yamlConfig found in asicConfig");
+      }
+    } catch (const std::exception& e) {
       /*
        * (TODO): Once asic config v2 is rolled out to the fleet, we
        * should remove this fallback and always use the config v2
        */
+      XLOG(INFO) << "Exception in SaiBcmPlatform::getHwConfig: " << e.what()
+                 << ", falling back to bcm.yamlConfig()";
       yamlConfig =
           *(config()->thrift.platform()->chip()->get_bcm().yamlConfig());
     }


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
Support NPU-specific `yamlConfig` loading on multi-NPU platforms (like `leh800bcls`) to allow differing hardware configurations  (such as distinct PHY polarities) per NPU.

# Background
Due to hardware routing and layout differences on the new dual-NPU `leh800bcls` platform, NPU 0 and NPU 1 require different polarity settings (`RX_POLARITY_FLIP` and `TX_POLARITY_FLIP` in HSDK's `yamlConfig`). 
Previously, `SaiBcmPlatform::getHwConfig()` always loaded configuration from `asicConfig.common()->get_yamlConfig()`, forcing both NPUs to apply the exact same hardware YAML settings. Under split agent setups, this makes it impossible to configure distinct polarities for different NPUs.

# Changes
Refactored `SaiBcmPlatform::getHwConfig()` in `fboss/agent/platforms/sai/SaiBcmPlatform.cpp`:
    - Retrieve the current platform's active logic switch index via the first-class `HwAsic` API `getAsic()->getSwitchIndex()`. This is guaranteed to be populated on both split agent test runners and unified software agents (e.g. `fboss_sw_agent`).
    - Query the `npuEntries` map in `PlatformConfig` using the switch index.
    - If an NPU-specific entry is found and of type `cfg::AsicConfigEntry::Type::yamlConfig`, extract and load its corresponding `yamlConfig`.
    - Fall back to `asicConfig.common()->get_yamlConfig()` if no NPU-specific configuration is specified.

# Test Plan
1. With two different NPU configurations, all ports are up.
```
agent config:
  "platform": {
    "chip": {
      "asicConfig": {
        "common": {
          "yamlConfig": ""
        },
        "npuEntries": {
          "0": {
            "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                ...
          },
          "1": {
            "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                ...
          }
        }
      }
    }
  },

[root@localhost cfg]# grep -B2 yamlConfig agent.conf | cut -c 1-200
      "asicConfig": {
        "common": {
          "yamlConfig": ""
--
        "npuEntries": {
          "0": {
            "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n
          },
          "1": {
            "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n

[root@localhost agent_ensemble]# diff /dev/shm/fboss/hw_config_idx0 /dev/shm/fboss/hw_config_idx1
351,352c351,352
<                 RX_POLARITY_FLIP: 0xf2
<                 TX_POLARITY_FLIP: 0x31
---
>                 RX_POLARITY_FLIP: 0x0d
>                 TX_POLARITY_FLIP: 0xce
363,364c363,364
<                 RX_POLARITY_FLIP: 0xf2
<                 TX_POLARITY_FLIP: 0x11
---
>                 RX_POLARITY_FLIP: 0x0d
>                 TX_POLARITY_FLIP: 0xee
387,388c387,388
<                 RX_POLARITY_FLIP: 0xf2
<                 TX_POLARITY_FLIP: 0x11
---
>                 RX_POLARITY_FLIP: 0x0d
>                 TX_POLARITY_FLIP: 0xee
399,400c399,400
<                 RX_POLARITY_FLIP: 0xb
<                 TX_POLARITY_FLIP: 0x77
---
>                 RX_POLARITY_FLIP: 0xf4
>                 TX_POLARITY_FLIP: 0x88
411,412c411,412
<                 RX_POLARITY_FLIP: 0xb
<                 TX_POLARITY_FLIP: 0x77
---
>                 RX_POLARITY_FLIP: 0xf4
>                 TX_POLARITY_FLIP: 0x88
423,424c423,424
<                 RX_POLARITY_FLIP: 0xb
<                 TX_POLARITY_FLIP: 0x77
---
>                 RX_POLARITY_FLIP: 0xf4
>                 TX_POLARITY_FLIP: 0x88
435,436c435,436
<                 RX_POLARITY_FLIP: 0xb
<                 TX_POLARITY_FLIP: 0x37
---
>                 RX_POLARITY_FLIP: 0xf4
>                 TX_POLARITY_FLIP: 0xc8

[root@localhost agent_ensemble]# fb show port | grep Up | wc -l
466

```
2. Using the previous/legacy configuration (i.e., placing yamlConfig in common) also works normally.
```
[root@localhost cfg]# grep -B2 yamlConfig agent.conf | cut -c 1-200
      "asicConfig": {
        "common": {
          "yamlConfig": "---\ndevice:\n    0:\n        PC_PM_CORE:\n            ?\n                PC_PM_ID: 1\n                CORE_INDEX: 0\n            :\n                RX_LANE_MAP_AUTO: 0\n
[root@localhost log]# fb show port | grep Up | wc -l
466
[root@localhost log]#

```