### PR TITLE
[Nexthop][distro] Raise root's nofile ulimit for hw tests

### DIFF
--- a/fboss-image/image_builder/templates/centos-09.0/root_files/etc/security/limits.d/99-fboss-nofile.conf
+++ b/fboss-image/image_builder/templates/centos-09.0/root_files/etc/security/limits.d/99-fboss-nofile.conf
@@ -1,0 +1,4 @@
+# Raise root's default nofile cap for hw tests that open one fd set per
+# transceiver slot (e.g. qsfp_hw_test on high-port-count platforms).
+root soft nofile 65536
+root hard nofile 65536


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`qsfp_hw_test` opens one thread per transceiver slot. On m4062nhp (129 transceiver slots) this exceeds the default `ulimit -n` of 1024, so every test case fails in `SetUp()` with "Too many open files". Lower-port platforms never hit this ceiling.

Raises root's nofile default to 65536 via a limits.d entry in the image template. No new capability granted: the hard limit was already 524288 system-wide.

# Test Plan

Applied the same `limits.conf` change on a live m4062nhp DUT and confirmed `ulimit -n` reads 65536 and the previously-failing qsfp hw tests now pass.