### PR TITLE
[Cisco] Allow overriding FBOSS stack build jobs

### DIFF
--- a/fboss/oss/scripts/build_fboss_stack.sh
+++ b/fboss/oss/scripts/build_fboss_stack.sh
@@ -21,12 +21,28 @@ log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
 
-if [ "$#" -lt 1 ]; then
-  echo "Usage: $0 forwarding|platform" >&2
+usage() {
+  echo "Usage: $0 forwarding|platform [--num-jobs N]" >&2
   exit 1
+}
+
+if [ "$#" -ne 1 ] && [ "$#" -ne 3 ]; then
+  usage
 fi
 
 stack_type="$1"
+
+job_override=""
+if [ "$#" -eq 3 ]; then
+  if [ "$2" != "--num-jobs" ]; then
+    usage
+  fi
+  job_override="$3"
+  if [[ ! $job_override =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid --num-jobs value: $job_override (expected a positive integer)" >&2
+    exit 1
+  fi
+fi
 
 need_sai=0
 stack_label=""
@@ -54,14 +70,19 @@ platform)
   ;;
 esac
 
-gb_per_core=$(free -g | awk '/^Mem:/{print int($2 / '$mem_per_core')}')
-num_cores=$(nproc)
-if [ "$num_cores" -gt "$gb_per_core" ]; then
-  num_jobs="$gb_per_core"
+if [ -n "$job_override" ]; then
+  num_jobs="$job_override"
 else
-  num_jobs="$num_cores"
+  gb_per_core=$(free -g | awk '/^Mem:/{print int($2 / '$mem_per_core')}')
+  num_cores=$(nproc)
+  if [ "$num_cores" -gt "$gb_per_core" ]; then
+    num_jobs="$gb_per_core"
+  else
+    num_jobs="$num_cores"
+  fi
 fi
 export num_jobs # Export so it's available in subshells
+log "Using num_jobs=${num_jobs} for ${stack_type} stack"
 
 BUILD_TYPE="${BUILD_TYPE:-MinSizeRel}"
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`build_fboss_stack.sh` currently selects its job count from the available CPUs and memory. Builds running under an external resource limit need a way to supply a lower explicit value.

Accept an optional `--num-jobs N` argument for forwarding and platform stack builds. The existing automatic selection remains the default. Explicit values must be canonical positive decimal integers, and the selected stack and job count are logged once.

# Test Plan

- Ran the upstream pre-commit hooks against the PR diff; `shellcheck` and `shfmt` passed.
- Exercised forwarding and platform argument handling with automatic selection and valid explicit values of `1` and a larger positive integer.
- Verified rejection of `0`, `08`, a non-numeric value, a missing value, an unknown flag, a duplicate flag, and extra arguments.
- Built the FBOSS forwarding stack with `--num-jobs 2`. The log and getdeps invocation used exactly two jobs, and the forwarding artifact was produced.
