### PR TITLE
[Celestica] Icecube: Config: Migrate icecube fan CPLD to fbfancpld and inline hardware configs

### DIFF
--- a/fboss/configs/platforms/celestica/icecube/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/icecube/platform_stack/platform_manager.json
@@ -634,9 +634,16 @@
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
           "address": "0x33",
-          "kernelDeviceName": "icecube_fancpld",
+          "kernelDeviceName": "fbfancpld",
           "pmUnitScopedName": "MCB_FAN_CPLD",
-          "isWatchdog": true
+          "isWatchdog": true,
+          "fanCpldConfig": {
+            "numFans": 4,
+            "pwmMax": 64,
+            "speedMultiplier": 300,
+            "hasRearTach": true,
+            "hasLeds": false
+          }
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_14",

--- a/fboss/platform/configs/icecube/platform_manager.json
+++ b/fboss/platform/configs/icecube/platform_manager.json
@@ -634,9 +634,16 @@
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
           "address": "0x33",
-          "kernelDeviceName": "icecube_fancpld",
+          "kernelDeviceName": "fbfancpld",
           "pmUnitScopedName": "MCB_FAN_CPLD",
-          "isWatchdog": true
+          "isWatchdog": true,
+          "fanCpldConfig": {
+            "numFans": 4,
+            "pwmMax": 64,
+            "speedMultiplier": 300,
+            "hasRearTach": true,
+            "hasLeds": false
+          }
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_14",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`


<img width="978" height="360" alt="icecube" src="https://github.com/user-attachments/assets/8fd229da-6c3d-4875-b4df-bfa822bc5393" />



# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Migrate the `icecube` fan CPLD kernel device definition from the legacy `icecube_fancpld` down to the unified upstream standard `fbfancpld` driver. 

Mainly change as follows:
- Set active fan count payload (`numFans: 4`).
- Set the absolute raw hardware register limitation (`pwmMax: 64`).
- Align the tachometer pulse factor mapping via `speedMultiplier: 300`.
- Enable dual-rotor status tracking via `hasRearTach: true`.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

1. **Syntax Validation**: Validated JSON syntax using `JSONLint`.
2. **Formatting**: Pretty-printed configurations using the `jq` command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Service Verification**: Confirmed that the following services start and run without errors:
   - `platform_manager`/`platform_hw_test`/`platform_manager_hw_test`
   - `sensor_service`/`sensor_service_client`/`sensor_service_sw_test`/`sensor_service_hw_test`

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

**Attachments**:
[icecube_2026_07_14_test_log.zip](https://github.com/user-attachments/files/30487644/icecube_2026_07_14_test_log.zip)



**Update (2026-08-26)**

To align with Meta's recent architectural change in Commit [634df25](https://github.com/facebook/fboss/commit/634df25b9315d75ae918b24c734c1712f04aba5e) (*"Move platform services configs"*), I have rebased this PR and updated the Icecube platform configuration accordingly.

- **Path Alignment**: Moved `platform_manager.json` to its new destination path under `fboss/configs/platforms/celestica/icecube/platform_stack/` to comply with the updated `ConfigLib` pathing logic.
- **New Alignment Commit**: [Commit 2644578](https://github.com/facebook/fboss/pull/1433/commits) (Updated `kernelDeviceName` to `fbfancpld` and injected inline `fanCpldConfig` at the new location).
- **New Verification Log**: 
[icecube_test_2026_08_26_log.zip](https://github.com/user-attachments/files/31455378/icecube_test_2026_08_26_log.zip)

