### PR TITLE
[Nexthop] Fix MoD ingress-port check on XGS (hw logical port)

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMirrorOnDropStatelessTest.cpp
@@ -9,6 +9,7 @@
 
 #include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/FbossError.h"
+#include "fboss/agent/SwSwitch.h"
 #include "fboss/agent/TxPacket.h"
 #include "fboss/agent/packet/PktUtil.h"
 #include "fboss/agent/test/TestUtils.h"
@@ -190,7 +191,19 @@ void AgentMirrorOnDropStatelessTest::validateMirrorOnDropPacket(
   // gids (constant across injection ports), not the injection PortID.
   // TODO: ask Cisco to exposes the original ingress port for ingress MoD.
   if (!isTajoImpl) {
-    EXPECT_EQ(fields.ingressPort, static_cast<uint16_t>(injectionPortId));
+    // XGS reports the hw logical port id (low bits of the SAI port OID), not
+    // the FBOSS PortID; translate before comparing. Stats-backed, so retry —
+    // the mapping lags a warm boot.
+    auto expectedIngressPort = static_cast<uint16_t>(injectionPortId);
+    std::optional<uint32_t> hwLogicalPortId;
+    WITH_RETRIES({
+      hwLogicalPortId = getSw()->getHwLogicalPortId(injectionPortId);
+      EXPECT_EVENTUALLY_TRUE(hwLogicalPortId.has_value());
+    });
+    if (hwLogicalPortId.has_value()) {
+      expectedIngressPort = static_cast<uint16_t>(*hwLogicalPortId);
+    }
+    EXPECT_EQ(fields.ingressPort, expectedIngressPort);
   }
   EXPECT_EQ(fields.dropReasonIngress, expectedReasons.ingressDropReason);
   EXPECT_EQ(fields.dropReasonEgress, expectedReasons.egressDropReason);


### PR DESCRIPTION
## Summary

`AgentMirrorOnDropStatelessTest.DefaultRouteDrop` and `.AclDrop` fail on Tomahawk5 / XGS, on cold and warm boot. `validateMirrorOnDropPacket` asserts that the MoD packet's ingress-port equals the FBOSS logical `PortID`. On XGS the PSAMP `ingressPort` field actually carries the Broadcom **hardware logical port id** (the low bits of the SAI port object id), which is a different numbering from the FBOSS `PortID`.

The failure shows up where the injection port's `PortID` differs from its hardware logical port: when `PortID 1` maps to hw logical port `3`, the assertion sees `3 vs 1`. Platforms where the two happen to coincide for the injection port passed the old assertion only by luck, so `ingressPort == PortID` was silently fragile.

## Fix

Inside the existing `if (!isTajoImpl)` branch, translate the injection `PortID` to its hardware logical port via `SwSwitch::getHwLogicalPortId()` before comparing. The lookup is wrapped in `WITH_RETRIES` because the stats-backed mapping can lag a warm boot. Where `PortID == hwLogicalPort` this yields the same value the old check used (no behavior change); where they differ it yields the real hardware port the MoD packet carries.

The Tajo branch is unchanged — its punt header redirects the drop to a fixed recycle port, so the exported ingress-port is constant across injection ports and isn't the injection `PortID` anyway.

## Test Plan

On a Tomahawk5 / XGS platform, `AgentMirrorOnDropStatelessTest.DefaultRouteDrop` and `.AclDrop` now pass on both cold and warm boot (previously failed warm boot with `ingressPort 3 vs 1`).
