### PR TITLE
gcc12: add ubuntu 24.04 system-package mapping

### DIFF
--- a/build/fbcode_builder/manifests/gcc12
+++ b/build/fbcode_builder/manifests/gcc12
@@ -3,3 +3,7 @@ name = gcc12
 
 [rpms.all(distro=centos_stream,distro_vers=9)]
 gcc-toolset-12
+
+[debs.all(distro=ubuntu,distro_vers="24.04")]
+gcc-12
+g++-12


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/BGP/pull/7

The BGP OSS GitHub Actions build runs getdeps directly on a bare `ubuntu-24.04` runner (unlike the on-diff/FBOSS builds, which run inside the CentOS Stream 9 container). getdeps fails while resolving the `gcc12` dependency:

  KeyError: 'project gcc12 has no fetcher configuration or system packages matching {distro=ubuntu, distro_vers=24.04, ...}'

The `gcc12` manifest only declares CentOS Stream 9 RPMs (`gcc-toolset-12`), with no ubuntu mapping and no fetcher, so getdeps cannot satisfy it on ubuntu. Both `bgp` and `fboss` depend on `gcc12`, so this blocks the whole BGP getdeps build.

Add a `[debs]` mapping for ubuntu 24.04 (`gcc-12`, `g++-12`, both available in noble's universe repo). This is purely additive — the CentOS path is unchanged — and fixes gcc12 resolution for every ubuntu getdeps consumer.

Differential Revision: D111946117


