### PR TITLE
[Nexthop] Add load-line droop compensation for AVS voltage rails in sensor_service

### DIFF
--- a/cmake/PlatformSensorServiceTest.cmake
+++ b/cmake/PlatformSensorServiceTest.cmake
@@ -6,6 +6,7 @@
 add_executable(sensor_service_sw_test
   fboss/platform/sensor_service/tests/ConfigValidatorTest.cpp
   fboss/platform/sensor_service/tests/PmUnitInfoFetcherTest.cpp
+  fboss/platform/sensor_service/tests/SensorServiceImplLoadLineTest.cpp
   fboss/platform/sensor_service/tests/SensorServiceImplTest.cpp
   fboss/platform/sensor_service/tests/SensorServiceThriftHandlerTest.cpp
   fboss/platform/sensor_service/tests/TestUtils.cpp

--- a/fboss/platform/sensor_service/ConfigValidator.cpp
+++ b/fboss/platform/sensor_service/ConfigValidator.cpp
@@ -7,6 +7,8 @@
 #include <re2/re2.h>
 #include <thrift/lib/cpp2/FieldRef.h>
 
+#include <unordered_map>
+
 #include "fboss/platform/sensor_service/utilities/PowerConfigUtils.h"
 
 namespace facebook::fboss::platform::sensor_service {
@@ -37,7 +39,11 @@ bool ConfigValidator::isValid(const SensorConfig& sensorConfig) {
   if (!isValidAsicCommand(sensorConfig)) {
     return false;
   }
+<<<<<<< HEAD
   if (!isValidLoggedSensorNames(sensorConfig)) {
+=======
+  if (!isValidLoadLineConfig(sensorConfig)) {
+>>>>>>> 3d9678bcd3 (NOS-10438: load-line droop compensation for AVS rail in FBOSS (#1231))
     return false;
   }
   return true;
@@ -83,6 +89,91 @@ bool ConfigValidator::isValidPmSensor(const sensor_config::PmSensor& pmSensor) {
   if (!pmSensor.sysfsPath().has_value() || pmSensor.sysfsPath()->empty()) {
     XLOG(ERR) << "PmSensor sysfsPath must be non-empty";
     return false;
+  }
+
+  // Load-line droop compensation fields must be set together, only on a
+  // VOLTAGE sensor, with a positive resistance. The referenced current
+  // sensor's existence and type are validated in isValidLoadLineConfig.
+  bool hasLoadLineCurrentSensor = pmSensor.loadLineCurrentSensor().has_value();
+  bool hasLoadLineuOhms = pmSensor.loadLineuOhms().has_value();
+  if (hasLoadLineCurrentSensor != hasLoadLineuOhms) {
+    XLOG(ERR) << fmt::format(
+        "PmSensor '{}' must set loadLineCurrentSensor and loadLineuOhms "
+        "together",
+        name);
+    return false;
+  }
+  if (hasLoadLineCurrentSensor) {
+    if (pmSensor.loadLineCurrentSensor()->empty()) {
+      XLOG(ERR) << fmt::format(
+          "PmSensor '{}' loadLineCurrentSensor must be non-empty", name);
+      return false;
+    }
+    if (*pmSensor.type() != SensorType::VOLTAGE) {
+      XLOG(ERR) << fmt::format(
+          "PmSensor '{}' sets load-line fields but is not a VOLTAGE sensor",
+          name);
+      return false;
+    }
+    if (*pmSensor.loadLineuOhms() <= 0) {
+      XLOG(ERR) << fmt::format(
+          "PmSensor '{}' loadLineuOhms must be positive", name);
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ConfigValidator::isValidLoadLineConfig(const SensorConfig& sensorConfig) {
+  XLOG(DBG1) << "Validating load-line config";
+  auto universalSensorNames = getAllUniversalSensorNames(sensorConfig);
+  std::unordered_map<std::string, SensorType> sensorTypes;
+  for (const auto& pmUnitSensors : *sensorConfig.pmUnitSensorsList()) {
+    for (const auto& pmSensor : *pmUnitSensors.sensors()) {
+      sensorTypes[*pmSensor.name()] = *pmSensor.type();
+    }
+    for (const auto& versionedPmSensor : *pmUnitSensors.versionedSensors()) {
+      for (const auto& pmSensor : *versionedPmSensor.sensors()) {
+        sensorTypes[*pmSensor.name()] = *pmSensor.type();
+      }
+    }
+  }
+  auto validateRef = [&](const PmSensor& pmSensor) {
+    if (!pmSensor.loadLineCurrentSensor().has_value()) {
+      return true;
+    }
+    const auto& currentSensorName = *pmSensor.loadLineCurrentSensor();
+    if (universalSensorNames.count(currentSensorName) == 0) {
+      XLOG(ERR) << fmt::format(
+          "loadLineCurrentSensor {} referenced by {} is not defined in "
+          "SensorConfig",
+          currentSensorName,
+          *pmSensor.name());
+      return false;
+    }
+    auto it = sensorTypes.find(currentSensorName);
+    if (it != sensorTypes.end() && it->second != SensorType::CURRENT) {
+      XLOG(ERR) << fmt::format(
+          "loadLineCurrentSensor {} referenced by {} is not a CURRENT sensor",
+          currentSensorName,
+          *pmSensor.name());
+      return false;
+    }
+    return true;
+  };
+  for (const auto& pmUnitSensors : *sensorConfig.pmUnitSensorsList()) {
+    for (const auto& pmSensor : *pmUnitSensors.sensors()) {
+      if (!validateRef(pmSensor)) {
+        return false;
+      }
+    }
+    for (const auto& versionedPmSensor : *pmUnitSensors.versionedSensors()) {
+      for (const auto& pmSensor : *versionedPmSensor.sensors()) {
+        if (!validateRef(pmSensor)) {
+          return false;
+        }
+      }
+    }
   }
   return true;
 }

--- a/fboss/platform/sensor_service/ConfigValidator.cpp
+++ b/fboss/platform/sensor_service/ConfigValidator.cpp
@@ -39,11 +39,10 @@ bool ConfigValidator::isValid(const SensorConfig& sensorConfig) {
   if (!isValidAsicCommand(sensorConfig)) {
     return false;
   }
-<<<<<<< HEAD
   if (!isValidLoggedSensorNames(sensorConfig)) {
-=======
+    return false;
+  }
   if (!isValidLoadLineConfig(sensorConfig)) {
->>>>>>> 3d9678bcd3 (NOS-10438: load-line droop compensation for AVS rail in FBOSS (#1231))
     return false;
   }
   return true;

--- a/fboss/platform/sensor_service/ConfigValidator.h
+++ b/fboss/platform/sensor_service/ConfigValidator.h
@@ -13,6 +13,7 @@ class ConfigValidator {
       const std::vector<sensor_config::PmUnitSensors>& pmUnitSensorsList);
   bool isValidPmSensors(const std::vector<sensor_config::PmSensor>& pmSensor);
   bool isValidPmSensor(const sensor_config::PmSensor& pmSensor);
+  bool isValidLoadLineConfig(const sensor_config::SensorConfig& sensorConfig);
   bool isValidPlatformName(const sensor_config::SensorConfig& sensorConfig);
   bool isValidTemperatureSensorThresholds(
       const sensor_config::SensorConfig& sensorConfig);

--- a/fboss/platform/sensor_service/SensorServiceImpl.cpp
+++ b/fboss/platform/sensor_service/SensorServiceImpl.cpp
@@ -182,6 +182,7 @@ SensorServiceImpl::prefetchPmUnitInfos() {
 
 void SensorServiceImpl::fetchSensorData() {
   std::map<std::string, SensorData> polledData;
+  std::vector<PmSensor> loadLineSensors;
 
   auto pmUnitInfoMap = prefetchPmUnitInfos();
 
@@ -265,7 +266,14 @@ void SensorServiceImpl::fetchSensorData() {
           sensor.compute().to_optional());
       sensorData.slotPath() = *pmUnitSensors.slotPath();
       polledData[sensorName] = sensorData;
-      publishPerSensorStats(sensorData);
+      // For AVS rails that use load-line regulation (Adaptive Voltage
+      // Positioning), we need to adjust their read vout to account for
+      // load-line droops. So we defer publishing the stats for such sensors.
+      if (sensor.loadLineuOhms().has_value()) {
+        loadLineSensors.push_back(sensor);
+      } else {
+        publishPerSensorStats(sensorData);
+      }
     }
   }
 
@@ -278,6 +286,8 @@ void SensorServiceImpl::fetchSensorData() {
   }
 
   processPower(polledData, *sensorConfig_.powerConfig(), pmUnitInfoMap);
+
+  processLoadLineDroopAdjust(polledData, loadLineSensors);
 
   processTemperature(polledData, *sensorConfig_.temperatureConfigs());
 
@@ -537,6 +547,45 @@ SensorData SensorServiceImpl::processAsicCmd(const AsicCommand& asicCommand) {
         "Failed to parse AsicCommand '{}' output: {}", output, e.what());
   }
   return sensorData;
+}
+
+void SensorServiceImpl::processLoadLineDroopAdjust(
+    std::map<std::string, SensorData>& polledData,
+    const std::vector<PmSensor>& loadLineSensors) {
+  auto getSensorValue = [&](const std::string& sensorName) {
+    auto it = polledData.find(sensorName);
+    if (it != polledData.end()) {
+      return it->second.value().to_optional();
+    }
+    return std::optional<float>(std::nullopt);
+  };
+
+  for (const auto& sensor : loadLineSensors) {
+    const auto& voltageSensorName = *sensor.name();
+    const auto& loadLineSensorName = *sensor.loadLineCurrentSensor();
+    const double uOhms = *sensor.loadLineuOhms();
+    auto voutIt = polledData.find(voltageSensorName);
+    if (voutIt == polledData.end()) {
+      XLOG(ERR) << fmt::format(
+          "Load-line sensor {} missing from polled data; skipping",
+          voltageSensorName);
+      continue;
+    }
+
+    auto rawVout = voutIt->second.value().to_optional();
+    auto loadLineAmps = getSensorValue(loadLineSensorName);
+
+    if (!rawVout || !loadLineAmps) {
+      XLOG(WARNING) << fmt::format(
+          "Skipping load-line adjustment for {}", voltageSensorName);
+      publishPerSensorStats(voutIt->second);
+      continue;
+    }
+
+    double vout = static_cast<double>(*rawVout) + uOhms * 1e-6 * *loadLineAmps;
+    voutIt->second.value() = static_cast<float>(vout);
+    publishPerSensorStats(voutIt->second);
+  }
 }
 
 void SensorServiceImpl::processPower(

--- a/fboss/platform/sensor_service/SensorServiceImpl.h
+++ b/fboss/platform/sensor_service/SensorServiceImpl.h
@@ -90,6 +90,12 @@ class SensorServiceImpl {
     return fsdbSyncer_.get();
   }
 
+  // For AVS rails that use load-line regulation (Adaptive Voltage Positioning),
+  // we need to adjust their read vout to account for load-line droops.
+  void processLoadLineDroopAdjust(
+      std::map<std::string, SensorData>& polledData,
+      const std::vector<PmSensor>& loadLineSensors);
+
   // pmUnitInfoMap (default empty): per-slot PmUnitInfo from
   // prefetchPmUnitInfos. processPower consults it to skip per-slot _POWER
   // publication when platform_manager reports a PSU/PEM slot absent. The

--- a/fboss/platform/sensor_service/if/sensor_config.thrift
+++ b/fboss/platform/sensor_service/if/sensor_config.thrift
@@ -72,12 +72,21 @@ struct Thresholds {
 // `compute`: Compute method, same format and calculation approach as lm_sensor, e.g. @*0.1
 //
 // `type`: See SensorType definition above.
+//
+// `loadLineCurrentSensor`: For AVS rails that use load-line regulation (Adaptive Voltage
+//                          Positioning), the name of the sensor supplying the load current. This is set
+//                          together with loadLineuOhms below to enable droop compensation on this sensor.
+//
+// `loadLineuOhms`: Load-line resistance in micro ohms. When set, this sensor's reported
+//                  voltage is droop-compensated.
 struct PmSensor {
   1: string name;
   2: string sysfsPath;
   3: optional Thresholds thresholds;
   4: optional string compute;
   5: SensorType type;
+  6: optional string loadLineCurrentSensor;
+  7: optional i32 loadLineuOhms;
 }
 
 // `VersionedPmSensor`: Describes a set of sensors which would exist in Platforms with

--- a/fboss/platform/sensor_service/tests/BUCK
+++ b/fboss/platform/sensor_service/tests/BUCK
@@ -19,6 +19,7 @@ cpp_library(
 cpp_unittest(
     name = "sensor_service_sw_test",
     srcs = [
+        "SensorServiceImplLoadLineTest.cpp",
         "SensorServiceImplTest.cpp",
         "SensorServiceThriftHandlerTest.cpp",
     ],

--- a/fboss/platform/sensor_service/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/sensor_service/tests/ConfigValidatorTest.cpp
@@ -24,6 +24,18 @@ PmSensor createPmSensor(
   return pmSensor;
 }
 
+PmSensor createLoadLineSensor(
+    const std::string& name,
+    const std::string& sysfsPath,
+    const std::string& loadLineCurrentSensor,
+    int32_t loadLineuOhms,
+    SensorType type = SensorType::VOLTAGE) {
+  auto pmSensor = createPmSensor(name, sysfsPath, type);
+  pmSensor.loadLineCurrentSensor() = loadLineCurrentSensor;
+  pmSensor.loadLineuOhms() = loadLineuOhms;
+  return pmSensor;
+}
+
 PerSlotPowerConfig createPerSlotPowerConfig(
     const std::string& name,
     const std::optional<std::string>& powerSensorName = std::nullopt,
@@ -1218,6 +1230,81 @@ TEST(ConfigValidatorTest, isValidPmSensor) {
       createPmSensor("VERSIONED_SENSOR", "/run/devmap/sensors/VERSIONED")};
   pmUnitSensors.versionedSensors() = {versionedSensor};
   EXPECT_TRUE(ConfigValidator().isValidPmUnitSensorsList({pmUnitSensors}));
+}
+
+TEST(ConfigValidatorTest, LoadLineSensorFields) {
+  // Valid: both fields set, positive uOhms, VOLTAGE type - should pass.
+  auto sensor = createLoadLineSensor(
+      "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", "VDD_CORE_IOUT", 59);
+  EXPECT_TRUE(ConfigValidator().isValidPmSensor(sensor));
+
+  // No load-line fields at all - should pass.
+  auto plain = createPmSensor(
+      "PLAIN_VOUT", "/run/devmap/sensors/VOUT", SensorType::VOLTAGE);
+  EXPECT_TRUE(ConfigValidator().isValidPmSensor(plain));
+
+  // Only loadLineCurrentSensor set - should fail.
+  sensor = createPmSensor(
+      "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", SensorType::VOLTAGE);
+  sensor.loadLineCurrentSensor() = "VDD_CORE_IOUT";
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+
+  // Only loadLineuOhms set - should fail.
+  sensor = createPmSensor(
+      "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", SensorType::VOLTAGE);
+  sensor.loadLineuOhms() = 59;
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+
+  // Zero uOhms - should fail.
+  sensor = createLoadLineSensor(
+      "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", "VDD_CORE_IOUT", 0);
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+
+  // Negative uOhms - should fail.
+  sensor = createLoadLineSensor(
+      "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", "VDD_CORE_IOUT", -1);
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+
+  // Empty current sensor name - should fail.
+  sensor =
+      createLoadLineSensor("VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", "", 59);
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+
+  // Load-line fields on a non-VOLTAGE sensor - should fail.
+  sensor = createLoadLineSensor(
+      "VDD_CORE_CUR",
+      "/run/devmap/sensors/CUR",
+      "VDD_CORE_IOUT",
+      59,
+      SensorType::CURRENT);
+  EXPECT_FALSE(ConfigValidator().isValidPmSensor(sensor));
+}
+
+TEST(ConfigValidatorTest, LoadLineConfig) {
+  SensorConfig config;
+  PmUnitSensors pmUnitSensors;
+  pmUnitSensors.slotPath() = "/";
+  pmUnitSensors.pmUnitName() = "MOCK";
+  pmUnitSensors.sensors() = {
+      createLoadLineSensor(
+          "VDD_CORE_VOUT", "/run/devmap/sensors/VOUT", "VDD_CORE_IOUT", 59),
+      createPmSensor(
+          "VDD_CORE_IOUT", "/run/devmap/sensors/IOUT", SensorType::CURRENT)};
+  config.pmUnitSensorsList() = {pmUnitSensors};
+
+  // Companion current sensor exists and is CURRENT - should pass.
+  EXPECT_TRUE(ConfigValidator().isValidLoadLineConfig(config));
+
+  // Reference a non-existent current sensor - should fail.
+  config.pmUnitSensorsList()[0].sensors()[0].loadLineCurrentSensor() =
+      "MISSING_IOUT";
+  EXPECT_FALSE(ConfigValidator().isValidLoadLineConfig(config));
+
+  // Reference a sensor that exists but is not CURRENT - should fail.
+  config.pmUnitSensorsList()[0].sensors()[0].loadLineCurrentSensor() =
+      "VDD_CORE_IOUT";
+  config.pmUnitSensorsList()[0].sensors()[1].type() = SensorType::VOLTAGE;
+  EXPECT_FALSE(ConfigValidator().isValidLoadLineConfig(config));
 }
 
 TEST(ConfigValidatorTest, PlatformNameValidation) {

--- a/fboss/platform/sensor_service/tests/SensorServiceImplLoadLineTest.cpp
+++ b/fboss/platform/sensor_service/tests/SensorServiceImplLoadLineTest.cpp
@@ -1,0 +1,195 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <fb303/ServiceData.h>
+#include <folly/FileUtil.h>
+#include <folly/testing/TestUtil.h>
+
+#include <gtest/gtest.h>
+
+#include "fboss/platform/sensor_service/SensorServiceImpl.h"
+
+using namespace facebook::fboss::platform::sensor_service;
+using namespace facebook::fboss::platform::sensor_config;
+
+namespace facebook::fboss {
+
+class SensorServiceImplLoadLineTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    PmUnitSensors pmUnitSensors;
+    pmUnitSensors.slotPath() = "/";
+    pmUnitSensors.pmUnitName() = "MOCK";
+    config_.pmUnitSensorsList() = {pmUnitSensors};
+  }
+
+  // Build a voltage PmSensor configured for load-line droop compensation.
+  PmSensor makeLoadLineSensor(
+      const std::string& name,
+      const std::string& currentSensorName,
+      int32_t uOhms) {
+    PmSensor sensor;
+    sensor.name() = name;
+    sensor.sysfsPath() = "/tmp/dummy/" + name;
+    sensor.type() = SensorType::VOLTAGE;
+    sensor.loadLineCurrentSensor() = currentSensorName;
+    sensor.loadLineuOhms() = uOhms;
+    return sensor;
+  }
+
+  std::map<std::string, SensorData> createPolledData(
+      const std::map<std::string, float>& sensorData) {
+    std::map<std::string, SensorData> polledData;
+    for (const auto& [sensorName, value] : sensorData) {
+      SensorData sData;
+      sData.name() = sensorName;
+      sData.value() = value;
+      sData.sensorType() = SensorType::VOLTAGE;
+      sData.thresholds() = Thresholds();
+      polledData.emplace(sensorName, sData);
+    }
+    return polledData;
+  }
+
+  // Add a polledData entry for a sensor whose read failed (no value set).
+  void addReadFailure(
+      std::map<std::string, SensorData>& polledData,
+      const std::string& sensorName) {
+    SensorData sData;
+    sData.name() = sensorName;
+    sData.sensorType() = SensorType::VOLTAGE;
+    sData.thresholds() = Thresholds();
+    polledData.emplace(sensorName, sData);
+  }
+
+  // Expected adjusted vout with load-line droops compensated
+  float expectedVout(float rawVout, int32_t uOhms, float amps) {
+    return static_cast<float>(
+        static_cast<double>(rawVout) + uOhms * 1e-6 * amps);
+  }
+
+  // Build a full SensorConfig with a load-line VOUT sensor and its IOUT
+  // companion, both backed by temp sysfs files, then write their raw
+  // readings. compute "@/1000" is applied during fetchSensorData.
+  void setupFetchConfig(
+      const std::string& rawVout,
+      const std::string& rawIout,
+      int32_t uOhms) {
+    auto voutPath = tmpDir_.path().string() + "/vout";
+    auto ioutPath = tmpDir_.path().string() + "/iout";
+
+    PmUnitSensors pmUnitSensors;
+    pmUnitSensors.slotPath() = "/";
+    pmUnitSensors.pmUnitName() = "MOCK";
+
+    PmSensor vout;
+    vout.name() = "VDD_CORE_VOUT";
+    vout.sysfsPath() = voutPath;
+    vout.type() = SensorType::VOLTAGE;
+    vout.compute() = "@/1000";
+    vout.loadLineCurrentSensor() = "VDD_CORE_IOUT";
+    vout.loadLineuOhms() = uOhms;
+    vout.thresholds() = Thresholds();
+
+    PmSensor iout;
+    iout.name() = "VDD_CORE_IOUT";
+    iout.sysfsPath() = ioutPath;
+    iout.type() = SensorType::CURRENT;
+    iout.compute() = "@/1000";
+
+    pmUnitSensors.sensors() = {std::move(vout), std::move(iout)};
+    config_.pmUnitSensorsList() = {std::move(pmUnitSensors)};
+
+    folly::writeFile(rawVout, voutPath.c_str());
+    folly::writeFile(rawIout, ioutPath.c_str());
+  }
+
+  void createImpl() {
+    impl_ = std::make_unique<SensorServiceImpl>(config_);
+  }
+
+  int64_t readValueCounter(const std::string& sensorName) {
+    return fb303::fbData->getCounter(
+        fmt::format(SensorServiceImpl::kReadValue, sensorName));
+  }
+
+  int64_t readFailureCounter(const std::string& sensorName) {
+    return fb303::fbData->getCounter(
+        fmt::format(SensorServiceImpl::kReadFailure, sensorName));
+  }
+
+  // tmpDir_ must outlive impl_ so its sysfs files remain readable while
+  // fetchSensorData runs.
+  folly::test::TemporaryDirectory tmpDir_;
+  SensorConfig config_;
+  std::unique_ptr<SensorServiceImpl> impl_;
+};
+
+TEST_F(SensorServiceImplLoadLineTest, AdjustsVoutByLoadLine) {
+  createImpl();
+  auto polledData =
+      createPolledData({{"VDD_CORE_VOUT", 0.766f}, {"VDD_CORE_IOUT", 172.75f}});
+  std::vector<PmSensor> loadLineSensors = {
+      makeLoadLineSensor("VDD_CORE_VOUT", "VDD_CORE_IOUT", 59)};
+  impl_->processLoadLineDroopAdjust(polledData, loadLineSensors);
+
+  EXPECT_FLOAT_EQ(
+      *polledData["VDD_CORE_VOUT"].value(), expectedVout(0.766f, 59, 172.75f));
+  EXPECT_EQ(readFailureCounter("VDD_CORE_VOUT"), 0);
+}
+
+TEST_F(SensorServiceImplLoadLineTest, ZeroCurrentLeavesVoutUnchanged) {
+  createImpl();
+  auto polledData =
+      createPolledData({{"VDD_CORE_VOUT", 0.766f}, {"VDD_CORE_IOUT", 0.0f}});
+  std::vector<PmSensor> loadLineSensors = {
+      makeLoadLineSensor("VDD_CORE_VOUT", "VDD_CORE_IOUT", 59)};
+  impl_->processLoadLineDroopAdjust(polledData, loadLineSensors);
+
+  EXPECT_FLOAT_EQ(*polledData["VDD_CORE_VOUT"].value(), 0.766f);
+}
+
+TEST_F(SensorServiceImplLoadLineTest, MissingCurrentSensorLeavesVoutUnchanged) {
+  createImpl();
+  auto polledData = createPolledData({{"VDD_CORE_VOUT", 0.766f}});
+  std::vector<PmSensor> loadLineSensors = {
+      makeLoadLineSensor("VDD_CORE_VOUT", "VDD_CORE_IOUT", 59)};
+  impl_->processLoadLineDroopAdjust(polledData, loadLineSensors);
+
+  EXPECT_FLOAT_EQ(*polledData["VDD_CORE_VOUT"].value(), 0.766f);
+  EXPECT_EQ(readFailureCounter("VDD_CORE_VOUT"), 0);
+}
+
+TEST_F(SensorServiceImplLoadLineTest, ReadFailureVoutStillPublished) {
+  createImpl();
+  auto polledData = createPolledData({{"FAIL_IOUT", 172.75f}});
+  addReadFailure(polledData, "FAIL_VOUT");
+  std::vector<PmSensor> loadLineSensors = {
+      makeLoadLineSensor("FAIL_VOUT", "FAIL_IOUT", 59)};
+  impl_->processLoadLineDroopAdjust(polledData, loadLineSensors);
+
+  EXPECT_FALSE(polledData["FAIL_VOUT"].value().has_value());
+  EXPECT_EQ(readFailureCounter("FAIL_VOUT"), 1);
+}
+
+TEST_F(SensorServiceImplLoadLineTest, MissingVoltageSensorSkipped) {
+  createImpl();
+  auto polledData = createPolledData({{"ABSENT_IOUT", 172.75f}});
+  std::vector<PmSensor> loadLineSensors = {
+      makeLoadLineSensor("ABSENT_VOUT", "ABSENT_IOUT", 59)};
+  impl_->processLoadLineDroopAdjust(polledData, loadLineSensors);
+
+  EXPECT_THROW(readValueCounter("ABSENT_VOUT"), std::invalid_argument);
+}
+
+TEST_F(SensorServiceImplLoadLineTest, FetchSensorDataAppliesLoadLine) {
+  setupFetchConfig("766", "172750", 59);
+  createImpl();
+  impl_->fetchSensorData();
+
+  auto all = impl_->getAllSensorData();
+  ASSERT_TRUE(all.find("VDD_CORE_VOUT") != all.end());
+  EXPECT_FLOAT_EQ(
+      *all["VDD_CORE_VOUT"].value(), expectedVout(0.766f, 59, 172.75f));
+}
+
+} // namespace facebook::fboss


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

AVS rails that use load-line regulation (Adaptive Voltage Positioning) intentionally droop their output voltage under load. Under high current, this droop can be large enough to trip low-voltage alarms even when the regulator is behaving correctly.

This change adds load-line droop compensation to sensor_service. For a configured voltage rail, the published value is corrected back toward the regulator set-point using the measured load current:

`vout = rawVout + (I_amps * R_uOhms * 1e-6)`

**Changes**

- Thrift schema (`sensor_config.thrift`): add two optional `PmSensor` fields:
     - `loadLineCurrentSensor`
     - `loadLineuOhms`
- `SensorServiceImpl`: rails with `loadLineuOhms` are collected into a deferred `loadLineSensors` collection during `fetchSensorData` and published only after their companion sensors have been read. `processLoadLineDroopAdjust` applies the formula above and then publishes the adjusted value.
- `ConfigValidator`: validates the new config fields:
     - fields must be set together
     - only valid on `VOLTAGE` sensors
     - resistance must be positive
     - the referenced companion current sensor must exist and be of type `CURRENT`
- Tests: new `SensorServiceImplLoadLineTest` coverage, including direct adjustment and fetchSensorData paths, plus new `ConfigValidator` cases.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

- `sensor_service_sw_test` passed, including the newly added test cases
- manually verified on hardware by comparing the stock service and patched binary on the live rail
- also tested with exaggerated load-line resistance to confirm that published voltage is driven by `iout × loadLineuOhms × 1e-6`

| config | raw VOUT | IOUT | computation | published VOUT |
| --- | --- | --- | --- | --- |
| Before / without compensation | `766 → 0.766 V` | `171500 → 171.5 A` | `no adjustment -> 0.766` | `0.77` |
| With compensation / `loadLineuOhms = 59` | `766 → 0.766 V` | `172750 → 172.75 A` | `0.766 + 172.75 x 59 x 1e-6 = 0.7762` | `0.78` |
| With compensation / `loadLineuOhms = 59000` | `766 → 0.766 V` | `~171 A` | `0.766 + 171 x 59000 x 1e-6 = 10.855` | `10.86` |

The realistic resistance case produces the expected small correction, and increasing the resistance scales the adjustment proportionally, confirming that the published value is driven by `iout × loadLineuOhms × 1e-6`.