### PR TITLE
[Nexthop][fboss2-dev] Create VLANs on the fly in "config vlan" and "switchport access vlan"

### DIFF
--- a/cmake/CliFboss2TestConfig.cmake
+++ b/cmake/CliFboss2TestConfig.cmake
@@ -33,6 +33,7 @@ add_executable(fboss2_cmd_config_test
   fboss/cli/fboss2/test/config/CmdConfigVlanManagerTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigVlanPortTaggingModeTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigVlanStaticMacTest.cpp
+  fboss/cli/fboss2/test/config/CmdConfigVlanTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteAclRuleTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteConfigInterfaceTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteInterfaceIpv6NdpTest.cpp

--- a/cmake/CliFboss2TestConfig.cmake
+++ b/cmake/CliFboss2TestConfig.cmake
@@ -37,6 +37,7 @@ add_executable(fboss2_cmd_config_test
   fboss/cli/fboss2/test/config/CmdConfigVlanManagerTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigVlanPortTaggingModeTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigVlanStaticMacTest.cpp
+  fboss/cli/fboss2/test/config/CmdConfigVlanTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteAclRuleTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteArpTest.cpp
   fboss/cli/fboss2/test/config/CmdDeleteConfigInterfaceTest.cpp

--- a/fboss/cli/fboss2/commands/config/interface/switchport/access/vlan/CmdConfigInterfaceSwitchportAccessVlan.cpp
+++ b/fboss/cli/fboss2/commands/config/interface/switchport/access/vlan/CmdConfigInterfaceSwitchportAccessVlan.cpp
@@ -14,6 +14,8 @@
 
 #include "fboss/cli/fboss2/CmdHandler.cpp"
 
+#include "fboss/agent/types.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 
 namespace facebook::fboss {
@@ -31,20 +33,11 @@ CmdConfigInterfaceSwitchportAccessVlan::queryClient(
   // Extract the VLAN ID (validation already done in VlanIdValue constructor)
   int32_t vlanId = vlanIdValue.getVlanId();
 
-  // Validate that the VLAN exists before modifying config
+  // Create the VLAN (and its barebone interface) on the fly if it doesn't
+  // exist yet.
   auto& config = ConfigSession::getInstance().getAgentConfig();
-  bool vlanExists = false;
-  for (const auto& vlan : *config.sw()->vlans()) {
-    if (*vlan.id() == vlanId) {
-      vlanExists = true;
-      break;
-    }
-  }
-  if (!vlanExists) {
-    throw std::invalid_argument(
-        "VLAN " + std::to_string(vlanId) +
-        " does not exist. Create the VLAN first before assigning ports to it.");
-  }
+  bool vlanCreated =
+      VlanManager::createVlan(*config.sw(), VlanID(vlanId)).first;
 
   // Collect the logical port IDs we need to update
   std::unordered_set<int32_t> portIds;
@@ -74,6 +67,9 @@ CmdConfigInterfaceSwitchportAccessVlan::queryClient(
   std::string interfaceList = folly::join(", ", interfaces.getNames());
   std::string message = "Successfully set access VLAN for interface(s) " +
       interfaceList + " to " + std::to_string(vlanId);
+  if (vlanCreated) {
+    message += " (VLAN " + std::to_string(vlanId) + " created)";
+  }
 
   return message;
 }

--- a/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.cpp
+++ b/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.cpp
@@ -12,7 +12,35 @@
 
 #include "fboss/cli/fboss2/CmdHandler.cpp"
 
+#include <fmt/format.h>
+#include <iostream>
+#include "fboss/agent/types.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+
 namespace facebook::fboss {
+
+CmdConfigVlanTraits::RetType CmdConfigVlan::queryClient(
+    const HostInfo& /* hostInfo */,
+    const ObjectArgType& vlanIdArg) {
+  auto& session = ConfigSession::getInstance();
+  auto& swConfig = *session.getAgentConfig().sw();
+  VlanID vlanId(vlanIdArg.getVlanId());
+
+  bool created = VlanManager::createVlan(swConfig, vlanId).first;
+  if (!created) {
+    return fmt::format("VLAN {} already exists", static_cast<uint16_t>(vlanId));
+  }
+
+  session.saveConfig();
+
+  return fmt::format(
+      "Successfully created VLAN {}", static_cast<uint16_t>(vlanId));
+}
+
+void CmdConfigVlan::printOutput(const RetType& logMsg) {
+  std::cout << logMsg << std::endl;
+}
 
 // Explicit template instantiation
 template void CmdHandler<CmdConfigVlan, CmdConfigVlanTraits>::run();

--- a/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.h
+++ b/fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.h
@@ -31,14 +31,9 @@ class CmdConfigVlan : public CmdHandler<CmdConfigVlan, CmdConfigVlanTraits> {
   using ObjectArgType = CmdConfigVlanTraits::ObjectArgType;
   using RetType = CmdConfigVlanTraits::RetType;
 
-  RetType queryClient(
-      const HostInfo& /* hostInfo */,
-      const ObjectArgType& /* vlanId */) {
-    throw std::runtime_error(
-        "Incomplete command, please use one of the subcommands");
-  }
+  RetType queryClient(const HostInfo& hostInfo, const ObjectArgType& vlanId);
 
-  void printOutput(const RetType& /* model */) {}
+  void printOutput(const RetType& logMsg);
 };
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/config/BUCK
+++ b/fboss/cli/fboss2/test/config/BUCK
@@ -36,6 +36,7 @@ cpp_unittest(
         "CmdConfigVlanManagerTest.cpp",
         "CmdConfigVlanPortTaggingModeTest.cpp",
         "CmdConfigVlanStaticMacTest.cpp",
+        "CmdConfigVlanTest.cpp",
         "CmdDeleteAclRuleTest.cpp",
         "CmdDeleteConfigInterfaceTest.cpp",
         "CmdDeleteInterfaceIpv6NdpTest.cpp",

--- a/fboss/cli/fboss2/test/config/BUCK
+++ b/fboss/cli/fboss2/test/config/BUCK
@@ -39,6 +39,7 @@ cpp_unittest(
         "CmdConfigVlanManagerTest.cpp",
         "CmdConfigVlanPortTaggingModeTest.cpp",
         "CmdConfigVlanStaticMacTest.cpp",
+        "CmdConfigVlanTest.cpp",
         "CmdDeleteAclRuleTest.cpp",
         "CmdDeleteArpTest.cpp",
         "CmdDeleteConfigInterfaceTest.cpp",

--- a/fboss/cli/fboss2/test/config/CmdConfigInterfaceSwitchportAccessVlanTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigInterfaceSwitchportAccessVlanTest.cpp
@@ -4,10 +4,13 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 
+#include "fboss/agent/types.h"
 #include "fboss/cli/fboss2/commands/config/interface/switchport/access/vlan/CmdConfigInterfaceSwitchportAccessVlan.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/utils/InterfaceList.h"
 
@@ -204,24 +207,31 @@ TEST_F(
 
 TEST_F(
     CmdConfigInterfaceSwitchportAccessVlanTestFixture,
-    queryClientThrowsWhenVlanDoesNotExist) {
+    queryClientCreatesVlanWhenMissing) {
   auto cmd = CmdConfigInterfaceSwitchportAccessVlan();
   utils::InterfaceList interfaces({"eth1/1/1"});
   VlanIdValue vlanId({"4094"});
 
-  try {
-    cmd.queryClient(localhost(), interfaces, vlanId);
-    FAIL() << "Expected std::invalid_argument";
-  } catch (const std::invalid_argument& e) {
-    std::string msg = e.what();
-    EXPECT_THAT(msg, HasSubstr("VLAN 4094"));
-    EXPECT_THAT(msg, HasSubstr("does not exist"));
-  }
+  auto result = cmd.queryClient(localhost(), interfaces, vlanId);
+
+  EXPECT_THAT(result, HasSubstr("Successfully set access VLAN"));
+  EXPECT_THAT(result, HasSubstr("(VLAN 4094 created)"));
 
   auto& config = ConfigSession::getInstance().getAgentConfig();
-  for (const auto& port : *config.sw()->ports()) {
+  auto& swConfig = *config.sw();
+
+  // The VLAN and its barebone interface were created
+  EXPECT_NE(VlanManager::findVlan(swConfig, VlanID(4094)), nullptr);
+  bool intfFound = std::any_of(
+      swConfig.interfaces()->cbegin(),
+      swConfig.interfaces()->cend(),
+      [](const auto& intf) { return *intf.vlanID() == 4094; });
+  EXPECT_TRUE(intfFound);
+
+  // And the port was moved to it
+  for (const auto& port : *swConfig.ports()) {
     if (*port.name() == "eth1/1/1") {
-      EXPECT_EQ(*port.ingressVlan(), 1);
+      EXPECT_EQ(*port.ingressVlan(), 4094);
     }
   }
 }

--- a/fboss/cli/fboss2/test/config/CmdConfigVlanTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigVlanTest.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <filesystem>
+#include <string>
+
+#include "fboss/agent/gen-cpp2/switch_config_types.h"
+#include "fboss/agent/types.h"
+#include "fboss/cli/fboss2/commands/config/vlan/CmdConfigVlan.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+class CmdConfigVlanTestFixture : public CmdConfigTestBase {
+ public:
+  CmdConfigVlanTestFixture()
+      : CmdConfigTestBase(
+            "fboss2_config_vlan_test_%%%%-%%%%-%%%%-%%%%",
+            R"({
+  "sw": {
+    "vlans": [
+      {
+        "id": 100,
+        "name": "vlan100"
+      }
+    ],
+    "interfaces": [
+      {"intfID": 100, "vlanID": 100, "routerID": 0, "type": 1, "mtu": 9412}
+    ]
+  }
+})") {}
+
+ protected:
+  const std::string cmdPrefix_ = "config vlan";
+};
+
+// "config vlan <id>" with a new id creates the VLAN and its barebone
+// interface, and persists the session config to disk.
+TEST_F(CmdConfigVlanTestFixture, queryClientCreatesVlan) {
+  setupTestableConfigSession(cmdPrefix_, "4005");
+  auto cmd = CmdConfigVlan();
+  VlanId vlanId({"4005"});
+
+  auto result = cmd.queryClient(localhost(), vlanId);
+
+  EXPECT_THAT(result, HasSubstr("Successfully created VLAN 4005"));
+
+  auto& swConfig = *ConfigSession::getInstance().getAgentConfig().sw();
+  EXPECT_NE(VlanManager::findVlan(swConfig, VlanID(4005)), nullptr);
+  bool intfFound = std::any_of(
+      swConfig.interfaces()->cbegin(),
+      swConfig.interfaces()->cend(),
+      [](const auto& intf) { return *intf.vlanID() == 4005; });
+  EXPECT_TRUE(intfFound);
+
+  // The change must be persisted to the on-disk session config.
+  ASSERT_TRUE(std::filesystem::exists(getSessionConfigPath()));
+  auto sessionContent = readFile(getSessionConfigPath());
+  EXPECT_THAT(sessionContent, HasSubstr("Vlan4005"));
+  EXPECT_THAT(sessionContent, HasSubstr("fboss4005"));
+}
+
+// "config vlan <id>" with an existing id reports it and doesn't duplicate.
+TEST_F(CmdConfigVlanTestFixture, queryClientVlanAlreadyExists) {
+  setupTestableConfigSession(cmdPrefix_, "100");
+  auto cmd = CmdConfigVlan();
+  VlanId vlanId({"100"});
+
+  auto result = cmd.queryClient(localhost(), vlanId);
+
+  EXPECT_THAT(result, HasSubstr("VLAN 100 already exists"));
+
+  auto& swConfig = *ConfigSession::getInstance().getAgentConfig().sw();
+  int count = 0;
+  for (const auto& vlan : *swConfig.vlans()) {
+    if (*vlan.id() == 100) {
+      ++count;
+    }
+  }
+  EXPECT_EQ(count, 1);
+}
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/ConfigVlanCreateTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigVlanCreateTest.cpp
@@ -27,6 +27,21 @@
  *    - Delete on a VLAN that doesn't exist returns "does not exist"
  *    - No VLAN is auto-created for a delete operation
  *
+ * 4. CreateVlanCommand
+ *    - "config vlan <id>" with no subcommand creates the VLAN in the session
+ *    - Re-running the command in the same session reports "already exists"
+ *    - Commit succeeds (VlanManager also created the barebone interface)
+ *
+ * 5. CreateVlanAlreadyExists
+ *    - "config vlan <id>" on a VLAN present in the running config reports
+ *      "already exists" and does not create anything
+ *
+ * 6. SwitchportAccessVlanAutoCreates
+ *    - "config interface <port> switchport access vlan <id>" on a missing
+ *      VLAN auto-creates it and appends "(VLAN <id> created)" to the output
+ *    - Second run in the same session does not print the created suffix
+ *    - Session is cleared without committing (the DUT is left untouched)
+ *
  * Requirements:
  * - FBOSS agent must be running with a valid configuration
  * - The test must be run as root (or with appropriate permissions)
@@ -73,6 +88,12 @@ class ConfigVlanCreateTest : public Fboss2IntegrationTest {
   static constexpr int kExistingVlanId = 2001;
   // A VLAN ID used to test auto-create; cleaned up before each run
   static constexpr int kNewVlanId = 3999;
+  // VLAN ID for the "config vlan <id>" create test (committed, then removed
+  // at the start of the next run by cleanupVlanFromConfig()).
+  static constexpr int kCreateVlanId = 3998;
+  // VLAN ID for the switchport auto-create test (session only, never
+  // committed).
+  static constexpr int kAccessVlanId = 3997;
   static constexpr const char* kTestMac = "02:00:00:00:27:01";
 
   // Interface name cached by SetUpTestSuite — valid for the lifetime of
@@ -314,4 +335,133 @@ TEST_F(ConfigVlanCreateTest, DeleteOnNonExistentVlanIsIdempotent) {
   EXPECT_THAT(
       result.stdout, ::testing::Not(::testing::HasSubstr("Created VLAN")));
   XLOG(INFO) << "  Output: " << result.stdout << " TEST PASSED";
+}
+
+TEST_F(ConfigVlanCreateTest, CreateVlanCommand) {
+  if (existingVlanId_ < 0) {
+    GTEST_SKIP()
+        << "No L2 VLAN with port members on this DUT (pure routed mode)";
+  }
+
+  // Step 0: Ensure the test VLAN is absent (idempotency across runs).
+  XLOG(INFO) << "[Step 0] Ensuring VLAN " << kCreateVlanId
+             << " is absent from running config...";
+  cleanupVlanFromConfig(kCreateVlanId);
+
+  // Step 1: "config vlan <id>" with no subcommand creates the VLAN.
+  XLOG(INFO) << "[Step 1] Creating VLAN " << kCreateVlanId
+             << " via 'config vlan'...";
+  auto result = runCli({"config", "vlan", std::to_string(kCreateVlanId)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "Successfully created VLAN " + std::to_string(kCreateVlanId)));
+  XLOG(INFO) << "  Output: " << result.stdout;
+
+  // Step 2: Re-running in the same session reports "already exists".
+  XLOG(INFO) << "[Step 2] Re-running create (already exists expected)...";
+  auto result2 = runCli({"config", "vlan", std::to_string(kCreateVlanId)});
+  ASSERT_EQ(result2.exitCode, 0) << "Command failed: " << result2.stderr;
+  EXPECT_THAT(
+      result2.stdout,
+      ::testing::HasSubstr(
+          "VLAN " + std::to_string(kCreateVlanId) + " already exists"));
+  EXPECT_THAT(
+      result2.stdout,
+      ::testing::Not(::testing::HasSubstr("Successfully created")));
+  XLOG(INFO) << "  Output: " << result2.stdout;
+
+  // Step 3: Commit — VlanManager created both the VLAN and its barebone
+  // interface, so the agent accepts the commit.
+  XLOG(INFO) << "[Step 3] Committing session...";
+  commitConfig();
+  XLOG(INFO) << "  Config committed.";
+
+  // Step 4: A new session on the committed config also reports the VLAN as
+  // existing (the create actually persisted).
+  XLOG(INFO) << "[Step 4] Verifying VLAN persisted after commit...";
+  auto result3 = runCli({"config", "vlan", std::to_string(kCreateVlanId)});
+  ASSERT_EQ(result3.exitCode, 0) << "Command failed: " << result3.stderr;
+  EXPECT_THAT(result3.stdout, ::testing::HasSubstr("already exists"));
+  runCli({"config", "session", "clear"});
+  XLOG(INFO) << "  TEST PASSED (VLAN " << kCreateVlanId
+             << " remains; removed by cleanup on next run)";
+}
+
+TEST_F(ConfigVlanCreateTest, CreateVlanAlreadyExists) {
+  if (existingVlanId_ < 0) {
+    GTEST_SKIP()
+        << "No L2 VLAN with port members on this DUT (pure routed mode)";
+  }
+  XLOG(INFO) << "Testing 'config vlan' on existing VLAN " << existingVlanId_
+             << "...";
+  auto result = runCli({"config", "vlan", std::to_string(existingVlanId_)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "VLAN " + std::to_string(existingVlanId_) + " already exists"));
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::Not(::testing::HasSubstr("Successfully created")));
+  // Nothing was modified; discard the session.
+  runCli({"config", "session", "clear"});
+  XLOG(INFO) << "  Output: " << result.stdout << " TEST PASSED";
+}
+
+TEST_F(ConfigVlanCreateTest, SwitchportAccessVlanAutoCreates) {
+  if (existingVlanId_ < 0) {
+    GTEST_SKIP()
+        << "No L2 VLAN with port members on this DUT (pure routed mode)";
+  }
+  XLOG(INFO) << "[Step 1] Using port=" << existingVlanPort_;
+
+  // Step 0: Start from a clean session so kAccessVlanId isn't left over from
+  // a previous (aborted) run. This test never commits, so the running config
+  // is untouched.
+  runCli({"config", "session", "clear"});
+
+  // Step 2: Assign the port to a non-existent VLAN — it gets auto-created.
+  XLOG(INFO) << "[Step 2] switchport access vlan " << kAccessVlanId
+             << " (auto-create expected)...";
+  auto result = runCli(
+      {"config",
+       "interface",
+       existingVlanPort_,
+       "switchport",
+       "access",
+       "vlan",
+       std::to_string(kAccessVlanId)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout, ::testing::HasSubstr("Successfully set access VLAN"));
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "(VLAN " + std::to_string(kAccessVlanId) + " created)"));
+  XLOG(INFO) << "  Output: " << result.stdout;
+
+  // Step 3: Second run in the same session — VLAN now exists, no suffix.
+  XLOG(INFO) << "[Step 3] Second run (no creation suffix expected)...";
+  auto result2 = runCli(
+      {"config",
+       "interface",
+       existingVlanPort_,
+       "switchport",
+       "access",
+       "vlan",
+       std::to_string(kAccessVlanId)});
+  ASSERT_EQ(result2.exitCode, 0) << "Command failed: " << result2.stderr;
+  EXPECT_THAT(
+      result2.stdout, ::testing::HasSubstr("Successfully set access VLAN"));
+  EXPECT_THAT(result2.stdout, ::testing::Not(::testing::HasSubstr("created")));
+  XLOG(INFO) << "  Output: " << result2.stdout;
+
+  // Step 4: Discard the session — never committed, DUT is unchanged.
+  XLOG(INFO) << "[Step 4] Clearing session (no commit)...";
+  auto clearResult = runCli({"config", "session", "clear"});
+  ASSERT_EQ(clearResult.exitCode, 0)
+      << "Failed to clear session: " << clearResult.stderr;
+  XLOG(INFO) << "  TEST PASSED";
 }

--- a/fboss/cli/fboss2/test/integration_test/ConfigVlanCreateTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigVlanCreateTest.cpp
@@ -28,6 +28,21 @@
  *    - Delete on a VLAN that doesn't exist returns "does not exist"
  *    - No VLAN is auto-created for a delete operation
  *
+ * 4. CreateVlanCommand
+ *    - "config vlan <id>" with no subcommand creates the VLAN in the session
+ *    - Re-running the command in the same session reports "already exists"
+ *    - Commit succeeds (VlanManager also created the barebone interface)
+ *
+ * 5. CreateVlanAlreadyExists
+ *    - "config vlan <id>" on a VLAN present in the running config reports
+ *      "already exists" and does not create anything
+ *
+ * 6. SwitchportAccessVlanAutoCreates
+ *    - "config interface <port> switchport access vlan <id>" on a missing
+ *      VLAN auto-creates it and appends "(VLAN <id> created)" to the output
+ *    - Second run in the same session does not print the created suffix
+ *    - Session is cleared without committing (the DUT is left untouched)
+ *
  * Requirements:
  * - FBOSS agent must be running with a valid configuration
  * - The test must be run as root (or with appropriate permissions)
@@ -237,4 +252,134 @@ TEST_F(ConfigVlanCreateTest, DeleteOnNonExistentVlanIsIdempotent) {
   EXPECT_THAT(
       result.stdout, ::testing::Not(::testing::HasSubstr("Created VLAN")));
   XLOG(INFO) << "  Output: " << result.stdout << " TEST PASSED";
+}
+
+TEST_F(ConfigVlanCreateTest, CreateVlanCommand) {
+  if (s_newVlanId_ == 0) {
+    GTEST_SKIP() << "No VLAN ID free in [" << kTestVlanMin << ", "
+                 << kTestVlanMax << "] on this switch";
+  }
+
+  // Step 0: Ensure the test VLAN is absent (idempotency across runs).
+  XLOG(INFO) << "[Step 0] Ensuring VLAN " << s_newVlanId_
+             << " is absent from running config...";
+  deleteVlanIfPresent(s_newVlanId_);
+
+  // Step 1: "config vlan <id>" with no subcommand creates the VLAN.
+  XLOG(INFO) << "[Step 1] Creating VLAN " << s_newVlanId_
+             << " via 'config vlan'...";
+  auto result = runCli({"config", "vlan", std::to_string(s_newVlanId_)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "Successfully created VLAN " + std::to_string(s_newVlanId_)));
+  XLOG(INFO) << "  Output: " << result.stdout;
+
+  // Step 2: Re-running in the same session reports "already exists".
+  XLOG(INFO) << "[Step 2] Re-running create (already exists expected)...";
+  auto result2 = runCli({"config", "vlan", std::to_string(s_newVlanId_)});
+  ASSERT_EQ(result2.exitCode, 0) << "Command failed: " << result2.stderr;
+  EXPECT_THAT(
+      result2.stdout,
+      ::testing::HasSubstr(
+          "VLAN " + std::to_string(s_newVlanId_) + " already exists"));
+  EXPECT_THAT(
+      result2.stdout,
+      ::testing::Not(::testing::HasSubstr("Successfully created")));
+  XLOG(INFO) << "  Output: " << result2.stdout;
+
+  // Step 3: Commit — VlanManager created both the VLAN and its barebone
+  // interface, so the agent accepts the commit.
+  XLOG(INFO) << "[Step 3] Committing session...";
+  commitConfig();
+  XLOG(INFO) << "  Config committed.";
+
+  // Step 4: A new session on the committed config also reports the VLAN as
+  // existing (the create actually persisted).
+  XLOG(INFO) << "[Step 4] Verifying VLAN persisted after commit...";
+  auto result3 = runCli({"config", "vlan", std::to_string(s_newVlanId_)});
+  ASSERT_EQ(result3.exitCode, 0) << "Command failed: " << result3.stderr;
+  EXPECT_THAT(result3.stdout, ::testing::HasSubstr("already exists"));
+  discardSession();
+  XLOG(INFO) << "  TEST PASSED (VLAN " << s_newVlanId_
+             << " removed by TearDown)";
+}
+
+TEST_F(ConfigVlanCreateTest, CreateVlanAlreadyExists) {
+  auto vp = findConfiguredVlanPort();
+  if (!vp.has_value()) {
+    GTEST_SKIP()
+        << "This DUT has no port that is a member of a configured VLAN via "
+           "sw.vlanPorts; 'config vlan <id>' needs a VLAN that already exists.";
+  }
+  const int existingVlanId = vp->first;
+  XLOG(INFO) << "Testing 'config vlan' on existing VLAN " << existingVlanId
+             << "...";
+  auto result = runCli({"config", "vlan", std::to_string(existingVlanId)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "VLAN " + std::to_string(existingVlanId) + " already exists"));
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::Not(::testing::HasSubstr("Successfully created")));
+  // Nothing was modified; discard the session.
+  discardSession();
+  XLOG(INFO) << "  Output: " << result.stdout << " TEST PASSED";
+}
+
+TEST_F(ConfigVlanCreateTest, SwitchportAccessVlanAutoCreates) {
+  if (s_newVlanId_ == 0) {
+    GTEST_SKIP() << "No VLAN ID free in [" << kTestVlanMin << ", "
+                 << kTestVlanMax << "] on this switch";
+  }
+  XLOG(INFO) << "[Step 1] Using port=" << s_testInterfaceName_;
+
+  // Step 0: Start from a clean session so the VLAN isn't left over from a
+  // previous (aborted) run. This test never commits, so the running config
+  // is untouched.
+  discardSession();
+
+  // Step 2: Assign the port to a non-existent VLAN — it gets auto-created.
+  XLOG(INFO) << "[Step 2] switchport access vlan " << s_newVlanId_
+             << " (auto-create expected)...";
+  auto result = runCli(
+      {"config",
+       "interface",
+       s_testInterfaceName_,
+       "switchport",
+       "access",
+       "vlan",
+       std::to_string(s_newVlanId_)});
+  ASSERT_EQ(result.exitCode, 0) << "Command failed: " << result.stderr;
+  EXPECT_THAT(
+      result.stdout, ::testing::HasSubstr("Successfully set access VLAN"));
+  EXPECT_THAT(
+      result.stdout,
+      ::testing::HasSubstr(
+          "(VLAN " + std::to_string(s_newVlanId_) + " created)"));
+  XLOG(INFO) << "  Output: " << result.stdout;
+
+  // Step 3: Second run in the same session — VLAN now exists, no suffix.
+  XLOG(INFO) << "[Step 3] Second run (no creation suffix expected)...";
+  auto result2 = runCli(
+      {"config",
+       "interface",
+       s_testInterfaceName_,
+       "switchport",
+       "access",
+       "vlan",
+       std::to_string(s_newVlanId_)});
+  ASSERT_EQ(result2.exitCode, 0) << "Command failed: " << result2.stderr;
+  EXPECT_THAT(
+      result2.stdout, ::testing::HasSubstr("Successfully set access VLAN"));
+  EXPECT_THAT(result2.stdout, ::testing::Not(::testing::HasSubstr("created")));
+  XLOG(INFO) << "  Output: " << result2.stdout;
+
+  // Step 4: Discard the session — never committed, DUT is unchanged.
+  XLOG(INFO) << "[Step 4] Clearing session (no commit)...";
+  discardSession();
+  XLOG(INFO) << "  TEST PASSED";
 }


### PR DESCRIPTION
# Summary

"config vlan 4005" with no subcommand used to fail with "Incomplete command, please use one of the subcommands", and "config interface <port> switchport access vlan <id>" refused to run when the VLAN didn't exist. Both now create the VLAN (and its barebone interface) via VlanManager::createVlan() in the config session:

- config vlan <id>: creates the VLAN, or reports "already exists". Implementation moved from the inline stub in CmdConfigVlan.h to CmdConfigVlan.cpp.
- config interface <port> switchport access vlan <id>: auto-creates a missing VLAN and notes "(VLAN <id> created)" in the output.

Add CmdConfigVlanTest.cpp covering creation (including persistence of the session config to disk) and idempotency, and rewrite the switchport access vlan "throws when VLAN missing" test to verify the new auto-create behavior.

# Test Plan

Add a new unit test / update existing unit test.

Tested on wedge800bnhp: "config vlan 4005" and "switchport access vlan 4021" both create the VLAN + fbossNNNN interface, visible in "config session diff"; re-running reports the VLAN already exists.
