### PR TITLE
[Meta] Add --local fast-dev mode to fboss-sim-docker-run.py

### DIFF
--- a/fboss-sim/scripts/fboss-sim-docker-package.py
+++ b/fboss-sim/scripts/fboss-sim-docker-package.py
@@ -94,7 +94,7 @@ def verify_binaries(build_dir: Path) -> None:
     print(f"  ✓ All {len(REQUIRED_BINARIES)} required binaries present")
 
 
-def resolve_dependencies(binary_path: Path) -> set[str]:
+def resolve_dependencies(binary_path: Path, installed_dir: Path) -> set[str]:
     """Use ldd to find shared library dependencies for a binary."""
     dependencies = set()
 
@@ -106,10 +106,24 @@ def resolve_dependencies(binary_path: Path) -> set[str]:
     except subprocess.CalledProcessError:
         return dependencies
 
-    # Resolve via the binary's own RUNPATH; strip any inherited LD_LIBRARY_PATH
-    # so a stale dep generation under installed/ can't shadow the correct one.
+    # Resolve via LD_LIBRARY_PATH pointed at THIS build's installed/ tree. The
+    # binaries' baked RUNPATH is the absolute build-time scratch path, which need
+    # not exist in the collect environment -- e.g. the CI collect container mounts
+    # the build tree at a different path than the one baked at build time -- so
+    # RUNPATH-only resolution reports every getdeps lib (folly, wangle, mvfst, ...)
+    # as "not found". Pointing ldd at the installed/ lib dirs resolves them
+    # wherever the tree is mounted.
     env = os.environ.copy()
