### PR TITLE
[Nexthop][m4062nhp] Add m4062nhp management QSFP platform_manager config

### DIFF
--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -129,6 +129,15 @@
               },
               "portNumber": -1,
               "ledId": 1
+            },
+            {
+              "fpgaIpBlockConfig": {
+                "pmUnitScopedName": "MGMT_QSFP_LED",
+                "deviceName": "mgmt_qsfp_led",
+                "csrOffset": "0x9c"
+              },
+              "portNumber": 129,
+              "ledId": 1
             }
           ],
           "ledCtrlBlockConfigs": [
@@ -301,6 +310,15 @@
               "numPorts": 8,
               "ledPerPort": 2,
               "startPort": 121
+            },
+            {
+              "pmUnitScopedNamePrefix": "MGMT_QSFP_LED",
+              "deviceName": "port_led",
+              "csrOffsetCalc": "0x9c",
+              "numPorts": 1,
+              "ledPerPort": 1,
+              "lanesPerPort": 4,
+              "startPort": 129
             }
           ],
           "xcvrCtrlBlockConfigs": [
@@ -331,6 +349,13 @@
               "csrOffsetCalc": "0x0",
               "startPort": 97,
               "numPorts": 32
+            },
+            {
+              "pmUnitScopedNamePrefix": "QSFP",
+              "deviceName": "xcvr_ctrl",
+              "csrOffsetCalc": "0x0",
+              "startPort": 129,
+              "numPorts": 1
             }
           ]
         }
@@ -696,10 +721,12 @@
     "/run/devmap/xcvrs/xcvr_io_127": "/SMB_SLOT@0/[SMB1_OSFP_I2C_55]",
     "/run/devmap/xcvrs/xcvr_ctrl_127": "/SMB_SLOT@0/[OSFP_XCVR_CTRL_PORT_127]",
     "/run/devmap/xcvrs/xcvr_io_128": "/SMB_SLOT@0/[SMB1_OSFP_I2C_56]",
-    "/run/devmap/xcvrs/xcvr_ctrl_128": "/SMB_SLOT@0/[OSFP_XCVR_CTRL_PORT_128]"
+    "/run/devmap/xcvrs/xcvr_ctrl_128": "/SMB_SLOT@0/[OSFP_XCVR_CTRL_PORT_128]",
+    "/run/devmap/xcvrs/xcvr_io_129": "/SMB_SLOT@0/[SMB0_IOB_I2C_3]",
+    "/run/devmap/xcvrs/xcvr_ctrl_129": "/SMB_SLOT@0/[QSFP_XCVR_CTRL_PORT_129]"
   },
   "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
-  "numXcvrs": 128,
+  "numXcvrs": 129,
   "bspKmodsRpmName": "nexthop_bsp_kmods",
   "bspKmodsRpmVersion": "1.0.0-1",
   "nonBspKmodsToLoad": [

--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -129,15 +129,6 @@
               },
               "portNumber": -1,
               "ledId": 1
-            },
-            {
-              "fpgaIpBlockConfig": {
-                "pmUnitScopedName": "MGMT_QSFP_LED",
-                "deviceName": "mgmt_qsfp_led",
-                "csrOffset": "0x9c"
-              },
-              "portNumber": 129,
-              "ledId": 1
             }
           ],
           "ledCtrlBlockConfigs": [
@@ -204,6 +195,24 @@
               "numPorts": 8,
               "ledPerPort": 2,
               "startPort": 89
+            },
+            {
+              "pmUnitScopedNamePrefix": "MGMT_QSFP_LED",
+              "deviceName": "mgmt_qsfp_led",
+              "csrOffsetCalc": "0x9c",
+              "numPorts": 1,
+              "ledPerPort": 1,
+              "lanesPerPort": 4,
+              "startPort": 129
+            }
+          ],
+          "xcvrCtrlBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "QSFP",
+              "deviceName": "xcvr_ctrl",
+              "csrOffsetCalc": "0x0",
+              "startPort": 129,
+              "numPorts": 1
             }
           ]
         },
@@ -310,15 +319,6 @@
               "numPorts": 8,
               "ledPerPort": 2,
               "startPort": 121
-            },
-            {
-              "pmUnitScopedNamePrefix": "MGMT_QSFP_LED",
-              "deviceName": "port_led",
-              "csrOffsetCalc": "0x9c",
-              "numPorts": 1,
-              "ledPerPort": 1,
-              "lanesPerPort": 4,
-              "startPort": 129
             }
           ],
           "xcvrCtrlBlockConfigs": [
@@ -349,13 +349,6 @@
               "csrOffsetCalc": "0x0",
               "startPort": 97,
               "numPorts": 32
-            },
-            {
-              "pmUnitScopedNamePrefix": "QSFP",
-              "deviceName": "xcvr_ctrl",
-              "csrOffsetCalc": "0x0",
-              "startPort": 129,
-              "numPorts": 1
             }
           ]
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Add FPGA0 platform_manager entries for the m4062nhp management QSFP (transceiver 129): LED control block, xcvr control block, devmap symlinks, and numXcvrs bump to 129. The initial motivation for this PR was the LED service test crashing when it hit transceiver 129.

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
Running all tests took 0:00:02.071123 between 2026-07-09 18:10:22.796196 and 2026-07-09 18:10:24.867319
[ PASSED ] cold_boot.LedServiceTest.checkForceLed (146 ms)
[ PASSED ] cold_boot.LedServiceTest.checkLedColorChange (648 ms)
[ PASSED ] cold_boot.LedServiceTest.checkLedBlinking (236 ms)
[ PASSED ] cold_boot.LedServiceTest.testTcvrLos (586 ms)
[ PASSED ] cold_boot.LedServiceTest.visualForceAllLeds (93 ms)
Summary:
   PASSED : 5
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```