### PR TITLE
[Celestica] Icecubem: Add QSFP and LED service support for icecubem

### DIFF
--- a/fboss/lib/platforms/PlatformProductInfo.cpp
+++ b/fboss/lib/platforms/PlatformProductInfo.cpp
@@ -223,7 +223,8 @@ void PlatformProductInfo::initMode() {
         modelName.find("TAHAN") == 0 || modelName.find("TAHAN800BC") == 0 ||
         modelName.find("R4063-F9001-01") == 0) {
       type_ = PlatformType::PLATFORM_TAHAN800BC;
-    } else if (modelName.find("ICECUBE") == 0) {
+    } else if (
+        modelName.find("ICECUBE") == 0 || modelName.find("ICECUBEM") == 0) {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;
     } else if (modelName.find("ICETEA") == 0) {
       type_ = PlatformType::PLATFORM_ICETEA800BC;
@@ -298,7 +299,7 @@ void PlatformProductInfo::initMode() {
         FLAGS_mode == "montblanc" || FLAGS_mode == "montblancm" ||
         FLAGS_mode == "minipack3ba") {
       type_ = PlatformType::PLATFORM_MONTBLANC;
-    } else if (FLAGS_mode == "icecube800bc") {
+    } else if (FLAGS_mode == "icecube800bc" || FLAGS_mode == "icecube800bcm") {
       type_ = PlatformType::PLATFORM_ICECUBE800BC;
     } else if (FLAGS_mode == "icetea800bc") {
       type_ = PlatformType::PLATFORM_ICETEA800BC;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
<img width="1016" height="368" alt="icecube_2" src="https://github.com/user-attachments/assets/e4e270b1-5d64-4efc-974c-83755c3205ee" />



# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Following the initial `icecubem` platform support implemented for `Netlake 2.0`, this PR registers and maps the new platform identification token within `PlatformProductInfo.cpp`. 

This enablement allows the `icecubem` architecture to fully leverage and reuse the existing established `qsfp_service` and `led_service` logic. By ensuring correct runtime `PlatformType` identification (resolving to the standard product token `ICECUBE800BCM`), it facilitates the flawless execution of hardware validation diagnostics (`qsfp_hw_test` and `led_service_hw_test`) without necessitating redundant or duplicated hardware-specific codebase branches.

# Key Changes
- **Platform Recognition**: Registered the `icecubem` platform signature in `PlatformProductInfo.cpp` to correctly match and parse the product string attributes retrieved from EEPROM/FRUID.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

The platform identification logic and core sanity suites have successfully passed. The platform is accurately recognized, and all functional test cases returned **PASSED**:

### 1. QSFP Service Verification (`qsfp_hw_test`)
- **Configuration Alignment**: Configured `"mode": "icecube800bcm"` in `qsfp.conf` and injected `"Product Name": "ICECUBEM"` into dummy `fruid.json`.
- **Result**: Platform identified successfully without errors; all functional optical validation sub-cases passed.
- **Execution Command**:
```bash
./bin/run_test.py qsfp --qsfp-config ./qsfp.conf \
  --filter_file=./share/hw_sanity_tests/t0_qsfp_hw_tests.conf >& t0_qsfp_hw_tests.log & 
```
### 2. LED Service Verification (`led_service_hw_test`)
- **Configuration Alignment**: Configured `"mode": "icecube800bcm"` in `led.conf` and injected `"Product Name": "ICECUBEM"` into dummy `fruid.json`.
- **Result**: Platform successfully identified; target color switching and blink sequences executed properly.
- **Execution Commands**:
  - **Verify LED Color Changes**:
    ```bash
    ./bin/led_service_hw_test --gtest_filter=LedServiceTest.checkLedColorChange \
      --led-config ./led.conf --visual_delay_sec 1 >& checkLedColorChange.log &
    ```
  - **Verify LED Blinking Matrix**:
    ```bash
    ./bin/led_service_hw_test --gtest_filter=LedServiceTest.checkLedBlinking \
      --led-config ./led.conf --visual_delay_sec 1 >& checkLedBlinking.log &
    ```

### 3. Detailed Verification Logs
The target test execution logs and structural trace outputs can be found here:
[Google Drive: icecubem_netlake2.0_before_bringup_qsfp_hw_test_and_led_service_hw_test](https://drive.google.com/drive/folders/1-KRTK0YhGfJwN0HmAsdGxwWOkDNaz775)
