### PR TITLE
[Cisco] Fix programmed status for resolved named next-hop groups

### DIFF
--- a/fboss/agent/state/FibInfo.cpp
+++ b/fboss/agent/state/FibInfo.cpp
@@ -135,14 +135,19 @@ FibInfo::getNextHopSetIdRefCountsFromRoutes() const {
   auto collectFromFib = [&refCounts](const auto& fib) {
     for (const auto& [_, route] : std::as_const(*fib)) {
       const auto& fwdInfo = route->getForwardInfo();
-      if (auto id = fwdInfo.getClientNextHopSetID()) {
-        ++refCounts[*id];
-      }
       if (auto id = fwdInfo.getResolvedNextHopSetID()) {
         ++refCounts[*id];
       }
       if (auto id = fwdInfo.getNormalizedResolvedNextHopSetID()) {
         ++refCounts[*id];
+      }
+      if (route->isResolved() &&
+          fwdInfo.getResolvedNextHopSetID().has_value() &&
+          !route->hasNoEntry()) {
+        const auto bestEntry = route->getBestEntry().second;
+        if (auto id = bestEntry->getClientNextHopSetID()) {
+          ++refCounts[*id];
+        }
       }
     }
   };

--- a/fboss/agent/state/tests/FibsInfoTests.cpp
+++ b/fboss/agent/state/tests/FibsInfoTests.cpp
@@ -578,34 +578,44 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutes) {
         folly::IPAddress(ip), InterfaceID(1), UCMP_DEFAULT_WEIGHT);
   };
 
+  auto makeClientEntry = [&makeNextHop](
+                             const std::string& ip, NextHopSetID clientId) {
+    RouteNextHopEntry entry(
+        RouteNextHopEntry::NextHopSet{makeNextHop(ip)}, AdminDistance::EBGP);
+    std::optional<NextHopSetID> clientIdOpt = clientId;
+    entry.setClientNextHopSetID(clientIdOpt);
+    return entry;
+  };
   auto makeFwdInfo = [&makeNextHop](
                          const std::string& ip,
-                         std::optional<NextHopSetID> clientId,
                          std::optional<NextHopSetID> resolvedId,
                          std::optional<NextHopSetID> normalizedId) {
     RouteNextHopEntry fwd(
         RouteNextHopEntry::NextHopSet{makeNextHop(ip)}, AdminDistance::EBGP);
-    fwd.setClientNextHopSetID(clientId);
     fwd.setResolvedNextHopSetID(resolvedId);
     fwd.setNormalizedResolvedNextHopSetID(normalizedId);
     return fwd;
   };
 
-  auto fwd1 = makeFwdInfo("10.0.0.1", clientId1, resolvedId1, normalizedId1);
-  auto fwd2 = makeFwdInfo("10.0.0.2", clientId2, resolvedId2, normalizedId2);
-  auto fwd3 = makeFwdInfo("2001:db8::1", clientId3, resolvedId3, normalizedId3);
+  auto fwd1 = makeFwdInfo("10.0.0.1", resolvedId1, normalizedId1);
+  auto fwd2 = makeFwdInfo("10.0.0.2", resolvedId2, normalizedId2);
+  auto fwd3 = makeFwdInfo("2001:db8::1", resolvedId3, normalizedId3);
 
   ForwardingInformationBaseV4 fibV4;
   auto route1 = std::make_shared<RouteV4>(
       RouteFields<folly::IPAddressV4>(
-          RoutePrefixV4{folly::IPAddressV4("10.0.0.0"), 24})
+          RoutePrefixV4{folly::IPAddressV4("10.0.0.0"), 24},
+          ClientID::BGPD,
+          makeClientEntry("10.0.0.1", clientId1))
           .toThrift());
   route1->setResolved(fwd1);
   fibV4.addNode(route1);
 
   auto route2 = std::make_shared<RouteV4>(
       RouteFields<folly::IPAddressV4>(
-          RoutePrefixV4{folly::IPAddressV4("192.168.1.0"), 24})
+          RoutePrefixV4{folly::IPAddressV4("192.168.1.0"), 24},
+          ClientID::BGPD,
+          makeClientEntry("10.0.0.2", clientId2))
           .toThrift());
   route2->setResolved(fwd2);
   fibV4.addNode(route2);
