### PR TITLE
[Celestica] Leh800bcls: Fix Multi-NPU Slow Path Benchmark Failures on multi-NPU (Split Agent) Platforms

### DIFF
--- a/fboss/agent/hw/benchmarks/HwRxSlowPathArpBenchmark.cpp
+++ b/fboss/agent/hw/benchmarks/HwRxSlowPathArpBenchmark.cpp
@@ -53,7 +53,8 @@ BENCHMARK(RxSlowPathArpBenchmark) {
     CHECK_GE(
         ensemble.masterLogicalPortIds({cfg::PortType::INTERFACE_PORT}).size(),
         1);
-    std::vector<PortID> ports = {ensemble.masterLogicalInterfacePortIds()[0]};
+    std::vector<PortID> ports = {ensemble.masterLogicalInterfacePortIds(
+        SwitchID(FLAGS_switch_id_for_testing))[0]};
 
     auto l3Asics = ensemble.getSw()->getHwAsicTable()->getL3Asics();
     auto asic = checkSameAndGetAsicForTesting(l3Asics);
@@ -65,7 +66,12 @@ BENCHMARK(RxSlowPathArpBenchmark) {
               asic,
               ensemble.masterLogicalPortIds(),
               ensemble.getSw()->getPlatformSupportsAddRemovePort(),
-              asic->desiredLoopbackModes())
+              asic->desiredLoopbackModes(),
+              true, /* interfaceHasSubnet */
+              utility::kBaseVlanId, /* baseVlanId */
+              true, /* optimizePortProfile */
+              true, /* setInterfaceMac */
+              ensemble.getSw()->getPlatformType())
         : utility::onePortPerInterfaceConfig(
               ensemble.getSw()->getPlatformMapping(),
               asic,
@@ -97,6 +103,8 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::optional<VlanID> vlanId{};
   if (intf->getType() == cfg::InterfaceType::VLAN) {
     vlanId = intf->getVlanID();
+    portDescriptor = PortDescriptor(ensemble->masterLogicalInterfacePortIds(
+        SwitchID(FLAGS_switch_id_for_testing))[0]);
   } else if (intf->getType() == cfg::InterfaceType::PORT) {
     portDescriptor = PortDescriptor(intf->getPortID());
   }
@@ -118,7 +126,7 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::this_thread::sleep_for(std::chrono::seconds(kBurnIntevalInSeconds));
   std::map<int, CpuPortStats> cpuStatsBefore;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsBefore);
-  auto statsBefore = cpuStatsBefore[0];
+  auto statsBefore = cpuStatsBefore[FLAGS_switch_id_for_testing];
   auto hwAsic = checkSameAndGetAsicForTesting(ensemble->getL3Asics());
   auto [pktsBefore, bytesBefore] = utility::getCpuQueueOutPacketsAndBytes(
       *statsBefore.portStats_(), utility::getCoppHighPriQueueId(hwAsic));
@@ -127,7 +135,7 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::this_thread::sleep_for(std::chrono::seconds(kBurnIntevalInSeconds));
   std::map<int, CpuPortStats> cpuStatsAfter;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsAfter);
-  auto statsAfter = cpuStatsAfter[0];
+  auto statsAfter = cpuStatsAfter[FLAGS_switch_id_for_testing];
   auto [pktsAfter, bytesAfter] = utility::getCpuQueueOutPacketsAndBytes(
       *statsAfter.portStats_(), utility::getCoppHighPriQueueId(hwAsic));
   auto timeAfter = std::chrono::steady_clock::now();

--- a/fboss/agent/hw/benchmarks/HwRxSlowPathArpBenchmark.cpp
+++ b/fboss/agent/hw/benchmarks/HwRxSlowPathArpBenchmark.cpp
@@ -65,7 +65,12 @@ BENCHMARK(RxSlowPathArpBenchmark) {
               asic,
               ensemble.masterLogicalPortIds(),
               ensemble.getSw()->getPlatformSupportsAddRemovePort(),
-              asic->desiredLoopbackModes())
+              asic->desiredLoopbackModes(),
+              true, /* interfaceHasSubnet */
+              utility::kBaseVlanId, /* baseVlanId */
+              true, /* optimizePortProfile */
+              true, /* setInterfaceMac */
+              ensemble.getSw()->getPlatformType())
         : utility::onePortPerInterfaceConfig(
               ensemble.getSw()->getPlatformMapping(),
               asic,
@@ -97,6 +102,8 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::optional<VlanID> vlanId{};
   if (intf->getType() == cfg::InterfaceType::VLAN) {
     vlanId = intf->getVlanID();
+    portDescriptor =
+        PortDescriptor(ensemble->masterLogicalInterfacePortIds()[0]);
   } else if (intf->getType() == cfg::InterfaceType::PORT) {
     portDescriptor = PortDescriptor(intf->getPortID());
   }
@@ -118,7 +125,7 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::this_thread::sleep_for(std::chrono::seconds(kBurnIntevalInSeconds));
   std::map<int, CpuPortStats> cpuStatsBefore;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsBefore);
