### PR TITLE
[Nexthop][fboss2-dev] sort show interface status and transceiver by numeric interface ID

### DIFF
--- a/fboss/cli/fboss2/commands/show/interface/status/CmdShowInterfaceStatus.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/status/CmdShowInterfaceStatus.cpp
@@ -77,6 +77,7 @@ CmdShowInterfaceStatus::RetType CmdShowInterfaceStatus::createModel(
       const auto operState = folly::copy(portInfo.operState().value());
 
       ifStatus.name() = portInfo.name().value();
+      ifStatus.portId() = folly::copy(portInfo.portId().value());
       ifStatus.description() = portInfo.description().value();
       ifStatus.status() =
           (operState == facebook::fboss::PortOperState::UP) ? "up" : "down";
@@ -111,8 +112,12 @@ CmdShowInterfaceStatus::RetType CmdShowInterfaceStatus::createModel(
   std::sort(
       model.interfaces()->begin(),
       model.interfaces()->end(),
-      [](cli::InterfaceStatus& a, cli::InterfaceStatus b) {
-        return a.name().value() < b.name().value();
+      [](const cli::InterfaceStatus& a, const cli::InterfaceStatus& b) {
+        return utils::comparePortNameOrId(
+            a.name().value(),
+            folly::copy(a.portId().value()),
+            b.name().value(),
+            folly::copy(b.portId().value()));
       });
   return model;
 }

--- a/fboss/cli/fboss2/commands/show/interface/status/model.thrift
+++ b/fboss/cli/fboss2/commands/show/interface/status/model.thrift
@@ -14,4 +14,5 @@ struct InterfaceStatus {
   5: string speed;
   6: string vendor;
   7: string mpn;
+  8: i32 portId;
 }

--- a/fboss/cli/fboss2/commands/show/port/CmdShowPort.cpp
+++ b/fboss/cli/fboss2/commands/show/port/CmdShowPort.cpp
@@ -534,7 +534,11 @@ RetType CmdShowPort::createModel(
       model.portEntries()->begin(),
       model.portEntries()->end(),
       [&](const cli::PortEntry& a, const cli::PortEntry& b) {
-        return utils::comparePortName(a.name().value(), b.name().value());
+        return utils::comparePortNameOrId(
+            a.name().value(),
+            folly::copy(a.id().value()),
+            b.name().value(),
+            folly::copy(b.id().value()));
       });
 
   return model;

--- a/fboss/cli/fboss2/commands/show/port/CmdShowPort.cpp
+++ b/fboss/cli/fboss2/commands/show/port/CmdShowPort.cpp
@@ -546,7 +546,11 @@ RetType CmdShowPort::createModel(
       model.portEntries()->begin(),
       model.portEntries()->end(),
       [&](const cli::PortEntry& a, const cli::PortEntry& b) {
-        return utils::comparePortName(a.name().value(), b.name().value());
+        return utils::comparePortNameOrId(
+            a.name().value(),
+            folly::copy(a.id().value()),
+            b.name().value(),
+            folly::copy(b.id().value()));
       });
 
   return model;

--- a/fboss/cli/fboss2/commands/show/transceiver/CmdShowTransceiver.cpp
+++ b/fboss/cli/fboss2/commands/show/transceiver/CmdShowTransceiver.cpp
@@ -58,7 +58,28 @@ void CmdShowTransceiver::printOutput(const RetType& model, std::ostream& out) {
        "Rx Power (dBm)",
        "Rx SNR"});
 
+  std::vector<const cli::TransceiverDetail*> sortedDetails;
+  sortedDetails.reserve(model.transceivers()->size());
   for (const auto& [portId, details] : model.transceivers().value()) {
+    sortedDetails.push_back(&details);
+  }
+  std::sort(
+      sortedDetails.begin(),
+      sortedDetails.end(),
+      [](const cli::TransceiverDetail* a, const cli::TransceiverDetail* b) {
+        // Bypass modules have no agent port, so fall back to the transceiver
+        // ID (the module index) for their numeric ordering.
+        auto id = [](const cli::TransceiverDetail* d) {
+          return d->portID().has_value()
+              ? folly::copy(d->portID().value())
+              : folly::copy(d->transceiverID().value());
+        };
+        return utils::comparePortNameOrId(
+            a->name().value(), id(a), b->name().value(), id(b));
+      });
+
+  for (const auto* detailsPtr : sortedDetails) {
+    const auto& details = *detailsPtr;
     outTable.addRow({
         details.name().value(),
         statusToString(
@@ -261,6 +282,11 @@ CmdShowTransceiver::RetType CmdShowTransceiver::createModel(
 
       cli::TransceiverDetail details;
       details.name() = intf;
+      details.transceiverID() = tcvrEntry.first;
+      if (auto portIdIter = interfaceToPortId.find(intf);
+          portIdIter != interfaceToPortId.end()) {
+        details.portID() = portIdIter->second;
+      }
 
       const auto& tcvrState = *transceiver.tcvrState();
       const auto& tcvrStats = *transceiver.tcvrStats();

--- a/fboss/cli/fboss2/commands/show/transceiver/model.thrift
+++ b/fboss/cli/fboss2/commands/show/transceiver/model.thrift
@@ -29,4 +29,7 @@ struct TransceiverDetail {
   17: transceiver.FlagLevels tempFlags;
   18: transceiver.FlagLevels vccFlags;
   19: transceiver.MediaInterfaceCode mediaInterface;
+  20: i32 transceiverID;
+  /* Logical port ID of the agent port; unset for bypass modules */
+  21: optional i32 portID;
 }

--- a/fboss/cli/fboss2/test/CmdShowInterfaceStatusTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowInterfaceStatusTest.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include <gmock/gmock.h>
+#include <gmock/gmock.h> // NOLINT(misc-include-cleaner)
 #include <gtest/gtest.h>
 
 #include "fboss/cli/fboss2/commands/show/interface/status/CmdShowInterfaceStatus.h"
@@ -118,6 +118,69 @@ TEST_F(CmdShowInterfaceStatusTestFixture, createModel) {
   EXPECT_EQ(statusModel[2].get_speed(), "400G");
   EXPECT_EQ(statusModel[2].get_vendor(), "Not Present");
   EXPECT_EQ(statusModel[2].get_mpn(), "Not Present");
+}
+
+namespace {
+facebook::fboss::PortInfoThrift makeSortTestPort(
+    int32_t portId,
+    const std::string& name) {
+  facebook::fboss::PortInfoThrift port;
+  port.portId() = portId;
+  port.name() = name;
+  port.description() = "";
+  port.operState() = facebook::fboss::PortOperState::UP;
+  port.speedMbps() = 100000;
+  return port;
+}
+} // namespace
+
+TEST_F(CmdShowInterfaceStatusTestFixture, createModelNaturalSort) {
+  // Interfaces with parseable names are ordered by their numeric
+  // module/port/subport components, not lexicographically (otherwise
+  // eth1/10/1 would sort before eth1/2/1). Port IDs are deliberately assigned
+  // against front panel order here, matching real platform mappings where
+  // logical port ID does not track the interface name.
+  std::map<int32_t, facebook::fboss::PortInfoThrift> ports;
+  for (const auto& [portId, name] :
+       std::vector<std::pair<int32_t, std::string>>{
+           {1, "eth1/100/1"},
+           {2, "eth1/10/1"},
+           {3, "eth1/2/1"},
+           {4, "eth1/1/1"},
+           {5, "eth2/1/1"}}) {
+    ports[portId] = makeSortTestPort(portId, name);
+  }
+
+  auto cmd = CmdShowInterfaceStatus();
+  auto model = cmd.createModel(ports, {}, {});
+  auto statusModel = model.interfaces().value();
+
+  ASSERT_EQ(statusModel.size(), 5);
+  EXPECT_EQ(statusModel[0].get_name(), "eth1/1/1");
+  EXPECT_EQ(statusModel[1].get_name(), "eth1/2/1");
+  EXPECT_EQ(statusModel[2].get_name(), "eth1/10/1");
+  EXPECT_EQ(statusModel[3].get_name(), "eth1/100/1");
+  EXPECT_EQ(statusModel[4].get_name(), "eth2/1/1");
+}
+
+TEST_F(CmdShowInterfaceStatusTestFixture, createModelFreeFormNames) {
+  // Interface names can be arbitrary (SVIs are named things like "downlinks")
+  // or unset entirely. Those must not throw, and must order by port ID after
+  // the interfaces whose names do encode a front panel position.
+  std::map<int32_t, facebook::fboss::PortInfoThrift> ports;
+  ports[7] = makeSortTestPort(7, "downlinks");
+  ports[3] = makeSortTestPort(3, "");
+  ports[5] = makeSortTestPort(5, "eth1/1/1");
+
+  auto cmd = CmdShowInterfaceStatus();
+  cli::ShowIntStatusModel model;
+  ASSERT_NO_THROW(model = cmd.createModel(ports, {}, {}));
+  auto statusModel = model.interfaces().value();
+
+  ASSERT_EQ(statusModel.size(), 3);
+  EXPECT_EQ(statusModel[0].get_name(), "eth1/1/1");
+  EXPECT_EQ(statusModel[1].get_name(), "");
+  EXPECT_EQ(statusModel[2].get_name(), "downlinks");
 }
 
 TEST_F(CmdShowInterfaceStatusTestFixture, printOutput) {

--- a/fboss/cli/fboss2/test/CmdShowInterfaceStatusTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowInterfaceStatusTest.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include <gmock/gmock.h>
+#include <gmock/gmock.h> // NOLINT(misc-include-cleaner)
 #include <gtest/gtest.h>
 
 #include "fboss/cli/fboss2/commands/show/interface/status/CmdShowInterfaceStatus.h"
@@ -118,6 +118,69 @@ TEST_F(CmdShowInterfaceStatusTestFixture, createModel) {
   EXPECT_EQ(statusModel[2].speed().value(), "400G");
   EXPECT_EQ(statusModel[2].vendor().value(), "Not Present");
   EXPECT_EQ(statusModel[2].mpn().value(), "Not Present");
+}
+
+namespace {
+facebook::fboss::PortInfoThrift makeSortTestPort(
+    int32_t portId,
+    const std::string& name) {
+  facebook::fboss::PortInfoThrift port;
+  port.portId() = portId;
+  port.name() = name;
+  port.description() = "";
+  port.operState() = facebook::fboss::PortOperState::UP;
+  port.speedMbps() = 100000;
+  return port;
+}
+} // namespace
+
+TEST_F(CmdShowInterfaceStatusTestFixture, createModelNaturalSort) {
+  // Interfaces with parseable names are ordered by their numeric
+  // module/port/subport components, not lexicographically (otherwise
+  // eth1/10/1 would sort before eth1/2/1). Port IDs are deliberately assigned
+  // against front panel order here, matching real platform mappings where
+  // logical port ID does not track the interface name.
+  std::map<int32_t, facebook::fboss::PortInfoThrift> ports;
+  for (const auto& [portId, name] :
+       std::vector<std::pair<int32_t, std::string>>{
+           {1, "eth1/100/1"},
+           {2, "eth1/10/1"},
+           {3, "eth1/2/1"},
+           {4, "eth1/1/1"},
+           {5, "eth2/1/1"}}) {
+    ports[portId] = makeSortTestPort(portId, name);
+  }
+
+  auto cmd = CmdShowInterfaceStatus();
+  auto model = cmd.createModel(ports, {}, {});
+  auto statusModel = model.interfaces().value();
+
+  ASSERT_EQ(statusModel.size(), 5);
+  EXPECT_EQ(statusModel[0].get_name(), "eth1/1/1");
+  EXPECT_EQ(statusModel[1].get_name(), "eth1/2/1");
+  EXPECT_EQ(statusModel[2].get_name(), "eth1/10/1");
+  EXPECT_EQ(statusModel[3].get_name(), "eth1/100/1");
+  EXPECT_EQ(statusModel[4].get_name(), "eth2/1/1");
+}
+
+TEST_F(CmdShowInterfaceStatusTestFixture, createModelFreeFormNames) {
+  // Interface names can be arbitrary (SVIs are named things like "downlinks")
+  // or unset entirely. Those must not throw, and must order by port ID after
+  // the interfaces whose names do encode a front panel position.
+  std::map<int32_t, facebook::fboss::PortInfoThrift> ports;
+  ports[7] = makeSortTestPort(7, "downlinks");
+  ports[3] = makeSortTestPort(3, "");
+  ports[5] = makeSortTestPort(5, "eth1/1/1");
+
+  auto cmd = CmdShowInterfaceStatus();
+  cli::ShowIntStatusModel model;
+  ASSERT_NO_THROW(model = cmd.createModel(ports, {}, {}));
+  auto statusModel = model.interfaces().value();
+
+  ASSERT_EQ(statusModel.size(), 3);
+  EXPECT_EQ(statusModel[0].get_name(), "eth1/1/1");
+  EXPECT_EQ(statusModel[1].get_name(), "");
+  EXPECT_EQ(statusModel[2].get_name(), "downlinks");
 }
 
 TEST_F(CmdShowInterfaceStatusTestFixture, printOutput) {

--- a/fboss/cli/fboss2/test/CmdShowPortTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowPortTest.cpp
@@ -427,25 +427,28 @@ TEST_F(CmdShowPortTestFixture, sortByName) {
 }
 
 TEST_F(CmdShowPortTestFixture, invalidPortName) {
+  // Interface names are free-form -- SVIs are named arbitrary things and the
+  // name may be unset -- so a name that doesn't follow the
+  // moduleNum/port/subport pattern must not abort the command. Such entries
+  // are ordered by their numeric port ID instead.
   auto invalidPortEntries = createInvalidPortEntries();
 
-  try {
-    CmdShowPort().createModel(
-        invalidPortEntries,
-        mockTransceiverEntries,
-        queriedEntries,
-        mockPortStats,
-        mockPortToPeer,
-        mockPeerDrainStates,
-        mockPeerPortInfo,
-        mockDrainedInterfaces);
-    FAIL();
-  } catch (const std::invalid_argument& expected) {
-    ASSERT_STREQ(
-        "Invalid port name: eth/5/1\n"
-        "Port name must match 'moduleNum/port/subport' pattern",
-        expected.what());
-  }
+  cli::ShowPortModel model;
+  ASSERT_NO_THROW(
+      model = CmdShowPort().createModel(
+          invalidPortEntries,
+          mockTransceiverEntries,
+          queriedEntries,
+          mockPortStats,
+          mockPortToPeer,
+          mockPeerDrainStates,
+          mockPeerPortInfo,
+          mockDrainedInterfaces));
+
+  auto portEntries = model.portEntries().value();
+  ASSERT_EQ(portEntries.size(), 2);
+  EXPECT_EQ(folly::copy(portEntries[0].id().value()), 1);
+  EXPECT_EQ(folly::copy(portEntries[1].id().value()), 2);
 }
 
 TEST_F(CmdShowPortTestFixture, queryClient) {

--- a/fboss/cli/fboss2/test/CmdShowPortTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowPortTest.cpp
@@ -428,25 +428,28 @@ TEST_F(CmdShowPortTestFixture, sortByName) {
 }
 
 TEST_F(CmdShowPortTestFixture, invalidPortName) {
+  // Interface names are free-form -- SVIs are named arbitrary things and the
+  // name may be unset -- so a name that doesn't follow the
+  // moduleNum/port/subport pattern must not abort the command. Such entries
+  // are ordered by their numeric port ID instead.
   auto invalidPortEntries = createInvalidPortEntries();
 
-  try {
-    CmdShowPort().createModel(
-        invalidPortEntries,
-        mockTransceiverEntries,
-        queriedEntries,
-        mockPortStats,
-        mockPortToPeer,
-        mockPeerDrainStates,
-        mockPeerPortInfo,
-        mockDrainedInterfaces);
-    FAIL();
-  } catch (const std::invalid_argument& expected) {
-    ASSERT_STREQ(
-        "Invalid port name: eth/5/1\n"
-        "Port name must match 'moduleNum/port/subport' pattern",
-        expected.what());
-  }
+  cli::ShowPortModel model;
+  ASSERT_NO_THROW(
+      model = CmdShowPort().createModel(
+          invalidPortEntries,
+          mockTransceiverEntries,
+          queriedEntries,
+          mockPortStats,
+          mockPortToPeer,
+          mockPeerDrainStates,
+          mockPeerPortInfo,
+          mockDrainedInterfaces));
+
+  auto portEntries = model.portEntries().value();
+  ASSERT_EQ(portEntries.size(), 2);
+  EXPECT_EQ(folly::copy(portEntries[0].id().value()), 1);
+  EXPECT_EQ(folly::copy(portEntries[1].id().value()), 2);
 }
 
 TEST_F(CmdShowPortTestFixture, queryClient) {

--- a/fboss/cli/fboss2/test/CmdShowTransceiverTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowTransceiverTest.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include <folly/IPAddressV4.h>
+#include <folly/IPAddressV4.h> // NOLINT(misc-include-cleaner)
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -195,7 +195,9 @@ cli::ShowTransceiverModel createTransceiverModel() {
   auto makeDefaultTcvrDetail = [](std::string name,
                                   std::optional<bool> isUp,
                                   bool isPresent,
-                                  MediaInterfaceCode media) {
+                                  MediaInterfaceCode media,
+                                  int32_t tcvrId,
+                                  std::optional<int32_t> portId) {
     cli::TransceiverDetail detail;
     detail.name() = name;
     if (isUp.has_value()) {
@@ -203,6 +205,10 @@ cli::ShowTransceiverModel createTransceiverModel() {
     }
     detail.isPresent() = isPresent;
     detail.mediaInterface() = media;
+    detail.transceiverID() = tcvrId;
+    if (portId.has_value()) {
+      detail.portID() = *portId;
+    }
 
     return detail;
   };
@@ -237,49 +243,59 @@ cli::ShowTransceiverModel createTransceiverModel() {
   cli::ShowTransceiverModel model;
 
   auto entry1 = makeDefaultTcvrDetail(
-      "eth1/1/1", true, true, MediaInterfaceCode::FR4_400G);
+      "eth1/1/1", true, true, MediaInterfaceCode::FR4_400G, 1, 1);
   setConfigAttributes(entry1, "vendorOne", "aa", "1", "1", "2");
   setValidationStatus(entry1, "Not Validated", "nonValidatedVendorPartNumber");
   setOperAttributes(entry1, 50.0, 25.0);
 
   auto entry2 = makeDefaultTcvrDetail(
-      "eth1/2/1", true, true, MediaInterfaceCode::UNKNOWN);
+      "eth1/2/1", true, true, MediaInterfaceCode::UNKNOWN, 2, 2);
   setConfigAttributes(entry2, "vendorTwo", "b", "3", "", "");
   setValidationStatus(entry2, "Not Validated", "missingVendor");
   setOperAttributes(entry2, 40.0, 25.0);
 
   auto entry3 = makeDefaultTcvrDetail(
-      "eth1/3/1", false, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/3/1", false, false, MediaInterfaceCode::UNKNOWN, 3, 3);
   setConfigAttributes(entry3, "vendorOne", "ab", "1", "", "");
   setValidationStatus(entry3, "--", "--");
   setOperAttributes(entry3, 0.0, 0.0);
 
   auto entry4 = makeDefaultTcvrDetail(
-      "eth1/4/1", false, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/4/1", false, false, MediaInterfaceCode::UNKNOWN, 4, 4);
   setConfigAttributes(entry4, "vendorOne", "ac", "1", "", "");
   setValidationStatus(entry4, "--", "--");
   setOperAttributes(entry4, 0.0, 0.0);
 
   auto entry5 = makeDefaultTcvrDetail(
-      "eth1/5/1", true, true, MediaInterfaceCode::LR4_400G_10KM);
+      "eth1/5/1", true, true, MediaInterfaceCode::LR4_400G_10KM, 5, 5);
   setConfigAttributes(entry5, "vendorOne", "ad", "2", "", "");
   setValidationStatus(entry5, "Not Validated", "invalidEepromChecksums");
   setOperAttributes(entry5, 0.0, 0.0);
 
   auto entry6 = makeDefaultTcvrDetail(
-      "eth1/6/1", true, true, MediaInterfaceCode::FR4_LITE_2x400G);
+      "eth1/6/1", true, true, MediaInterfaceCode::FR4_LITE_2x400G, 6, 6);
   setConfigAttributes(entry6, "vendorThree", "c", "4", "3", "4");
   setValidationStatus(entry6, "Validated", "--");
   setOperAttributes(entry6, 30.0, 30.0);
 
   auto bypassEntry = makeDefaultTcvrDetail(
-      "eth1/7/1", std::nullopt, true, MediaInterfaceCode::UNKNOWN);
+      "eth1/7/1",
+      std::nullopt,
+      true,
+      MediaInterfaceCode::UNKNOWN,
+      7,
+      std::nullopt);
   setConfigAttributes(bypassEntry, "vendorBypass", "d", "5", "4", "5");
   setValidationStatus(bypassEntry, "--", "--");
   setOperAttributes(bypassEntry, 0.0, 0.0);
 
   auto absentBypassEntry = makeDefaultTcvrDetail(
-      "eth1/8/1", std::nullopt, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/8/1",
+      std::nullopt,
+      false,
+      MediaInterfaceCode::UNKNOWN,
+      8,
+      std::nullopt);
   setConfigAttributes(absentBypassEntry, "", "", "", "", "");
   setValidationStatus(absentBypassEntry, "--", "--");
   setOperAttributes(absentBypassEntry, 0.0, 0.0);
@@ -807,6 +823,62 @@ TEST_F(CmdShowTransceiverTestFixture, printOutput) {
       " eth1/8/1   Bypass  Absent           --             --                                                                                               0.00             0.00                                                              \n\n";
 
   EXPECT_EQ(output, expectOutput);
+}
+
+TEST_F(CmdShowTransceiverTestFixture, printOutputSortsByNumericId) {
+  // Rows are ordered by (transceiver ID, port ID), not by name. The model is
+  // keyed by name, so a name that sorts early lexicographically but has a high
+  // transceiver ID must still be printed last.
+  auto model = normalizedModel;
+  auto detail = model.transceivers()->at("eth1/1/1");
+  detail.name() = "eth1/10/1";
+  detail.transceiverID() = 10;
+  detail.portID() = 10;
+  model.transceivers()->emplace("eth1/10/1", std::move(detail));
+
+  std::stringstream ss;
+  CmdShowTransceiver().printOutput(model, ss);
+  std::string output = ss.str();
+
+  ASSERT_NE(output.find("eth1/10/1"), std::string::npos);
+  EXPECT_GT(output.find("eth1/10/1"), output.find("eth1/8/1"));
+}
+
+TEST_F(CmdShowTransceiverTestFixture, printOutputFreeFormNames) {
+  // Interface names can be arbitrary (e.g. SVIs named "downlinks") or unset.
+  // Ordering stays numeric and printing must not throw.
+  cli::ShowTransceiverModel model;
+  auto makeDetail = [](const std::string& name, int32_t tcvrId) {
+    cli::TransceiverDetail detail;
+    detail.name() = name;
+    detail.transceiverID() = tcvrId;
+    detail.isPresent() = false;
+    detail.mediaInterface() = MediaInterfaceCode::UNKNOWN;
+    detail.vendor() = "";
+    detail.serial() = "";
+    detail.partNumber() = "";
+    detail.appFwVer() = "";
+    detail.dspFwVer() = "";
+    detail.validationStatus() = "--";
+    detail.notValidatedReason() = "--";
+    detail.temperature() = 0.0;
+    detail.voltage() = 0.0;
+    detail.currentMA() = {};
+    detail.txPower() = {};
+    detail.rxPower() = {};
+    detail.rxSnr() = {};
+    return detail;
+  };
+  model.transceivers()->emplace("downlinks", makeDetail("downlinks", 3));
+  model.transceivers()->emplace("eth1/1/1", makeDetail("eth1/1/1", 1));
+
+  std::stringstream ss;
+  ASSERT_NO_THROW(CmdShowTransceiver().printOutput(model, ss));
+  std::string output = ss.str();
+
+  ASSERT_NE(output.find("downlinks"), std::string::npos);
+  // Parseable names come first; "downlinks" carries no ordering.
+  EXPECT_GT(output.find("downlinks"), output.find("eth1/1/1"));
 }
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/CmdShowTransceiverTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowTransceiverTest.cpp
@@ -1,6 +1,6 @@
 // (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
 
-#include <folly/IPAddressV4.h>
+#include <folly/IPAddressV4.h> // NOLINT(misc-include-cleaner)
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -195,7 +195,9 @@ cli::ShowTransceiverModel createTransceiverModel() {
   auto makeDefaultTcvrDetail = [](std::string name,
                                   std::optional<bool> isUp,
                                   bool isPresent,
-                                  MediaInterfaceCode media) {
+                                  MediaInterfaceCode media,
+                                  int32_t tcvrId,
+                                  std::optional<int32_t> portId) {
     cli::TransceiverDetail detail;
     detail.name() = name;
     if (isUp.has_value()) {
@@ -203,6 +205,10 @@ cli::ShowTransceiverModel createTransceiverModel() {
     }
     detail.isPresent() = isPresent;
     detail.mediaInterface() = media;
+    detail.transceiverID() = tcvrId;
+    if (portId.has_value()) {
+      detail.portID() = *portId;
+    }
 
     return detail;
   };
@@ -237,49 +243,59 @@ cli::ShowTransceiverModel createTransceiverModel() {
   cli::ShowTransceiverModel model;
 
   auto entry1 = makeDefaultTcvrDetail(
-      "eth1/1/1", true, true, MediaInterfaceCode::FR4_400G);
+      "eth1/1/1", true, true, MediaInterfaceCode::FR4_400G, 1, 1);
   setConfigAttributes(entry1, "vendorOne", "aa", "1", "1", "2");
   setValidationStatus(entry1, "Not Validated", "nonValidatedVendorPartNumber");
   setOperAttributes(entry1, 50.0, 25.0);
 
   auto entry2 = makeDefaultTcvrDetail(
-      "eth1/2/1", true, true, MediaInterfaceCode::UNKNOWN);
+      "eth1/2/1", true, true, MediaInterfaceCode::UNKNOWN, 2, 2);
   setConfigAttributes(entry2, "vendorTwo", "b", "3", "", "");
   setValidationStatus(entry2, "Not Validated", "missingVendor");
   setOperAttributes(entry2, 40.0, 25.0);
 
   auto entry3 = makeDefaultTcvrDetail(
-      "eth1/3/1", false, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/3/1", false, false, MediaInterfaceCode::UNKNOWN, 3, 3);
   setConfigAttributes(entry3, "vendorOne", "ab", "1", "", "");
   setValidationStatus(entry3, "--", "--");
   setOperAttributes(entry3, 0.0, 0.0);
 
   auto entry4 = makeDefaultTcvrDetail(
-      "eth1/4/1", false, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/4/1", false, false, MediaInterfaceCode::UNKNOWN, 4, 4);
   setConfigAttributes(entry4, "vendorOne", "ac", "1", "", "");
   setValidationStatus(entry4, "--", "--");
   setOperAttributes(entry4, 0.0, 0.0);
 
   auto entry5 = makeDefaultTcvrDetail(
-      "eth1/5/1", true, true, MediaInterfaceCode::LR4_400G_10KM);
+      "eth1/5/1", true, true, MediaInterfaceCode::LR4_400G_10KM, 5, 5);
   setConfigAttributes(entry5, "vendorOne", "ad", "2", "", "");
   setValidationStatus(entry5, "Not Validated", "invalidEepromChecksums");
   setOperAttributes(entry5, 0.0, 0.0);
 
   auto entry6 = makeDefaultTcvrDetail(
-      "eth1/6/1", true, true, MediaInterfaceCode::FR4_LITE_2x400G);
+      "eth1/6/1", true, true, MediaInterfaceCode::FR4_LITE_2x400G, 6, 6);
   setConfigAttributes(entry6, "vendorThree", "c", "4", "3", "4");
   setValidationStatus(entry6, "Validated", "--");
   setOperAttributes(entry6, 30.0, 30.0);
 
   auto bypassEntry = makeDefaultTcvrDetail(
-      "eth1/7/1", std::nullopt, true, MediaInterfaceCode::UNKNOWN);
+      "eth1/7/1",
+      std::nullopt,
+      true,
+      MediaInterfaceCode::UNKNOWN,
+      7,
+      std::nullopt);
   setConfigAttributes(bypassEntry, "vendorBypass", "d", "5", "4", "5");
   setValidationStatus(bypassEntry, "--", "--");
   setOperAttributes(bypassEntry, 0.0, 0.0);
 
   auto absentBypassEntry = makeDefaultTcvrDetail(
-      "eth1/8/1", std::nullopt, false, MediaInterfaceCode::UNKNOWN);
+      "eth1/8/1",
+      std::nullopt,
+      false,
+      MediaInterfaceCode::UNKNOWN,
+      8,
+      std::nullopt);
   setConfigAttributes(absentBypassEntry, "", "", "", "", "");
   setValidationStatus(absentBypassEntry, "--", "--");
   setOperAttributes(absentBypassEntry, 0.0, 0.0);
@@ -814,6 +830,62 @@ TEST_F(CmdShowTransceiverTestFixture, printOutput) {
 TEST_F(CmdShowTransceiverTestFixture, wikiDocHooks) {
   EXPECT_FALSE(CmdShowTransceiverTraits::description().empty());
   EXPECT_FALSE(CmdShowTransceiver::sampleModel().transceivers()->empty());
+}
+
+TEST_F(CmdShowTransceiverTestFixture, printOutputSortsByNumericId) {
+  // Rows are ordered by (transceiver ID, port ID), not by name. The model is
+  // keyed by name, so a name that sorts early lexicographically but has a high
+  // transceiver ID must still be printed last.
+  auto model = normalizedModel;
+  auto detail = model.transceivers()->at("eth1/1/1");
+  detail.name() = "eth1/10/1";
+  detail.transceiverID() = 10;
+  detail.portID() = 10;
+  model.transceivers()->emplace("eth1/10/1", std::move(detail));
+
+  std::stringstream ss;
+  CmdShowTransceiver().printOutput(model, ss);
+  std::string output = ss.str();
+
+  ASSERT_NE(output.find("eth1/10/1"), std::string::npos);
+  EXPECT_GT(output.find("eth1/10/1"), output.find("eth1/8/1"));
+}
+
+TEST_F(CmdShowTransceiverTestFixture, printOutputFreeFormNames) {
+  // Interface names can be arbitrary (e.g. SVIs named "downlinks") or unset.
+  // Ordering stays numeric and printing must not throw.
+  cli::ShowTransceiverModel model;
+  auto makeDetail = [](const std::string& name, int32_t tcvrId) {
+    cli::TransceiverDetail detail;
+    detail.name() = name;
+    detail.transceiverID() = tcvrId;
+    detail.isPresent() = false;
+    detail.mediaInterface() = MediaInterfaceCode::UNKNOWN;
+    detail.vendor() = "";
+    detail.serial() = "";
+    detail.partNumber() = "";
+    detail.appFwVer() = "";
+    detail.dspFwVer() = "";
+    detail.validationStatus() = "--";
+    detail.notValidatedReason() = "--";
+    detail.temperature() = 0.0;
+    detail.voltage() = 0.0;
+    detail.currentMA() = {};
+    detail.txPower() = {};
+    detail.rxPower() = {};
+    detail.rxSnr() = {};
+    return detail;
+  };
+  model.transceivers()->emplace("downlinks", makeDetail("downlinks", 3));
+  model.transceivers()->emplace("eth1/1/1", makeDetail("eth1/1/1", 1));
+
+  std::stringstream ss;
+  ASSERT_NO_THROW(CmdShowTransceiver().printOutput(model, ss));
+  std::string output = ss.str();
+
+  ASSERT_NE(output.find("downlinks"), std::string::npos);
+  // Parseable names come first; "downlinks" carries no ordering.
+  EXPECT_GT(output.find("downlinks"), output.find("eth1/1/1"));
 }
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/utils/CmdUtils.cpp
+++ b/fboss/cli/fboss2/utils/CmdUtils.cpp
@@ -141,6 +141,37 @@ bool isRunningOnSwitch() {
 #endif
 }
 
+std::optional<PortNameParts> parsePortName(const std::string& name) {
+  static const RE2 exp(R"(([a-z][a-z][a-z])(\d+)/(\d+)/(\d+))");
+  std::string moduleName, moduleNumStr, portNumStr, subportNumStr;
+  if (!RE2::FullMatch(
+          name, exp, &moduleName, &moduleNumStr, &portNumStr, &subportNumStr)) {
+    return std::nullopt;
+  }
+  return PortNameParts{
+      moduleName, stoi(moduleNumStr), stoi(portNumStr), stoi(subportNumStr)};
+}
+
+bool comparePortNameOrId(
+    const std::string& nameA,
+    int32_t idA,
+    const std::string& nameB,
+    int32_t idB) {
+  const auto partsA = parsePortName(nameA);
+  const auto partsB = parsePortName(nameB);
+  // Interface names are free-form: SVIs are named arbitrary things like
+  // "downlinks" and may be unset entirely. Prefer front panel ordering from
+  // the name when it encodes one, and fall back to the numeric ID otherwise.
+  if (partsA && partsB) {
+    return *partsA < *partsB;
+  }
+  if (partsA.has_value() != partsB.has_value()) {
+    // Keep physical ports ahead of names that carry no ordering.
+    return partsA.has_value();
+  }
+  return idA < idB;
+}
+
 bool comparePortName(
     const std::basic_string<char>& nameA,
     const std::basic_string<char>& nameB) {

--- a/fboss/cli/fboss2/utils/CmdUtils.h
+++ b/fboss/cli/fboss2/utils/CmdUtils.h
@@ -15,19 +15,21 @@
 #include <folly/String.h>
 #include <folly/gen/Base.h>
 #include <re2/re2.h>
+#include <optional>
 #include <stdexcept>
 #include <string>
-#include <variant>
+#include <tuple>
+#include <variant> // NOLINT(misc-include-cleaner)
 
 #include "fboss/agent/if/gen-cpp2/FbossCtrlAsyncClient.h"
-#include "fboss/cli/fboss2/CmdGlobalOptions.h"
-#include "fboss/cli/fboss2/gen-cpp2/cli_types.h"
-#include "fboss/cli/fboss2/utils/CmdClientUtils.h"
+#include "fboss/cli/fboss2/CmdGlobalOptions.h" // NOLINT(misc-include-cleaner)
+#include "fboss/cli/fboss2/gen-cpp2/cli_types.h" // NOLINT(misc-include-cleaner)
+#include "fboss/cli/fboss2/utils/CmdClientUtils.h" // NOLINT(misc-include-cleaner)
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 #include "fboss/cli/fboss2/utils/HostInfo.h"
 #include "fboss/cli/fboss2/utils/PrbsUtils.h"
 #include "fboss/cli/fboss2/utils/Table.h"
-#include "fboss/fsdb/if/gen-cpp2/FsdbService.h"
+#include "fboss/fsdb/if/gen-cpp2/FsdbService.h" // NOLINT(misc-include-cleaner)
 #include "fboss/lib/phy/gen-cpp2/phy_types.h"
 #include "fboss/lib/phy/gen-cpp2/prbs_types.h"
 
@@ -520,6 +522,40 @@ std::string getl2EntryTypeStr(L2EntryType l2EntryType);
 bool comparePortName(
     const std::basic_string<char>& nameA,
     const std::basic_string<char>& nameB);
+
+struct PortNameParts {
+  std::string moduleName;
+  int moduleNum{0};
+  int portNum{0};
+  int subportNum{0};
+
+  auto tie() const {
+    return std::tie(moduleName, moduleNum, portNum, subportNum);
+  }
+  bool operator<(const PortNameParts& other) const {
+    return tie() < other.tie();
+  }
+};
+
+/*
+ * Parses a "moduleNum/port/subport" interface name (e.g. eth1/5/3). Returns
+ * std::nullopt for names that don't follow the pattern, rather than throwing
+ * the way comparePortName does.
+ */
+std::optional<PortNameParts> parsePortName(const std::string& name);
+
+/*
+ * Orders interfaces for display. Interface names are free-form -- SVIs are
+ * named arbitrary things like "downlinks" and may be unset -- so names that
+ * parse are ordered by their numeric module/port/subport components (front
+ * panel order) and anything else falls back to the numeric port/interface ID.
+ * Never throws.
+ */
+bool comparePortNameOrId(
+    const std::string& nameA,
+    int32_t idA,
+    const std::string& nameB,
+    int32_t idB);
 
 bool compareSystemPortName(
     const std::basic_string<char>& nameA,


### PR DESCRIPTION
# Summary

`show interface status` and `show transceiver` ordered interfaces by a plain lexicographic comparison of the interface name, so ports came out as:

```
eth1/1/1
eth1/10/1
eth1/100/1
eth1/101/1
eth1/2/1
```

`show port` doesn't have this problem because it sorts with `utils::comparePortName`, which parses the `moduleNum/port/subport` components and compares them numerically. This PR points the other two commands at the same comparator so all three sort consistently:

```
eth1/1/1
eth1/2/1
eth1/10/1
eth1/100/1
eth1/101/1
```

- Adds `utils::parsePortName()` — a non-throwing parse returning `std::optional<PortNameParts>`.
- Adds `utils::comparePortNameOrId(nameA, idA, nameB, idB)`: orders by numeric module/port/subport when the name encodes a front panel position, falls back to the numeric ID when it doesn't, and keeps physical ports ahead of unparseable names. Never throws.
- Points `show port`, `show interface status` and `show transceiver` at it, plumbing the numeric IDs through their models (`InterfaceStatus.portId`; `TransceiverDetail.transceiverID` + optional `portID`, since bypass modules have no agent port).

# Test Plan

Added unit tests:

- `CmdShowInterfaceStatusTest.createModelNaturalSort` — feeds `eth1/2/1, eth1/10/1, eth1/1/1, eth1/100/1, eth2/1/1` and asserts the model comes out in numeric order.
- `CmdShowInterfaceStatusTest.createModelFreeFormNames` — `downlinks` and an unset name alongside a normal port; `ASSERT_NO_THROW`, and the unparseable names order by ID after the physical port.
- `CmdShowTransceiverTest.printOutputNaturalSort` — injects `eth1/10/1` (which sorts between `eth1/1/1` and `eth1/2/1` as a string) and asserts it is printed after `eth1/8/1`, so same coverage for the transceiver path, including a bypass module with no port ID.

Existing `CmdShowPortTest` / `CmdShowTransceiverTest` expectations are unchanged; the transceiver fixture now populates the new ID fields.