### PR TITLE
[Nexthop] benchmark --filter/--filter_file accept the gtest filter grammar

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/frameworks/benchmark_framework.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/frameworks/benchmark_framework.py
@@ -84,60 +84,80 @@ class BenchmarkFramework:
                 if name and re.match(r"^[A-Za-z]\w*$", name):
                     benchmarks.append(name)
             return benchmarks
-        except (
-            subprocess.CalledProcessError,
-            subprocess.TimeoutExpired,
-            OSError,
-        ) as e:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
             print(f"Warning: Failed to list benchmarks from {binary_path}: {e}")
             return None
 
-    def _load_requested_benchmarks(self, filter_file: str) -> list[str] | None:
-        """Load benchmark names from a filter file (one per line)."""
-        if not os.path.exists(filter_file):
-            print(f"Error: Configuration file not found: {filter_file}")
-            return None
-        names = load_from_file(filter_file)
-        if not names:
-            print(f"Error: No benchmarks found in {filter_file}")
-            return None
-        return names
+    @staticmethod
+    def _wildcards_to_regex(pattern: str) -> str:
+        """Expand ``*``/``?`` to ``.*``/``.``, leaving wildcards that are already
+        part of a regex alone so ``.*Route.*`` does not become ``..*Route..*``."""
+        pattern = re.sub(r"(?<![.\\*])\?", ".", pattern)
+        return re.sub(r"(?<![.\\])\*", ".*", pattern)
+
+    @staticmethod
+    def _split_filter(filter_string: str) -> tuple[list[str], list[str]]:
+        """Split a ``--gtest_filter``-style string into (includes, excludes):
+        colon-separated patterns, everything after the first ``-`` excluded.
+        Benchmark names are ``\\w`` only, so ``-`` never appears in a pattern."""
+        include_part, _, exclude_part = filter_string.partition("-")
+        return (
+            [p.strip() for p in include_part.split(":") if p.strip()],
+            [p.strip() for p in exclude_part.split(":") if p.strip()],
+        )
+
+    @staticmethod
+    def _compile_patterns(patterns: list[str], kind: str) -> list[re.Pattern] | None:
+        """Compile filter patterns, or return None if any one is invalid."""
+        compiled = []
+        for pattern in patterns:
+            try:
+                compiled.append(
+                    re.compile(BenchmarkFramework._wildcards_to_regex(pattern))
+                )
+            except re.error as e:
+                print(f"Error: Invalid {kind} pattern '{pattern}': {e}")
+                return None
+        return compiled
 
     def _get_benchmarks_to_run(
         self, all_benchmarks: list[str], args: Namespace
     ) -> list[str] | None:
-        """Apply ``--filter`` and ``--filter_file`` to narrow the benchmark
-        list. Returns the filtered list, or None on error."""
-        benchmarks = list(all_benchmarks)
-        available_set = set(all_benchmarks)
-
-        if args.filter:
-            try:
-                benchmarks = [
-                    name for name in benchmarks if re.search(args.filter, name)
-                ]
-            except re.error as e:
-                print(f"Error: Invalid --filter regex '{args.filter}': {e}")
-                return None
-            if not benchmarks:
-                print(f"No benchmarks matching --filter '{args.filter}'")
-                return None
-            print(f"--filter '{args.filter}' matched {len(benchmarks)} benchmarks")
-
+        """Narrow the benchmark list by ``--filter`` / ``--filter_file``, both of
+        which take the gtest grammar (``include:include:-exclude``) so a filter
+        file written for the gtest runners selects the same way. ``--filter_file``
+        wins when both are given. Returns None on error."""
         if args.filter_file:
-            requested = self._load_requested_benchmarks(args.filter_file)
-            if requested is None:
+            if not os.path.exists(args.filter_file):
+                print(f"Error: Configuration file not found: {args.filter_file}")
                 return None
-            not_found = [name for name in requested if name not in available_set]
-            if not_found:
-                print(
-                    f"\nWarning: {len(not_found)} benchmark names not found in binary:"
-                )
-                for name in not_found:
-                    print(f"  - {name}")
-            requested_set = set(requested)
-            benchmarks = [name for name in benchmarks if name in requested_set]
+            patterns = load_from_file(args.filter_file, args.profile)
+            if not patterns:
+                print(f"Error: No benchmark filters found in {args.filter_file}")
+                return None
+            filter_string = ":".join(patterns)
+        else:
+            filter_string = args.filter or ""
 
