### PR TITLE
[Celestica]montblancm: OCP change and compatible with Renesas COMe card

### DIFF
--- a/fboss/platform/configs/montblancm/platform_manager.json
+++ b/fboss/platform/configs/montblancm/platform_manager.json
@@ -170,6 +170,56 @@
           ]
         },
         "productSubVersion": 1
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMA_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMB_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 3
       }
     ],
     "MINIPACK3M_3V3_L": [

--- a/fboss/platform/configs/montblancm/sensor_service.json
+++ b/fboss/platform/configs/montblancm/sensor_service.json
@@ -1029,6 +1029,148 @@
           "productionState": 1,
           "productionSubState": 3,
           "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_MISC_VIN",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+            "type": 1,
+            "thresholds": {
+              "lowerCriticalVal": 10.7,
+              "minAlarmVal": 10.82,
+              "maxAlarmVal": 13.22,
+              "upperCriticalVal": 13.35
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.75,
+              "upperCriticalVal": 1.82
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.36,
+              "upperCriticalVal": 1.46
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 131.84
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 30.9
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 164.8
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 38.625
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDDCR_SOC_MISC_VIN",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+            "type": 1,
+            "thresholds": {
+              "lowerCriticalVal": 10.7,
+              "minAlarmVal": 10.82,
+              "maxAlarmVal": 13.22,
+              "upperCriticalVal": 13.35
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.29,
+              "upperCriticalVal": 1.42
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 24.72
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 30.9
+            },
+            "compute": "@/1000"
+          }
+          ],
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 3
         }
       ]
     },
@@ -1965,20 +2107,20 @@
           "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 15,
-            "maxAlarmVal": 10
+            "upperCriticalVal": 22,
+            "maxAlarmVal": 20
           },
-          "compute": "0.274*@/1000"
+          "compute": "0.402*@/1000"
         },
         {
           "name": "SCM_12V_COME_POWER",
           "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/power1_input",
           "type": 0,
           "thresholds": {
-            "upperCriticalVal": 200,
-            "maxAlarmVal": 180
+            "upperCriticalVal": 290,
+            "maxAlarmVal": 250
           },
-          "compute": "0.238*@/1000000"
+          "compute": "0.35*@/1000000"
         },
         {
           "name": "SCM_12V_HSC_PIN",


### PR DESCRIPTION
**Pre-submission checklist**
- [✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓] `pre-commit run`

# Summary

1.Update TPS25990 thresholds and calculation coefficients for Netlake 2.0 COMe and new SCM board in sensor_service.json.
2.Add support for Netlake 2.0 COMe V3 (Renesas solution) by updating sensor_service.json and platform_manager.json.

# Test Plan

1. run platform_manager
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/platform_manager -config_file ./configs/montblancm/platform_manager.json --enable_pkg_mgmnt=false –run_once=true --reload_kmods > platform_manager_log.txt 2>&1

2. run sensor_service
Execution Command:
1). LD_LIBRARY_PATH=./lib/ ./bin/platform_manager -enable_pkg_mgmnt=false -run_once=false --reload_kmods &
2). LD_LIBRARY_PATH=./lib/ ./bin/sensor_service -config_file ./configs/montblancm/sensor_service.json > sensor_service_log.txt 2>&1

3. run sensor_service_hw_test
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/sensor_service_hw_test -config_file ./configs/montblancm/sensor_service.json > sensor_service_hw_test_log.txt 2>&1

4. run sensor_service_client
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/sensor_service_client > sensor_service_client_log.txt 2>&1

**Result:** Platform identified successfully; all sensor tests PASSED.
1. The threshold has been updated.
<img width="1224" height="216" alt="OCP_change" src="https://github.com/user-attachments/assets/2acdba78-2ca1-41c6-bfb4-06e9b05659e6" />
Please see the detailed logs: 
[ocp_change_log.zip](https://github.com/user-attachments/files/29991672/ocp_change_log.zip)


2. The Renesas sensor readings are displayed.
   
<img width="1389" height="272" alt="Netlake20_1_3_3_renesas" src="https://github.com/user-attachments/assets/9c722973-400b-4bdb-ac21-d4031f38b5de" />
<img width="1392" height="515" alt="RAA228244_VALUE" src="https://github.com/user-attachments/assets/1172a3b2-47ea-4bce-8b61-3686cd497658" />
Please see the detailed logs:
[Renesas_support_log.zip](https://github.com/user-attachments/files/29991673/Renesas_support_log.zip)



