### PR TITLE
[Accton][minipack3bta] Re-enable SET_TC ACL action for TomahawkUltra1

### DIFF
--- a/fboss/agent/test/utils/AclTestUtils.cpp
+++ b/fboss/agent/test/utils/AclTestUtils.cpp
@@ -103,20 +103,6 @@ std::vector<cfg::AclTableActionType> genAclActionTypesConfig(
       cfg::AclTableActionType::MIRROR_INGRESS,
       cfg::AclTableActionType::MIRROR_EGRESS,
   };
-  if (asicType == cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1) {
-    // TU1 does not support the SET_TC action in the ingress ACL table.
-    std::set<cfg::AclTableActionType> remove{
-        cfg::AclTableActionType::SET_TC,
-    };
-    auto iter = actions.begin();
-    while (iter != actions.end()) {
-      if (remove.find(*iter) != remove.end()) {
-        iter = actions.erase(iter);
-      } else {
-        ++iter;
-      }
-    }
-  }
   return actions;
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR.
- [x] pre-commit run

# Summary

Earlier Broadcom SAI did not support `SAI_ACL_ENTRY_ATTR_ACTION_SET_TC` on TU1 (BCM78920). A guard was added in `genAclActionTypesConfig()` to remove SET_TC from the supported action types list for this ASIC.

The current SAI version now supports this action. Remove the TU1-specific guard so SET_TC is included in the ingress ACL table action types.

# Test Plan:

- Verified ACL table creation with SET_TC action passes on minipack3bta (BCM78920 TU1 A0).
- Confirmed SET_TC entries can be programmed in ingress ACL without error.
- Platform: BCM78920 (Tomahawk Ultra 1) A0
