### PR TITLE
[Nexthop][fboss2-dev] Fix config interface ip-address/ipv6-address not saving the session config

### DIFF
--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
@@ -433,6 +433,7 @@ CmdConfigInterfaceTraits::RetType CmdConfigInterface::queryClient(
               ipAddresses.end()) {
             ipAddresses.push_back(value);
           }
+          changed = true;
         }
       }
       results.push_back(fmt::format("{}={}", attr, value));

--- a/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigInterfaceTest.cpp
@@ -396,6 +396,43 @@ TEST_F(CmdConfigInterfaceTestFixture, queryClientSetsMtu) {
   }
 }
 
+// Regression test: ip-address/ipv6-address must persist the session config
+// to disk. A missing `changed = true` in the ip-address branch used to skip
+// saveConfig() while still reporting success (so `config session diff`
+// showed no changes).
+TEST_F(CmdConfigInterfaceTestFixture, queryClientIpAddressesPersistedToDisk) {
+  setupTestableConfigSession(
+      cmdPrefix_, "eth1/1/1 ip-address 10.0.0.1/31 ipv6-address cafe::1/127");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config(
+      {"eth1/1/1", "ip-address", "10.0.0.1/31", "ipv6-address", "cafe::1/127"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+  EXPECT_THAT(result, HasSubstr("ip-address=10.0.0.1/31"));
+  EXPECT_THAT(result, HasSubstr("ipv6-address=cafe::1/127"));
+
+  // Verify the addresses were added to the in-memory config
+  auto& session = ConfigSession::getInstance();
+  auto& intfs = *session.getAgentConfig().sw()->interfaces();
+  for (const auto& intf : intfs) {
+    if (*intf.name() == "eth1/1/1") {
+      EXPECT_THAT(
+          *intf.ipAddresses(),
+          UnorderedElementsAre("10.0.0.1/31", "cafe::1/127"));
+    } else {
+      EXPECT_THAT(*intf.ipAddresses(), IsEmpty());
+    }
+  }
+
+  // Verify the session config was persisted to disk (i.e. saveConfig() ran)
+  ASSERT_TRUE(std::filesystem::exists(getSessionConfigPath()));
+  auto sessionContent = readFile(getSessionConfigPath());
+  EXPECT_THAT(sessionContent, HasSubstr("10.0.0.1/31"));
+  EXPECT_THAT(sessionContent, HasSubstr("cafe::1/127"));
+}
+
 // Test setting both description and MTU
 TEST_F(CmdConfigInterfaceTestFixture, queryClientSetsBothAttributes) {
   setupTestableConfigSession(


### PR DESCRIPTION
# Summary

The ip-address/ipv6-address branch of CmdConfigInterface::queryClient() updated the in-memory config but never set `changed = true`, so saveConfig() was skipped and the session config was never written to disk — while the CLI still reported "Successfully configured". As a result `config session diff` showed no changes and commits dropped the address.

# Test Plan

Added a regression test. All the other sub commands had unit tests but this one didn't, so that's now fixed.