### PR TITLE
[Nexthop][fboss2-dev] Pre-create /etc/coop with coop:switching ownership and group-writable ACLs

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/config.sh
@@ -14,6 +14,30 @@ mkdir -p /var/facebook/logs/fboss/sdk
 semanage fcontext -a -t var_log_t '/var/facebook/logs/fboss(/.*)?'
 restorecon -Rv /var/facebook/logs/fboss
 
+# Create the coop user/group and /etc/coop directory at image-build time so
+# every image ships with consistent ownership, rather than relying on
+# fboss_init.sh to set it up (with default root-owned permissions) at first
+# boot. Must run before RPM/component installs below: some packages (e.g.
+# bgpd) install files into /etc/coop but don't own the directory itself, so
+# they won't touch its permissions once it already exists.
+#
+# Individual operators (all members of "switching") run `fboss2-dev config`
+# commands that create files/subdirs directly under /etc/coop as themselves,
+# with no privilege elevation. The setgid bit makes new entries inherit the
+# switching group, but the *write* bit on newly created files/dirs still
+# depends on each operator's ambient umask (e.g. a 022 umask yields
+# non-group-writable 0755 dirs / 0644 files, locking other operators out). A
+# default ACL forces group rwx on every new file/dir regardless of umask, and
+# is itself inherited by new subdirectories, so it cascades indefinitely.
+echo "Creating coop user/group and /etc/coop directory..."
+groupadd -f -r switching
+useradd -r -g switching -s /sbin/nologin -M -d /nonexistent coop
+mkdir -p /etc/coop
+chown -R coop:switching /etc/coop
+chmod 2775 /etc/coop
+setfacl -R -m g:switching:rwx /etc/coop
+setfacl -R -d -m g:switching:rwx -m o::rx /etc/coop
+
 # Default to python 3.12, also simulate the Debian python-is-python3 package
 update-alternatives --install /usr/bin/python python /usr/bin/python3.12 1
 update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1

--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -46,7 +46,7 @@
     </preferences>
     <users>
         <user name="root" password="root" pwdformat="plain" groups="root" home="/root"/>
-        <user name="netops" password="netops" pwdformat="plain" groups="netops,wheel" home="/home/netops"/>
+        <user name="netops" password="netops" pwdformat="plain" groups="netops,wheel,switching" home="/home/netops"/>
     </users>
 
     <repository type="rpm-md" alias="CentOS9-ExtrasCommon" sourcetype="metalink">
@@ -71,6 +71,7 @@
 
     <packages type="image">
         <!-- Do not install any specific kernel package, those are done in config.sh -->
