### PR TITLE
[Nexthop][platform_manager][m4062nhp] Record sysfs path for miscCtrlConfigs entries

### DIFF
--- a/fboss/platform/platform_manager/PciExplorer.cpp
+++ b/fboss/platform/platform_manager/PciExplorer.cpp
@@ -312,7 +312,7 @@ std::string PciExplorer::createInfoRom(
     uint32_t instanceId) {
   auto auxData = getAuxData(infoRomConfig, instanceId);
   create(pciDevice, infoRomConfig, auxData);
-  return getInfoRomSysfsPath(infoRomConfig, instanceId);
+  return getFpgaIpBlockSysfsPath(infoRomConfig, instanceId);
 }
 
 std::string PciExplorer::createWatchdog(
@@ -355,12 +355,13 @@ std::string PciExplorer::createRtmCtrl(
       pciDevice, *rtmCtrlConfig.fpgaIpBlockConfig(), instanceId);
 }
 
-void PciExplorer::createFpgaIpBlock(
+std::string PciExplorer::createFpgaIpBlock(
     const PciDevice& pciDevice,
     const FpgaIpBlockConfig& fpgaIpBlockConfig,
     uint32_t instanceId) {
   auto auxData = getAuxData(fpgaIpBlockConfig, instanceId);
   create(pciDevice, fpgaIpBlockConfig, auxData);
+  return getFpgaIpBlockSysfsPath(fpgaIpBlockConfig, instanceId);
 }
 
 void PciExplorer::create(
@@ -711,20 +712,20 @@ std::string PciExplorer::getGpioChipCharDevPath(
       *fpgaIpBlockConfig.pmUnitScopedName());
 }
 
-std::string PciExplorer::getInfoRomSysfsPath(
-    const FpgaIpBlockConfig& infoRomConfig,
+std::string PciExplorer::getFpgaIpBlockSysfsPath(
+    const FpgaIpBlockConfig& fpgaIpBlockConfig,
     uint32_t instanceId) {
   const auto auxDevSysfsPath = "/sys/bus/auxiliary/devices";
   if (!fs::exists(auxDevSysfsPath)) {
     throw PciSubDeviceRuntimeError(
         fmt::format(
-            "Unable to find InfoRom sysfs path for {}. Reason: '{}' path doesn't exist.",
-            *infoRomConfig.pmUnitScopedName(),
+            "Unable to find aux-device sysfs path for {}. Reason: '{}' path doesn't exist.",
+            *fpgaIpBlockConfig.pmUnitScopedName(),
             auxDevSysfsPath),
-        *infoRomConfig.pmUnitScopedName());
+        *fpgaIpBlockConfig.pmUnitScopedName());
   }
   std::string expectedEnding =
-      fmt::format(".{}.{}", *infoRomConfig.deviceName(), instanceId);
+      fmt::format(".{}.{}", *fpgaIpBlockConfig.deviceName(), instanceId);
   for (const auto& dirEntry : fs::directory_iterator(auxDevSysfsPath)) {
     if (dirEntry.path().filename().string().ends_with(expectedEnding)) {
       return dirEntry.path().string();
@@ -732,10 +733,10 @@ std::string PciExplorer::getInfoRomSysfsPath(
   }
   throw PciSubDeviceRuntimeError(
       fmt::format(
-          "Couldn't find InfoRom {} sysfs path under {}",
-          *infoRomConfig.pmUnitScopedName(),
+          "Couldn't find aux-device sysfs path for {} under {}",
+          *fpgaIpBlockConfig.pmUnitScopedName(),
           auxDevSysfsPath),
-      *infoRomConfig.pmUnitScopedName());
+      *fpgaIpBlockConfig.pmUnitScopedName());
 }
 
 std::string PciExplorer::getWatchDogCharDevPath(

--- a/fboss/platform/platform_manager/PciExplorer.h
+++ b/fboss/platform/platform_manager/PciExplorer.h
@@ -135,8 +135,9 @@ class PciExplorer {
       uint32_t instanceId);
 
   // Create the generic device block based on the given FpgaIpBlockConfig
-  // residing at the given PciDevice. Throw std::runtime_error on failure.
-  void createFpgaIpBlock(
+  // residing at the given PciDevice. Returns the auxiliary device's sysfs
+  // path. Throws std::runtime_error on failure.
+  std::string createFpgaIpBlock(
       const PciDevice& pciDevice,
       const FpgaIpBlockConfig& fpgaIpBlockConfig,
       uint32_t instanceId);
@@ -185,8 +186,8 @@ class PciExplorer {
       const PciDevice& pciDevice,
       const SpiMasterConfig& spiMasterConfig,
       uint32_t instanceId);
-  std::string getInfoRomSysfsPath(
-      const FpgaIpBlockConfig& infoRomConfig,
+  std::string getFpgaIpBlockSysfsPath(
+      const FpgaIpBlockConfig& fpgaIpBlockConfig,
       uint32_t instanceId);
   std::string getWatchDogCharDevPath(
       const PciDevice& pciDevice,

--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -755,7 +755,12 @@ void PlatformExplorer::explorePciDevices(
         *pciDeviceConfig.miscCtrlConfigs(),
         ExplorationErrorType::PCI_SUB_DEVICE_CREATE_MISC_CTRL,
         [&](const auto& miscCtrlConfig) {
-          pciExplorer_.createFpgaIpBlock(pciDevice, miscCtrlConfig, instId++);
+          auto miscCtrlSysfsPath = pciExplorer_.createFpgaIpBlock(
+              pciDevice, miscCtrlConfig, instId++);
+          dataStore_.updateSysfsPath(
+              Utils().createDevicePath(
+                  slotPath, *miscCtrlConfig.pmUnitScopedName()),
+              miscCtrlSysfsPath);
         });
     createPciSubDevices(
         slotPath,


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Makes `PciExplorer::createFpgaIpBlock()` return the created auxiliary device's sysfs path, and has `PlatformExplorer` record that path in the DataStore for `miscCtrlConfigs` entries (as already done for other FPGA IP blocks). Without it, downstream services (e.g. `sensor_service`) can't locate a misc-control FPGA IP block's sysfs node, so registers exposed via `miscCtrlConfigs`, such as an ASIC temperature register, can't be read.

# Test Plan

Built and verified against hardware.