### PR TITLE
[Nexthop][fboss2-dev] Use recorded action level when rolling back config

### DIFF
--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -1287,6 +1287,41 @@ void ConfigSession::rebase() {
   }
 }
 
+std::map<cli::ServiceType, cli::ConfigActionLevel>
+ConfigSession::rolledBackActionLevels(const std::string& resolvedSha) const {
+  std::map<cli::ServiceType, cli::ConfigActionLevel> levels;
+  for (const auto& commit : git_->log(getSystemMetadataPath())) {
+    if (commit.sha1 == resolvedSha) {
+      return levels;
+    }
+    try {
+      folly::dynamic json = folly::parseJson(
+          git_->fileAtRevision(commit.sha1, kMetadataGitRelPath));
+      cli::ConfigSessionMetadata metadata;
+      facebook::thrift::from_dynamic(
+          metadata,
+          json,
+          facebook::thrift::dynamic_format::PORTABLE,
+          facebook::thrift::format_adherence::LENIENT);
+      for (const auto& [service, level] : *metadata.action()) {
+        auto it = levels.find(service);
+        if (it == levels.end() ||
+            static_cast<int>(level) > static_cast<int>(it->second)) {
+          levels[service] = level;
+        }
+      }
+    } catch (const std::exception& ex) {
+      // A commit with unreadable metadata contributes nothing; the service's
+      // default rollback action still applies as a floor.
+      LOG(WARNING) << "Failed to read metadata at revision "
+                   << Git::shortSha1(commit.sha1) << ": " << ex.what();
+    }
+  }
+  // resolvedSha never touched the metadata file (or predates it): every
+  // metadata-bearing commit was scanned, which is the conservative answer.
+  return levels;
+}
+
 std::string ConfigSession::rollback(const HostInfo& hostInfo) {
   // Find the previous commit using the metadata file's history. The metadata
   // (cli/cli_metadata.json) is committed by every config commit -- agent OR
@@ -1320,7 +1355,7 @@ std::string ConfigSession::rollback(
   std::string targetConfigData =
       git_->fileAtRevision(resolvedSha, "cli/agent.conf");
   std::string targetMetadataData =
-      git_->fileAtRevision(resolvedSha, "cli/cli_metadata.json");
+      git_->fileAtRevision(resolvedSha, kMetadataGitRelPath);
   std::string metadataPath = fmt::format("{}/cli_metadata.json", cliConfigDir);
 
   // Target BGP config at that revision ("" if the commit predates BGP config).
@@ -1360,6 +1395,52 @@ std::string ConfigSession::rollback(
   const bool agentChanged = targetConfigData != oldConfigData;
   const bool bgpChanged = targetBgpData != oldBgpData;
 
+  // Reload/restart only the services whose config changed. Each starts at its
+  // default rollback action level and is promoted to the highest level
+  // recorded by any commit being undone: undoing a change needs at least the
+  // action applying it did (e.g. a VLAN membership change cannot be applied
+  // with a hitless reload in either direction). Computed before any file is
+  // touched so a git failure here aborts cleanly.
+  auto recordedLevels = rolledBackActionLevels(resolvedSha);
+  std::map<cli::ServiceType, cli::ConfigActionLevel> actions;
+  auto actionFor = [&recordedLevels](
+                       cli::ServiceType service, cli::ConfigActionLevel floor) {
+    auto it = recordedLevels.find(service);
+    if (it != recordedLevels.end() &&
+        static_cast<int>(it->second) > static_cast<int>(floor)) {
+      return it->second;
+    }
+    return floor;
+  };
+  if (agentChanged) {
+    actions[cli::ServiceType::AGENT] =
+        actionFor(cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+  }
+  if (bgpChanged) {
+    actions[cli::ServiceType::BGP] =
+        actionFor(cli::ServiceType::BGP, cli::ConfigActionLevel::BGP_RESTART);
+  }
+
+  // The rollback commit's metadata must record the actions IT applied, not the
+  // target commit's: a later rollback undoing this one crosses the same
+  // changes and reads this action map to pick its own level.
+  try {
+    folly::dynamic json = folly::parseJson(targetMetadataData);
+    cli::ConfigSessionMetadata metadata;
+    facebook::thrift::from_dynamic(
+        metadata,
+        json,
+        facebook::thrift::dynamic_format::PORTABLE,
+        facebook::thrift::format_adherence::LENIENT);
+    metadata.action() = actions;
+    targetMetadataData = folly::toPrettyJson(
+        facebook::thrift::to_dynamic(
+            metadata, facebook::thrift::dynamic_format::PORTABLE));
+  } catch (const std::exception& ex) {
+    LOG(WARNING) << "Failed to record rollback actions in metadata: "
+                 << ex.what();
+  }
+
   // Always restore the metadata (it records the new rollback base). Only
   // rewrite the agent config + symlink when it actually changed, to avoid
   // needless writes and symlink churn on a BGP-only rollback.
@@ -1396,18 +1477,7 @@ std::string ConfigSession::rollback(
   // Apply the rolled-back config - if this fails, restore prior state.
   std::string newCommitSha;
   try {
-    // Reload the agent only if its config changed.
-    if (agentChanged) {
-      auto client = utils::createClient<
-          apache::thrift::Client<facebook::fboss::FbossCtrl>>(hostInfo);
-      client->sync_reloadConfig();
-    }
-    // Restart bgpd only if its config changed.
-    if (bgpChanged) {
-      ensureFbossServiceUtil(hostInfo);
-      fbossServiceUtil_->restartService(
-          cli::ServiceType::BGP, cli::ConfigActionLevel::BGP_RESTART);
-    }
+    applyServiceActions(actions, hostInfo);
 
     // Create a Git commit for the rollback. Metadata always changes; the agent
     // config + symlink are included only when they were actually rewritten

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -305,12 +305,24 @@ class ConfigSession {
 
   // git relative path of the bgpd config tracked in the /etc/coop repo.
   static constexpr auto kBgpGitRelPath = "bgpcpp/bgpcpp.conf";
+  // git relative path of the CLI metadata tracked in the /etc/coop repo.
+  static constexpr auto kMetadataGitRelPath = "cli/cli_metadata.json";
   // Like Git::fileAtRevision but returns "" instead of throwing when the path
   // does not exist at that revision (e.g. a pre-BGP commit). Used by
   // rebase/rollback/diff so a missing bgpcpp.conf is treated as empty.
   std::string fileAtRevisionOrEmpty(
       const std::string& revision,
       const std::string& gitRelPath) const;
+
+  // Highest per-service action level recorded in the metadata of every commit
+  // a rollback to resolvedSha would undo (i.e. commits in (resolvedSha, HEAD]).
+  // Undoing a change needs at least the action level applying it did (e.g. a
+  // VLAN membership change requires an agent warmboot in both directions), so
+  // rollback() promotes each service's default action to this level.
+  // If resolvedSha is not found in the metadata history, the max over the
+  // whole history is returned (conservative).
+  std::map<cli::ServiceType, cli::ConfigActionLevel> rolledBackActionLevels(
+      const std::string& resolvedSha) const;
 
   // Track the highest action level required for pending config changes per
   // service. Persisted to disk so it survives across CLI invocations within a

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionTest.cpp
@@ -16,6 +16,7 @@
 #include <string>
 
 #include "fboss/cli/fboss2/test/TestableConfigSession.h"
+#include "fboss/cli/fboss2/test/config/MockFbossServiceUtil.h"
 #include "fboss/cli/fboss2/test/config/MockSystemdInterface.h"
 
 namespace fs = std::filesystem;
@@ -1591,6 +1592,93 @@ TEST_F(ConfigSessionTestFixture, noArgRollbackReachesBaseline) {
     std::string rb;
     EXPECT_NO_THROW(rb = s->rollback(localhost()));
     EXPECT_FALSE(rb.empty());
+  }
+}
+
+// Rolling back a commit that required an agent warmboot (e.g. a VLAN
+// membership change) must restart the agent, not apply the rolled-back config
+// with a HITLESS reloadConfig(): undoing a change needs at least the action
+// level that applying it needed.
+TEST_F(ConfigSessionTestFixture, rollbackUsesRecordedActionLevel) {
+  fs::path sessionDir = getTestHomeDir() / ".fboss2";
+
+  auto makeSession = [&](MockFbossServiceUtil*& mockOut) {
+    auto mock = std::make_unique<::testing::StrictMock<MockFbossServiceUtil>>();
+    mockOut = mock.get();
+    return std::make_unique<TestableConfigSession>(
+        sessionDir.string(),
+        (getTestEtcDir() / "coop").string(),
+        std::move(mock));
+  };
+
+  std::string firstCommitSha;
+  // First commit: a HITLESS change (e.g. a description edit).
+  {
+    MockFbossServiceUtil* mock = nullptr;
+    auto session = makeSession(mock);
+    EXPECT_CALL(*mock, reloadConfig(cli::ServiceType::AGENT, ::testing::_))
+        .Times(1);
+    session->setCommandLine(
+        "config interface eth1/1/1 description First version");
+    (*session->getAgentConfig().sw()->ports())[0].description() =
+        "First version";
+    session->saveConfig(
+        cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+    firstCommitSha = session->commit(localhost()).commitSha;
+    ASSERT_FALSE(firstCommitSha.empty());
+  }
+
+  // Second commit: a change that requires an agent warmboot, like
+  // `config interface eth1/1/1 switchport access vlan 3000` does.
+  {
+    MockFbossServiceUtil* mock = nullptr;
+    auto session = makeSession(mock);
+    EXPECT_CALL(
+        *mock,
+        restartService(
+            cli::ServiceType::AGENT, cli::ConfigActionLevel::AGENT_WARMBOOT))
+        .Times(1);
+    session->setCommandLine(
+        "config interface eth1/1/1 switchport access vlan 3000");
+    (*session->getAgentConfig().sw()->ports())[0].description() =
+        "Second version";
+    session->saveConfig(
+        cli::ServiceType::AGENT, cli::ConfigActionLevel::AGENT_WARMBOOT);
+    ASSERT_FALSE(session->commit(localhost()).commitSha.empty());
+  }
+
+  // Rollback to the first commit: this undoes the warmboot-level change, so it
+  // must warmboot-restart the agent. reloadConfig() must NOT be called (the
+  // StrictMock enforces this).
+  {
+    MockFbossServiceUtil* mock = nullptr;
+    auto session = makeSession(mock);
+    EXPECT_CALL(
+        *mock,
+        restartService(
+            cli::ServiceType::AGENT, cli::ConfigActionLevel::AGENT_WARMBOOT))
+        .Times(1);
+    std::string rollbackSha = session->rollback(localhost(), firstCommitSha);
+    EXPECT_FALSE(rollbackSha.empty());
+  }
+
+  // Rollback forward to the pre-rollback state (undoing the rollback commit)
+  // crosses the same warmboot-level change again, so it too must restart the
+  // agent. This exercises the rollback commit recording the action level it
+  // applied.
+  std::string headBeforeSecondRollback;
+  {
+    MockFbossServiceUtil* mock = nullptr;
+    auto session = makeSession(mock);
+    headBeforeSecondRollback = session->getGit().getHead();
+    EXPECT_CALL(
+        *mock,
+        restartService(
+            cli::ServiceType::AGENT, cli::ConfigActionLevel::AGENT_WARMBOOT))
+        .Times(1);
+    // No-arg rollback: back to the "Second version" commit.
+    std::string rollbackSha = session->rollback(localhost());
+    EXPECT_FALSE(rollbackSha.empty());
   }
 }
 


### PR DESCRIPTION
## Problem
`fboss2-dev config rollback` fails when the commit being undone required an agent warmboot (e.g. a VLAN membership change):

```
Thrift call failed: 'Failed to rollback config: Failed to reload config, config was restored automatically: Channel got EOF. Check for server hitting connection limit, connection age timeout, server connection idle timeout, and server crashes.'
```

`ConfigSession::rollback()` always applied the agent config with a HITLESS `reloadConfig()`, but the agent cannot apply a VLAN membership change hitlessly and crashes mid-call — the very reason the original commit warmboot-restarted the agent.

## Fix
Every commit's `cli/cli_metadata.json` already records the action level that commit needed. `rollback()` now:
- walks the metadata history over the commits being undone (`(target, HEAD]`) and takes the max recorded level per service (new `rolledBackActionLevels()`),
- promotes each changed service's action from its floor (agent: HITLESS, bgpd: BGP_RESTART) to that level, applying them via `applyServiceActions()`,
- records the actions the rollback itself applied in the rollback commit's metadata, so a later rollback undoing a rollback also picks the right level.

## Testing
- New regression test `ConfigSessionTestFixture.rollbackUsesRecordedActionLevel`: a StrictMock of `FbossServiceUtil` asserts the rollback warmboot-restarts the agent (and never calls `reloadConfig()`), in both rollback directions. It failed with the exact bug before the fix and passes after.
- On a device: reproduced the exact failure above, then with the fix `config rollback` warmboot-restarts the agents and succeeds in both directions (VLAN removed, then restored when rolling back over the rollback commit), agents active throughout.
