### PR TITLE
[Nexthop] Fix RibSyncFibBenchmark SIGABRT on FIB NextHop ID consistency check

### DIFF
--- a/fboss/agent/hw/benchmarks/HwRibSyncFibBenchmark.cpp
+++ b/fboss/agent/hw/benchmarks/HwRibSyncFibBenchmark.cpp
@@ -38,10 +38,15 @@ BENCHMARK(RibSyncFibBenchmark) {
   const auto& routeChunks = gen.getThriftRoutes();
   CHECK_EQ(1, routeChunks.size());
   // Create a dummy rib since we don't want to go through
-  // AgentSwitchEnsemble and write to HW
+  // AgentSwitchEnsemble and write to HW. The FibsInfoMap is needed so the
+  // dummy rib's NextHopIDManager is reconstructed from the programmed state
+  // instead of minting a fresh, colliding ID space.
   auto rib = RoutingInformationBase::fromThrift(
-      ensemble->getSw()->getRib()->toThrift(), nullptr, nullptr, nullptr);
-  auto switchState = ensemble->getSw()->getState();
+      ensemble->getSw()->getRib()->toThrift(),
+      ensemble->getProgrammedState()->getFibsInfoMap(),
+      nullptr,
+      nullptr);
+  auto switchState = ensemble->getProgrammedState();
   rib->update(
       ensemble->getSw()->getScopeResolver(),
       RouterID(0),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
Benchmarks.RibSyncFibBenchmark hits SIGABRT while running on wedge800bnhp:
```
E SwitchStateNextHopIdUpdater.cpp:173] FIB NextHop ID consistency check failed for route 0.0.0.1/32:
  resolvedNextHopSetID nexthops mismatch.
  Expected Inline Nexthops: 1.0.0.2@I2000x0 2.0.0.3@I2001x0 3.0.0.4@I2002x0 4.0.0.5@I2003x0
  Resolved NextHops from ID: 3.0.0.1@I2002x1
F RibToSwitchStateUpdater.cpp:61] Check failed: nhopStateUpdater_.verifyNextHopIdConsistency(nextState)
```
# Test Plan
wedge800bnhp passes:
```
{
  "RibSyncFibBenchmark": 832930890000
}
{
  "cpu_time_usec": 7606478,
  "max_rss": 2038344
}

########## Benchmark RibSyncFibBenchmark completed
  >> WARNING: no benchmark threshold defined for RibSyncFibBenchmark on brcm/13.3.0.0_odp/tomahawk5; this benchmark WILL ALWAYS PASS until thresholds are added.

########## Benchmark results written to: benchmark_results_20260729_152603.csv

================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
RibSyncFibBenchmark: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
```