### PR TITLE
[Nexthop] Enable kernel config for interrupt-driven Xilinx I2C support

### DIFF
--- a/fboss-image/kernel/configs/fboss-local-overrides.yaml
+++ b/fboss-image/kernel/configs/fboss-local-overrides.yaml
@@ -38,6 +38,10 @@ common_overrides: |
   CONFIG_SERIAL_8250_DWLIB=m
   CONFIG_SERIAL_8250_PNP=y
 
+  # Drivers for interrupt-driven I2C support
+  CONFIG_I2C_XILINX=m
+  CONFIG_GPIO_PCI_IDIO_16=m
+  
 
 # Kernel version overrides
 # Add kernel version as key, then add config lines in the value


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Enable the kernel config needed for interrupt-driven FPGA I2C support, replacing a polling-based `AXI-IIC` path with the upstream interrupt-driven `xiic-i2c` driver.

- `CONFIG_I2C_XILINX=m`: enables the upstream Xilinx AXI IIC platform driver (`xiic-i2c`) used for the FPGA I2C controllers.
- `CONFIG_GPIO_PCI_IDIO_16=m`: pulls in `REGMAP_IRQ` transitively, which is used by the parent PCI driver to demultiplex MSI vectors into per-controller Linux IRQs.

# Test Plan

- Built an image with this config change.

- Verified on test hardware that the running kernel has the expected config and exports the required `REGMAP_IRQ` symbols.

### Kernel config check:

```
grep -E "CONFIG_REGMAP_IRQ|CONFIG_I2C_XILINX|CONFIG_GPIO_PCI_IDIO_16" \
   /usr/src/kernels/$(uname -r)/.config /boot/config-$(uname -r) 2>/dev/null
```

### Output:

```
CONFIG_REGMAP_IRQ=y
CONFIG_I2C_XILINX=m
CONFIG_GPIO_PCI_IDIO_16=m
```

### Exported symbols check:

```
grep -E "regmap_irq_get_virq|devm_regmap_add_irq_chip" \
   /usr/src/kernels/$(uname -r)/Module.symvers || echo "REGMAP_IRQ symbols NOT exported by this kernel"
```

### Output:

```
0x79b55a2a      devm_regmap_add_irq_chip_fwnode vmlinux EXPORT_SYMBOL_GPL
0xe27c38b7      devm_regmap_add_irq_chip        vmlinux EXPORT_SYMBOL_GPL
0x55784228      regmap_irq_get_virq             vmlinux EXPORT_SYMBOL_GPL
```

Hardware-tested with the built image. The system imaged successfully, booted into FBOSS, and platform bring-up completed successfully.

