### PR TITLE
[Nexthop][fboss2-dev] Add lookup-class CLI to config/delete interface commands

### DIFF
--- a/cmake/CliFboss2TestIntegrationTest.cmake
+++ b/cmake/CliFboss2TestIntegrationTest.cmake
@@ -28,6 +28,7 @@ add_executable(fboss2_integration_test
   fboss/cli/fboss2/test/integration_test/ConfigPtpTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceFlowControlTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceLldpExpectedValueTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigInterfaceLookupClassTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceLoopbackModeTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceTypeTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigQosPolicyMapTest.cpp

--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
@@ -15,6 +15,7 @@
 #include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/String.h>
+#include <thrift/lib/cpp/util/EnumUtils.h>
 #include <thrift/lib/cpp2/FieldRef.h>
 #include <algorithm>
 #include <cctype>
@@ -58,6 +59,7 @@ const std::unordered_set<std::string> kKnownAttributes = [] {
       "type",
       "shutdown",
       "no-shutdown",
+      "lookup-class",
   };
   for (const auto& name : lldpAttrNames()) {
     attrs.insert(name);
@@ -74,7 +76,7 @@ const std::unordered_set<std::string> kValuelessAttributes = {
 constexpr auto kValidConfigAttrs =
     "description, mtu, ip-address, ipv6-address, profile, loopback-mode, "
     "flow-control-rx, flow-control-tx, lldp-expected-*, type, shutdown, "
-    "no-shutdown";
+    "no-shutdown, lookup-class";
 
 // The value of the `profile` attribute if the parsed attribute list configures
 // one, else nullopt. Centralized (single scan) so the InterfacesConfig
@@ -370,6 +372,129 @@ bool applyLoopbackMode(
   return changed;
 }
 
+// Port.lookupClasses drives queue-per-host (MH-NIC) neighbor classification,
+// so only the CLASS_QUEUE_PER_HOST_QUEUE_* classes are configurable here.
+// The other AclLookupClass members (CLASS_DROP, DST_CLASS_L3_LOCAL_*, ...)
+// are assigned by the agent itself; putting one of them in a port's list
+// would make LookupClassUpdater tag neighbors with an agent-reserved class.
+bool isQueuePerHostClass(cfg::AclLookupClass lookupClass) {
+  return lookupClass >= cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_0 &&
+      lookupClass <= cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_9;
+}
+
+// Human-readable list of every configurable lookup class as "<id> (<name>)".
+std::string validLookupClasses() {
+  std::vector<std::string> entries;
+  for (const auto value :
+       apache::thrift::TEnumTraits<cfg::AclLookupClass>::values) {
+    if (!isQueuePerHostClass(value)) {
+      continue;
+    }
+    entries.push_back(
+        fmt::format(
+            "{} ({})",
+            static_cast<int>(value),
+            apache::thrift::util::enumNameSafe(value)));
+  }
+  return folly::join(", ", entries);
+}
+
+// Parses a single lookup-class token: a numeric id (e.g. "10") or an enum
+// name (e.g. "CLASS_QUEUE_PER_HOST_QUEUE_0", case-insensitive). Only
+// queue-per-host classes are accepted.
+cfg::AclLookupClass parseLookupClassId(const std::string& token) {
+  cfg::AclLookupClass lookupClass{
+      cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_0};
+  int32_t classId = 0;
+  if (folly::tryTo<int32_t>(token).hasValue()) {
+    classId = folly::to<int32_t>(token);
+    lookupClass = static_cast<cfg::AclLookupClass>(classId);
+    if (apache::thrift::TEnumTraits<cfg::AclLookupClass>::findName(
+            lookupClass) == nullptr) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Invalid lookup-class value '{}'. Valid values: {}",
+              token,
+              validLookupClasses()));
+    }
+  } else {
+    std::string tokenUpper = token;
+    std::transform(
+        tokenUpper.begin(),
+        tokenUpper.end(),
+        tokenUpper.begin(),
+        [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+    if (!apache::thrift::TEnumTraits<cfg::AclLookupClass>::findValue(
+            tokenUpper, &lookupClass)) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Invalid lookup-class value '{}': must be a numeric id or class "
+              "name. Valid values: {}",
+              token,
+              validLookupClasses()));
+    }
+  }
+
+  if (!isQueuePerHostClass(lookupClass)) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Invalid lookup-class value '{}': {} is reserved for agent use. "
+            "Valid values: {}",
+            token,
+            apache::thrift::util::enumNameSafe(lookupClass),
+            validLookupClasses()));
+  }
+  return lookupClass;
+}
+
+// Parses a comma-separated list of lookup classes
+// (e.g. "10" or "10,11,12,13,14"). Rejects empty slots and duplicates.
+std::vector<cfg::AclLookupClass> parseLookupClassList(
+    const std::string& value) {
+  std::vector<std::string> parts;
+  folly::split(',', value, parts, /*ignoreEmpty=*/false);
+
+  std::vector<cfg::AclLookupClass> classes;
+  for (auto& part : parts) {
+    part = folly::trimWhitespace(part).str();
+    if (part.empty()) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Invalid lookup-class value '{}': empty id in list", value));
+    }
+    auto lookupClass = parseLookupClassId(part);
+    if (std::find(classes.begin(), classes.end(), lookupClass) !=
+        classes.end()) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Invalid lookup-class value '{}': duplicate id {}",
+              value,
+              static_cast<int32_t>(lookupClass)));
+    }
+    classes.push_back(lookupClass);
+  }
+  return classes;
+}
+
+// Parses a comma-separated list of AclLookupClass ids and applies it to all
+// ports, replacing any existing lookupClasses list. Returns true if any port
+// was modified.
+bool applyLookupClass(
+    const std::string& value,
+    const utils::InterfaceList& interfaces) {
+  auto lookupClasses = parseLookupClassList(value);
+
+  bool changed = false;
+  for (const utils::Intf& intf : interfaces) {
+    cfg::Port* port = intf.getPort();
+    if (port) {
+      port->lookupClasses() = lookupClasses;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 CmdConfigInterfaceTraits::RetType CmdConfigInterface::queryClient(
     const HostInfo& hostInfo,
     const ObjectArgType& interfaceConfig) {
@@ -483,6 +608,9 @@ CmdConfigInterfaceTraits::RetType CmdConfigInterface::queryClient(
     } else if (attr == "type") {
       changed |= applyPortType(value, effectiveInterfaces);
       results.push_back(fmt::format("type={}", value));
+    } else if (attr == "lookup-class") {
+      changed |= applyLookupClass(value, effectiveInterfaces);
+      results.push_back(fmt::format("lookup-class={}", value));
     } else if (attr == "shutdown") {
       for (const utils::Intf& intf : effectiveInterfaces) {
         cfg::Port* port = intf.getPort();

--- a/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.cpp
+++ b/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.cpp
@@ -36,7 +36,7 @@ namespace {
 // The lldp-expected-* names come from the shared lldpAttrToTag() list so the
 // config and delete commands cannot drift apart.
 const std::unordered_set<std::string> kValuelessDeleteAttributes = [] {
-  std::unordered_set<std::string> attrs = {"loopback-mode"};
+  std::unordered_set<std::string> attrs = {"loopback-mode", "lookup-class"};
   for (const auto& name : lldpAttrNames()) {
     attrs.insert(name);
   }
@@ -52,7 +52,7 @@ const std::unordered_set<std::string> kKnownDeleteAttributes = [] {
 }();
 
 const std::string kValidDeleteAttrs = fmt::format(
-    "loopback-mode, {}, ip-address, ipv6-address",
+    "loopback-mode, lookup-class, {}, ip-address, ipv6-address",
     folly::join(", ", lldpAttrNames()));
 
 } // namespace
@@ -177,7 +177,8 @@ CmdDeleteInterfaceTraits::RetType CmdDeleteInterface::queryClient(
                 folly::join(", ", missingNames)));
       }
     } else {
-      // Port-level valueless reset (loopback-mode, lldp-expected-*).
+      // Port-level valueless reset (loopback-mode, lookup-class,
+      // lldp-expected-*).
       std::vector<std::string> resetNames;
       std::vector<std::string> skippedNames;
       for (const utils::Intf& intf : interfaces) {
@@ -189,6 +190,11 @@ CmdDeleteInterfaceTraits::RetType CmdDeleteInterface::queryClient(
         if (attr == "loopback-mode") {
           if (*port->loopbackMode() != cfg::PortLoopbackMode::NONE) {
             port->loopbackMode() = cfg::PortLoopbackMode::NONE;
+            changed = true;
+          }
+        } else if (attr == "lookup-class") {
+          if (!port->lookupClasses()->empty()) {
+            port->lookupClasses()->clear();
             changed = true;
           }
         } else if (auto tag = lldpTagForAttr(attr); tag.has_value()) {

--- a/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h
+++ b/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h
@@ -25,7 +25,7 @@ namespace facebook::fboss {
  * Usage: delete interface <port-list> [<attr> [<value>] ...]
  *
  * Valueless attributes (reset to default):
- *   loopback-mode, lldp-expected-value, lldp-expected-chassis,
+ *   loopback-mode, lookup-class, lldp-expected-value, lldp-expected-chassis,
  *   lldp-expected-ttl, lldp-expected-port-desc, lldp-expected-system-name,
  *   lldp-expected-system-desc
  *
@@ -45,7 +45,7 @@ struct CmdDeleteInterfaceTraits : public WriteCommandTraits {
     cmd.add_option(
         "interface_delete_config",
         args,
-        "<port-list> [loopback-mode|lldp-expected-*|ip-address <cidr>|ipv6-address <cidr>]");
+        "<port-list> [loopback-mode|lookup-class|lldp-expected-*|ip-address <cidr>|ipv6-address <cidr>]");
   }
   using ObjectArgType = InterfaceDeleteConfig;
   using RetType = std::string;

--- a/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
@@ -1961,4 +1961,256 @@ TEST_F(
   EXPECT_EQ(config, before);
 }
 
+// ============================================================================
+// lookup-class tests
+// ============================================================================
+
+// Test valid config with port + lookup-class is parsed as an attribute pair
+TEST_F(CmdConfigInterfaceTestFixture, interfaceConfigValidPortAndLookupClass) {
+  setupTestableConfigSession();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10"});
+  EXPECT_EQ(config.getInterfaces().size(), 1);
+  EXPECT_TRUE(config.hasAttributes());
+  ASSERT_EQ(config.getAttributes().size(), 1);
+  EXPECT_EQ(config.getAttributes()[0].first, "lookup-class");
+  EXPECT_EQ(config.getAttributes()[0].second, "10");
+}
+
+// Test setting a valid lookup-class replaces lookupClasses with [id]
+TEST_F(CmdConfigInterfaceTestFixture, queryClientSetsLookupClass) {
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 lookup-class 10");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+  EXPECT_THAT(result, HasSubstr("eth1/1/1"));
+  EXPECT_THAT(result, HasSubstr("lookup-class=10"));
+
+  auto& session = ConfigSession::getInstance();
+  auto& ports = *session.getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    if (*port.name() == "eth1/1/1") {
+      ASSERT_EQ(port.lookupClasses()->size(), 1);
+      EXPECT_EQ(
+          port.lookupClasses()->at(0),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_0);
+    } else {
+      // Other ports should be untouched.
+      EXPECT_TRUE(port.lookupClasses()->empty());
+    }
+  }
+}
+
+// Test comma-separated list sets the full lookupClasses pool
+TEST_F(CmdConfigInterfaceTestFixture, queryClientSetsLookupClassList) {
+  setupTestableConfigSession(
+      cmdPrefix_, "eth1/1/1 lookup-class 10,11,12,13,14");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10,11,12,13,14"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+  EXPECT_THAT(result, HasSubstr("lookup-class=10,11,12,13,14"));
+
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    if (*port.name() == "eth1/1/1") {
+      ASSERT_EQ(port.lookupClasses()->size(), 5);
+      EXPECT_EQ(
+          port.lookupClasses()->at(0),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_0);
+      EXPECT_EQ(
+          port.lookupClasses()->at(1),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_1);
+      EXPECT_EQ(
+          port.lookupClasses()->at(2),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_2);
+      EXPECT_EQ(
+          port.lookupClasses()->at(3),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_3);
+      EXPECT_EQ(
+          port.lookupClasses()->at(4),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_4);
+    } else {
+      EXPECT_TRUE(port.lookupClasses()->empty());
+    }
+  }
+}
+
+TEST_F(
+    CmdConfigInterfaceTestFixture,
+    interfaceConfigValidPortAndLookupClassList) {
+  setupTestableConfigSession();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10,11,12"});
+  ASSERT_EQ(config.getAttributes().size(), 1);
+  EXPECT_EQ(config.getAttributes()[0].second, "10,11,12");
+}
+
+// Test that setting a new lookup-class replaces any pre-existing list
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassReplacesList) {
+  auto cmd = CmdConfigInterface();
+
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 lookup-class 10,11");
+  cmd.queryClient(
+      localhost(), InterfacesConfig({"eth1/1/1", "lookup-class", "10,11"}));
+
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 lookup-class 12,13,14");
+  cmd.queryClient(
+      localhost(), InterfacesConfig({"eth1/1/1", "lookup-class", "12,13,14"}));
+
+  auto& session = ConfigSession::getInstance();
+  auto& ports = *session.getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    if (*port.name() == "eth1/1/1") {
+      ASSERT_EQ(port.lookupClasses()->size(), 3);
+      EXPECT_EQ(
+          port.lookupClasses()->at(0),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_2);
+      EXPECT_EQ(
+          port.lookupClasses()->at(1),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_3);
+      EXPECT_EQ(
+          port.lookupClasses()->at(2),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_4);
+    }
+  }
+}
+
+// Test setting lookup-class on multiple interfaces
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassMultiPort) {
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 eth1/2/1 lookup-class 12");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "eth1/2/1", "lookup-class", "12"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+  EXPECT_THAT(result, HasSubstr("eth1/1/1"));
+  EXPECT_THAT(result, HasSubstr("eth1/2/1"));
+
+  auto& session = ConfigSession::getInstance();
+  auto& ports = *session.getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    ASSERT_EQ(port.lookupClasses()->size(), 1);
+    EXPECT_EQ(
+        port.lookupClasses()->at(0),
+        cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_2);
+  }
+}
+
+// Test a class name (case-insensitive) is accepted in place of a numeric id
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassByName) {
+  setupTestableConfigSession(
+      cmdPrefix_, "eth1/1/1 lookup-class class_queue_per_host_queue_0");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config(
+      {"eth1/1/1", "lookup-class", "class_queue_per_host_queue_0"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+
+  auto& session = ConfigSession::getInstance();
+  auto& ports = *session.getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    if (*port.name() == "eth1/1/1") {
+      ASSERT_EQ(port.lookupClasses()->size(), 1);
+      EXPECT_EQ(
+          port.lookupClasses()->at(0),
+          cfg::AclLookupClass::CLASS_QUEUE_PER_HOST_QUEUE_0);
+    }
+  }
+}
+
+// Test an agent-reserved class id (valid enum member, not queue-per-host)
+// is rejected
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsReserved) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  // 9 is CLASS_DROP, reserved for the agent's blocked-neighbor feature.
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "9"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("reserved for agent use"));
+    EXPECT_THAT(e.what(), HasSubstr("CLASS_DROP"));
+  }
+}
+
+// Test non-integer lookup-class value throws
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassNonNumeric) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "abc"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Invalid lookup-class value"));
+    EXPECT_THAT(e.what(), HasSubstr("abc"));
+  }
+}
+
+// Test an integer that is not a valid AclLookupClass enum value throws
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassInvalidEnum) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  // 999 is not a member of AclLookupClass.
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "999"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Invalid lookup-class value"));
+    EXPECT_THAT(e.what(), HasSubstr("Valid values"));
+  }
+}
+
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsDuplicate) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10,11,10"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("duplicate id"));
+  }
+}
+
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsEmptySlot) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10,,11"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("empty id"));
+  }
+}
+
+TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsBadInList) {
+  setupTestableConfigSession();
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"eth1/1/1", "lookup-class", "10,999"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "Expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("Invalid lookup-class value"));
+    EXPECT_THAT(e.what(), HasSubstr("Valid values"));
+  }
+}
+
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
@@ -2184,6 +2184,13 @@ TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsDuplicate) {
   } catch (const std::invalid_argument& e) {
     EXPECT_THAT(e.what(), HasSubstr("duplicate id"));
   }
