### PR TITLE
[Nexthop][m4062nhp] Register m4062nhp in platform mapping verification test

### DIFF
--- a/fboss/lib/platform_mapping_v2/test/verify_generated_files.py
+++ b/fboss/lib/platform_mapping_v2/test/verify_generated_files.py
@@ -5,12 +5,9 @@ import filecmp
 import os
 import sys
 import unittest
-from typing import Dict, List
+from typing import ClassVar
 
-from fboss.lib.platform_mapping_v2.gen import (
-    generate_platform_mappings,
-    INPUT_DIR as input_dir,
-)
+from fboss.lib.platform_mapping_v2.gen import generate_platform_mappings, INPUT_DIR
 
 
 class TestVerifyPlatformMappingGeneratedFiles(unittest.TestCase):
@@ -22,8 +19,9 @@ class TestVerifyPlatformMappingGeneratedFiles(unittest.TestCase):
     This test will be run in OSS for all open-sourced platforms.
     """
 
-    _OSS_MULTI_NPU_SUPPORTED_PLATFORMS: Dict[bool, List[str]] = {
+    _OSS_MULTI_NPU_SUPPORTED_PLATFORMS: ClassVar[dict[bool, list[str]]] = {
         False: [
+            "m4062nhp",
             "montblanc",
             "montblanc_odd_ports_8x100G",
             "montblanc_gtsw_yolo",
@@ -103,21 +101,20 @@ class TestVerifyPlatformMappingGeneratedFiles(unittest.TestCase):
                         os.rmdir(dir_path)
                     except OSError as e:
                         print(
-                            f"Failed to delete {dir_path}. Reason: {e}",
-                            file=sys.stderr,
+                            f"Failed to delete {dir_path}. Reason: {e}", file=sys.stderr
                         )
 
     def _generate_all_oss_platform_mappings_in_tmp(self) -> None:
         for is_multi_npu, platforms in self._OSS_MULTI_NPU_SUPPORTED_PLATFORMS.items():
             for platform in platforms:
                 generate_platform_mappings(
-                    input_dir + platform,
+                    INPUT_DIR + platform,
                     self._TMP_GENERATED_DIR,
                     platform,
                     is_multi_npu,
                 )
 
-    def _get_relative_files(self, directory: str) -> List[str]:
+    def _get_relative_files(self, directory: str) -> list[str]:
         relative_files = []
         for root, _, filenames in os.walk(directory):
             for filename in filenames:
@@ -163,9 +160,7 @@ class TestVerifyPlatformMappingGeneratedFiles(unittest.TestCase):
         gen_files = self._get_relative_files(self._TMP_GENERATED_DIR)
 
         self.assertEqual(
-            ref_files,
-            gen_files,
-            "Fbcode and tmp generated files don't match",
+            ref_files, gen_files, "Fbcode and tmp generated files don't match"
         )
 
         for filename in ref_files:


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Registers m4062nhp in verify_generated_files.py's platform list so platform mapping generation for it is verified in OSS CI. Also applies the pre-commit ruff-check and ruff-format fixes to the same file: builtin generics in place of typing.Dict/List, a ClassVar annotation on the supported-platforms dict, INPUT_DIR imported without the alias, and formatter line reflow. No behavior change beyond the added platform.

Split out of #1394 per review feedback. Depends on #1419 , which adds the m4062nhp CSVs this test generates from, and should land first.

# Test Plan

- Platform Mapping Generation Verification CI regenerates m4062nhp_platform_mapping.json from the CSVs and confirms it matches the checked-in file.
- `pre-commit run --files fboss/lib/platform_mapping_v2/test/verify_generated_files.py` passes clean.
