### PR TITLE
[Nexthop][Distro] drop dead KiwiTools OBS repo from centos-09.0 image config

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/config.xml
+++ b/fboss-image/image_builder/templates/centos-09.0/config.xml
@@ -65,10 +65,6 @@
         <source path="http://download.fedoraproject.org/pub/epel/9/Everything/x86_64/"/>
     </repository>
 
-    <repository type="rpm-md" alias="KiwiTools">
-        <source path="https://download.opensuse.org/repositories/Virtualization:/Appliances:/Builder/CentOS_10/"/>
-    </repository>
-
     <packages type="image">
         <!-- Do not install any specific kernel package, those are done in config.sh -->
         <package name="acl"/>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
The Virtualization:Appliances:Builder OBS project dropped its CentOS_10 directory entirely (404 on repomd.xml), breaking every platform image build. All the dracut-kiwi-* packages that repo supplied are already available in EPEL 9 (v10.3.0-1.el9), so the repo is no longer needed.

# Test Plan
We can build the distro image again after this change.
