### PR TITLE
[Celestica] Leh800bcls: Config: Update Netlake2.0 COME inlet and outlet sensor

### DIFF
--- a/fboss/platform/configs/leh800bclsm/platform_manager.json
+++ b/fboss/platform/configs/leh800bclsm/platform_manager.json
@@ -83,17 +83,16 @@
               "busName": "INCOMING@1",
               "address": "0x4c",
               "kernelDeviceName": "tmp75",
-              "pmUnitScopedName": "COME_INLET_TSENSOR"
+              "pmUnitScopedName": "COME_OUTLET_TSENSOR"
             },
             {
               "busName": "INCOMING@1",
               "address": "0x4a",
               "kernelDeviceName": "tmp75",
-              "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+              "pmUnitScopedName": "COME_INLET_TSENSOR"
             },
             {
-              "busName": "INCOMING@1",
-              "address": "0x50",
+              "busName": "INCOMING@1",              "address": "0x50",
               "kernelDeviceName": "spd5118",
               "pmUnitScopedName": "COME_DIMM1_TSENSOR"
             },
@@ -542,17 +541,16 @@
           "busName": "INCOMING@1",
           "address": "0x4c",
           "kernelDeviceName": "tmp75",
-          "pmUnitScopedName": "COME_INLET_TSENSOR"
+          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
         },
         {
           "busName": "INCOMING@1",
           "address": "0x4a",
           "kernelDeviceName": "tmp75",
-          "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+          "pmUnitScopedName": "COME_INLET_TSENSOR"
         },
         {
-          "busName": "INCOMING@1",
-          "address": "0x50",
+          "busName": "INCOMING@1",          "address": "0x50",
           "kernelDeviceName": "spd5118",
           "pmUnitScopedName": "COME_DIMM1_TSENSOR"
         },

--- a/fboss/platform/configs/leh800bclsm/sensor_service.json
+++ b/fboss/platform/configs/leh800bclsm/sensor_service.json
@@ -451,25 +451,24 @@
           "compute": "10*@/1000.0"
         },
         {
-          "name": "COME_U28_INLET_SENSOR_TMP75_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_INLET_TSENSOR/temp1_input",
+          "name": "COME_U28_OUTLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 46.3,
+            "maxAlarmVal": 80,
             "upperCriticalVal": 100
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "COME_U29_OUTLET_SENSOR_TMP75_TEMP",
-          "sysfsPath": "/run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input",
+          "name": "COME_U29_INLET_SENSOR_TMP75_TEMP",
+          "sysfsPath": "/run/devmap/sensors/COME_INLET_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "maxAlarmVal": 65.4,
+            "maxAlarmVal": 60,
             "upperCriticalVal": 100
           },
-          "compute": "@/1000.0"
-        },
+          "compute": "@/1000.0"        },
         {
           "name": "COME_JCN1_DIMM_CHA_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_DIMM1_TSENSOR/temp1_input",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR is to update Netlake2.0 COME inlet and outlet sensor.

For Anacapa Netlake2.0 project, the COME inlet and outlet sensors are the opposite of those defined by ww.
    ww：inlet-U28；outlet-U29
    anacapa：inlet-U29；outlet-U28

<img width="590" height="508" alt="image" src="https://github.com/user-attachments/assets/c5ccfcbc-0aa6-45b1-a6eb-a562881bcb8e" />

1. Exchange the COME inlet and outlet sensors in `platform_manager.json`
2. Exchange the corresponding sensors in `sensor_service.json`
3. Update thresholds


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Before
| name                          | value  | status | criticalRange    | alarmRange       | lastUpdated | sysfsPath |
|---|---|---|---|---|---|---|
| COME_U28_INLET_SENSOR_TMP75_TEMP      | 30.50 | PASS   | [, 100.00]     | [, 46.30]      | 3s ago      | /run/devmap/sensors/COME_INLET_TSENSOR/temp1_input  |
| COME_U29_OUTLET_SENSOR_TMP75_TEMP     | 25.69 | PASS   | [, 100.00]     | [, 65.40]      | 3s ago      | /run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input |

After
| name                          | value  | status | criticalRange    | alarmRange       | lastUpdated | sysfsPath |
|---|---|---|---|---|---|---|
| COME_U28_OUTLET_SENSOR_TMP75_TEMP     | 27.56 | PASS   | [, 100.00]     | [, 80.00]      | 4s ago      | /run/devmap/sensors/COME_OUTLET_TSENSOR/temp1_input |
| COME_U29_INLET_SENSOR_TMP75_TEMP      | 31.25 | PASS   | [, 100.00]     | [, 60.00]      | 4s ago      | /run/devmap/sensors/COME_INLET_TSENSOR/temp1_input  |

