### PR TITLE
[Cisco][SRv6] Sync configured MySIDs from RIB to switch state

### DIFF
--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -72,6 +72,7 @@
 #include "fboss/agent/RouteUpdateLogger.h"
 #include "fboss/agent/RxPacket.h"
 #include "fboss/agent/StaticL2ForNeighborObserver.h"
+#include "fboss/agent/SwSwitchMySidUpdater.h"
 #include "fboss/agent/SwSwitchRouteUpdateWrapper.h"
 #include "fboss/agent/SwSwitchWarmBootHelper.h"
 #include "fboss/agent/SwitchIdScopeResolver.h"
@@ -3748,6 +3749,16 @@ void SwSwitch::applyConfig(
   setConfigImpl(std::move(newAgentConfig));
 }
 
+void SwSwitch::syncStaticMySidSwitchStateFromRib() {
+  if (!rib_) {
+    return;
+  }
+  auto ribMySidToSwitchStateFunc =
+      createRibMySidToSwitchStateFunction(std::nullopt);
+  rib_->syncMySidSwitchState(
+      getScopeResolver(), ribMySidToSwitchStateFunc, this);
+}
+
 void SwSwitch::applyConfigImpl(
     const std::string& reason,
     const cfg::SwitchConfig& newConfig) {
@@ -3813,6 +3824,10 @@ void SwSwitch::applyConfigImpl(
    * update wrapper abstraction
    */
   routeUpdater.program();
+  if (oldConfig.mySidConfig().has_value() ||
+      newConfig.mySidConfig().has_value()) {
+    syncStaticMySidSwitchStateFromRib();
+  }
   runFsdbSyncFunction([&oldConfig, &newConfig](auto& syncer) {
     syncer->cfgUpdated(oldConfig, newConfig);
   });

--- a/fboss/agent/SwSwitch.h
+++ b/fboss/agent/SwSwitch.h
@@ -1184,6 +1184,8 @@ class SwSwitch : public HwSwitchCallback {
       const std::string& reason,
       const cfg::SwitchConfig& newConfig);
 
+  void syncStaticMySidSwitchStateFromRib();
+
   void setConfigImpl(std::unique_ptr<AgentConfig> config);
 
   std::shared_ptr<SwitchState> preInit(

--- a/fboss/agent/rib/RoutingInformationBase.cpp
+++ b/fboss/agent/rib/RoutingInformationBase.cpp
@@ -524,6 +524,13 @@ void RibRouteTables::reconfigure(
   }
 }
 
+void RibRouteTables::syncMySidSwitchState(
+    const SwitchIdScopeResolver* resolver,
+    const RibMySidToSwitchStateFunction& ribMySidToSwitchStateFunc,
+    void* cookie) {
+  updateFib(resolver, ribMySidToSwitchStateFunc, cookie);
+}
+
 void RibRouteTables::updateRemoteInterfaceRoutes(
     const SwitchIdScopeResolver* resolver,
     const RouterIDAndNetworkToInterfaceRoutes& toAdd,
@@ -1162,6 +1169,18 @@ void RoutingInformationBase::reconfigure(
         staticMySids,
         ribToSwitchStateFunc,
         cookie);
+  };
+  ribUpdateEventBase_.runInFbossEventBaseThreadAndWait(updateFn);
+}
+
+void RoutingInformationBase::syncMySidSwitchState(
+    const SwitchIdScopeResolver* resolver,
+    const RibMySidToSwitchStateFunction& ribMySidToSwitchStateFunc,
+    void* cookie) {
+  ensureRunning();
+  auto updateFn = [&] {
+    ribTables_.syncMySidSwitchState(
+        resolver, ribMySidToSwitchStateFunc, cookie);
   };
   ribUpdateEventBase_.runInFbossEventBaseThreadAndWait(updateFn);
 }

--- a/fboss/agent/rib/RoutingInformationBase.h
+++ b/fboss/agent/rib/RoutingInformationBase.h
@@ -224,6 +224,16 @@ class RibRouteTables {
       RibToSwitchStateFunction ribToSwitchStateFunc,
       void* cookie);
 
+  /*
+   * Push the current RIB MySid table to SwitchState without touching routes.
+   * Used after config reload when ApplyThriftConfig returns changed=false but
+   * static mySidConfig still needs to be reflected in SwitchState.
+   */
+  void syncMySidSwitchState(
+      const SwitchIdScopeResolver* resolver,
+      const RibMySidToSwitchStateFunction& ribMySidToSwitchStateFunc,
+      void* cookie);
+
   void updateRemoteInterfaceRoutes(
       const SwitchIdScopeResolver* resolver,
       const RouterIDAndNetworkToInterfaceRoutes& toAdd,
@@ -511,6 +521,11 @@ class RoutingInformationBase {
       const std::vector<cfg::StaticMplsRouteNoNextHops>& staticMplsRoutesToCpu,
       const std::vector<MySidWithNextHops>& staticMySids,
       RibToSwitchStateFunction ribToSwitchStateFunc,
+      void* cookie);
+
+  void syncMySidSwitchState(
+      const SwitchIdScopeResolver* resolver,
+      const RibMySidToSwitchStateFunction& ribMySidToSwitchStateFunc,
       void* cookie);
 
   void updateRemoteInterfaceRoutes(

--- a/fboss/agent/test/MySidApplyConfigTest.cpp
+++ b/fboss/agent/test/MySidApplyConfigTest.cpp
@@ -258,6 +258,30 @@ TEST_F(MySidApplyConfigTest, LocatorPrefixChange) {
       getMySid("3002:db8:7fff::/48")->getClientId(), ClientID::STATIC_ROUTE);
 }
 
+TEST_F(MySidApplyConfigTest, ReapplySameConfigSyncsMySidFromRib) {
+  auto config = baseConfig_;
+  cfg::MySidConfig mySidConfig;
+  mySidConfig.locatorPrefix() = "3001:db8::/32";
+  cfg::MySidEntryConfig entry;
+  entry.decap() = cfg::DecapMySidConfig{};
+  mySidConfig.entries()[0x100] = entry;
+  config.mySidConfig() = mySidConfig;
+  applyConfig(config);
+  ASSERT_NE(getMySid("3001:db8:100::/48"), nullptr);
+
+  // Simulate stale SwitchState (RIB still has static MySID after reload).
+  sw_->updateStateBlocking("clear mySids", [](const auto& state) {
+    auto newState = state->clone();
+    newState->resetMySids(std::make_shared<MultiSwitchMySidMap>());
+    return newState;
+  });
+  EXPECT_EQ(getMySidCount(), 0);
+
+  applyConfig(config);
+  EXPECT_EQ(getMySidCount(), 1);
+  EXPECT_NE(getMySid("3001:db8:100::/48"), nullptr);
+}
+
 TEST_F(MySidApplyConfigTest, InvalidPortNameThrows) {
   auto config = baseConfig_;
   cfg::MySidConfig mySidConfig;


### PR DESCRIPTION
## Summary

Applying an unchanged configuration can produce no `ApplyThriftConfig` state
delta even when static MySIDs retained by the RIB need to be republished into
`SwitchState`. This change:

- adds a focused RIB API to republish the current MySID table;
- resynchronizes static MySIDs after config operations that add, update, or
  remove `mySidConfig`;
- restores MySIDs when the configuration is unchanged but `SwitchState` is
  stale;
- adds regression coverage for reapplying the same configuration.

## Test Plan

- `pre-commit` passed for all changed files.
- Installed the combined SRv6 image on an FBOSS switch and:
  - committed `mySidConfig` through the config-session workflow;
  - verified all configured entries were published through `show mysid`;
  - verified the generated agent config retained the expected MySID entries
    after config reload.

Validation artifacts:

- [SRv6 console log](https://gist.githubusercontent.com/selekkala/d104d72e5dc2e2969d894da12636199b/raw/76245e76e417e45b4de17dd9288386654fe4a4b7/srv6-console.log)
- [Generated agent.conf](https://gist.githubusercontent.com/selekkala/d104d72e5dc2e2969d894da12636199b/raw/666d04c69086cc7dd6a6037cb18684d53534d1a9/agent.conf)