@@ -614,7 +624,9 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutes) {
   ForwardingInformationBaseV6 fibV6;
   auto route3 = std::make_shared<RouteV6>(
       RouteFields<folly::IPAddressV6>(
-          RoutePrefixV6{folly::IPAddressV6("2001:db8::"), 64})
+          RoutePrefixV6{folly::IPAddressV6("2001:db8::"), 64},
+          ClientID::BGPD,
+          makeClientEntry("2001:db8::1", clientId3))
           .toThrift());
   route3->setResolved(fwd3);
   fibV6.addNode(route3);
@@ -639,7 +651,7 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutes) {
   EXPECT_EQ(refCounts[resolvedId3], 2);
 }
 
-TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutesRecursiveResolution) {
+TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutesBestClientOnly) {
   auto fibInfo = std::make_shared<FibInfo>();
   auto fibsMap = std::make_shared<ForwardingInformationBaseMap>();
   auto fibContainer =
@@ -649,6 +661,9 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutesRecursiveResolution) {
   // Named NHG "nhg1" has clientNextHopSetID=42 (unresolved loopback nexthops)
   // After recursive resolution, resolvedNextHopSetID=500 (link-local nexthops)
   NextHopSetID namedNhgClientId(42);
+  NextHopSetID backupClientId(43);
+  NextHopSetID unresolvedClientId(44);
+  NextHopSetID dropClientId(45);
   NextHopSetID resolvedLinkLocalId(500);
 
   auto makeNextHop = [](const std::string& ip) {
@@ -656,22 +671,56 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutesRecursiveResolution) {
         folly::IPAddress(ip), InterfaceID(1), UCMP_DEFAULT_WEIGHT);
   };
 
+  auto makeClientEntry = [&makeNextHop](
+                             const std::string& ip,
+                             AdminDistance distance,
+                             NextHopSetID clientId) {
+    RouteNextHopEntry entry(
+        RouteNextHopEntry::NextHopSet{makeNextHop(ip)}, distance);
+    std::optional<NextHopSetID> clientIdOpt = clientId;
+    entry.setClientNextHopSetID(clientIdOpt);
+    return entry;
+  };
+
   RouteNextHopEntry fwd(
       RouteNextHopEntry::NextHopSet{makeNextHop("fe80::1")},
       AdminDistance::EBGP);
-  std::optional<NextHopSetID> clientOpt = namedNhgClientId;
   std::optional<NextHopSetID> resolvedOpt = resolvedLinkLocalId;
-  fwd.setClientNextHopSetID(clientOpt);
   fwd.setResolvedNextHopSetID(resolvedOpt);
   fwd.setNormalizedResolvedNextHopSetID(resolvedOpt);
 
   ForwardingInformationBaseV6 fibV6;
   auto route = std::make_shared<RouteV6>(
       RouteFields<folly::IPAddressV6>(
-          RoutePrefixV6{folly::IPAddressV6("2001:db8::"), 48})
+          RoutePrefixV6{folly::IPAddressV6("2001:db8::"), 48},
+          ClientID::BGPD,
+          makeClientEntry("2001:db8::1", AdminDistance::EBGP, namedNhgClientId))
           .toThrift());
+  route->update(
+      ClientID::OPENR,
+      makeClientEntry("2001:db8::2", AdminDistance::IBGP, backupClientId));
   route->setResolved(fwd);
   fibV6.addNode(route);
+
+  auto unresolvedRoute = std::make_shared<RouteV6>(
+      RouteFields<folly::IPAddressV6>(
+          RoutePrefixV6{folly::IPAddressV6("2001:db8:1::"), 64},
+          ClientID::BGPD,
+          makeClientEntry(
+              "2001:db8:1::1", AdminDistance::EBGP, unresolvedClientId))
+          .toThrift());
+  unresolvedRoute->setUnresolvable();
+  fibV6.addNode(unresolvedRoute);
+
+  auto dropRoute = std::make_shared<RouteV6>(
+      RouteFields<folly::IPAddressV6>(
+          RoutePrefixV6{folly::IPAddressV6("2001:db8:2::"), 64},
+          ClientID::BGPD,
+          makeClientEntry("2001:db8:2::1", AdminDistance::EBGP, dropClientId))
+          .toThrift());
+  dropRoute->setResolved(RouteNextHopEntry(
+      RouteForwardAction::DROP, AdminDistance::MAX_ADMIN_DISTANCE));
+  fibV6.addNode(dropRoute);
   fibContainer->setFib(fibV6.clone());
 
   fibsMap->updateForwardingInformationBaseContainer(fibContainer);
