### PR TITLE
[Cisco] Reduce VerifySingleWRRAndNC runtime by flooding only competing queues.

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentOlympicQosSchedulerTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentOlympicQosSchedulerTests.cpp
@@ -156,14 +156,13 @@ void AgentOlympicQosSchedulerTest::verifySingleWRRAndSP(
   auto verify = [=, this]() {
     for (auto queue : queueIds) {
       if (queue != trafficQueueId) {
-        XLOG(DBG2) << "send traffic to WRR queue " << queue << " and SP queue "
-                   << trafficQueueId;
-        sendUdpPktsForAllQueues(
-            {queue, trafficQueueId}, utility::kOlympicQueueToDscp());
+        XLOG(DBG2) << "verify SP starvation for WRR queue " << queue
+                   << " and SP queue " << trafficQueueId;
         EXPECT_TRUE(verifySPHelper(
-            trafficQueueId, queueIds, utility::kOlympicQueueToDscp()));
-        // toggle route to stop traffic, and then send traffic to each WRR
-        // queue and SP queue
+            trafficQueueId,
+            {queue, trafficQueueId},
+            utility::kOlympicQueueToDscp()));
+        // toggle route to stop traffic before testing the next WRR queue
         XLOG(DBG2) << "unprogram routes";
         unprogramRoutes(ecmpHelper6);
         // wait for no traffic going out of port


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Speed up VerifySingleWRRAndNC test by removing duplicate traffic injection in verifySingleWRRAndSP and passing only the per-iteration WRR+SP queue pair to verifySPHelper instead of all queues.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

Manually ran AgentOlympicQosSchedulerTest.VerifySingleWRRAndNC on HW and test Passed in ~9 min (down from ~19.5 min)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
