### PR TITLE
[Accton][minipack3bam] platform: Add NETLAKE2 PVT versioned support

### DIFF
--- a/fboss/platform/configs/minipack3bam/platform_manager.json
+++ b/fboss/platform/configs/minipack3bam/platform_manager.json
@@ -170,6 +170,56 @@
           ]
         },
         "productSubVersion": 1
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "raa228228",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "raa228228",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 3
       }
     ],
     "3V3_L": [

--- a/fboss/platform/configs/minipack3bam/sensor_service.json
+++ b/fboss/platform/configs/minipack3bam/sensor_service.json
@@ -692,16 +692,6 @@
       "pmUnitName": "NETLAKE",
       "sensors": [
         {
-          "name": "COME_PU1_PVDDCR_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.82,
-            "maxAlarmVal": 1.75
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU1_PVDDCR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
           "type": 3,
@@ -712,32 +702,12 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU1_PVDDCR_SOC_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.46,
-            "maxAlarmVal": 1.36
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU1_PVDDCR_SOC_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
           "type": 3,
           "thresholds": {
             "upperCriticalVal": 100,
             "maxAlarmVal": 100
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "COME_PU37_PVDD_MISC_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.42,
-            "maxAlarmVal": 1.29
           },
           "compute": "@/1000"
         },
@@ -784,7 +754,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_U28_OUTLET_SENSOR_TEMP",
+          "name": "COME_U28_INLET_SENSOR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
@@ -794,7 +764,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_U29_INLET_SENSOR_TEMP",
+          "name": "COME_U29_OUTLET_SENSOR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
@@ -808,9 +778,7 @@
           "sysfsPath": "/run/devmap/sensors/COME_DIMM1_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 80,
-            "maxAlarmVal": 79,
-            "minAlarmVal": 10
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         },
@@ -819,9 +787,7 @@
           "sysfsPath": "/run/devmap/sensors/COME_DIMM2_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 80,
-            "maxAlarmVal": 79,
-            "minAlarmVal": 10
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         }
@@ -840,6 +806,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
               "type": 2,
@@ -860,6 +836,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -878,6 +864,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -907,6 +903,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -927,6 +933,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
               "type": 2,
@@ -945,6 +961,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -974,6 +1000,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
               "type": 2,
@@ -994,6 +1030,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -1012,6 +1058,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -1041,6 +1097,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -1059,6 +1125,16 @@
                 "maxAlarmVal": 27.81
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
@@ -1081,6 +1157,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU37_PVDD_MISC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
               "type": 2,
@@ -1094,6 +1180,297 @@
           "productionState": 1,
           "productionSubState": 3,
           "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 3
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary
Add versioned configuration support for NETLAKE2 PVT on the minipack3bam platform.
NETLAKE2 PVT boards use different voltage regulator (VR) sources depending on the hardware sub-version.
This change introduces per-version configs in both `platform_manager` and `sensor_service` to ensure proper initialization and sensor monitoring across all variants.

### Changes
**platform_manager:**
- Added a new `VersionedPmUnitConfig` entry with `productSubVersion: 3` (Renesas) for the COMESE_SLOT PM unit.
  - Registers `raa228228` VR devices (COME_VOLTAGE_MONITOR1/2), `ina230`, `tmp75` temperature sensors, and `spd5118` DIMM thermal sensors.
  - Version-to-VR mapping: productSubVersion 1 (Infineon), 2 (MPS), 3 (Renesas)

**sensor_service:**
- Introduced `versionedSensors` entries (keyed by `respinVariantIndicator`) to distinguish sensor sysfsPath differences among NETLAKE2 VR variants:
  - `respinVariantIndicator: 1` → v3.1.1 (Infineon) — uses `power2/in2/curr2` and `power3/in3/curr3` channels
  - `respinVariantIndicator: 2` → v3.1.2 (MPS) — uses `power3/in2/curr3` and `power4/in3/curr4` channels
  - `respinVariantIndicator: 3` → v3.1.3 (Renesas) — uses `power3/in3/curr3` and `power4/in4/curr4` channels

## Dependencies
- Kernel config `CONFIG_SENSORS_ISL68137` must be enabled (provides `raa228228` hwmon driver for Renesas VR).

