### PR TITLE
[Nexthop] Add usb0 and eth0.4088 NetworkManager profiles

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/config.sh
@@ -393,7 +393,7 @@ systemctl enable fboss_hw_agents.target
 
 # 8. Fix NetworkManager connection profile permissions
 # NM ignores profiles that are world-readable
-chmod 600 /etc/NetworkManager/system-connections/eth0.nmconnection
+chmod 600 /etc/NetworkManager/system-connections/*.nmconnection
 
 # 9. Done! Cleanup and install additional packages
 echo "Cleaning up /repos directory..."

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/etc/NetworkManager/system-connections/eth0.4088.nmconnection
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/etc/NetworkManager/system-connections/eth0.4088.nmconnection
@@ -1,0 +1,15 @@
+[connection]
+id=eth0.4088
+type=vlan
+interface-name=eth0.4088
+autoconnect=true
+
+[vlan]
+parent=eth0
+id=4088
+
+[ipv4]
+method=disabled
+
+[ipv6]
+method=link-local

--- a/fboss-image/image_builder/templates/centos-09.0/root_files/etc/NetworkManager/system-connections/usb0.nmconnection
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/etc/NetworkManager/system-connections/usb0.nmconnection
@@ -1,0 +1,12 @@
+[connection]
+id=usb0
+type=ethernet
+interface-name=usb0
+autoconnect=true
+
+[ipv4]
+method=disabled
+
+[ipv6]
+method=manual
+addresses=fe80::2/64


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add NetworkManager profiles for the two private host-to-BMC links (`usb0` and `eth0.4088`) so they are brought up automatically at boot instead of being configured at test time.

- `usb0` profile: static `fe80::2/64`, matching the BMC's `fe80::1` peer.
- `eth0.4088` profile: VLAN 4088 on `eth0`, link-local IPv6.
- `config.sh`: widen the existing `chmod 600` to cover all `*.nmconnection` profiles so the new files are loaded by NetworkManager.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

Verified end-to-end on a Minipack3 DUT, freshly PXE-prepared with the build produced by this change. No manual `nmcli` commands were run after boot.

On the resulting image:
- NetworkManager profiles present under `/etc/NetworkManager/system-connections/` with mode `0600`
- NetworkManager loaded `eth0`, `usb0`, and `eth0.4088` automatically
- `usb0` came up with static `fe80::2/64`
- `eth0.4088` was created on `eth0` with IPv6 link-local
- SSH to the BMC worked over both `usb0` and `eth0.4088`

Representative output:

```
# ls -la /etc/NetworkManager/system-connections/
-rw-------. 1 root root 156 May 21 22:29 eth0.4088.nmconnection
-rw-------. 1 root root 112 May 21 22:29 eth0.nmconnection
-rw-------. 1 root root 139 May 21 22:29 usb0.nmconnection

# nmcli connection show
NAME       UUID                                  TYPE      DEVICE
eth0       7ba00b1d-8cdd-30da-91ad-bb83ed4f7474  ethernet  eth0
usb0       4dab958c-b697-371b-8130-fdefa9c6f529  ethernet  usb0
eth0.4088  cdef5711-7598-314f-9c07-dbc2e438b482  vlan      eth0.4088
lo         f953e31a-389b-452e-b5c0-505609d57444  loopback  lo
```

```
# ip -6 addr show usb0
4: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
    inet6 fe80::2/64 scope link noprefixroute

# ip link show eth0.4088
3: eth0.4088@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> ...
```

```
# ssh root@fe80::1%usb0
root@bmc-oob:~#

# ssh root@fe80::1%eth0.4088
root@bmc-oob:~#
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