+        if not filter_string:
+            return list(all_benchmarks)
+
+        includes, excludes = self._split_filter(filter_string)
+        include_res = self._compile_patterns(includes, "include")
+        exclude_res = self._compile_patterns(excludes, "exclude")
+        if include_res is None or exclude_res is None:
+            return None
+
+        benchmarks = [
+            name
+            for name in all_benchmarks
+            if (not include_res or any(r.search(name) for r in include_res))
+            and not any(r.search(name) for r in exclude_res)
+        ]
+        if not benchmarks:
+            print(f"No benchmarks matching filter '{filter_string}'")
+            return None
+        print(f"Filter '{filter_string}' matched {len(benchmarks)} benchmarks")
         return benchmarks
 
     def _filter_known_bad(
@@ -262,10 +282,7 @@ class BenchmarkFramework:
 
         try:
             process = subprocess.Popen(
-                run_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
+                run_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
             )
 
             stdout_lines: list[str] = []
@@ -428,20 +445,18 @@ class BenchmarkFramework:
         benchmarks_to_run, unsupported_skipped = self._filter_unsupported(
             benchmarks_to_run, unsupported_regexes
         )
-        if not benchmarks_to_run:
-            print("No benchmarks to run after filtering unsupported")
-            return
-
         benchmarks_to_run, skipped_count = self._filter_known_bad(
             benchmarks_to_run, known_bad_regexes
         )
-        if not benchmarks_to_run:
-            print("No benchmarks to run after filtering")
-            return
 
         if args.list_tests:
             for name in benchmarks_to_run:
                 print(name)
+            return
+
+        if not benchmarks_to_run:
+            print("No benchmarks to run after filtering known bad/unsupported")
+            self._write_results_and_summary([], skipped_count + unsupported_skipped)
             return
 
         print(f"\nRunning {len(benchmarks_to_run)} benchmarks")

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_benchmark_framework.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_benchmark_framework.py
@@ -14,10 +14,10 @@ import io
 import json
 import os
 import subprocess
-import tempfile
 from unittest.mock import Mock, patch
 
 import pytest
+
 from fboss_test_runner.frameworks.benchmark_framework import BenchmarkFramework
 from fboss_test_runner.frameworks.benchmark_suite import BenchmarkSuite
 
@@ -72,6 +72,7 @@ def bench_args():
     args = Mock()
     args.filter = None
     args.filter_file = None
+    args.profile = None
     args.list_tests = False
     args.fruid_path = None
     args.test_run_timeout = 300
@@ -104,43 +105,112 @@ def test_list_benchmarks_filters_noise(framework):
 
 def test_list_benchmarks_failure_returns_none(framework, capsys):
     with patch(
-        "subprocess.check_output",
-        side_effect=subprocess.CalledProcessError(1, "cmd"),
+        "subprocess.check_output", side_effect=subprocess.CalledProcessError(1, "cmd")
     ):
         assert framework._list_benchmarks(_BIN) is None
     assert "Failed to list benchmarks" in capsys.readouterr().out
 
 
-# ---- filter file (_load_requested_benchmarks) ----------------------------
+# ---- filter grammar (_get_benchmarks_to_run) -----------------------------
+
+_ALL = [
+    "HwFswScaleRouteAddBenchmark",
+    "HwVoqScaleRouteAddBenchmark",
+    "HwEcmpGroupShrink",
+]
 
 
-def test_load_requested_benchmarks_reads_names(framework):
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
-        f.write("benchmark1\nbenchmark2\nbenchmark3\n")
-        path = f.name
-    try:
-        assert framework._load_requested_benchmarks(path) == [
-            "benchmark1",
-            "benchmark2",
-            "benchmark3",
-        ]
-    finally:
-        os.unlink(path)
+def _filter_file(tmp_path, *lines):
+    path = tmp_path / "tests.conf"
+    path.write_text("".join(f"{line}\n" for line in lines))
+    return str(path)
 
 
-def test_load_requested_benchmarks_missing_file(framework, capsys):
-    assert framework._load_requested_benchmarks("/nonexistent/file.conf") is None
+@pytest.mark.parametrize(
+    ("filter_string", "expected"),
+    [
+        ("*Route*", ["HwFswScaleRouteAddBenchmark", "HwVoqScaleRouteAddBenchmark"]),
+        ("*Fsw*:*Ecmp*", ["HwFswScaleRouteAddBenchmark", "HwEcmpGroupShrink"]),
+        ("-*Voq*", ["HwFswScaleRouteAddBenchmark", "HwEcmpGroupShrink"]),
+        ("*Route*:-*Voq*", ["HwFswScaleRouteAddBenchmark"]),
+        ("*:-*Voq*:*Ecmp*", ["HwFswScaleRouteAddBenchmark"]),
+        ("*Ecmp?roupShrink", ["HwEcmpGroupShrink"]),
+        (".*Route.*", ["HwFswScaleRouteAddBenchmark", "HwVoqScaleRouteAddBenchmark"]),
+    ],
+)
+def test_get_benchmarks_to_run_grammar(framework, bench_args, filter_string, expected):
+    bench_args.filter = filter_string
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) == expected
+
+
+@pytest.mark.parametrize(
+    ("pattern", "expected"),
+    [
+        ("*Route*", ".*Route.*"),
+        (".*Route.*", ".*Route.*"),
+        (r"Hw\*Literal", r"Hw\*Literal"),
+        ("Ecmp?Group", "Ecmp.Group"),
+        (".*?Route", ".*?Route"),
+    ],
+)
+def test_wildcards_to_regex(framework, pattern, expected):
+    assert framework._wildcards_to_regex(pattern) == expected
+
+
+def test_plain_regex_matches_name_at_position_zero(framework, bench_args):
+    bench_args.filter = ".*Route.*"
+    assert framework._get_benchmarks_to_run(["RouteAdd", "EcmpShrink"], bench_args) == [
+        "RouteAdd"
+    ]
+
+
+def test_get_benchmarks_to_run_no_filter_returns_all(framework, bench_args):
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) == _ALL
+
+
+def test_get_benchmarks_to_run_no_match_is_error(framework, bench_args, capsys):
+    bench_args.filter = "*NoSuchThing*"
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) is None
+    assert "No benchmarks matching filter" in capsys.readouterr().out
+
+
+def test_get_benchmarks_to_run_invalid_pattern(framework, bench_args, capsys):
+    bench_args.filter = "Hw(Unclosed"
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) is None
+    assert "Invalid include pattern" in capsys.readouterr().out
+
+
+def test_get_benchmarks_to_run_invalid_exclude_pattern(framework, bench_args, capsys):
+    bench_args.filter = "*:-Hw(Unclosed"
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) is None
+    assert "Invalid exclude pattern" in capsys.readouterr().out
+
+
+def test_filter_file_lines_are_patterns(framework, bench_args, tmp_path):
+    bench_args.filter_file = _filter_file(tmp_path, "*Route*", "-*Voq*")
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) == [
+        "HwFswScaleRouteAddBenchmark"
+    ]
+
+
+def test_filter_file_wins_over_filter(framework, bench_args, tmp_path):
+    bench_args.filter = "*Ecmp*"
+    bench_args.filter_file = _filter_file(tmp_path, "*Voq*")
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) == [
+        "HwVoqScaleRouteAddBenchmark"
+    ]
+
+
+def test_filter_file_missing(framework, bench_args, capsys):
+    bench_args.filter_file = "/nonexistent/file.conf"
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) is None
     assert "Configuration file not found" in capsys.readouterr().out
 
 
