### PR TITLE
[Nexthop] Hardlink staged image artifacts instead of copying

### DIFF
--- a/fboss-image/distro_cli/builder/image_builder.py
+++ b/fboss-image/distro_cli/builder/image_builder.py
@@ -8,6 +8,7 @@
 """Image Builder - handles building FBOSS images from manifests."""
 
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -213,7 +214,12 @@ class ImageBuilder:
 
             for artifact_path in artifacts_to_copy:
                 dest_path = component_dir / artifact_path.name
-                shutil.copy2(artifact_path, dest_path)
+                # Hardlink (same fs, read-only in container) to avoid duplicating
+                # multi-GB artifacts; copy if the link fails (e.g. cross-device).
+                try:
+                    os.link(artifact_path, dest_path)
+                except OSError:
+                    shutil.copy2(artifact_path, dest_path)
                 logger.info(f"Staged {component_name}: {artifact_path.name}")
 
         return Path("/image_builder/deps_staging")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Instead of copying the multi-GB artifacts, link them instead.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
