### PR TITLE
[Cisco] Regenerate empty FRUID cache

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/usr/local/bin/fboss_init.sh
@@ -57,8 +57,8 @@ copy_config() {
 }
 
 generate_fruid() {
-  if [[ -e $FRUID_FILE ]]; then
-    log "fruid.json already exists at $FRUID_FILE (skipping)"
+  if [[ -s $FRUID_FILE ]]; then
+    log "Non-empty fruid.json already exists at $FRUID_FILE (skipping)"
     return
   fi
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`fboss_init` currently skips FRUID generation whenever `fruid.json` exists, including when the file is empty. An empty cache is not usable and later fails JSON parsing.

Require the cached file to be non-empty before preserving it. Missing or empty files are regenerated, while existing non-empty data is left unchanged.

# Test Plan

- Ran the upstream pre-commit hooks against the PR diff.
- Exercised FRUID generation with a missing file, an empty file, and an existing non-empty file. Missing and empty files were generated, while the non-empty file remained unchanged.
- Verified that a generator failure removes its partial output.
- Built and booted the resulting FBOSS image on target hardware and confirmed that the FBOSS agent started with a non-empty FRUID cache.
