### PR TITLE
[Nexthop] Build packet with the different smac than interface mac for AgentMacLearningAndMyStationInteractionTest

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentMacLearningTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentMacLearningTests.cpp
@@ -697,10 +697,11 @@ class AgentMacLearningAndMyStationInteractionTest
         auto vlanId =
             VlanID(*initialConfig(*getAgentEnsemble()).vlanPorts()[0].vlanID());
         auto intfMac = utility::getInterfaceMac(getProgrammedState(), vlanId);
+        auto smac = utility::MacAddressGenerator().get(intfMac.u64HBO() + 1);
         auto txPacket = utility::makeIpTxPacket(
             [sw = getSw()](uint32_t size) { return sw->allocatePacket(size); },
             vlanId,
-            intfMac,
+            smac,
             intfMac,
             folly::IPAddress("1000::1"),
             folly::IPAddress("2000::1"));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Some ASICs like leaba/25.11.4210/25.11.4210/graphene202x do not accept packet with smac same as the inport MAC by default. In AgentMacLearningAndMyStationInteractionTest, we were building the packet with smac and dmac same as interface/router MAC. As a result, this was causing packet to be discarded at ingress.

By using a different smac, we avoid such discards for such ASICs.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

Before the fix.

```
 Interface Name Input Errors Input Discards Output Errors Output Discards
------------------------------------------------------------------------------------  
 eth1/2/1       0            17              0            0
 ```
 
The test `AgentMacLearningAndMyStationInteractionTestHw.verifyInteraction(Hw|Sw)MacLearning` failed.

After the fix:

No discards.
The test `AgentMacLearningAndMyStationInteractionTestHw.verifyInteraction(Hw|Sw)MacLearning` passed.

```
Running all tests took 0:03:22.865364 between 2026-07-09 18:17:39.446182 and 2026-07-09 18:21:02.311546
[ PASSED ] cold_boot.AgentMacLearningAndMyStationInteractionTestHw.verifyInteractionHwMacLearning (92468 ms)
[ PASSED ] warm_boot.AgentMacLearningAndMyStationInteractionTestHw.verifyInteractionHwMacLearning (78841 ms)
Summary:
   PASSED : 2
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
 
 ```
Running all tests took 0:04:41.396642 between 2026-07-09 18:21:31.895733 and 2026-07-09 18:26:13.292375
[ PASSED ] cold_boot.AgentMacLearningAndMyStationInteractionTestSw.verifyInteractionSwMacLearning (92422 ms)
[ PASSED ] warm_boot.AgentMacLearningAndMyStationInteractionTestSw.verifyInteractionSwMacLearning (78816 ms)
Summary:
   PASSED : 2
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
 ```


<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
