### PR TITLE
[Nexthop][m4062nhp] Add PLATFORM_M4062NHP to ProdConfigFactory

### DIFF
--- a/fboss/agent/hw/test/ProdConfigFactory.cpp
+++ b/fboss/agent/hw/test/ProdConfigFactory.cpp
@@ -117,6 +117,7 @@ uint16_t uplinksCountFromSwitch(PlatformType mode) {
     case PM::PLATFORM_ICECUBE800BC:
     case PM::PLATFORM_ICETEA800BC:
     case PM::PLATFORM_MONTBLANC:
+    case PM::PLATFORM_M4062NHP:
     case PM::PLATFORM_M5120CSC:
       return 4;
     case PM::PLATFORM_MINIPACK3N:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add `PLATFORM_M4062NHP` to ProdConfigFactory. Missing `M4062NHP` handling in `uplinksCountFromSwitch()` caused `AgentRouteCounterOverflowTest.overflowRouteCounters` to fail. Add the platform to the test utility.

# Test Plan

- `AgentRouteCounterOverflowTest.overflowRouteCounters` passes.