+
+  // The list is fully parsed before any port is mutated, so a rejected list
+  // must leave lookupClasses empty — the valid prefix "10" is not applied.
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    EXPECT_TRUE(port.lookupClasses()->empty());
+  }
 }
 
 TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsEmptySlot) {
@@ -2210,6 +2217,13 @@ TEST_F(CmdConfigInterfaceTestFixture, queryClientLookupClassRejectsBadInList) {
   } catch (const std::invalid_argument& e) {
     EXPECT_THAT(e.what(), HasSubstr("Invalid lookup-class value"));
     EXPECT_THAT(e.what(), HasSubstr("Valid values"));
+  }
+
+  // The list is fully parsed before any port is mutated, so a rejected list
+  // must leave lookupClasses empty — the valid prefix "10" is not applied.
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    EXPECT_TRUE(port.lookupClasses()->empty());
   }
 }
 

--- a/fboss/cli/fboss2/test/config/CmdDeleteInterfaceIpv6NdpTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdDeleteInterfaceIpv6NdpTest.cpp
@@ -17,6 +17,7 @@
 #include "fboss/cli/fboss2/commands/delete/interface/ipv6/ndp/CmdDeleteInterfaceIpv6Ndp.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
+#include "fboss/cli/fboss2/utils/InterfaceList.h"
 
 using namespace ::testing;
 

