### PR TITLE
[Celestica] Icecube: Config: Abstract CPU I2C bus name to CPU_BUS@0 in platform_manager

### DIFF
--- a/fboss/platform/configs/icecube/platform_manager.json
+++ b/fboss/platform/configs/icecube/platform_manager.json
@@ -6,7 +6,7 @@
     "MCB_SLOT": {
       "numOutgoingI2cBuses": 0,
       "idpromConfig": {
-        "busName": "SMBus I801 adapter at 5000",
+        "busName": "CPU_BUS@0",
         "address": "0x53",
         "kernelDeviceName": "24c02"
       },
@@ -59,7 +59,7 @@
     }
   },
   "i2cAdaptersFromCpu": [
-    "SMBus I801 adapter at 5000"
+    "CPU_BUS@0"
   ],
   "versionedPmUnitConfigs": {
     "NETLAKE": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`


<img width="1340" height="354" alt="icecube" src="https://github.com/user-attachments/assets/b9bf1aed-4162-450e-8e35-73e6ed70824a" />


# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Abstract the legacy CPU I2C adapter bus definition in `icecube`'s `platform_manager.json` to align with the unified CPU bus naming convention.

Mainly change as follows:
- Abstract the hardcoded I2C bus name `SMBus I801 adapter at 5000` to the standardized virtual bus `CPU_BUS@0`.
- Update the `idpromConfig` entry under `MCB_SLOT` to use `CPU_BUS@0`.
- Align `i2cAdaptersFromCpu` declaration list with `CPU_BUS@0`.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

1. **Syntax Validation**: Validated JSON syntax using `JSONLint`.
2. **Formatting**: Pretty-printed configurations using the `jq` command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Dual-Kernel Service Verification**: Confirmed backward/forward kernel compatibility by verifying that the full platform test suite runs without errors across both **Kernel 6.11.1** and **Kernel 6.16.1** target hardware environments:
   - `platform_manager`/`platform_hw_test`/`platform_manager_hw_test`
   - `sensor_service`/`sensor_service_client`/`sensor_service_sw_test`/`sensor_service_hw_test`

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

**Attachments**:


[icecube_test_log_2026_7_27.zip](https://github.com/user-attachments/files/30451768/icecube_test_log_2026_7_27.zip)