### PR TITLE
[Accton][minipack3bta] Disable src-mac==dst-mac drop for L3 loopback fwd test

### DIFF
--- a/fboss/oss/hw_test_configs/minipack3bta_14x400g_1x100g.agent.materialized_JSON
+++ b/fboss/oss/hw_test_configs/minipack3bta_14x400g_1x100g.agent.materialized_JSON
@@ -1103,6 +1103,7 @@ bcm_device:
         global:
             afr_enable: 0
             pktio_mode: 0
+            sai_disable_srcmacqedstmac_ctrl: 0x1
             sai_l3_byte1_udf_disable: 1
             sai_rdma_udf_disable: 1
             sai_brcm_sonic_trap_group: 1


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`AgentL3ForwardingTest.ttl255` injects a packet whose src MAC == dst MAC (the interface/router MAC) out of a port, relies on loopback to re-ingress on a front panel port, and expects it to be L3-routed to the next hop. On BCM78920 (minipack3bta) the front-port ingress drops a frame whose src MAC == dst MAC before routing, so the egress port never counts the packet and the test fails.

This sets `sai_disable_srcmacqedstmac_ctrl: 0x1` in the minipack3bta agent config `bcm_device:0:global` section to disable that drop.

# Test Plan

On-box (BCM78920 / SAI_15_4_EA_ODP): the `ttl255` packet (src == dst MAC) injected via diag `tx` with port loopback is dropped at ingress (RDBGC_0) and not routed; the same packet with a different src MAC routes and egresses correctly. With this config the drop is disabled so the loopback-based forwarding test can route.


[AgentL3ForwardingTest.ttl255_20260717_184821.zip](https://github.com/user-attachments/files/30121401/AgentL3ForwardingTest.ttl255_20260717_184821.zip)
