### PR TITLE
[Nexthop] [fboss2] Move delete interface commands to fboss2-config lib

### DIFF
--- a/cmake/CliFboss2Test.cmake
+++ b/cmake/CliFboss2Test.cmake
@@ -70,7 +70,6 @@ add_executable(fboss2_cmd_test
   fboss/cli/fboss2/test/CmdShowProductTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigTestBase.cpp
   fboss/cli/fboss2/test/config/CmdConfigIpRouteTest.cpp
-  fboss/cli/fboss2/test/config/CmdDeleteConfigInterfaceTest.cpp
   fboss/cli/fboss2/test/CmdShowRouteDetailsTest.cpp
   fboss/cli/fboss2/test/CmdShowRouteSummaryTest.cpp
   fboss/cli/fboss2/test/CmdShowSystemPortTest.cpp


### PR DESCRIPTION
# Summary

A few `delete` command source files were registered in the wrong fboss2
library and were inconsistent between the cmake and buck builds:

- `CmdDeleteInterface`, `CmdDeleteInterfaceIpv6`, `CmdDeleteInterfaceIpv6Ndp`
  were in `fboss2-lib` (cmake) and duplicated into both `fboss2-lib`
  and `fboss2-config-lib` (buck). Their sibling `delete/tunnel/*` commands
  already live in `fboss2-config-lib`.
- `CmdDeleteProtocol`, `CmdDeleteProtocolStatic`, `CmdDeleteProtocolStaticRoute`
  were consistently in `fboss2-lib` across both builds, but are also
  config-mutating delete commands (they delete static routes/protocols
  from the running config) and belong alongside the rest of the
  `delete/config` commands in `fboss2-config-lib`.

The moves of all six delete commands (`.cpp` + `.h`) into
`fboss2-config-lib` in `cmake/CliFboss2.cmake` and `fboss/cli/fboss2/BUCK`
are already present on upstream main (they arrived via the periodic
re-sync), so the remaining delta carried by this PR is dropping the stray
`CmdDeleteConfigInterfaceTest.cpp` registration from the `fboss2_cmd_test`
(fboss2-lib) target in `cmake/CliFboss2Test.cmake` — that test is already
built in `fboss2_cmd_config_test`, and buck never registered it in the
non-config test target.

Only `commands/delete/config/*` (`CmdDeleteConfig`) remain in `fboss2-lib`,
since those are the base delete-config scaffolding rather than a specific
delete-config subcommand.

# Test Plan

Build-file only change (no code changes). `CmdDeleteConfigInterfaceTest.cpp`
is already registered and built in `fboss2_cmd_config_test`; this only
removes the duplicate registration from `fboss2_cmd_test`.