-    env.pop("LD_LIBRARY_PATH", None)
+    lib_dirs = [
+        str(d)
+        for pat in ("*/lib", "*/lib64")
+        for d in sorted(installed_dir.glob(pat))
+        if d.is_dir()
+    ]
+    if lib_dirs:
+        env["LD_LIBRARY_PATH"] = ":".join(lib_dirs)
+    else:
+        env.pop("LD_LIBRARY_PATH", None)
 
     try:
         output = subprocess.check_output(
@@ -203,7 +217,7 @@ def copy_artifacts(
     all_deps: set[str] = set()
     for binary in REQUIRED_BINARIES:
         binary_path = build_dir / binary
-        all_deps.update(resolve_dependencies(binary_path))
+        all_deps.update(resolve_dependencies(binary_path, installed_dir))
 
     for lib_path in sorted(all_deps):
         lib_name = os.path.basename(lib_path)

--- a/fboss-sim/scripts/fboss-sim-docker-run.py
+++ b/fboss-sim/scripts/fboss-sim-docker-run.py
@@ -4,11 +4,24 @@
 """
 Run fboss-sim runtime container with proper configuration.
 
-This script launches the minimal fboss-sim runtime container created by
-fboss-sim-docker-package.py with all necessary flags and capabilities.
+Two modes:
+
+- Default (production-like): launch the minimal runtime image built by
+  fboss-sim-docker-package.py. Binaries + libs are baked into the image at
+  /opt/fboss.
+
+- --local (fast dev loop): skip the collect/package/image-build entirely.
+  Launch the same systemd environment from the getdeps *build* image with the
+  repo and the build scratch bind-mounted, symlink the freshly built binaries
+  into /opt/fboss/bin, and bring the agents up as systemd services. Rebuild
+  binaries and just restart the agents to iterate — no image rebuild.
+
+Both modes give a production-like systemd container (PID 1 = /sbin/init,
+agents run as systemd units), which is required for the config-mutation
+fboss2_integration_test cases (they restart agents via `systemctl`).
 
 Features:
-- Proper systemd support (--cgroupns=host)
+- Proper systemd support (--cgroupns=host, /sbin/init as PID 1)
 - Shared memory configuration (--shm-size=512m) to prevent malloc corruption
 - Network capabilities for interface management
 - IPv6-enabled Docker network so Thrift servers bind to :: (not 0.0.0.0)
@@ -16,15 +29,21 @@ Features:
 - Automatically stops and removes existing container
 """
 
+import argparse
 import getpass
 import hashlib
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 USERNAME = getpass.getuser()
 DEFAULT_IMAGE_NAME = f"fboss_sim_runtime_{USERNAME}"
 DEFAULT_CONTAINER_NAME = f"fboss_sim_runtime_{USERNAME}"
+
+# In --local mode we run from the getdeps build image (has the toolchain +
+# system libs) instead of the packaged runtime image.
+DEFAULT_BUILD_IMAGE = "fboss_docker:latest"
 
 
 def user_subnet_v6(username: str) -> str:
@@ -100,16 +119,29 @@ def stop_existing_container(container_name: str) -> None:
         print("  → No existing container found")
 
 
-def run_container() -> int:
-    image_tag = f"{DEFAULT_IMAGE_NAME}:latest"
-    print("\n🚀 Starting fboss-sim runtime container...")
-    print(f"  Image:     {image_tag}")
-    print(f"  Container: {DEFAULT_CONTAINER_NAME}")
-    print(f"  Network:   {NETWORK_NAME} (IPv6-enabled)")
+def teardown() -> int:
+    """Stop + remove the sim container (gracefully) and its IPv6 network."""
+    print("\n🧹 Tearing down fboss-sim container + network...")
+    # stop_existing_container does `docker stop` (STOPSIGNAL SIGRTMIN+3 -> clean
+    # systemd shutdown) then `docker rm`.
+    stop_existing_container(DEFAULT_CONTAINER_NAME)
+    result = subprocess.run(
+        ["docker", "network", "rm", NETWORK_NAME],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        print(f"  ✓ Network {NETWORK_NAME} removed")
+    else:
+        print(f"  → Network {NETWORK_NAME}: {result.stderr.strip() or 'not found'}")
+    print("✓ Teardown complete")
+    return 0
 
-    cmd = [
-        "docker",
-        "run",
+
+def _base_run_flags() -> list[str]:
+    """Systemd + networking + capability flags shared by both modes."""
+    return [
         "-d",
         # CAP_NET_ADMIN: TunManager network interface creation
         # CAP_SYS_ADMIN: systemd cgroup management
@@ -128,10 +160,22 @@ def run_container() -> int:
         "/run",
         "--tmpfs",
         "/tmp",
-        "--name",
-        DEFAULT_CONTAINER_NAME,
-        image_tag,
     ]
+
+
+def run_container() -> int:
+    """Production-like mode: run the packaged runtime image (systemd baked in)."""
+    image_tag = f"{DEFAULT_IMAGE_NAME}:latest"
+    print("\n🚀 Starting fboss-sim runtime container...")
+    print(f"  Image:     {image_tag}")
+    print(f"  Container: {DEFAULT_CONTAINER_NAME}")
+    print(f"  Network:   {NETWORK_NAME} (IPv6-enabled)")
+
+    cmd = (
+        ["docker", "run"]
+        + _base_run_flags()
+        + ["--name", DEFAULT_CONTAINER_NAME, image_tag]
+    )
 
     result = subprocess.run(cmd, check=False, capture_output=True, text=True)
     if result.returncode != 0:
@@ -142,6 +186,164 @@ def run_container() -> int:
 
     container_id = result.stdout.strip()
     print(f"  ✓ Container started (ID: {container_id[:12]})")
+    return 0
+
+
+# --- Local (fast dev) mode -------------------------------------------------
+#
+# Bring-up run inside a fresh container launched from the build image with
+# PID 1 = /sbin/init (a new, dedicated sim container — not the getdeps build
+# container). Mirrors what Dockerfile.runtime does at image-build time, but
+# symlinks the freshly built binaries from the mounted build tree instead of
+# copying them, so a rebuild + `systemctl restart` is all that's needed to
+# iterate.
+#
+# NOTE on RUNPATH: getdeps bakes an absolute RUNPATH (the build scratch path)
+# into the binaries, so the build scratch must appear at that exact path inside
+# the container. We bind-mount --build-dir at --runpath-dir for that reason;
+# for a native (host) build the two are identical.
+_LOCAL_SETUP = r"""
+set -e
+REPO="{repo}"
+B="{runpath}/build/fboss"
+ROOTFS="$REPO/fboss-image/image_builder/templates/centos-09.0/root_files"
+
+echo "→ Installing runtime deps..."
+dnf install -y iproute procps-ng jemalloc jq >/dev/null
+
+mkdir -p /opt/fboss/bin /opt/fboss/lib /opt/fboss/share /etc/coop /root/config \
+         /var/facebook/fboss /var/facebook/logs/fboss /dev/shm/fboss
+
+echo "→ Installing systemd units + rootfs overlay..."
+cp -a "$ROOTFS"/. /
+
+echo "→ Symlinking freshly built binaries into /opt/fboss/bin..."
+for f in wedge_agent-sai_impl fboss_sw_agent fboss_hw_agent-sai_impl \
+         fboss2 fboss2-dev fboss2_integration_test; do
+  ln -sfn "$B/$f" "/opt/fboss/bin/$f"
+done
+ln -sfn "$REPO/fboss/oss/scripts/run_scripts/setup_fboss_env" \
+        /opt/fboss/bin/setup_fboss_env
+
+echo "→ Installing configs + fruid..."
+cp "$REPO/fboss-sim/docker/runtime/mono.conf" /root/config/mono.conf
+jq '.defaultCommandLineArgs.multi_switch="true"' \
+   /root/config/mono.conf > /root/config/split.conf
+cp "$REPO/fboss-sim/docker/runtime/fruid.json" /var/facebook/fboss/fruid.json
+
+echo "→ Running setup-container.sh (jemalloc, service enable, /etc/coop git)..."
+cp "$REPO/fboss-sim/docker/runtime/setup-container.sh" /tmp/setup-container.sh
+chmod +x /tmp/setup-container.sh
+/tmp/setup-container.sh
+
+# Disable host TUN for sw_agent: TunManager isn't needed for the sim's CLI /
+# config testing and crashes under fake SAI (getTableId->l3SwitchType).
+# mono.conf/split.conf also set tun_intf=false; this drop-in enforces it.
+echo "→ Applying --tun_intf=false drop-in for fboss_sw_agent..."
+mkdir -p /etc/systemd/system/fboss_sw_agent.service.d
+cat > /etc/systemd/system/fboss_sw_agent.service.d/override.conf <<'DROPIN'
+[Service]
+ExecStart=
+ExecStart=/bin/bash -c 'source /opt/fboss/bin/setup_fboss_env && exec /opt/fboss/bin/fboss_sw_agent --fsdb_client_ssl_preferred=false --thrift_ssl_policy=disabled --tun_intf=false'
+DROPIN
+systemctl daemon-reload
+
+# Neither switch-agent-mode.sh nor a wedge_agent.service unit ship in the
+# centos-09.0 overlay, so mono mode and live mode-switching don't work out of
+# the box. Install the mode switcher and synthesize a wedge_agent.service
+# (running wedge_agent-sai_impl) so `switch-agent-mode.sh mono|split` works on a
+# live container. setup-container.sh masks wedge_agent by default (split stays
+# the default); switch-agent-mode.sh unmasks it when switching to mono.
+echo "→ Installing switch-agent-mode.sh + wedge_agent.service (mono)..."
+cp "$REPO/fboss-sim/docker/runtime/switch-agent-mode.sh" \
+   /usr/local/bin/switch-agent-mode.sh
+chmod +x /usr/local/bin/switch-agent-mode.sh
+cat > /usr/lib/systemd/system/wedge_agent.service <<'UNIT'
+[Unit]
+Description=FBOSS Wedge Agent (mono)
+StartLimitIntervalSec=0
+[Service]
+Type=simple
+LimitNOFILE=10000000
+Environment="PATH=/opt/fboss/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin"
+Environment="LD_LIBRARY_PATH=/opt/fboss/lib"
+Environment="LD_PRELOAD=/usr/lib64/libjemalloc.so.2"
+WorkingDirectory=/opt/fboss
+ExecStart=/bin/bash -c 'source /opt/fboss/bin/setup_fboss_env && exec /opt/fboss/bin/wedge_agent-sai_impl --fsdb_client_ssl_preferred=false --thrift_ssl_policy=disabled --tun_intf=false'
+Restart=always
+StandardOutput=append:/var/facebook/logs/fboss/wedge_agent.log
+StandardError=append:/var/facebook/logs/fboss/wedge_agent.log
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+echo "✓ local setup complete"
+"""
+
+
+def _docker_exec(container: str, script: str) -> int:
+    return subprocess.run(
+        ["docker", "exec", container, "bash", "-c", script], check=False
+    ).returncode
+
+
+def run_local(args: argparse.Namespace) -> int:
+    repo = os.path.abspath(args.repo_dir)
+    build_dir = os.path.abspath(args.build_dir)
+    runpath = args.runpath_dir or build_dir
+    if not os.path.isdir(os.path.join(build_dir, "build", "fboss")):
+        print(f"❌ No build/fboss under --build-dir {build_dir}")
+        print(
+            "   Point --build-dir at your getdeps scratch (contains build/, installed/)."
+        )
+        return 1
+
+    print("\n🚀 Starting fboss-sim LOCAL dev container (systemd)...")
+    print(f"  Image:     {args.build_image}")
+    print(f"  Container: {DEFAULT_CONTAINER_NAME}")
+    print(f"  Repo:      {repo} -> /var/FBOSS/fboss")
+    print(f"  Build:     {build_dir} -> {runpath}  (RUNPATH-matching)")
+    print(f"  Mode:      {args.mode}")
+
+    cmd = (
+        ["docker", "run"]
+        + _base_run_flags()
+        + [
+            "-v",
+            f"{repo}:/var/FBOSS/fboss",
+            "-v",
+            f"{build_dir}:{runpath}",
+            "--name",
+            DEFAULT_CONTAINER_NAME,
+            args.build_image,
+            "/sbin/init",
+        ]
+    )
+    result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+    if result.returncode != 0:
+        print("❌ Failed to start container")
+        if result.stderr:
+            print(f"Error: {result.stderr}")
+        return result.returncode
+    print(f"  ✓ Container started (ID: {result.stdout.strip()[:12]})")
+
+    print("\n🔧 Setting up sim environment inside the container...")
+    setup = _LOCAL_SETUP.format(repo="/var/FBOSS/fboss", runpath=runpath)
+    rc = _docker_exec(DEFAULT_CONTAINER_NAME, setup)
+    if rc != 0:
+        print("❌ In-container setup failed")
+        return rc
+
+    print(f"\n▶ Starting agents ({args.mode} mode)...")
+    if args.mode == "mono":
+        rc = _docker_exec(DEFAULT_CONTAINER_NAME, "switch-agent-mode.sh mono")
+    else:
+        rc = _docker_exec(
+            DEFAULT_CONTAINER_NAME, "systemctl start fboss_hw_agent@0 fboss_sw_agent"
+        )
+    if rc != 0:
+        print("❌ Failed to start agents")
+        return rc
     return 0
 
 
@@ -160,10 +362,103 @@ def emit_github_output(key: str, value: str) -> None:
         fh.write(f"{key}={value}\n")
 
 
+def _find_repo_root() -> str:
+    """Walk up from this script to the fboss repo root.
+
+    Robust to the script's nesting depth (fboss-sim/scripts vs deeper): the repo
+    root is the first ancestor that contains both `fboss-sim` and `fboss-image`.
+    """
+    start = Path(__file__).resolve().parent
+    for cand in [start, *start.parents]:
+        if (cand / "fboss-sim").is_dir() and (cand / "fboss-image").is_dir():
+            return str(cand)
+    return str(Path(__file__).resolve().parents[2])
+
+
+def _parse_args() -> argparse.Namespace:
+    default_repo = _find_repo_root()
+    parser = argparse.ArgumentParser(description="Run the fboss-sim runtime container")
+    parser.add_argument(
+        "--local",
+        action="store_true",
+        help="Fast dev mode: run from the build image with the build tree "
+        "bind-mounted (no runtime image build).",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["mono", "multi"],
+        default="multi",
+        help="Agent mode for --local (default: multi).",
+    )
+    parser.add_argument(
+        "--build-dir",
+        default=os.path.join(default_repo, ".build_dir"),
+        help="[--local] Host path to the getdeps scratch (contains build/, "
+        "installed/). Default: <repo>/.build_dir",
+    )
+    parser.add_argument(
+        "--runpath-dir",
+        default=None,
+        help="[--local] In-container path to mount --build-dir at; must match "
+        "the binaries' baked RUNPATH. Default: same as --build-dir.",
+    )
+    parser.add_argument(
+        "--repo-dir",
+        default=default_repo,
+        help="[--local] Host path to the fboss repo root. Default: derived "
+        "from this script's location.",
+    )
+    parser.add_argument(
+        "--build-image",
+        default=DEFAULT_BUILD_IMAGE,
+        help=f"[--local] Build image to run. Default: {DEFAULT_BUILD_IMAGE}",
+    )
+    parser.add_argument(
+        "--teardown",
+        action="store_true",
+        help="Stop and remove the sim container and its IPv6 network, then exit.",
+    )
+    return parser.parse_args()
+
+
+def _print_usage_footer(is_mono: bool) -> None:
+    c = DEFAULT_CONTAINER_NAME
+    mode = (
+        "mono (wedge_agent)" if is_mono else "split (fboss_sw_agent + fboss_hw_agent)"
+    )
+    other_mode = "split" if is_mono else "mono"
+    print(f"\n{'=' * 60}")
+    print("✅ Container started successfully!")
+    print(f"{'=' * 60}")
+    print(f"\nContainer name: {c}")
+    print(f"Agent mode:     {mode}")
+    print("\nUseful commands:")
+    if is_mono:
+        print(f"  • Agent status:     docker exec {c} systemctl status wedge_agent")
+    else:
+        print(f"  • SW agent status:  docker exec {c} systemctl status fboss_sw_agent")
+        print(
+            f"  • HW agent status:  docker exec {c} systemctl status fboss_hw_agent@0"
+        )
+    print(f"  • Switch mode:      docker exec {c} switch-agent-mode.sh {other_mode}")
+    print(
+        f"  • View logs:        docker exec {c} tail -f /var/facebook/logs/fboss/wedge_agent.log"
+    )
+    print(f"  • Enter shell:      docker exec -it {c} bash")
+    print(
+        f"  • Run CLI test:     docker exec {c} /opt/fboss/bin/fboss2_integration_test"
+    )
+    print()
+
+
 def main() -> int:
+    args = _parse_args()
     print("=" * 60)
     print("fboss-sim Runtime Container Launcher")
     print("=" * 60)
+
+    if args.teardown:
+        return teardown()
 
     print("\n🔍 Checking for existing container...")
     stop_existing_container(DEFAULT_CONTAINER_NAME)
@@ -171,33 +466,17 @@ def main() -> int:
     print("\n🌐 Setting up network...")
     ensure_network(NETWORK_NAME)
 
-    ret = run_container()
+    if args.local:
+        ret = run_local(args)
+        is_mono = args.mode == "mono"
+    else:
+        ret = run_container()
+        is_mono = False
     if ret != 0:
         return ret
 
     emit_github_output("container_name", DEFAULT_CONTAINER_NAME)
-
-    print(f"\n{'=' * 60}")
-    print("✅ Container started successfully!")
-    print(f"{'=' * 60}")
-    print(f"\nContainer name: {DEFAULT_CONTAINER_NAME}")
-    print("Agent mode:     split (fboss_sw_agent + fboss_hw_agent)")
-    print("\nUseful commands:")
-    print(
-        f"  • SW agent status:  docker exec {DEFAULT_CONTAINER_NAME} systemctl status fboss_sw_agent"
-    )
-    print(
-        f"  • HW agent status:  docker exec {DEFAULT_CONTAINER_NAME} systemctl status fboss_hw_agent@0"
-    )
-    print(f"  • View logs:        docker logs {DEFAULT_CONTAINER_NAME}")
-    print(f"  • Enter shell:      docker exec -it {DEFAULT_CONTAINER_NAME} bash")
-    print(
-        f"  • Switch to mono:   docker exec {DEFAULT_CONTAINER_NAME} switch-agent-mode.sh mono"
-    )
-    print(
-        f"  • Run CLI test:     docker exec {DEFAULT_CONTAINER_NAME} /opt/fboss/bin/fboss2_integration_test"
-    )
-    print()
+    _print_usage_footer(is_mono)
     return 0
 
 

--- a/fboss/agent/hw/sai/fake/FakeSaiPort.h
+++ b/fboss/agent/hw/sai/fake/FakeSaiPort.h
@@ -81,24 +81,24 @@ struct FakePort {
   sai_object_id_t egressMacsecAcl{SAI_NULL_OBJECT_ID};
   uint16_t systemPortId{0};
   sai_port_ptp_mode_t ptpMode{SAI_PORT_PTP_MODE_NONE};
-  sai_port_eye_values_list_t portEyeValues;
+  sai_port_eye_values_list_t portEyeValues{};
 #if SAI_API_VERSION >= SAI_VERSION(1, 10, 3)
-  sai_port_lane_latch_status_list_t portRxSignalDetect;
-  sai_port_lane_latch_status_list_t portRxLockStatus;
-  sai_port_lane_latch_status_list_t portFecAlignmentLockStatus;
-  sai_latch_status_t portPcsLinkStatus;
-  sai_latch_status_t portCrcErrDetect;
+  sai_port_lane_latch_status_list_t portRxSignalDetect{};
+  sai_port_lane_latch_status_list_t portRxLockStatus{};
+  sai_port_lane_latch_status_list_t portFecAlignmentLockStatus{};
+  sai_latch_status_t portPcsLinkStatus{};
+  sai_latch_status_t portCrcErrDetect{};
 #endif
 #if SAI_API_VERSION >= SAI_VERSION(1, 13, 0)
-  sai_port_frequency_offset_ppm_list_t portRxPPM;
-  sai_port_snr_list_t portRxSNR;
+  sai_port_frequency_offset_ppm_list_t portRxPPM{};
+  sai_port_snr_list_t portRxSNR{};
 #endif
   sai_port_priority_flow_control_mode_t priorityFlowControlMode{
       SAI_PORT_PRIORITY_FLOW_CONTROL_MODE_COMBINED};
   sai_uint8_t priorityFlowControl{0xff};
   sai_uint8_t priorityFlowControlRx{0xff};
   sai_uint8_t priorityFlowControlTx{0xff};
-  sai_port_err_status_list_t portError;
+  sai_port_err_status_list_t portError{};
   std::vector<sai_port_err_status_t> portErrStatusList;
   std::vector<sai_object_id_t> ingressPriorityGroupList;
   sai_uint32_t numberOfIngressPriorityGroups{0};


### PR DESCRIPTION
Summary:
Adds a `--local` mode to `fboss-sim-docker-run.py` so you can run the
fake-SAI sim against a live getdeps build without building the ~1.2 GB
runtime image.

- Default (unchanged): run the packaged runtime image.
- `--local`: launch the same systemd environment (PID 1 = `/sbin/init`,
  agents as systemd units) from the getdeps *build* image, bind-mounting the
  repo and the build scratch, symlinking the freshly built binaries into
  `/opt/fboss/bin`, and bringing agents up via `systemctl`. Rebuild binaries
  and `systemctl restart` to iterate — no image rebuild.

Both modes give a production-like systemd container, which is required for the
config-mutation `fboss2_integration_test` cases (they restart agents via
`systemctl`).

Reuses `setup-container.sh`, the `centos-09.0` rootfs overlay, and
`mono.conf`/`fruid.json` — the `--local` path only adds the build-image launch,
bind mounts, binary symlinks, and agent start. `--build-dir` is mounted at
`--runpath-dir` so the binaries' baked (absolute) RUNPATH resolves. A
`fboss_sw_agent` drop-in adds `--tun_intf=false` to work around the (separate,
still-open) TunManager crash under fake SAI.

Differential Revision: D113604599