@@ -680,6 +729,9 @@ TEST_F(FibInfoTest, GetNextHopSetIdRefCountsFromRoutesRecursiveResolution) {
   auto refCounts = fibInfo->getNextHopSetIdRefCountsFromRoutes();
   // The named NHG's clientNextHopSetID should be in the refcounts
   EXPECT_EQ(refCounts[namedNhgClientId], 1);
+  EXPECT_EQ(refCounts.count(backupClientId), 0);
+  EXPECT_EQ(refCounts.count(unresolvedClientId), 0);
+  EXPECT_EQ(refCounts.count(dropClientId), 0);
   // The resolved link-local ID should also be counted (resolved + normalized)
   EXPECT_EQ(refCounts[resolvedLinkLocalId], 2);
 }

--- a/fboss/agent/test/ThriftTest.cpp
+++ b/fboss/agent/test/ThriftTest.cpp
@@ -3491,7 +3491,9 @@ void addUnicastRouteWithNamedNextHopGroup(
   auto route = std::make_unique<UnicastRoute>();
   route->dest()->ip() = toBinaryAddress(network.first);
   route->dest()->prefixLength() = network.second;
-  route->namedRouteDestination()->nextHopGroup() = nhgName;
+  NamedRouteDestination namedDestination;
+  namedDestination.nextHopGroup() = nhgName;
+  route->namedRouteDestination() = std::move(namedDestination);
   route->adminDistance() = AdminDistance::EBGP;
   handler.addUnicastRoute(
       static_cast<int16_t>(ClientID::BGPD), std::move(route));
@@ -3722,6 +3724,7 @@ TEST_F(NamedNextHopGroupThriftTest, getNextHopGroupsNamedIsProgrammed) {
   ASSERT_EQ(nameToProgrammedState.count("multi_ref"), 1);
   ASSERT_EQ(nameToProgrammedState.count("single_ref"), 1);
   ASSERT_EQ(nameToProgrammedState.count("orphan"), 1);
+  EXPECT_TRUE(nameToProgrammedState.at("multi_ref"));
   EXPECT_FALSE(nameToProgrammedState.at("single_ref"));
   EXPECT_FALSE(nameToProgrammedState.at("orphan"));
   EXPECT_EQ(nameToProgrammedState, namedApiProgrammedState);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've run the linters locally and fixed lint errors related to the files I modified in this PR.
- [x] `pre-commit run --files fboss/agent/state/FibInfo.cpp fboss/agent/state/tests/FibsInfoTests.cpp fboss/agent/test/ThriftTest.cpp`

# Summary

Fix `isProgrammed` reporting for recursively resolved named next-hop groups.

The prerequisite route-ID allocation change is already present on `main` in
commit [`151cbb6670`](https://github.com/facebook/fboss/commit/151cbb66703d02f0e3dbcb731411dc8d08b2de8b).
That change stores the original `clientNextHopSetID` on each route client
entry. The FIB forwarding entry contains the resolved and normalized IDs, but
does not reliably retain that original client ID after recursive resolution.

`FibInfo::getNextHopSetIdRefCountsFromRoutes()` was reading the client ID from
the forwarding entry, so a named group could be forwarding successfully while
both Thrift GET APIs returned `isProgrammed=false`.

This change:

- Keeps the existing resolved and normalized next-hop-set reference counting.
- Reads the original client ID from the route's selected best client entry.
- Counts that client ID only when the route is resolved, has a resolved
  next-hop-set ID, and is not a DROP/TO_CPU/no-entry route.
- Does not count a worse administrative-distance backup client.
- Does not change the Thrift API or hardware programming path.

The previous `ThriftHandler.cpp` and `FibInfo.h` helper changes are no longer
needed. The final PR is rebased onto current `main` and contains only the
focused `FibInfo.cpp` fix plus its state and Thrift regression tests.

# Test Plan

## Focused unit tests

The focused GoogleTest runners use the same scenarios as the modified FBOSS
tests and link against the FBOSS libraries produced by the image build.

Covered cases:

1. IPv4 and IPv6 resolved routes count the best client's original ID and keep
   existing resolved/normalized ID counts.
2. Recursive resolution counts only the selected best client.
3. Backup, unresolved, and DROP routes do not mark their client NHG as
   programmed.
4. `getNextHopGroups()` and `getNamedNextHopGroups()` agree: the referenced,
   resolved group is `true`; unused groups are `false`.

Result: **3/3 focused tests passed**.

<details>
<summary>Unit-test console logs</summary>

```text
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from NhgIsProgrammedUnitTest
[ RUN      ] NhgIsProgrammedUnitTest.CollectsV4V6ClientResolvedAndNormalizedIds
[       OK ] NhgIsProgrammedUnitTest.CollectsV4V6ClientResolvedAndNormalizedIds (0 ms)
[ RUN      ] NhgIsProgrammedUnitTest.CountsBestClientOnlyAndSkipsUnresolvedDrop
[       OK ] NhgIsProgrammedUnitTest.CountsBestClientOnlyAndSkipsUnresolvedDrop (0 ms)
[----------] 2 tests from NhgIsProgrammedUnitTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 2 tests.

[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from NamedNextHopGroupThriftUnitTest
[ RUN      ] NamedNextHopGroupThriftUnitTest.BothApisReportOnlyResolvedReferencedGroupProgrammed
[       OK ] NamedNextHopGroupThriftUnitTest.BothApisReportOnlyResolvedReferencedGroupProgrammed (128 ms)
[----------] 1 test from NamedNextHopGroupThriftUnitTest (128 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (128 ms total)
[  PASSED  ] 1 test.
```

</details>

## Formatting and image build

- `git diff --check`: passed
- Focused `pre-commit`: passed
- FBOSS distro image build with the final three-file patch: passed

## Live switch validation

The image was installed on an FBOSS switch and exercised through the named-NHG
Thrift APIs. Temporary routes and groups were removed after testing.

| Scenario | Expected/result |
| --- | --- |
| Unreferenced group | `false` |
| Selected best-client group | `true` |
| Worse-distance backup | `false` |
| Best-client promotion/fallback | Flag moved to the selected group |
| Equal-distance clients | Only the deterministic winner was `true` |
| Real member update | Forwarding updated and remained `true` |
| Identical no-op update | Client/resolved/normalized IDs stayed stable |
| Two names with identical members | Both names were `true` because named NHGs intentionally deduplicate to the same next-hop-set ID |
| Multiple route references | Stayed `true` until the last route was removed |
| IPv4 and IPv6 FIB routes | Correctly reported `true` when forwarding |
| Unresolved route | DROP with `isProgrammed=false` |
| Partially resolved ECMP | `true`; unresolved member was pruned |
| Missing group reference | Rejected without installing a route |
| Delete referenced group | Rejected without disturbing forwarding |

Post-test health checks showed both SW and HW agents active with zero restarts,
no error-level agent journal entries, and the original named group still
forwarding with unchanged next-hop-set IDs.

<details>
<summary>FBOSS switch console output</summary>

```text
$ PYTHONPATH=/opt/openr/python python3 /tmp/nhg_thrift.py get-nhg
named NHG count: 1
  name=svc-srv6-r1 isProgrammed=True
    - 1:1:1::1 weight=0 SRv6_ENCAP segs=[fdad:ffff:27d6:27cc:7fff::] tunnel=srv6_tunnel

$ systemctl show fboss_sw_agent -p ActiveState -p SubState -p NRestarts --no-pager
NRestarts=0
ActiveState=active
SubState=running

$ systemctl show fboss_hw_agent@0 -p ActiveState -p SubState -p NRestarts --no-pager
NRestarts=0
ActiveState=active
SubState=running
```

</details>

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