-  auto statsBefore = cpuStatsBefore[0];
+  auto statsBefore = cpuStatsBefore[FLAGS_switch_id_for_testing];
   auto hwAsic = checkSameAndGetAsicForTesting(ensemble->getL3Asics());
   auto [pktsBefore, bytesBefore] = utility::getCpuQueueOutPacketsAndBytes(
       *statsBefore.portStats_(), utility::getCoppHighPriQueueId(hwAsic));
@@ -127,7 +134,7 @@ BENCHMARK(RxSlowPathArpBenchmark) {
   std::this_thread::sleep_for(std::chrono::seconds(kBurnIntevalInSeconds));
   std::map<int, CpuPortStats> cpuStatsAfter;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsAfter);
-  auto statsAfter = cpuStatsAfter[0];
+  auto statsAfter = cpuStatsAfter[FLAGS_switch_id_for_testing];
   auto [pktsAfter, bytesAfter] = utility::getCpuQueueOutPacketsAndBytes(
       *statsAfter.portStats_(), utility::getCoppHighPriQueueId(hwAsic));
   auto timeAfter = std::chrono::steady_clock::now();


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```
# Summary
Under the multi-switch (Split Agent) dual-switch Broadcom Tomahawk6 platform (Ladakh800bcls/Leh800bcls), running the benchmark suite consistently encounters the following issues:
RxSlowPathArpBenchmark case will report timeout:
```
 ########## Benchmark RxSlowPathArpBenchmark timed out after 1200 seconds
```
in fboss_hw_agent-sai_impl:
It will raise exception due to:
```
fboss_hw_agent_oss0.log:Jul 27 10:50:10 localhost.localdomain fboss_hw_agent_oss@0[86766]: Error: counter_get() failed(Invalid unit).
```
# Root Cause
- Calling oneL3IntfConfig without passing PlatformType prevents the configuration factory from mapping dual-switch layouts properly, causing initialization failures under dual-NPU modes on Ladakh/Leh.
- In VLAN mode, calling sendPacketAsync without an explicit portDescriptor triggers the SwSwitch's unguided traffic fallback, which routes all packets to the first connected switch (SwitchID(0) / NPU0). When testing NPU1, all packets are physical loopbacks on NPU0.
- The benchmark fetched CPU queue stats using hardcoded cpuStatsBefore[0] and cpuStatsAfter[0], querying NPU0's queue counters even when the active test target was NPU1. Since NPU1 received zero packets, the assertion CHECK_NE(pktsBefore, 0) failed, crashing the test process.

# Solution
- Passed ensemble.getSw()->getPlatformType() down to oneL3IntfConfig() to ensure correct configuration instantiation on dual-switch layouts.
- In VLAN mode, explicitly bound the subinterface's portDescriptor to the first active interface port of the tested NPU. This forces the packet engine to route loopback traffic to the correct NPU, bypassing the single-switch fallback drift.
- Replaced hardcoded CPU statistics index [0] with [FLAGS_switch_id_for_testing] to accurately query CPU queue metrics on the active NPU.

# Test Plan
the case RxSlowPathArpBenchmark passed on both NPU0 and NPU1.
- NPU0
```
########## Benchmark RxSlowPathArpBenchmark completed
  >> WARNING: no benchmark threshold defined for RxSlowPathArpBenchmark on brcm/14.2.0.0_odp/tomahawk6/multi_switch; this benchmark WILL ALWAYS PASS until thresholds are added.

########## Benchmark results written to: benchmark_results_20260803_073154.csv

================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
RxSlowPathArpBenchmark: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x
log is /root/gangtao/log/BenchmarkTest_Npu0_RxSlowPathArpBenchmark/sai_multi_switch_all_benchmarks-sai_impl_RxSlowPathArpBenchmark_20260803_073043.log

```
- NPU1
```
########## Benchmark results written to: benchmark_results_20260803_073316.csv

================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
RxSlowPathArpBenchmark: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x
log is /root/gangtao/log/BenchmarkTest_Npu1_RxSlowPathArpBenchmark/sai_multi_switch_all_benchmarks-sai_impl_RxSlowPathArpBenchmark_20260803_073206.log

```