### PR TITLE
[Nexthop] Guard getNonSflowSampledInterfacePort against an unconfigured management port

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentSflowMirrorTest.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSflowMirrorTest.cpp
@@ -329,13 +329,17 @@ device:
   }
 
   PortID getNonSflowSampledInterfacePort() const {
-    return checkSameAndGetAsic()->isSupported(HwAsic::Feature::MANAGEMENT_PORT)
+    return checkSameAndGetAsic()->isSupported(
+               HwAsic::Feature::MANAGEMENT_PORT) &&
+            !masterLogicalPortIds({cfg::PortType::MANAGEMENT_PORT}).empty()
         ? masterLogicalPortIds({cfg::PortType::MANAGEMENT_PORT})[0]
         : masterLogicalInterfacePortIds()[0];
   }
 
   cfg::PortType getNonSflowSampledInterfacePortType() const {
-    return checkSameAndGetAsic()->isSupported(HwAsic::Feature::MANAGEMENT_PORT)
+    return checkSameAndGetAsic()->isSupported(
+               HwAsic::Feature::MANAGEMENT_PORT) &&
+            !masterLogicalPortIds({cfg::PortType::MANAGEMENT_PORT}).empty()
         ? cfg::PortType::MANAGEMENT_PORT
         : cfg::PortType::INTERFACE_PORT;
   }


### PR DESCRIPTION
## Summary

`getNonSflowSampledInterfacePort()` and `getNonSflowSampledInterfacePortType()` index `masterLogicalPortIds({cfg::PortType::MANAGEMENT_PORT})[0]` whenever the ASIC reports `isSupported(HwAsic::Feature::MANAGEMENT_PORT)`. An ASIC can support the management-port feature while a given platform configures no management port, leaving that vector empty — so `[0]` dereferences past the end and the test crashes (SIGSEGV) during setup.

## Fix

Guard the management-port branch with `!empty()` and fall back to `masterLogicalInterfacePortIds()[0]` — the same path already taken by platforms whose ASIC does not support a management port. On platforms that do configure a management port there is no behavior change.

## Test Plan

On a Tomahawk5 / XGS platform that supports `MANAGEMENT_PORT` but configures none, the `AgentSflowMirror*` tests previously SIGSEGV'd at setup on both cold and warm boot; with this guard they pass. Platforms that configure a management port are unaffected.
