### PR TITLE
[Meta] Fix GHA fboss2 fake sai cli.

### DIFF
--- a/cmake/Agent.cmake
+++ b/cmake/Agent.cmake
@@ -816,6 +816,7 @@ target_link_libraries(fboss_sw_agent
   handler
   -Wl,--whole-archive
   setup_thrift_prod
+  thrift_service_client
   -Wl,--no-whole-archive
 )
 

--- a/cmake/AgentPlatformsSai.cmake
+++ b/cmake/AgentPlatformsSai.cmake
@@ -129,6 +129,7 @@ function(BUILD_SAI_WEDGE_AGENT SAI_IMPL_NAME SAI_IMPL_ARG)
     sai_platform
     sai_traced_api
     setup_thrift_prod
+    thrift_service_client
     ${SAI_IMPL_ARG}
     -Wl,--no-whole-archive
     ${CMAKE_THREAD_LIBS_INIT}
@@ -161,6 +162,7 @@ function(BUILD_SAI_WEDGE_AGENT SAI_IMPL_NAME SAI_IMPL_ARG)
     load_agent_config
     sai_platform
     hwagent
+    thrift_service_client
     ${SAI_IMPL_ARG}
     -Wl,--no-whole-archive
   )


### PR DESCRIPTION
Summary:
`fboss_hw_agent-sai_impl` crash-loops on startup and the
agent never becomes ready:

```
  ERROR: unknown command line flag 'fsdb_client_ssl_preferred'
  fboss_hw_agent@0.service: Main process exited, code=exited, status=1/FAILURE
  fboss_hw_agent@0.service: Scheduled restart job, restart counter is at 2971.
```

**Root cause:** 

- `DEFINE_bool(fsdb_client_ssl_preferred)` lives in `fboss/lib/thrift_service_client/ConnectionOptions.cpp`, compiled into the static archive `thrift_service_client`.
- In the OSS CMake build that archive is pulled in only transitively, outside any `-Wl,--whole-archive` block, so the linker keeps `ConnectionOptions.o` only if some referenced symbol lives in it.
- The HwAgent link (`hwagent-main`/`fboss_common_init`/`load_agent_config`/`sai_platform`/`hwagent`) referenced nothing in that TU after the recent SAI-platform split/cleanup (D113583404) , so the object was garbage collected and the flag never registered. `fboss_hw_agent@.service` still starts the binary with ` -fsdb_client_ssl_preferred=false`, so gflags exits 1.

**Fix:**  force-link `thrift_service_client` inside the `-Wl,--whole-archive` block of `fboss_hw_agent` (the fix) and `wedge_agent` / `fboss_sw_agent` (defensive, so a future refactor can't silently drop it again).

Differential Revision: D114643266