-def test_load_requested_benchmarks_empty_file(framework, capsys):
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
-        path = f.name
-    try:
-        assert framework._load_requested_benchmarks(path) is None
-        assert "No benchmarks found" in capsys.readouterr().out
-    finally:
-        os.unlink(path)
+def test_filter_file_empty(framework, bench_args, tmp_path, capsys):
+    bench_args.filter_file = _filter_file(tmp_path)
+    assert framework._get_benchmarks_to_run(_ALL, bench_args) is None
+    assert "No benchmark filters found" in capsys.readouterr().out
 
 
 def test_find_jsons_in_str(framework):
@@ -317,21 +387,47 @@ def test_run_filter_regex(mock_list, mock_run, _mock_write, framework, bench_arg
 @patch.object(BenchmarkFramework, "_write_results_and_summary")
 @patch.object(BenchmarkFramework, "_run_benchmark_binary")
 @patch.object(BenchmarkFramework, "_list_benchmarks")
-def test_run_with_filter_file_intersects_and_warns(
-    mock_list, mock_run, _mock_write, framework, bench_args, capsys
+def test_run_with_filter_file(
+    mock_list, mock_run, _mock_write, framework, bench_args, tmp_path
 ):
-    mock_list.return_value = ["RouteAdd", "RouteDel"]
+    mock_list.return_value = ["RouteAdd", "RouteDel", "EcmpShrink"]
     mock_run.return_value = _ok_result("RouteAdd")
-    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".conf") as f:
-        # RouteAdd exists; Missing does not -> only RouteAdd runs, warning emitted
-        f.write("RouteAdd\nMissing\n")
-        bench_args.filter_file = f.name
-    try:
+    bench_args.filter_file = _filter_file(tmp_path, "*Route*", "-*Del*")
+    framework.run(bench_args)
+    assert mock_run.call_count == 1
+
+
+@patch.object(BenchmarkFramework, "_run_benchmark_binary")
+@patch.object(BenchmarkFramework, "_list_benchmarks")
+def test_run_all_selected_unsupported_reports_skips(
+    mock_list, mock_run, suite, bench_args, tmp_path, capsys
+):
+    cfg = tmp_path / "bench.json"
+    cfg.write_text(
+        json.dumps({"unsupported_tests": {"plat": [{"test_name_regex": ".*Voq.*"}]}})
+    )
+    suite._config_path = str(cfg)
+    mock_list.return_value = ["HwVoqA", "HwVoqB"]
+    bench_args.skip_known_bad_tests = "plat"
+    framework = BenchmarkFramework(suite)
+    with patch.object(framework, "_write_results_and_summary") as mock_write:
         framework.run(bench_args)
-        assert mock_run.call_count == 1
-        assert "not found in binary" in capsys.readouterr().out
-    finally:
-        os.unlink(bench_args.filter_file)
+    mock_run.assert_not_called()
+    mock_write.assert_called_once_with([], 2)
+    assert "No benchmarks to run after filtering" in capsys.readouterr().out
+
+
+@patch.object(BenchmarkFramework, "_run_benchmark_binary")
+@patch.object(BenchmarkFramework, "_list_benchmarks")
+def test_run_list_tests_does_not_write_results(
+    mock_list, mock_run, framework, bench_args
+):
+    mock_list.return_value = ["A"]
+    bench_args.list_tests = True
+    with patch.object(framework, "_write_results_and_summary") as mock_write:
+        framework.run(bench_args)
+    mock_run.assert_not_called()
+    mock_write.assert_not_called()
 
 
 @patch.object(BenchmarkFramework, "_write_results_and_summary")


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
`benchmark --filter` and `--filter_file` didn't take the filter syntax every other test runner takes. `--filter` was a single regex and `--filter_file` matched exact benchmark names, so when a runner wrote `*StatsCollection*` into a filter file it matched nothing.

Both now take the gtest grammar: `include:include:-exclude`, with `*` and `?` wildcards. Same thing `test_runner.py` does when it builds `--gtest_filter`. Plain regexes still work, because `*` only gets expanded where it isn't already part of a regex. Rewriting it blindly turns `.*Route.*` into `..*Route..*`, which then matches no name starting with Route. If both flags are given, `--filter_file` wins, same as on the gtest path.

Second thing, while I was in here: a run where every benchmark is known-bad or unsupported on the platform used to return early and write no results CSV. Callers look for that CSV to decide whether the run produced anything, so this read as an infra failure instead of "this platform doesn't have these benchmarks". It now writes the CSV and reports the skips. It never came up while a single test ran every benchmark, but it does as soon as callers filter down to one family.

# Test Plan
275 unit tests pass in `fboss/oss/scripts/run_scripts/fboss_test_runner/unittests`, covering includes, excludes, multiple patterns, `?`, plain regexes, invalid patterns, missing and empty filter files, and the all-unsupported skip path.
