### PR TITLE
Add integrated_transceiver_mapping.py to OSS platform mapping gen sources

### DIFF
--- a/cmake/PlatformMappingGenNoRegressionTest.cmake
+++ b/cmake/PlatformMappingGenNoRegressionTest.cmake
@@ -11,6 +11,7 @@ set(
     "fboss/lib/platform_mapping_v2/asic_vendor_config.py"
     "fboss/lib/platform_mapping_v2/gen.py"
     "fboss/lib/platform_mapping_v2/helpers.py"
+    "fboss/lib/platform_mapping_v2/integrated_transceiver_mapping.py"
     "fboss/lib/platform_mapping_v2/platform_mapping_v2.py"
     "fboss/lib/platform_mapping_v2/port_profile_mapping.py"
     "fboss/lib/platform_mapping_v2/profile_settings.py"

--- a/cmake/PlatformMappingGenUnitTest.cmake
+++ b/cmake/PlatformMappingGenUnitTest.cmake
@@ -11,6 +11,7 @@ set(
     "fboss/lib/platform_mapping_v2/asic_vendor_config.py"
     "fboss/lib/platform_mapping_v2/gen.py"
     "fboss/lib/platform_mapping_v2/helpers.py"
+    "fboss/lib/platform_mapping_v2/integrated_transceiver_mapping.py"
     "fboss/lib/platform_mapping_v2/platform_mapping_v2.py"
     "fboss/lib/platform_mapping_v2/port_profile_mapping.py"
     "fboss/lib/platform_mapping_v2/profile_settings.py"

--- a/cmake/PlatformMappingV2ConfigCli.cmake
+++ b/cmake/PlatformMappingV2ConfigCli.cmake
@@ -10,6 +10,7 @@ set(
     "fboss/lib/platform_mapping_v2/asic_vendor_config.py"
     "fboss/lib/platform_mapping_v2/gen.py"
     "fboss/lib/platform_mapping_v2/helpers.py"
+    "fboss/lib/platform_mapping_v2/integrated_transceiver_mapping.py"
     "fboss/lib/platform_mapping_v2/platform_mapping_v2.py"
     "fboss/lib/platform_mapping_v2/port_profile_mapping.py"
     "fboss/lib/platform_mapping_v2/profile_settings.py"


### PR DESCRIPTION
Summary:
The OSS build enumerates the `platform_mapping_v2` Python sources by hand in cmake (unlike the internal Buck build, which globs `srcs`). D107602208 added `fboss/lib/platform_mapping_v2/integrated_transceiver_mapping.py` and imported it from `platform_mapping_v2.py`, but did not add it to these lists. As a result the OSS-packaged `platform_mapping_gen_unit_test`, `platform_mapping_gen_no_regression_test`, and the `fboss-platform-mapping-gen` binary were missing the module and failed at import with `ModuleNotFoundError: No module named 'fboss.lib.platform_mapping_v2.integrated_transceiver_mapping'`. Internal CI stayed green because Buck globs the sources.

Add the module to all three `PLATFORM_MAPPING_PY_SRCS` lists.

Differential Revision: D110524523


