### PR TITLE
[Nexthop] [distro] Make PXE IPv6 console generic like IPv4

### DIFF
--- a/fboss-image/distro_infra/parts/autoexec.ipxe
+++ b/fboss-image/distro_infra/parts/autoexec.ipxe
@@ -15,7 +15,7 @@ set stub_name FBOSS-Distro-Image.x86_64-1.0
 
 initrd ${hbase}/pxeboot.${stub_name}.initrd
 
-kernel ${hbase}/pxeboot.${stub_name}.kernel console=ttyS4,57600n8 nomodeset rd.neednet=1 rd.kiwi.install.pxe ip=eno1:dhcp rd.kiwi.install.image=${hbase}/${stub_name}.xz rd.kiwi.install.target=/dev/nvme0n1
+kernel ${hbase}/pxeboot.${stub_name}.kernel console=ttyS0,57600n8 8250.nr_uarts=1 nomodeset rd.neednet=1 rd.kiwi.install.pxe ip=eno1:dhcp rd.kiwi.install.image=${hbase}/${stub_name}.xz rd.kiwi.install.target=/dev/nvme0n1
 
 # Download a marker file via TFTP so we can use it as a signal to remove the dnsmasq configuration
 imgfetch ${tbase}/pxeboot_complete /pxeboot_complete


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [X] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [X] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Align the PXE install kernel console parameters in `distro_infra/parts/autoexec.ipxe` with the image template (`image_builder/templates/centos-09.0/config.xml:34`):

- `console=ttyS4,57600n8` -> `console=ttyS0,57600n8`
- add `8250.nr_uarts=1`

The previous ttyS4 value was Minipack3-specific from early development. Later the distro image template was changed to be system-generic by using 8250.ns_uarts=1, but updating the IPv6 PXE trampoline was missed.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Verified console operation when booting over PXE IPv6 on a non-Minipack3 system where the old configurations is not valid.