### PR TITLE
[Nexthop][fsdb] drop duplicate gflags DEFINE stat_publish_interval_ms

### DIFF
--- a/fboss/fsdb/server/Server.cpp
+++ b/fboss/fsdb/server/Server.cpp
@@ -26,12 +26,6 @@ DEFINE_int32(
     "Delay after which connection to a publisher that has not "
     "published to any metric is closed");
 
-DEFINE_int32(
-    stat_publish_interval_ms,
-    1000,
-    "How frequently to publish thread-local stats back to the "
-    "global store. This should generally be less than 1 second.");
-
 DEFINE_bool(
     enable_thrift_acceptor,
     false,

--- a/fboss/fsdb/server/Server.h
+++ b/fboss/fsdb/server/Server.h
@@ -10,8 +10,6 @@
 
 #include <signal.h>
 
-DECLARE_int32(stat_publish_interval_ms);
-
 namespace facebook::fboss::fsdb {
 
 class SignalHandler : public folly::AsyncSignalHandler {


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
`fboss/fsdb/server/Server.cpp` defines `stat_publish_interval_ms`, and `fboss/agent/AgentFeatures.cpp` defines the same flag. Same name, same default, same help string. fsdb never reads it though. The only readers are `HwAgentMain.cpp` and `SwAgentInitializer.cpp`, and both pick it up from `AgentFeatures`.

That stays harmless right up until something links both objects into one binary. gflags hits `ReportError(DIE, ...)` on a second `DEFINE` of a flag it already has from a different file, and it does that inside the `FlagRegisterer` constructor, so the process dies in static init and never reaches `main()`. fsdb doesn't link `agent_features` today, so nobody has tripped it, but it's a trap for anything that touches fsdb's link line.

So drop the fsdb `DEFINE`/`DECLARE`. The agent copy stays, and it's the only one anyone reads.

One caveat worth flagging: fsdb parses with `gflags::ParseCommandLineFlags`, so `--stat_publish_interval_ms` on an fsdb command line is now an unknown-flag error. Nothing in the tree passes it to fsdb, and the flag did nothing for fsdb anyway, but if a config somewhere outside the repo sets it, that needs to go.

# Test Plan
Grepped the flag after the change: four hits left, all agent side, none under `fboss/fsdb`. Built the cmake `fsdb` target, compiles and links. `pre-commit run` clean on both files.
