### PR TITLE
[Nexthop][m4062nhp] Add firmware FPGA versions to Platform Manager

### DIFF
--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -35,6 +35,13 @@
               "startAdapterIndex": 0,
               "numAdapters": 10
             }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "SCM_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            }
           ]
         }
       ],
@@ -214,6 +221,13 @@
               "startPort": 129,
               "numPorts": 1
             }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "SMB0_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            }
           ]
         },
         {
@@ -350,6 +364,13 @@
               "startPort": 97,
               "numPorts": 32
             }
+          ],
+          "infoRomConfigs": [
+            {
+              "pmUnitScopedName": "SMB1_IOB_INFO_ROM",
+              "deviceName": "fpga_info_iob",
+              "csrOffset": "0x0000"
+            }
           ]
         }
       ],
@@ -432,6 +453,7 @@
     "/run/devmap/sensors/DPM_2": "/[DPM_2]",
     "/run/devmap/sensors/SWITCH_CARD_TEMP_SENSOR": "/SMB_SLOT@0/[SWITCH_CARD_TEMP_SENSOR]",
     "/run/devmap/fpgas/SCM_IOB": "/[SCM_IOB]",
+    "/run/devmap/inforoms/SCM_IOB_INFO_ROM": "/[SCM_IOB_INFO_ROM]",
     "/run/devmap/i2c-busses/SCM_IOB_I2C_0": "/[SCM_IOB_I2C_0]",
     "/run/devmap/i2c-busses/SCM_IOB_I2C_1": "/[SCM_IOB_I2C_1]",
     "/run/devmap/i2c-busses/SCM_IOB_I2C_2": "/[SCM_IOB_I2C_2]",
@@ -444,6 +466,8 @@
     "/run/devmap/i2c-busses/SCM_IOB_I2C_9": "/[SCM_IOB_I2C_9]",
     "/run/devmap/fpgas/SMB_IOB_0": "/SMB_SLOT@0/[SMB_IOB_0]",
     "/run/devmap/fpgas/SMB_IOB_1": "/SMB_SLOT@0/[SMB_IOB_1]",
+    "/run/devmap/inforoms/SMB0_IOB_INFO_ROM": "/SMB_SLOT@0/[SMB0_IOB_INFO_ROM]",
+    "/run/devmap/inforoms/SMB1_IOB_INFO_ROM": "/SMB_SLOT@0/[SMB1_IOB_INFO_ROM]",
     "/run/devmap/sensors/ASIC_TEMP": "/SMB_SLOT@0/[SMB_IOB_ASIC_TEMP]",
     "/run/devmap/sensors/PSU_PRESENT": "/SMB_SLOT@0/[SMB_IOB_PSU_PRESENT]",
     "/run/devmap/i2c-busses/SMB0_IOB_I2C_0": "/SMB_SLOT@0/[SMB0_IOB_I2C_0]",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Add FPGA info ROM entries to platform_manager.json for m4062nhp so PlatformManager creates the corresponding devmap nodes for SCM_IOB, SMB0_IOB, and SMB1_IOB. 

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

PlatformManager starts successfully and creates the expected devmap nodes:
/run/devmap/inforoms/SCM_IOB_INFO_ROM
/run/devmap/inforoms/SMB0_IOB_INFO_ROM
/run/devmap/inforoms/SMB1_IOB_INFO_ROM


<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