--- a/fboss/cli/fboss2/test/config/CmdDeleteInterfaceIpv6NdpTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdDeleteInterfaceIpv6NdpTest.cpp
@@ -17,7 +17,6 @@
 #include "fboss/cli/fboss2/commands/delete/interface/ipv6/ndp/CmdDeleteInterfaceIpv6Ndp.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
-#include "fboss/cli/fboss2/utils/InterfaceList.h"
 
 using namespace ::testing;
 

--- a/fboss/cli/fboss2/test/config/CmdDeleteInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdDeleteInterfaceTest.cpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "fboss/agent/gen-cpp2/switch_config_types.h"
 #include "fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
@@ -40,6 +41,7 @@ class CmdDeleteInterfaceTestFixture : public CmdConfigTestBase {
         "state": 2,
         "speed": 100000,
         "loopbackMode": 1,
+        "lookupClasses": [10, 11],
         "expectedLLDPValues": {
           "2": "ge-0/0/0"
         }
@@ -217,6 +219,62 @@ TEST_F(CmdDeleteInterfaceTestFixture, printOutput) {
   cmd.printOutput("test output");
   std::string output = testing::internal::GetCapturedStdout();
   EXPECT_THAT(output, HasSubstr("test output"));
+}
+
+// ---------------------------------------------------------------------------
+// queryClient: clears lookupClasses back to empty
+// ---------------------------------------------------------------------------
+
+TEST_F(CmdDeleteInterfaceTestFixture, queryClientClearsLookupClasses) {
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 lookup-class");
+  auto cmd = CmdDeleteInterface();
+  auto deleteAttrs = InterfaceDeleteConfig({"eth1/1/1", "lookup-class"});
+
+  auto result = cmd.queryClient(localhost(), deleteAttrs);
+
+  EXPECT_THAT(result, HasSubstr("lookup-class"));
+  EXPECT_THAT(result, HasSubstr("eth1/1/1"));
+
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  EXPECT_TRUE(ports[0].lookupClasses()->empty());
+}
+
+// ---------------------------------------------------------------------------
+// queryClient: idempotent when port has no lookupClasses set
+// ---------------------------------------------------------------------------
+
+TEST_F(CmdDeleteInterfaceTestFixture, queryClientIdempotentNoLookupClasses) {
+  // eth1/2/1 has no lookupClasses in the initial config
+  setupTestableConfigSession(cmdPrefix_, "eth1/2/1 lookup-class");
+  auto cmd = CmdDeleteInterface();
+  auto deleteAttrs = InterfaceDeleteConfig({"eth1/2/1", "lookup-class"});
+
+  EXPECT_NO_THROW({
+    auto result = cmd.queryClient(localhost(), deleteAttrs);
+    EXPECT_THAT(result, HasSubstr("lookup-class"));
+  });
+}
+
+// ---------------------------------------------------------------------------
+// queryClient: clears lookupClasses across multiple ports
+// ---------------------------------------------------------------------------
+
+TEST_F(CmdDeleteInterfaceTestFixture, queryClientMultiplePortsLookupClasses) {
+  setupTestableConfigSession(cmdPrefix_, "eth1/1/1 eth1/2/1 lookup-class");
+  auto cmd = CmdDeleteInterface();
+  auto deleteAttrs =
+      InterfaceDeleteConfig({"eth1/1/1", "eth1/2/1", "lookup-class"});
+
+  auto result = cmd.queryClient(localhost(), deleteAttrs);
+
+  EXPECT_THAT(result, HasSubstr("lookup-class"));
+  EXPECT_THAT(result, HasSubstr("eth1/1/1"));
+  EXPECT_THAT(result, HasSubstr("eth1/2/1"));
+
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  for (const auto& port : ports) {
+    EXPECT_TRUE(port.lookupClasses()->empty());
+  }
 }
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/CmdDeleteInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdDeleteInterfaceTest.cpp
@@ -237,6 +237,9 @@ TEST_F(CmdDeleteInterfaceTestFixture, queryClientClearsLookupClasses) {
 
   auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
   EXPECT_TRUE(ports[0].lookupClasses()->empty());
+  // Clearing lookup-class must not disturb the port's other attributes.
+  EXPECT_EQ(*ports[0].loopbackMode(), cfg::PortLoopbackMode::PHY);
+  EXPECT_EQ(ports[0].expectedLLDPValues()->count(cfg::LLDPTag::PORT), 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -249,10 +252,12 @@ TEST_F(CmdDeleteInterfaceTestFixture, queryClientIdempotentNoLookupClasses) {
   auto cmd = CmdDeleteInterface();
   auto deleteAttrs = InterfaceDeleteConfig({"eth1/2/1", "lookup-class"});
 
-  EXPECT_NO_THROW({
-    auto result = cmd.queryClient(localhost(), deleteAttrs);
-    EXPECT_THAT(result, HasSubstr("lookup-class"));
-  });
+  auto result = cmd.queryClient(localhost(), deleteAttrs);
+  EXPECT_THAT(result, HasSubstr("lookup-class"));
+
+  // eth1/2/1 had no lookupClasses; delete is a no-op and leaves it empty.
+  auto& ports = *ConfigSession::getInstance().getAgentConfig().sw()->ports();
+  EXPECT_TRUE(ports[1].lookupClasses()->empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -27,6 +27,7 @@ cpp_binary(
         "ConfigInterfaceFlowControlTest.cpp",
         "ConfigInterfaceIpv6NdpTest.cpp",
         "ConfigInterfaceLldpExpectedValueTest.cpp",
+        "ConfigInterfaceLookupClassTest.cpp",
         "ConfigInterfaceLoopbackModeTest.cpp",
         "ConfigInterfaceMtuTest.cpp",
         "ConfigInterfaceProfileTest.cpp",

--- a/fboss/cli/fboss2/test/integration_test/ConfigInterfaceLookupClassTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigInterfaceLookupClassTest.cpp
@@ -27,11 +27,10 @@ using namespace facebook::fboss;
 class ConfigInterfaceLookupClassTest : public Fboss2IntegrationTest {
  protected:
   void TearDown() override {
-    // Never leave a staged lookup-class change behind for the next test.
-    discardSession();
-    // A test that failed between its set-commit and clear-commit would leave
-    // the committed class list on the port; clear it (best-effort) so the
-    // device is restored even on failure.
+    // If the test failed after committing a lookup-class change but before
+    // clearing it, best-effort restore the port so a shared DUT is left
+    // clean. (A committed change survives discardSession(), which the base
+    // SetUp already runs to clear any staged session before the next test.)
     if (!committedPort_.empty()) {
       try {
         if (!portLookupClasses(getRunningConfig(), committedPort_).empty()) {
@@ -39,11 +38,8 @@ class ConfigInterfaceLookupClassTest : public Fboss2IntegrationTest {
           commitConfig();
         }
       } catch (const std::exception&) {
-        // Restoration is best-effort; do not mask the test result.
+        // Best-effort; do not mask the test result.
       }
-      // A failed restore may itself have staged a delete; never leave a
-      // half-staged session behind for whatever runs next.
-      discardSession();
     }
     Fboss2IntegrationTest::TearDown();
   }
@@ -74,161 +70,53 @@ class ConfigInterfaceLookupClassTest : public Fboss2IntegrationTest {
     return {};
   }
 
-  // Stage lookup-class ids on the interface, commit, and wait until the
-  // running config shows exactly the expected list.
-  void setLookupClassAndVerify(
-      const std::string& ifaceName,
-      const std::string& ids,
-      const std::vector<int>& expected) {
-    auto result =
-        runCli({"config", "interface", ifaceName, "lookup-class", ids});
-    ASSERT_EQ(result.exitCode, 0)
-        << "Failed to stage lookup-class " << ids << ": " << result.stderr;
-    committedPort_ = ifaceName;
-    commitConfig();
-    auto config = waitForRunningConfig([&](const folly::dynamic& c) {
-      return portLookupClasses(c, ifaceName) == expected;
-    });
-    EXPECT_EQ(portLookupClasses(config, ifaceName), expected)
-        << "Running config does not show lookupClasses " << ids << " on "
-        << ifaceName;
-  }
-
-  // Delete lookup-class on the interface, commit, and wait until the running
-  // config shows an empty lookupClasses list.
-  void clearLookupClassAndVerify(const std::string& ifaceName) {
-    auto result = runCli({"delete", "interface", ifaceName, "lookup-class"});
-    ASSERT_EQ(result.exitCode, 0)
-        << "Failed to delete lookup-class: " << result.stderr;
-    commitConfig();
-    auto config = waitForRunningConfig([&](const folly::dynamic& c) {
-      return portLookupClasses(c, ifaceName).empty();
-    });
-    EXPECT_TRUE(portLookupClasses(config, ifaceName).empty())
-        << "Running config still shows lookupClasses on " << ifaceName;
-  }
-
-  // First eth port whose lookupClasses list is empty in the running config.
-  // The set -> clear cycle needs an empty baseline so the device is restored
-  // to its original state; scanning (instead of insisting on the first eth
-  // port) keeps the test runnable on a device that already has lookup
-  // classes on some ports. Returns an empty string when every eth port has
-  // classes configured.
-  std::string findEthPortWithEmptyLookupClasses() {
-    auto config = getRunningConfig();
-    if (!config.isObject() || !config.count("sw")) {
-      return "";
-    }
-    const auto& sw = config["sw"];
-    if (!sw.isObject() || !sw.count("ports")) {
-      return "";
-    }
-    for (const auto& port : sw["ports"]) {
-      if (!port.count("name")) {
-        continue;
-      }
-      auto name = port["name"].asString();
-      if (name.rfind("eth", 0) != 0) {
-        continue;
-      }
-      if (portLookupClasses(config, name).empty()) {
-        return name;
-      }
-    }
-    return "";
-  }
-
   // Port a test committed a lookup-class list on; cleared in TearDown if the
   // test did not restore it itself.
   std::string committedPort_;
 };
 
-// A non-numeric value is rejected before anything is staged; the running
-// config is untouched.
-TEST_F(ConfigInterfaceLookupClassTest, RejectsNonNumericLookupClass) {
-  Interface iface = findFirstEthInterface();
-  auto before = portLookupClasses(getRunningConfig(), iface.name);
-  auto result =
-      runCli({"config", "interface", iface.name, "lookup-class", "bogus"});
-  EXPECT_NE(result.exitCode, 0)
-      << "Expected non-zero exit for non-numeric lookup-class value";
-  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
-      << "Rejected command must not change the running config";
-}
-
-// An integer that is not a valid AclLookupClass enum value is rejected; the
-// running config is untouched.
-TEST_F(ConfigInterfaceLookupClassTest, RejectsInvalidLookupClassId) {
-  Interface iface = findFirstEthInterface();
-  auto before = portLookupClasses(getRunningConfig(), iface.name);
-  auto result =
-      runCli({"config", "interface", iface.name, "lookup-class", "999"});
-  EXPECT_NE(result.exitCode, 0)
-      << "Expected non-zero exit for out-of-range lookup-class id 999";
-  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
-      << "Rejected command must not change the running config";
-}
-
-// A list with an invalid id is rejected entirely; the running config is
-// untouched.
-TEST_F(ConfigInterfaceLookupClassTest, RejectsInvalidIdInList) {
-  Interface iface = findFirstEthInterface();
-  auto before = portLookupClasses(getRunningConfig(), iface.name);
-  auto result =
-      runCli({"config", "interface", iface.name, "lookup-class", "10,999"});
-  EXPECT_NE(result.exitCode, 0)
-      << "Expected non-zero exit for lookup-class list containing 999";
-  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
-      << "Rejected command must not change the running config";
-}
-
-// Duplicate ids in the list are rejected; the running config is untouched.
-TEST_F(ConfigInterfaceLookupClassTest, RejectsDuplicateIdsInList) {
-  Interface iface = findFirstEthInterface();
-  auto before = portLookupClasses(getRunningConfig(), iface.name);
-  auto result =
-      runCli({"config", "interface", iface.name, "lookup-class", "10,11,10"});
-  EXPECT_NE(result.exitCode, 0)
-      << "Expected non-zero exit for duplicate lookup-class ids";
-  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
-      << "Rejected command must not change the running config";
-}
-
-// Set a single id, commit, verify it in the running config, then delete +
-// commit and verify the running config is restored.
-TEST_F(ConfigInterfaceLookupClassTest, SetThenDeleteLookupClass) {
-  std::string ifaceName = findEthPortWithEmptyLookupClasses();
-  if (ifaceName.empty()) {
-    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
-  }
-
-  setLookupClassAndVerify(ifaceName, "10", {10});
-  clearLookupClassAndVerify(ifaceName);
-}
-
-// Set the full queue-per-host pool, commit, verify, then clear + verify.
+// Stage the full queue-per-host class list on a port, commit, verify it in
+// the agent's running config, then delete + commit and verify it is cleared.
 TEST_F(ConfigInterfaceLookupClassTest, SetThenDeleteLookupClassList) {
-  std::string ifaceName = findEthPortWithEmptyLookupClasses();
+  // Pick a port with an empty lookupClasses list so the set -> clear cycle
+  // restores the device to its original state.
+  auto config = getRunningConfig();
+  std::string ifaceName;
+  if (config.isObject() && config.count("sw") && config["sw"].count("ports")) {
+    for (const auto& port : config["sw"]["ports"]) {
+      if (port.count("name") &&
+          portLookupClasses(config, port["name"].asString()).empty()) {
+        ifaceName = port["name"].asString();
+        break;
+      }
+    }
+  }
   if (ifaceName.empty()) {
-    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
+    GTEST_SKIP() << "Every port already has lookupClasses configured";
   }
 
-  setLookupClassAndVerify(ifaceName, "10,11,12,13,14", {10, 11, 12, 13, 14});
-  clearLookupClassAndVerify(ifaceName);
-}
+  // Stage the class list, commit, and verify it in the agent running config.
+  const std::vector<int> expected = {10, 11, 12, 13, 14};
+  auto setResult = runCli(
+      {"config", "interface", ifaceName, "lookup-class", "10,11,12,13,14"});
+  ASSERT_EQ(setResult.exitCode, 0)
+      << "Failed to stage lookup-class: " << setResult.stderr;
+  committedPort_ = ifaceName;
+  commitConfig();
+  auto afterSet = waitForRunningConfig([&](const folly::dynamic& c) {
+    return portLookupClasses(c, ifaceName) == expected;
+  });
+  EXPECT_EQ(portLookupClasses(afterSet, ifaceName), expected)
+      << "Running config does not show lookupClasses on " << ifaceName;
 
-// Delete on a port whose lookupClasses list is already empty succeeds and
-// stages nothing, so the running config is unchanged. (No commit: an
-// unchanged session has nothing to commit.)
-TEST_F(ConfigInterfaceLookupClassTest, DeleteLookupClassIdempotent) {
-  std::string ifaceName = findEthPortWithEmptyLookupClasses();
-  if (ifaceName.empty()) {
-    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
-  }
-
+  // Delete, commit, and verify the list is cleared.
   auto delResult = runCli({"delete", "interface", ifaceName, "lookup-class"});
-  EXPECT_EQ(delResult.exitCode, 0)
-      << "Expected delete on empty lookupClasses to succeed: "
-      << delResult.stderr;
-  EXPECT_TRUE(portLookupClasses(getRunningConfig(), ifaceName).empty());
+  ASSERT_EQ(delResult.exitCode, 0)
+      << "Failed to delete lookup-class: " << delResult.stderr;
+  commitConfig();
+  auto afterClear = waitForRunningConfig([&](const folly::dynamic& c) {
+    return portLookupClasses(c, ifaceName).empty();
+  });
+  EXPECT_TRUE(portLookupClasses(afterClear, ifaceName).empty())
+      << "Running config still shows lookupClasses on " << ifaceName;
 }

--- a/fboss/cli/fboss2/test/integration_test/ConfigInterfaceLookupClassTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigInterfaceLookupClassTest.cpp
@@ -1,0 +1,234 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end tests for the lookup-class attribute:
+ *   'fboss2-dev config interface <name> lookup-class <id>[,<id>...]'
+ *   'fboss2-dev delete interface <name> lookup-class'
+ *
+ * Happy-path cases stage a set, commit it, and verify the port's
+ * lookupClasses list in the agent's running config, then delete + commit and
+ * verify the list is cleared again. The change is applied hitlessly (normal
+ * port-settings delta): commit reloads the agent config without restarting
+ * the agents.
+ *
+ * Requirements:
+ * - FBOSS agent must be running with a valid configuration.
+ */
+
+#include <folly/dynamic.h>
+#include <gtest/gtest.h>
+#include <exception>
+#include <string>
+#include <vector>
+#include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+
+using namespace facebook::fboss;
+
+class ConfigInterfaceLookupClassTest : public Fboss2IntegrationTest {
+ protected:
+  void TearDown() override {
+    // Never leave a staged lookup-class change behind for the next test.
+    discardSession();
+    // A test that failed between its set-commit and clear-commit would leave
+    // the committed class list on the port; clear it (best-effort) so the
+    // device is restored even on failure.
+    if (!committedPort_.empty()) {
+      try {
+        if (!portLookupClasses(getRunningConfig(), committedPort_).empty()) {
+          runCli({"delete", "interface", committedPort_, "lookup-class"});
+          commitConfig();
+        }
+      } catch (const std::exception&) {
+        // Restoration is best-effort; do not mask the test result.
+      }
+      // A failed restore may itself have staged a delete; never leave a
+      // half-staged session behind for whatever runs next.
+      discardSession();
+    }
+    Fboss2IntegrationTest::TearDown();
+  }
+
+  // lookupClasses ids for portName in a running config (as returned by
+  // getRunningConfig()); empty when the port or the field is absent.
+  static std::vector<int> portLookupClasses(
+      const folly::dynamic& config,
+      const std::string& portName) {
+    if (!config.isObject() || !config.count("sw")) {
+      return {};
+    }
+    const auto& sw = config["sw"];
+    if (!sw.isObject() || !sw.count("ports")) {
+      return {};
+    }
+    for (const auto& port : sw["ports"]) {
+      if (port.count("name") && port["name"].asString() == portName) {
+        std::vector<int> ids;
+        if (port.count("lookupClasses")) {
+          for (const auto& c : port["lookupClasses"]) {
+            ids.push_back(static_cast<int>(c.asInt()));
+          }
+        }
+        return ids;
+      }
+    }
+    return {};
+  }
+
+  // Stage lookup-class ids on the interface, commit, and wait until the
+  // running config shows exactly the expected list.
+  void setLookupClassAndVerify(
+      const std::string& ifaceName,
+      const std::string& ids,
+      const std::vector<int>& expected) {
+    auto result =
+        runCli({"config", "interface", ifaceName, "lookup-class", ids});
+    ASSERT_EQ(result.exitCode, 0)
+        << "Failed to stage lookup-class " << ids << ": " << result.stderr;
+    committedPort_ = ifaceName;
+    commitConfig();
+    auto config = waitForRunningConfig([&](const folly::dynamic& c) {
+      return portLookupClasses(c, ifaceName) == expected;
+    });
+    EXPECT_EQ(portLookupClasses(config, ifaceName), expected)
+        << "Running config does not show lookupClasses " << ids << " on "
+        << ifaceName;
+  }
+
+  // Delete lookup-class on the interface, commit, and wait until the running
+  // config shows an empty lookupClasses list.
+  void clearLookupClassAndVerify(const std::string& ifaceName) {
+    auto result = runCli({"delete", "interface", ifaceName, "lookup-class"});
+    ASSERT_EQ(result.exitCode, 0)
+        << "Failed to delete lookup-class: " << result.stderr;
+    commitConfig();
+    auto config = waitForRunningConfig([&](const folly::dynamic& c) {
+      return portLookupClasses(c, ifaceName).empty();
+    });
+    EXPECT_TRUE(portLookupClasses(config, ifaceName).empty())
+        << "Running config still shows lookupClasses on " << ifaceName;
+  }
+
+  // First eth port whose lookupClasses list is empty in the running config.
+  // The set -> clear cycle needs an empty baseline so the device is restored
+  // to its original state; scanning (instead of insisting on the first eth
+  // port) keeps the test runnable on a device that already has lookup
+  // classes on some ports. Returns an empty string when every eth port has
+  // classes configured.
+  std::string findEthPortWithEmptyLookupClasses() {
+    auto config = getRunningConfig();
+    if (!config.isObject() || !config.count("sw")) {
+      return "";
+    }
+    const auto& sw = config["sw"];
+    if (!sw.isObject() || !sw.count("ports")) {
+      return "";
+    }
+    for (const auto& port : sw["ports"]) {
+      if (!port.count("name")) {
+        continue;
+      }
+      auto name = port["name"].asString();
+      if (name.rfind("eth", 0) != 0) {
+        continue;
+      }
+      if (portLookupClasses(config, name).empty()) {
+        return name;
+      }
+    }
+    return "";
+  }
+
+  // Port a test committed a lookup-class list on; cleared in TearDown if the
+  // test did not restore it itself.
+  std::string committedPort_;
+};
+
+// A non-numeric value is rejected before anything is staged; the running
+// config is untouched.
+TEST_F(ConfigInterfaceLookupClassTest, RejectsNonNumericLookupClass) {
+  Interface iface = findFirstEthInterface();
+  auto before = portLookupClasses(getRunningConfig(), iface.name);
+  auto result =
+      runCli({"config", "interface", iface.name, "lookup-class", "bogus"});
+  EXPECT_NE(result.exitCode, 0)
+      << "Expected non-zero exit for non-numeric lookup-class value";
+  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
+      << "Rejected command must not change the running config";
+}
+
+// An integer that is not a valid AclLookupClass enum value is rejected; the
+// running config is untouched.
+TEST_F(ConfigInterfaceLookupClassTest, RejectsInvalidLookupClassId) {
+  Interface iface = findFirstEthInterface();
+  auto before = portLookupClasses(getRunningConfig(), iface.name);
+  auto result =
+      runCli({"config", "interface", iface.name, "lookup-class", "999"});
+  EXPECT_NE(result.exitCode, 0)
+      << "Expected non-zero exit for out-of-range lookup-class id 999";
+  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
+      << "Rejected command must not change the running config";
+}
+
+// A list with an invalid id is rejected entirely; the running config is
+// untouched.
+TEST_F(ConfigInterfaceLookupClassTest, RejectsInvalidIdInList) {
+  Interface iface = findFirstEthInterface();
+  auto before = portLookupClasses(getRunningConfig(), iface.name);
+  auto result =
+      runCli({"config", "interface", iface.name, "lookup-class", "10,999"});
+  EXPECT_NE(result.exitCode, 0)
+      << "Expected non-zero exit for lookup-class list containing 999";
+  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
+      << "Rejected command must not change the running config";
+}
+
+// Duplicate ids in the list are rejected; the running config is untouched.
+TEST_F(ConfigInterfaceLookupClassTest, RejectsDuplicateIdsInList) {
+  Interface iface = findFirstEthInterface();
+  auto before = portLookupClasses(getRunningConfig(), iface.name);
+  auto result =
+      runCli({"config", "interface", iface.name, "lookup-class", "10,11,10"});
+  EXPECT_NE(result.exitCode, 0)
+      << "Expected non-zero exit for duplicate lookup-class ids";
+  EXPECT_EQ(portLookupClasses(getRunningConfig(), iface.name), before)
+      << "Rejected command must not change the running config";
+}
+
+// Set a single id, commit, verify it in the running config, then delete +
+// commit and verify the running config is restored.
+TEST_F(ConfigInterfaceLookupClassTest, SetThenDeleteLookupClass) {
+  std::string ifaceName = findEthPortWithEmptyLookupClasses();
+  if (ifaceName.empty()) {
+    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
+  }
+
+  setLookupClassAndVerify(ifaceName, "10", {10});
+  clearLookupClassAndVerify(ifaceName);
+}
+
+// Set the full queue-per-host pool, commit, verify, then clear + verify.
+TEST_F(ConfigInterfaceLookupClassTest, SetThenDeleteLookupClassList) {
+  std::string ifaceName = findEthPortWithEmptyLookupClasses();
+  if (ifaceName.empty()) {
+    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
+  }
+
+  setLookupClassAndVerify(ifaceName, "10,11,12,13,14", {10, 11, 12, 13, 14});
+  clearLookupClassAndVerify(ifaceName);
+}
+
+// Delete on a port whose lookupClasses list is already empty succeeds and
+// stages nothing, so the running config is unchanged. (No commit: an
+// unchanged session has nothing to commit.)
+TEST_F(ConfigInterfaceLookupClassTest, DeleteLookupClassIdempotent) {
+  std::string ifaceName = findEthPortWithEmptyLookupClasses();
+  if (ifaceName.empty()) {
+    GTEST_SKIP() << "Every eth port already has lookupClasses configured";
+  }
+
+  auto delResult = runCli({"delete", "interface", ifaceName, "lookup-class"});
+  EXPECT_EQ(delResult.exitCode, 0)
+      << "Expected delete on empty lookupClasses to succeed: "
+      << delResult.stderr;
+  EXPECT_TRUE(portLookupClasses(getRunningConfig(), ifaceName).empty());
+}


### PR DESCRIPTION
# Summary

This PR adds a new attribute, `lookup-class`, to the existing `fboss2-dev config interface` and `delete interface` command families:

```
fboss2-dev config interface <interface-name> lookup-class <id>[,<id>...]   # replace the port's lookup-class list
fboss2-dev delete interface <interface-name> lookup-class                  # clear the port's lookup classes
```

**What is a lookup class?** Each front-panel port in the agent config carries a list field, `Port.lookupClasses` (a `list<AclLookupClass>` in `switch_config.thrift`). When this list is non-empty, the agent tags every neighbor (host) learned on that port with one of the class IDs from the list, and ACLs then match on those class IDs to steer each host's traffic into a specific egress queue. This is the mechanism behind the "queue-per-host" feature used on multi-host NICs (MH-NIC): several hosts share one physical switch port, and lookup classes let the switch give each host its own queue so one host cannot starve the others.

**How the commands behave:**

- **Set** replaces whatever list the port currently has with the given list. Real queue-per-host deployments configure the full class pool (e.g. `10,11,12,13,14`) so the agent can spread hosts across five queues; a single id is also accepted.
- **Delete** resets the list to empty (`[]`), the field's default ("no per-host classification on this port"). Deleting individual ids from the list is intentionally not supported — clear-all covers the use case; an id-list delete form can be added later if a real need appears.
- **Validation**: only the queue-per-host classes (`CLASS_QUEUE_PER_HOST_QUEUE_0..9`, ids 10-19) are accepted — the other `AclLookupClass` members (`CLASS_DROP`, `DST_CLASS_L3_LOCAL_*`, ...) are assigned by the agent itself and are rejected as reserved. Ids and enum names (case-insensitive) are both accepted. Unknown values, duplicate ids, and empty list slots (`10,,11`) are all rejected; the error lists every valid id and its name.
- **No traffic impact when applied (HITLESS)**: the change is staged in a config session and, on commit, flows through the agent's normal port-settings update path. Verified on hardware: committing reloads the config for `fboss_sw_agent` without restarting the agents or disrupting the port.

Changed files:

| File | Change |
|------|--------|
| `commands/config/interface/CmdConfigInterface.cpp` | `lookup-class` attribute; id-list parse/validate (enum check, duplicates, empty slots) + apply |
| `commands/delete/interface/CmdDeleteInterface.{h,cpp}` | `lookup-class` valueless delete attribute (clears `lookupClasses`) |
| `test/config/CmdConfigInterfaceTest.cpp` | 13 unit tests (set path: single id, lists, names, error cases) |
| `test/config/CmdDeleteInterfaceTest.cpp` | 3 unit tests (delete path: clear, idempotent, multi-port) |
| `test/integration_test/ConfigInterfaceLookupClassTest.cpp` | 7 end-to-end tests, all verifying the running config (4 rejection + 3 commit-path) |
| `cmake/CliFboss2TestIntegrationTest.cmake`, `test/integration_test/BUCK` | wire the new test file into both build systems |

# Test Plan

- Unit tests: set path (parse, apply single id and comma-separated lists, replacing an existing list, multiple ports, rejecting non-numeric / out-of-range / duplicate / empty-slot input) and delete path (clear all, idempotent when already empty, multiple ports); full `cmd_config_test` suite run to check for regressions
- Integration tests against a real switch (an NH-4010-F lab device): every test verifies the port's `lookupClasses` in the agent running config — rejected inputs assert it is unchanged; happy-path tests pick an eth port with an empty lookupClasses baseline, commit the staged change and verify the port's `lookupClasses` in the agent running config, then delete + commit and verify it clears — the device is restored to its original state; `fboss_sw_agent` / `fboss_hw_agent@0` stayed active through all commits (hitless)

Sample usage, including the committed result in the live agent config:

```
$ fboss2-dev config interface eth1/1/1 lookup-class 10,11,12,13,14
Successfully configured interface(s) eth1/1/1: lookup-class=10,11,12,13,14
$ fboss2-dev config session commit
Config session committed successfully and config reloaded for fboss_sw_agent.

# /etc/coop/agent.conf now has eth1/1/1 lookupClasses [10, 11, 12, 13, 14]

$ fboss2-dev delete interface eth1/1/1 lookup-class
Successfully reset attribute 'lookup-class' for interface(s): eth1/1/1
$ fboss2-dev config session commit

# eth1/1/1 lookupClasses now [] (back to default)

$ fboss2-dev config interface eth1/1/1 lookup-class 999
Invalid lookup-class value '999'. Valid values: 10 (CLASS_QUEUE_PER_HOST_QUEUE_0),
11 (CLASS_QUEUE_PER_HOST_QUEUE_1), ... 19 (CLASS_QUEUE_PER_HOST_QUEUE_9)

$ fboss2-dev config interface eth1/1/1 lookup-class 9
Invalid lookup-class value '9': CLASS_DROP is reserved for agent use. Valid values: 10 (CLASS_QUEUE_PER_HOST_QUEUE_0), ...

$ fboss2-dev delete interface eth1/1/1 lookup-class 11,13
Unknown delete attribute '11,13'. Valid attributes are: loopback-mode, lookup-class, ...
```