## Test Plan
**Hardware Verification** — Verified on minipack3bam devices equipped with each NETLAKE2 variant:

0. **COME EEPROM verification** (`weutil -eeprom COME`) — Confirmed hardware identity for each DUT:
   - All boards report: Product Name `NETLAKE20`, Production State `PVT`, Production Sub-State `1`
   - `Re-Spin/Variant Indicator: 1` → v3.1.1 (Infineon)
   - `Re-Spin/Variant Indicator: 2` → v3.1.2 (MPS)
   - `Re-Spin/Variant Indicator: 3` → v3.1.3 (Renesas)
[mp3bam_weutil_come_come_3.1.1.txt](https://github.com/user-attachments/files/29960951/mp3bam_weutil_come_come_3.1.1.txt)
[mp3bam_weutil_come_come_3.1.2.txt](https://github.com/user-attachments/files/29960952/mp3bam_weutil_come_come_3.1.2.txt)
[mp3bam_weutil_come_come_3.1.3.txt](https://github.com/user-attachments/files/29960953/mp3bam_weutil_come_come_3.1.3.txt)

1. **platform_manager** started and initialized correctly on all versions.
[mp3bam_platform_manager_come_3.1.1.txt](https://github.com/user-attachments/files/29960930/mp3bam_platform_manager_come_3.1.1.txt)
[mp3bam_platform_manager_come_3.1.2.txt](https://github.com/user-attachments/files/29960932/mp3bam_platform_manager_come_3.1.2.txt)
[mp3bam_platform_manager_come_3.1.3.txt](https://github.com/user-attachments/files/29960934/mp3bam_platform_manager_come_3.1.3.txt)

2. **platform_manager_hw_test** — All test cases passed.
[mp3bam_platform_manager_hw_test_come_3.1.1.txt](https://github.com/user-attachments/files/29960935/mp3bam_platform_manager_hw_test_come_3.1.1.txt)
[mp3bam_platform_manager_hw_test_come_3.1.2.txt](https://github.com/user-attachments/files/29960936/mp3bam_platform_manager_hw_test_come_3.1.2.txt)
[mp3bam_platform_manager_hw_test_come_3.1.3.txt](https://github.com/user-attachments/files/29960939/mp3bam_platform_manager_hw_test_come_3.1.3.txt)

3. **sensor_service** correctly resolved versioned configs:
   - Resolved to `versionedPmSensors` (v3.1.1 / v3.1.2 / v3.1.3) for NETLAKE2 at `/SCM_SLOT@0/COMESE_SLOT@0`
[mp3bam_sensor_service_come_3.1.1.txt](https://github.com/user-attachments/files/29960943/mp3bam_sensor_service_come_3.1.1.txt)
[mp3bam_sensor_service_come_3.1.2.txt](https://github.com/user-attachments/files/29960944/mp3bam_sensor_service_come_3.1.2.txt)
[mp3bam_sensor_service_come_3.1.3.txt](https://github.com/user-attachments/files/29960945/mp3bam_sensor_service_come_3.1.3.txt)

4. **sensor_service_hw_test** — All test cases passed.
[mp3bam_sensor_service_hw_test_come_3.1.1.txt](https://github.com/user-attachments/files/29960948/mp3bam_sensor_service_hw_test_come_3.1.1.txt)
[mp3bam_sensor_service_hw_test_come_3.1.2.txt](https://github.com/user-attachments/files/29960949/mp3bam_sensor_service_hw_test_come_3.1.2.txt)
[mp3bam_sensor_service_hw_test_come_3.1.3.txt](https://github.com/user-attachments/files/29960950/mp3bam_sensor_service_hw_test_come_3.1.3.txt)

5. **sensor_service_client** — All test cases passed.
[mp3bam_sensor_service_client_come_3.1.1.txt](https://github.com/user-attachments/files/29960940/mp3bam_sensor_service_client_come_3.1.1.txt)
[mp3bam_sensor_service_client_come_3.1.2.txt](https://github.com/user-attachments/files/29960941/mp3bam_sensor_service_client_come_3.1.2.txt)
[mp3bam_sensor_service_client_come_3.1.3.txt](https://github.com/user-attachments/files/29960942/mp3bam_sensor_service_client_come_3.1.3.txt)