### PR TITLE
Skip verifyL4SrcPortRandomization on ASICs without eventor sFlow

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentSflowMirrorTest.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSflowMirrorTest.cpp
@@ -1951,6 +1951,11 @@ TEST_F(AgentSflowMirrorAddressFamilySwitchingTest, MoveToV4) {
 }
 
 TEST_F(AgentSflowMirrorTruncateTestV6, verifyL4SrcPortRandomization) {
+  // Randomized sFlow src-port needs the eventor sFlow datapath; skip otherwise.
+  if (!isSupportedOnAllAsics(HwAsic::Feature::EVENTOR_PORT_FOR_SFLOW)) {
+    GTEST_SKIP() << "ASIC does not randomize the sFlow UDP source port "
+                    "(requires the eventor sFlow datapath, e.g. Jericho3)";
+  }
   auto setup = [=, this]() {
     auto config = initialConfig(*getAgentEnsemble());
     configureMirrorWithSampling(


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`AgentSflowMirrorTruncateTestV6.verifyL4SrcPortRandomization` programs an sFlow mirror with `udpSrcPort = 0` to request hardware randomization of the outer L4 (UDP) source port, and asserts that sampled packets carry more than one distinct source port (`EXPECT_GT(l4SrcPorts.size(), 1)`).

That randomization is provided by the eventor sFlow datapath, advertised via `HwAsic::Feature::EVENTOR_PORT_FOR_SFLOW` (true on Jericho3/Jericho4/Qumran4D). On ASICs without it — e.g. all Tomahawk — the sFlow encapsulation uses a single fixed UDP source port, so every sample carries the same port and the assertion fails (`l4SrcPorts.size() == 1`). This was observed running SDK `14.3.0.0_odp` on Tomahawk3.

Gate the test with the existing `isSupportedOnAllAsics(...) + GTEST_SKIP()` idiom (as used e.g. in `AgentLoadBalancerTests`) so it runs on eventor-capable ASICs and is skipped elsewhere. This matches the current de-facto behavior:

- In the published qualification results (`docs/static/test_results/*.csv`) this test passes only on Jericho3 and is absent from every Tomahawk run, while the sibling `AgentSflowMirrorTruncateTestV6` tests run and pass on Tomahawk.
- The known-bad list already carries this test for Tomahawk (e.g. `.../tomahawk3|tomahawk4|tomahawk5/...`). A code-level capability gate makes those per-SDK/per-ASIC known-bad entries unnecessary, and also covers newer SDK scopes that do not have an entry yet.

Note for maintainers: this reuses the existing `EVENTOR_PORT_FOR_SFLOW` feature to avoid touching every `HwAsic::isSupported()`. If a dedicated, vendor-neutral capability is preferred, I'm happy to switch to a new `HwAsic::Feature::SFLOW_UDP_SRC_PORT_RANDOMIZATION` (more explicit, but adds a case to each ASIC's `isSupported()`). Please advise which you prefer.

# Test Plan

- Jericho3 (`EVENTOR_PORT_FOR_SFLOW` supported): `verifyL4SrcPortRandomization` runs (unchanged; passes).
- Tomahawk3 / Tomahawk5 (feature not supported): `verifyL4SrcPortRandomization` is skipped; other `AgentSflowMirror*` tests are unaffected.
- The change is limited to a single test and relies on the existing `isSupportedOnAllAsics(...) + GTEST_SKIP()` pattern. A full local FBOSS build was not available on the dev machine (buck2/SDK), so CI build + the affected-test run provide the compile and behavioral validation.
- Ran `pre-commit run` (clang-format v21.1.2 + trailing-whitespace / end-of-file / merge-conflict hooks) locally against the modified file — all applicable hooks pass with no changes.
