### PR TITLE
[Nexthop] Add LED Test Runner

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/constants.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/constants.py
@@ -37,6 +37,7 @@ SUB_CMD_SAI_AGENT = "sai_agent"
 SUB_CMD_SAI_AGENT_SCALE = "sai_agent_scale"
 SUB_CMD_SAI_INVARIANT_AGENT = "sai_invariant_agent"
 SUB_CMD_PLATFORM = "platform"
+SUB_CMD_LED = "led"
 SUB_CMD_FBOSS2_INTEGRATION = "fboss2_integration"
 SUB_CMD_BENCHMARK = "benchmark"
 

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/main.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/main.py
@@ -13,6 +13,7 @@ from fboss_test_runner.constants import (
     SUB_CMD_BCM,
     SUB_CMD_BENCHMARK,
     SUB_CMD_FBOSS2_INTEGRATION,
+    SUB_CMD_LED,
     SUB_CMD_LINK,
     SUB_CMD_PLATFORM,
     SUB_CMD_QSFP,
@@ -32,6 +33,7 @@ from fboss_test_runner.runners.benchmark_test_runner import BenchmarkTestRunner
 from fboss_test_runner.runners.fboss2_integration_test_runner import (
     Fboss2IntegrationTestRunner,
 )
+from fboss_test_runner.runners.led_test_runner import LedTestRunner
 from fboss_test_runner.runners.link_test_runner import LinkTestRunner
 from fboss_test_runner.runners.platform_services_test_runner import (
     PlatformServicesTestRunner,
@@ -79,6 +81,7 @@ def _build_parser() -> ArgumentParser:
     _register_runner(SUB_CMD_SAI, "run sai tests", SaiTestRunner)
     _register_runner(SUB_CMD_QSFP, "run qsfp tests", QsfpTestRunner)
     _register_runner(SUB_CMD_LINK, "run link tests", LinkTestRunner)
+    _register_runner(SUB_CMD_LED, "run led service tests", LedTestRunner)
     _register_runner(SUB_CMD_SAI_AGENT, "run sai agent tests", SaiAgentTestRunner)
     _register_runner(
         SUB_CMD_SAI_AGENT_SCALE, "run sai agent scale tests", SaiAgentScaleTestRunner

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/led_test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/led_test_runner.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# @noautodeps
+# (c) 2026 Nexthop Systems Inc.
+
+from argparse import Namespace
+
+from fboss_test_runner.runners.test_runner import TestRunner
+
+LED_TEST_BINARY = "/opt/fboss/bin/led_service_hw_test"
+
+
+class LedTestRunner(TestRunner):
+    """Runner for the led_service_hw_test gtest binary.
+
+    The binary reads its platform/LED config from /etc/coop/led.conf (the same
+    file led_service uses on the DUT), so no --config or --qsfp-config is
+    passed. led_service must stay running while the test runs, so it is
+    deliberately omitted from TEST_DISABLE_SERVICES. The
+    test's hardware readback path (LedManager::getLedStateFromHW, exercised by
+    testTcvrLos' slow-blink LOS checks) depends on led_service having
+    initialized the LED controllers. Stopping led_service tears that down and
+    makes the physical readback fail even though the in-process color/blink
+    logic is correct. LED tests do not warmboot.
+    """
+
+    def _get_test_binary_name(self) -> str:
+        return LED_TEST_BINARY
+
+    def _get_warmboot_check_file(self) -> str:
+        return ""
+
+    def _get_test_run_args(self, conf_file: str) -> list[str]:  # noqa: ARG002
+        return []
+
+    def run_test(self, args: Namespace) -> None:
+        # led_service_hw_test does not accept --fruid_filepath (it derives its
+        # platform from /etc/coop/led.conf), so null the default fruid path to
+        # keep the base runner from appending a gflag the binary would reject.
+        args.fruid_path = None
+
+        # LED hw tests do not support warmboot setup/warmboot verification.
+        # Force the shared runner down the coldboot-only path so it does not
+        # pass --setup-for-warmboot to led_service_hw_test.
+        args.coldboot_only = True
+
+        super().run_test(args)

--- a/fboss/oss/scripts/run_scripts/run_test.py
+++ b/fboss/oss/scripts/run_scripts/run_test.py
@@ -11,6 +11,7 @@
 # - qsfp: QSFP hardware tests
 # - link: Link tests
 # - platform: Platform service hardware tests
+# - led: LED service hardware tests
 # - sai_agent_scale: SAI agent scale tests
 # - sai_invariant_agent: SAI agent invariant config tests
 # - benchmark: Benchmark tests


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Currently, all other tests are run using the test runners, but led service test is run manually using the binary. This doesn't present any functional issues, but adding it to the test runner as a suite allows for more consistency.

Major changes:
run_test.py / fboss_test_runner: new led subcommand backed by LedTestRunner. The binary reads its platform from /etc/coop/led.conf (same file led_service uses on the DUT), so no --config is passed; fruid_path is nulled so the base runner doesn't append a --fruid_filepath gflag the binary would reject.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
