### PR TITLE
[Accton][minipack3bta] Disable UDF_HASH_FIELD_QUERY for TomahawkUltra1

### DIFF
--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -71,7 +71,6 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::IN_DISCARDS_EXCLUDES_PFC:
     case HwAsic::Feature::WARMBOOT:
     case HwAsic::Feature::SAI_CONFIGURE_SIX_TAP:
-    case HwAsic::Feature::UDF_HASH_FIELD_QUERY:
     case HwAsic::Feature::SAI_SAMPLEPACKET_TRAP:
     case HwAsic::Feature::SAI_UDF_HASH:
     case HwAsic::Feature::SEPARATE_BYTE_AND_PACKET_ACL_COUNTER:
@@ -241,6 +240,7 @@ bool TomahawkUltra1Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SAI_USER_DEFINED_TRAP:
     case HwAsic::Feature::SAI_SET_TC_WITH_USER_DEFINED_TRAP_CPU_ACTION:
     case HwAsic::Feature::ECMP_RANDOM_SPRAY_HIERARCHICAL_LEVEL:
+    case HwAsic::Feature::UDF_HASH_FIELD_QUERY:
       return false;
   }
   return false;


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR.
- [x] pre-commit run

# Summary

TU1 SAI SDK does not support querying SAI_HASH_ATTR_UDF_GROUP_LIST on ECMP hash objects. During warm boot, FBOSS calls getProgrammedHashAttr() which queries UDFGroupList to rebuild internal hash state. The SDK returns SAI_STATUS_ATTR_NOT_SUPPORTED, causing a fatal error and warm boot failure.

Move UDF_HASH_FIELD_QUERY from the supported (return true) block to the unsupported (return false) block in TomahawkUltra1Asic::isSupported() so that the UDFGroupList query is skipped during warm boot reconciliation.

Broadcom CSP: CS00012468941

# Test Plan

- Verified warm boot AgentEnsembleEmptyLinkTest.CheckInit passes on minipack3bta (BCM78920 TU1 A0) after this change.
- Confirmed with Broadcom FAE that UDF hash query is not supported on TU1.
- Platform: BCM78920 (Tomahawk Ultra 1) A0, SAI SDK 15.2.0.1 EA XGS