### PR TITLE
[Cisco][SAI][SRv6] Defer unresolved uN MySID programming

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiSrv6MySidManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiSrv6MySidManager.cpp
@@ -252,6 +252,14 @@ void SaiSrv6MySidManager::addMySidEntry(
     }
   }
 
+  // Unresolved uN is kept in switch state (visible via show mysid) but some
+  // platforms reject SAI create with a null next hop. Defer HW programming
+  // until RIB resolves the configured node-address.
+  if (mySid->getType() == MySidType::NODE_MICRO_SID &&
+      !resolvedNextHopsId.has_value()) {
+    return;
+  }
+
   std::shared_ptr<SaiObject<SaiSrv6TunnelTraits>> decapTunnel;
   std::optional<SaiMySidEntryTraits::Attributes::TunnelId> tunnelIdAttr;
 #if SAI_API_VERSION >= SAI_VERSION(1, 12, 0)
@@ -286,6 +294,10 @@ void SaiSrv6MySidManager::removeMySidEntry(
   auto key = getMySidAdapterHostKey(*mySid, managerTable_);
   auto itr = handles_.find(key);
   if (itr == handles_.end()) {
+    if (mySid->getType() == MySidType::NODE_MICRO_SID &&
+        !mySid->getResolvedNextHopsId().has_value()) {
+      return;
+    }
     throw FbossError("MySid entry does not exist for ", mySid->getID());
   }
   handles_.erase(itr);

--- a/fboss/agent/hw/sai/switch/tests/MySidManagerTest.cpp
+++ b/fboss/agent/hw/sai/switch/tests/MySidManagerTest.cpp
@@ -81,9 +81,9 @@ TEST_F(MySidManagerTest, addDuplicateThrows) {
 TEST_F(MySidManagerTest, addUnresolvedUASidProgramsWithDropAction) {
   auto mySid = makeMySid("fc00:100::1", 48, MySidType::ADJACENCY_MICRO_SID);
   auto state = getProgrammedState();
-  // uA / uN unresolved entries are programmed in SAI with PacketAction=DROP
-  // so a midpoint packet hits the SRv6 lookup and increments the discard
-  // counter rather than silently falling through to regular IP routing.
+  // uA unresolved entries are programmed in SAI with PacketAction=DROP so a
+  // midpoint packet hits the SRv6 lookup and increments the discard counter
+  // rather than silently falling through to regular IP routing.
   saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
 
   auto key = getMySidAdapterHostKey(*mySid, saiManagerTable);
@@ -98,6 +98,23 @@ TEST_F(MySidManagerTest, addUnresolvedUASidProgramsWithDropAction) {
   auto gotNextHopId =
       srv6Api.getAttribute(key, SaiMySidEntryTraits::Attributes::NextHopId{});
   EXPECT_EQ(gotNextHopId, SAI_NULL_OBJECT_ID);
+}
+
+TEST_F(MySidManagerTest, addUnresolvedUNSidDefersSaiProgramming) {
+  auto mySid = makeMySid("fc00:100::1", 48, MySidType::NODE_MICRO_SID);
+  auto state = getProgrammedState();
+  saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
+
+  auto key = getMySidAdapterHostKey(*mySid, saiManagerTable);
+  EXPECT_EQ(saiManagerTable->srv6MySidManager().getMySidObject(key), nullptr);
+}
+
+TEST_F(MySidManagerTest, removeDeferredUNSidNoOp) {
+  auto mySid = makeMySid("fc00:100::1", 48, MySidType::NODE_MICRO_SID);
+  auto state = getProgrammedState();
+  saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
+  EXPECT_NO_THROW(
+      saiManagerTable->srv6MySidManager().removeMySidEntry(mySid, state));
 }
 
 TEST_F(MySidManagerTest, removeDecapsulateAndLookup) {
@@ -123,7 +140,7 @@ TEST_F(MySidManagerTest, removeNonexistentThrows) {
 TEST_F(MySidManagerTest, removeUnresolvedUASidErasesHandle) {
   auto mySid = makeMySid("fc00:100::1", 48, MySidType::ADJACENCY_MICRO_SID);
   auto state = getProgrammedState();
-  // uA / uN unresolved entries ARE programmed (with PacketAction=DROP), so
+  // uA unresolved entries ARE programmed (with PacketAction=DROP), so
   // removeMySidEntry must erase the SAI handle.
   saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
 
@@ -287,6 +304,25 @@ TEST_F(MySidManagerWithNextHopIdTest, changeUnresolvedToResolved) {
   EXPECT_EQ(gotAction, SAI_PACKET_ACTION_FORWARD);
 }
 
+TEST_F(MySidManagerWithNextHopIdTest, unresolvedUNProgramsOnResolve) {
+  auto mySid = makeMySid("fc00:100::1", 48, MySidType::NODE_MICRO_SID);
+  auto state = getProgrammedState();
+  saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
+
+  auto key = getMySidAdapterHostKey(*mySid, saiManagerTable);
+  EXPECT_EQ(saiManagerTable->srv6MySidManager().getMySidObject(key), nullptr);
+
+  RouteNextHopSet nhopSet;
+  nhopSet.insert(makeNextHop(testInterfaces[0]));
+  auto allocResult = nextHopIDManager_->getOrAllocRouteNextHopSetID(nhopSet);
+  state = getProgrammedState();
+  auto resolvedMySid = mySid->clone();
+  resolvedMySid->setResolvedNextHopsId(allocResult.nextHopIdSetIter->second.id);
+  saiManagerTable->srv6MySidManager().changeMySidEntry(
+      mySid, resolvedMySid, state);
+  EXPECT_NE(saiManagerTable->srv6MySidManager().getMySidObject(key), nullptr);
+}
+
 TEST_F(MySidManagerWithNextHopIdTest, addNodeMicroSidWithResolvedNextHop) {
   RouteNextHopSet nhopSet;
   nhopSet.insert(makeNextHop(testInterfaces[0]));
@@ -311,6 +347,37 @@ TEST_F(MySidManagerWithNextHopIdTest, addNodeMicroSidWithResolvedNextHop) {
   auto gotAction = srv6Api.getAttribute(
       key, SaiMySidEntryTraits::Attributes::PacketAction{});
   EXPECT_EQ(gotAction, SAI_PACKET_ACTION_FORWARD);
+}
+
+TEST_F(
+    MySidManagerWithNextHopIdTest,
+    addNodeMicroSidWithoutConcreteNextHopDrops) {
+  RouteNextHopSet nhopSet;
+  nhopSet.insert(makeNextHop(testInterfaces[0]));
+  nhopSet.insert(makeNextHop(testInterfaces[1]));
+  auto allocResult = nextHopIDManager_->getOrAllocRouteNextHopSetID(nhopSet);
+  auto nextHopSetId = allocResult.nextHopIdSetIter->second.id;
+
+  auto state = getProgrammedState();
+
+  auto mySid = makeMySid("fc00:100::1", 48, MySidType::NODE_MICRO_SID);
+  mySid->setResolvedNextHopsId(nextHopSetId);
+  saiManagerTable->srv6MySidManager().addMySidEntry(mySid, state);
+
+  auto key = getMySidAdapterHostKey(*mySid, saiManagerTable);
+  auto saiEntry = saiManagerTable->srv6MySidManager().getMySidObject(key);
+  ASSERT_NE(saiEntry, nullptr);
+
+  // In fake SAI, NHG members are managed/deferred, so the NHG has no concrete
+  // adapter key yet. uN must remain DROP until the hardware next hop exists.
+  auto& srv6Api = saiApiTable->srv6Api();
+  auto gotAction = srv6Api.getAttribute(
+      key, SaiMySidEntryTraits::Attributes::PacketAction{});
+  EXPECT_EQ(gotAction, SAI_PACKET_ACTION_DROP);
+
+  auto gotNextHopId =
+      srv6Api.getAttribute(key, SaiMySidEntryTraits::Attributes::NextHopId{});
+  EXPECT_EQ(gotNextHopId, SAI_NULL_OBJECT_ID);
 }
 
 class MySidBindingSidTest : public MySidManagerWithNextHopIdTest {

--- a/fboss/agent/test/MySidApplyConfigTest.cpp
+++ b/fboss/agent/test/MySidApplyConfigTest.cpp
@@ -97,6 +97,44 @@ TEST_F(MySidApplyConfigTest, AddMultipleEntries) {
   EXPECT_NE(getMySid("3001:db8:3::/48"), nullptr);
 }
 
+TEST_F(MySidApplyConfigTest, UnresolvedNodeEntryVisibleToShowMySid) {
+  auto config = baseConfig_;
+  cfg::MySidConfig mySidConfig;
+  mySidConfig.locatorPrefix() = "3001:db8::/32";
+
+  cfg::MySidEntryConfig nodeEntry;
+  cfg::NodeMySidConfig nodeConfig;
+  nodeConfig.nodeAddress() = "fc00:100::1";
+  nodeEntry.node() = nodeConfig;
+  mySidConfig.entries()[3] = nodeEntry;
+
+  config.mySidConfig() = mySidConfig;
+  applyConfig(config);
+
+  auto mySid = getMySid("3001:db8:3::/48");
+  ASSERT_NE(mySid, nullptr);
+  EXPECT_EQ(mySid->getType(), MySidType::NODE_MICRO_SID);
+  EXPECT_FALSE(mySid->getResolvedNextHopsId().has_value());
+
+  // fboss2 show mysid reads this RPC, so verify the unresolved uN remains
+  // visible even though SAI programming is deferred until resolution.
+  ThriftHandler handler(sw_);
+  std::vector<MySidEntry> entries;
+  handler.getMySidEntries(entries);
+  ASSERT_EQ(entries.size(), 1);
+  EXPECT_EQ(*entries[0].type(), MySidType::NODE_MICRO_SID);
+  auto ip =
+      facebook::network::toIPAddress(*entries[0].mySid()->prefixAddress());
+  EXPECT_EQ(
+      folly::IPAddress::networkToString(
+          {ip, static_cast<uint8_t>(*entries[0].mySid()->prefixLength())}),
+      "3001:db8:3::/48");
+  ASSERT_EQ(entries[0].nextHops()->size(), 1);
+  EXPECT_EQ(
+      facebook::network::toIPAddress(*entries[0].nextHops()->front().address()),
+      folly::IPAddress("fc00:100::1"));
+}
+
 TEST_F(MySidApplyConfigTest, RemoveStaticEntry) {
   // First, add two entries
   auto config = baseConfig_;


### PR DESCRIPTION
## Summary

Some platforms reject a node micro-SID SAI entry when no concrete next hop is
available. This change keeps unresolved uN entries visible in `SwitchState`
while deferring their SAI programming:

- retain an unresolved node micro-SID in `SwitchState`;
- defer SAI MySID creation until its next hop resolves;
- make removal of a deferred unresolved uN entry a no-op;
- preserve the existing unresolved uA drop behavior;
- keep unresolved configured uN entries visible through `show mysid`.

## Test Plan

- `pre-commit` passed for all changed files.
- Facebook Internal Builds & Tests passed.
- The SAI test run covered:
  - deferring an unresolved uN entry;
  - removing a deferred uN entry;
  - programming the entry when its next hop resolves;
  - keeping the entry in drop state when no concrete next hop exists.
- The agent test run verified that an unresolved configured node entry remains
  visible to `show mysid`.
- Installed the combined SRv6 image on an FBOSS switch and confirmed the
  configured node micro-SID was present in `show mysid`.

Validation artifact:

- [SRv6 console log](https://gist.githubusercontent.com/selekkala/d104d72e5dc2e2969d894da12636199b/raw/76245e76e417e45b4de17dd9288386654fe4a4b7/srv6-console.log)