+        <package name="acl"/>
         <package name="epel-release"/>
         <package name="syslinux"/>
         <package name="gdisk"/>

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
@@ -75,7 +75,17 @@ generate_fruid() {
 
 setup_coop_configs() {
   local platform_dir="$1"
+  # /etc/coop is created with the right ownership, setgid bit, and default
+  # ACL at image-build time (config.sh); re-assert it here in case it's ever
+  # missing or drifted. The setgid bit (mode 2775) makes new entries created
+  # by individual operators (via `fboss2-dev config`) inherit the switching
+  # group; the default ACL forces group rwx on new entries regardless of the
+  # creating operator's umask.
   mkdir -p "$COOP_DIR"
+  chown coop:switching "$COOP_DIR"
+  chmod 2775 "$COOP_DIR"
+  setfacl -m g:switching:rwx "$COOP_DIR"
+  setfacl -d -m g:switching:rwx -m o::rx "$COOP_DIR"
   copy_config "${platform_dir}/agent.conf" "${COOP_DIR}/agent.conf" "agent.conf"
   copy_config "${platform_dir}/qsfp.conf" "${COOP_DIR}/qsfp.conf" "qsfp.conf"
 }

--- a/fboss/cli/fboss2/session/Git.cpp
+++ b/fboss/cli/fboss2/session/Git.cpp
@@ -59,6 +59,10 @@ class ScopedUmask {
 class ScopedFileLock {
  public:
   explicit ScopedFileLock(const std::string& lockPath) {
+    // Ensure the lock file is created group-writable so a different
+    // operator (same "switching" group) can later open it for O_RDWR,
+    // regardless of this process's ambient umask.
+    ScopedUmask scopedUmask(0002);
     fd_ = open(lockPath.c_str(), O_CREAT | O_RDWR, 0664);
     if (fd_ < 0) {
       throw std::runtime_error(


### PR DESCRIPTION
# Summary

Bake the `coop` user, `switching` group, and `/etc/coop` (setgid + default ACL) into the image at build time instead of creating it ad hoc at first boot with default root-owned permissions. Individual operators (all expected to be members of the `switching` group) write directly into `/etc/coop` via `fboss2-dev config` with no privilege elevation, so the default ACL is needed to force new files/dirs group-writable regardless of each operator's ambient umask. Also fix the Git commit lock file in the CLI to use the same umask override so it isn't created non-group-writable and lock out other operators.

# Test Plan

Booted a DUT on an image built with this change, the permissions in `/etc/coop` are correct out of the box:
```
[benoit@gold402 ~]$ touch /etc/coop/foo
[benoit@gold402 ~]$ mkdir /etc/coop/bar
[benoit@gold402 ~]$ touch /etc/coop/bar/baz
[benoit@gold402 ~]$ ls -lFha /etc/coop
total 2.0M
drwxrwsr-x+ 1 coop   switching   96 Jul  7 22:26 ./
drwxr-xr-x  1 root   root      2.9K Jul  7 22:26 ../
-rw-r--r--+ 1 root   switching 546K Jul  7 22:24 agent.conf
drwxrwsr-x+ 1 benoit switching    6 Jul  7 22:27 bar/
-rw-r--r--  1 root   root      1.4M Jul  4 10:11 bgpcpp.conf
-rw-rw-r--+ 1 benoit switching    0 Jul  7 22:26 foo
drwxrwxr-x  1 coop   switching   14 Jul  7 22:23 fsdb/
-rw-r--r--+ 1 root   switching   74 Jul  7 22:24 led.conf
-rw-r--r--+ 1 root   switching  272 Jul  7 22:24 qsfp.conf
[benoit@gold402 ~]$ ls -lFha /etc/coop/bar
total 0
drwxrwsr-x+ 1 benoit switching  6 Jul  7 22:27 ./
drwxrwsr-x+ 1 coop   switching 96 Jul  7 22:26 ../
-rw-rw-r--+ 1 benoit switching  0 Jul  7 22:27 baz
```
The CLI works out of the box:
```
[benoit@gold402 ~]$ fboss2-dev config interface eth1/1/1 description foo
Successfully configured interface(s) eth1/1/1: description="foo"
[benoit@gold402 ~]$ fboss2-dev config session commit
Config session committed successfully as 01bf7ef and config reloaded for fboss_sw_agent.
[benoit@gold402 ~]$ ls -lFha /etc/coop/.git
total 20K
drwxrwsr-x+ 1 benoit switching 164 Jul  7 22:29 ./
drwxrwsr-x+ 1 coop   switching 110 Jul  7 22:29 ../
-rw-rw-r--+ 1 benoit switching  24 Jul  7 22:29 COMMIT_EDITMSG
-rw-rw-r--+ 1 benoit switching 206 Jul  7 22:28 config
-rw-rw-r--+ 1 benoit switching  73 Jul  7 22:28 description
-rw-rw-r--+ 1 benoit switching   0 Jul  7 22:28 fboss2-commit.lock
-rw-rw-r--+ 1 benoit switching  21 Jul  7 22:28 HEAD
drwxrwsr-x+ 1 benoit switching 556 Jul  7 22:28 hooks/
-rw-rw-r--+ 1 benoit switching 341 Jul  7 22:29 index
drwxrwsr-x+ 1 benoit switching  14 Jul  7 22:28 info/
drwxrwsr-x+ 1 benoit switching  16 Jul  7 22:28 logs/
drwxrwsr-x+ 1 benoit switching  56 Jul  7 22:29 objects/
drwxrwsr-x+ 1 benoit switching  18 Jul  7 22:28 refs/
```

Multi-user CLI works out of the box as well:

```
[benoit-test@gold402 ~]$ id
uid=1002(benoit-test) gid=1002(benoit-test) groups=1002(benoit-test),10(wheel),100(users),997(switching),1000(netops)
[benoit-test@gold402 ~]$ fboss2-dev config interface eth1/1/1 description bar
Successfully configured interface(s) eth1/1/1: description="bar"
[benoit-test@gold402 ~]$ fboss2-dev config session commit
Config session committed successfully as be9052d and config reloaded for fboss_sw_agent.
```
