### PR TITLE
[Cisco] Add GCC Toolset libatomic linker support

### DIFF
--- a/fboss/oss/docker/Dockerfile
+++ b/fboss/oss/docker/Dockerfile
@@ -64,7 +64,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python && \
 RUN rpm -e binutils --nodeps
 
 # Set up gcc.
-RUN dnf install -y --allowerasing gcc-toolset-12 gcc-toolset-12-libasan-devel gcc-toolset-12-libubsan-devel && \
+RUN dnf install -y --allowerasing gcc-toolset-12 gcc-toolset-12-libasan-devel gcc-toolset-12-libatomic-devel gcc-toolset-12-libubsan-devel && \
     update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-12/root/usr/bin/gcc 100 \
     --slave /usr/bin/g++ g++ /opt/rh/gcc-toolset-12/root/usr/bin/g++ \
     --slave /usr/bin/c++ c++ /opt/rh/gcc-toolset-12/root/usr/bin/g++ \


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The FBOSS builder installs GCC Toolset 12 and its sanitizer development packages, but not the development package that provides the `libatomic` linker input. Builds that link with `-latomic` can therefore fail even though the runtime library is installed.

Install `gcc-toolset-12-libatomic-devel` alongside the existing GCC Toolset packages. This uses the packaged linker file without changing the FBOSS runtime image or requiring a manually created symlink.

# Test Plan

- Ran the upstream pre-commit hooks against the PR diff.
- Built the FBOSS builder image and confirmed that the package provides the `libatomic` linker input.
- Linked a 128-bit atomic test with both Clang 21 and GCC 12 using `-latomic`.
- Built the FBOSS forwarding stack with the updated builder and confirmed that the forwarding artifact was produced.
