### PR TITLE
[Celestica] Ladakh800bcls: Phy Bsp Mapping: Adapt BSP function of retimer

### DIFF
--- a/fboss/lib/bsp/BspResetUtils.cpp
+++ b/fboss/lib/bsp/BspResetUtils.cpp
@@ -31,7 +31,7 @@ bool holdResetViaSysfs(
       *resetPath);
 
   try {
-    writeSysfs(*resetPath, "1");
+    writeSysfs(*resetPath, "0");
     usleep(kResetHoldDelayUs);
     return true;
   } catch (const std::exception& ex) {
@@ -62,7 +62,7 @@ bool releaseResetViaSysfs(
       *resetPath);
 
   try {
-    writeSysfs(*resetPath, "0");
+    writeSysfs(*resetPath, "1");
     return true;
   } catch (const std::exception& ex) {
     XLOG(ERR) << fmt::format(

--- a/fboss/lib/bsp/ladakh800bcls/Ladakh800bclsBspPlatformMapping.cpp
+++ b/fboss/lib/bsp/ladakh800bcls/Ladakh800bclsBspPlatformMapping.cpp
@@ -85,259 +85,227 @@ constexpr auto kJsonBspPlatformMappingStr = R"(
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_2/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_2_1/rtm_reset_2"
         },
         "1": {
-          "phyId": 1,
-          "phyIOControllerId": 3,
+          "phyId": 1,          "phyIOControllerId": 3,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_3/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_3_1/rtm_reset_3"
         },
         "2": {
-          "phyId": 2,
-          "phyIOControllerId": 4,
+          "phyId": 2,          "phyIOControllerId": 4,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_4/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_4_1/rtm_reset_4"
         },
         "3": {
-          "phyId": 3,
-          "phyIOControllerId": 1,
+          "phyId": 3,          "phyIOControllerId": 1,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_1/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_1_1/rtm_reset_1"
         },
         "4": {
-          "phyId": 4,
-          "phyIOControllerId": 5,
+          "phyId": 4,          "phyIOControllerId": 5,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_5/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_5_1/rtm_reset_5"
         },
         "5": {
-          "phyId": 5,
-          "phyIOControllerId": 7,
+          "phyId": 5,          "phyIOControllerId": 7,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_7/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_7_1/rtm_reset_7"
         },
         "6": {
-          "phyId": 6,
-          "phyIOControllerId": 8,
+          "phyId": 6,          "phyIOControllerId": 8,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_8/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_8_1/rtm_reset_8"
         },
         "7": {
-          "phyId": 7,
-          "phyIOControllerId": 6,
+          "phyId": 7,          "phyIOControllerId": 6,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_6/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_6_1/rtm_reset_6"
         },
         "8": {
-          "phyId": 8,
-          "phyIOControllerId": 10,
+          "phyId": 8,          "phyIOControllerId": 10,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_10/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_10_1/rtm_reset_10"
         },
         "9": {
-          "phyId": 9,
-          "phyIOControllerId": 12,
+          "phyId": 9,          "phyIOControllerId": 12,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_12/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_12_1/rtm_reset_12"
         },
         "10": {
-          "phyId": 10,
-          "phyIOControllerId": 11,
+          "phyId": 10,          "phyIOControllerId": 11,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_11/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_11_1/rtm_reset_11"
         },
         "11": {
-          "phyId": 11,
-          "phyIOControllerId": 9,
+          "phyId": 11,          "phyIOControllerId": 9,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_9/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_9_1/rtm_reset_9"
         },
         "12": {
-          "phyId": 12,
-          "phyIOControllerId": 13,
+          "phyId": 12,          "phyIOControllerId": 13,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_13/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_13_1/rtm_reset_13"
         },
         "13": {
-          "phyId": 13,
-          "phyIOControllerId": 15,
+          "phyId": 13,          "phyIOControllerId": 15,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_15/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_15_1/rtm_reset_15"
         },
         "14": {
-          "phyId": 14,
-          "phyIOControllerId": 16,
+          "phyId": 14,          "phyIOControllerId": 16,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_16/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_16_1/rtm_reset_16"
         },
         "15": {
-          "phyId": 15,
-          "phyIOControllerId": 14,
+          "phyId": 15,          "phyIOControllerId": 14,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_l_14/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_l_14_1/rtm_reset_14"
         },
         "16": {
-          "phyId": 16,
-          "phyIOControllerId": 18,
+          "phyId": 16,          "phyIOControllerId": 18,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_2/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_2_1/rtm_reset_18"
         },
         "17": {
-          "phyId": 17,
-          "phyIOControllerId": 19,
+          "phyId": 17,          "phyIOControllerId": 19,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_3/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_3_1/rtm_reset_19"
         },
         "18": {
-          "phyId": 18,
-          "phyIOControllerId": 20,
+          "phyId": 18,          "phyIOControllerId": 20,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_4/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_4_1/rtm_reset_20"
         },
         "19": {
-          "phyId": 19,
-          "phyIOControllerId": 17,
+          "phyId": 19,          "phyIOControllerId": 17,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_1/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_1_1/rtm_reset_17"
         },
         "20": {
-          "phyId": 20,
-          "phyIOControllerId": 21,
+          "phyId": 20,          "phyIOControllerId": 21,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_5/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_5_1/rtm_reset_21"
         },
         "21": {
-          "phyId": 21,
-          "phyIOControllerId": 23,
+          "phyId": 21,          "phyIOControllerId": 23,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_7/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_7_1/rtm_reset_23"
         },
         "22": {
-          "phyId": 22,
-          "phyIOControllerId": 24,
+          "phyId": 22,          "phyIOControllerId": 24,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_8/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_8_1/rtm_reset_24"
         },
         "23": {
-          "phyId": 23,
-          "phyIOControllerId": 22,
+          "phyId": 23,          "phyIOControllerId": 22,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_6/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_6_1/rtm_reset_22"
         },
         "24": {
-          "phyId": 24,
-          "phyIOControllerId": 26,
+          "phyId": 24,          "phyIOControllerId": 26,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_10/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_10_1/rtm_reset_26"
         },
         "25": {
-          "phyId": 25,
-          "phyIOControllerId": 28,
+          "phyId": 25,          "phyIOControllerId": 28,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_12/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_12_1/rtm_reset_28"
         },
         "26": {
-          "phyId": 26,
-          "phyIOControllerId": 27,
+          "phyId": 26,          "phyIOControllerId": 27,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_11/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_11_1/rtm_reset_27"
         },
         "27": {
-          "phyId": 27,
-          "phyIOControllerId": 25,
+          "phyId": 27,          "phyIOControllerId": 25,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_9/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_9_1/rtm_reset_25"
         },
         "28": {
-          "phyId": 28,
-          "phyIOControllerId": 29,
+          "phyId": 28,          "phyIOControllerId": 29,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_13/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_13_1/rtm_reset_29"
         },
         "29": {
-          "phyId": 29,
-          "phyIOControllerId": 31,
+          "phyId": 29,          "phyIOControllerId": 31,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_15/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_15_1/rtm_reset_31"
         },
         "30": {
-          "phyId": 30,
-          "phyIOControllerId": 32,
+          "phyId": 30,          "phyIOControllerId": 32,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_16/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_16_1/rtm_reset_32"
         },
         "31": {
-          "phyId": 31,
-          "phyIOControllerId": 30,
+          "phyId": 31,          "phyIOControllerId": 30,
           "phyAddr": 0,
           "phyCoreId": 0,
           "pimId": 1,
-          "phyResetPath": "/run/devmap/mdio-busses/mdio_bus_ctrl_r_14/reset_rtm_0"
+          "phyResetPath": "/run/devmap/rtms/rtm_ctrl_mdio_r_14_1/rtm_reset_30"
         }
       },
-      "phyIOControllers": {
-        "1": {
+      "phyIOControllers": {        "1": {
           "controllerId": 1,
           "type": 1,
           "devicePath": "/run/devmap/mdio-busses/mdio_bus_io_l_1",

--- a/fboss/platform/configs/ladakh800bcls/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bcls/platform_manager.json
@@ -6,7 +6,7 @@
     "MCB_SLOT": {
       "numOutgoingI2cBuses": 0,
       "idpromConfig": {
-        "busName": "SMBus I801 adapter at 5000",
+        "busName": "CPU_BUS@0",
         "address": "0x53",
         "kernelDeviceName": "24c02"
       }
@@ -61,7 +61,7 @@
     }
   },
   "i2cAdaptersFromCpu": [
-    "SMBus I801 adapter at 5000"
+    "CPU_BUS@0"
   ],
   "versionedPmUnitConfigs": {
     "NETLAKE": [

--- a/fboss/platform/configs/ladakh800bclsm/platform_manager.json
+++ b/fboss/platform/configs/ladakh800bclsm/platform_manager.json
@@ -308,15 +308,29 @@
               "pmUnitScopedNamePrefix": "RTM_L_MDIO_BUS",
               "deviceName": "mdio_controller",
               "csrOffsetCalc": "0x48200 + {busIndex}*0x20",
-              "numBuses": 16,
-              "iobufOffsetCalc": "0x480c0 + {busIndex}*0x4"
+              "numBuses": 16
             },
             {
               "pmUnitScopedNamePrefix": "RTM_R_MDIO_BUS",
               "deviceName": "mdio_controller",
               "csrOffsetCalc": "0x40200 + {busIndex}*0x20",
-              "numBuses": 16,
-              "iobufOffsetCalc": "0x400c0 + {busIndex}*0x4"
+              "numBuses": 16
+            }
+          ],
+          "rtmCtrlBlockConfigs": [
+            {
+              "pmUnitScopedNamePrefix": "RTM_L",
+              "deviceName": "rtm_ctrl",
+              "csrOffsetCalc": "0x480c0 + ({portNum} - {startPort})*0x4",
+              "numPorts": 16,
+              "startPort": 1
+            },
+            {
+              "pmUnitScopedNamePrefix": "RTM_R",
+              "deviceName": "rtm_ctrl",
+              "csrOffsetCalc": "0x400c0 + ({portNum} - {startPort})*0x4",
+              "numPorts": 16,
+              "startPort": 17
             }
           ]
         }
@@ -1654,6 +1668,38 @@
     "/run/devmap/mdio-busses/mdio_bus_io_r_14": "/[RTM_R_MDIO_BUS_14]",
     "/run/devmap/mdio-busses/mdio_bus_io_r_15": "/[RTM_R_MDIO_BUS_15]",
     "/run/devmap/mdio-busses/mdio_bus_io_r_16": "/[RTM_R_MDIO_BUS_16]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_1_1": "/[RTM_L_RTM_CTRL_PORT_1]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_2_1": "/[RTM_L_RTM_CTRL_PORT_2]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_3_1": "/[RTM_L_RTM_CTRL_PORT_3]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_4_1": "/[RTM_L_RTM_CTRL_PORT_4]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_5_1": "/[RTM_L_RTM_CTRL_PORT_5]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_6_1": "/[RTM_L_RTM_CTRL_PORT_6]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_7_1": "/[RTM_L_RTM_CTRL_PORT_7]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_8_1": "/[RTM_L_RTM_CTRL_PORT_8]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_9_1": "/[RTM_L_RTM_CTRL_PORT_9]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_10_1": "/[RTM_L_RTM_CTRL_PORT_10]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_11_1": "/[RTM_L_RTM_CTRL_PORT_11]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_12_1": "/[RTM_L_RTM_CTRL_PORT_12]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_13_1": "/[RTM_L_RTM_CTRL_PORT_13]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_14_1": "/[RTM_L_RTM_CTRL_PORT_14]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_15_1": "/[RTM_L_RTM_CTRL_PORT_15]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_l_16_1": "/[RTM_L_RTM_CTRL_PORT_16]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_1_1": "/[RTM_R_RTM_CTRL_PORT_17]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_2_1": "/[RTM_R_RTM_CTRL_PORT_18]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_3_1": "/[RTM_R_RTM_CTRL_PORT_19]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_4_1": "/[RTM_R_RTM_CTRL_PORT_20]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_5_1": "/[RTM_R_RTM_CTRL_PORT_21]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_6_1": "/[RTM_R_RTM_CTRL_PORT_22]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_7_1": "/[RTM_R_RTM_CTRL_PORT_23]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_8_1": "/[RTM_R_RTM_CTRL_PORT_24]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_9_1": "/[RTM_R_RTM_CTRL_PORT_25]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_10_1": "/[RTM_R_RTM_CTRL_PORT_26]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_11_1": "/[RTM_R_RTM_CTRL_PORT_27]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_12_1": "/[RTM_R_RTM_CTRL_PORT_28]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_13_1": "/[RTM_R_RTM_CTRL_PORT_29]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_14_1": "/[RTM_R_RTM_CTRL_PORT_30]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_15_1": "/[RTM_R_RTM_CTRL_PORT_31]",
+    "/run/devmap/rtms/rtm_ctrl_mdio_r_16_1": "/[RTM_R_RTM_CTRL_PORT_32]",
     "/run/devmap/sensors/RUNBMC_THERMAL_SENSOR": "/RUNBMC_SLOT@0/[RUNBMC_THERMAL_SENSOR]",
     "/run/devmap/sensors/COME_HWMON1": "/COMESE_SLOT@0/[COME_HWMON1]",
     "/run/devmap/sensors/COME_HWMON2": "/COMESE_SLOT@0/[COME_HWMON2]",
@@ -1725,6 +1771,7 @@
   },
   "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
   "numXcvrs": 2,
+  "numRtms": 32,
   "bspKmodsRpmName": "fboss_bsp_kmods",
   "bspKmodsRpmVersion": "4.4.1-1",
   "nonBspKmodsToLoad": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR is to adapt BSP function of retimer.

1. Update `phyResetPath` in BSP Phy mapping cpp.
2. Adapt retimer reset logic of latest BSP.
3. Sync retimer config to Netlake2.0.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
########## Coldboot test results (1/1): Note: Google Test filter = EmptyHwTest.CheckInit
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from EmptyHwTest
[ RUN      ] EmptyHwTest.CheckInit
[       OK ] EmptyHwTest.CheckInit (412880 ms)
[----------] 1 test from EmptyHwTest (412880 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (412880 ms total)
[  PASSED  ] 1 test.
```
[qsfp_t0.zip](https://github.com/user-attachments/files/30299970/qsfp_t0.zip)

