### PR TITLE
[Nexthop][platform_manager] fail fast on missing BSP rpm, support bspKmodsRpmVersion wildcard

### DIFF
--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -1272,6 +1272,11 @@ bool ConfigValidator::isValidBspKmodsRpmVersion(
     XLOG(ERR) << "BspKmodsRpmVersion cannot be empty";
     return false;
   }
+  // Wildcard: PkgManager resolves it to the newest BSP rpm shipped in the
+  // image. See kBspKmodsRpmVersionWildcard in PkgManager.h.
+  if (bspKmodsRpmVersion == "*") {
+    return true;
+  }
   if (!re2::RE2::FullMatch(bspKmodsRpmVersion, kRpmVersionRegex)) {
     XLOG(ERR) << fmt::format(
         "Invalid BspKmodsRpmVersion : {}", bspKmodsRpmVersion);

--- a/fboss/platform/platform_manager/Main.cpp
+++ b/fboss/platform/platform_manager/Main.cpp
@@ -66,7 +66,9 @@ int main(int argc, char** argv) {
       XLOG(INFO) << "Config changed since last run, reloading kmods";
     }
     bool reloadKmods = FLAGS_reload_kmods || configChanged;
-    PkgManager pkgManager(config);
+    auto systemInterface = std::make_shared<package_manager::SystemInterface>();
+    resolveBspKmodsRpmVersion(config, *systemInterface);
+    PkgManager pkgManager(config, systemInterface);
     pkgManager.processAll(FLAGS_enable_pkg_mgmnt, reloadKmods);
     PlatformExplorer platformExplorer(config, dataStore.value());
     platformExplorer.explore();

--- a/fboss/platform/platform_manager/PkgManager.cpp
+++ b/fboss/platform/platform_manager/PkgManager.cpp
@@ -59,6 +59,33 @@ const std::unordered_set<std::string_view> kTolerableKmodLoadFailures = {
     "aadm1266"};
 } // namespace
 
+void resolveBspKmodsRpmVersion(
+    PlatformConfig& config,
+    const package_manager::SystemInterface& systemInterface) {
+  if (*config.bspKmodsRpmVersion() != kBspKmodsRpmVersionWildcard) {
+    return;
+  }
+  const auto& rpmBaseName = *config.bspKmodsRpmName();
+  auto availableVersions =
+      systemInterface.getLocalRepoBspRpmVersions(rpmBaseName);
+  if (availableVersions.empty()) {
+    throw std::runtime_error(
+        fmt::format(
+            "bspKmodsRpmVersion is \"{}\", but no {} rpm for kernel {} was "
+            "found in {}",
+            kBspKmodsRpmVersionWildcard,
+            rpmBaseName,
+            systemInterface.getHostKernelVersion(),
+            FLAGS_local_rpm_repo_path));
+  }
+  XLOG(INFO) << fmt::format(
+      "Resolved bspKmodsRpmVersion \"{}\" to {} (available: {})",
+      kBspKmodsRpmVersionWildcard,
+      availableVersions.front(),
+      folly::join(", ", availableVersions));
+  config.bspKmodsRpmVersion() = availableVersions.front();
+}
+
 PkgManager::PkgManager(
     const PlatformConfig& config,
     const std::shared_ptr<package_manager::SystemInterface>& systemInterface,
@@ -158,22 +185,43 @@ void PkgManager::processRpms() const {
 
   removeInstalledRpms();
 
-  int exitStatus{0};
+  package_manager::RpmInstallResult result;
   auto bspKmodsRpmName = getKmodsRpmName();
-  for (auto [success, attempt] = std::pair{false, 0}; attempt < 3 && !success;
-       attempt++) {
+  for (int attempt = 0; attempt < 3; attempt++) {
     XLOG(INFO) << fmt::format(
         "Installing BSP {}, Attempt #{}", bspKmodsRpmName, attempt);
-    exitStatus = systemInterface_->installRpm(bspKmodsRpmName, "kernel");
-    success = exitStatus == 0;
+    result = systemInterface_->installRpm(bspKmodsRpmName, "kernel");
+    if (result.exitStatus == 0) {
+      break;
+    }
+    // No repo has this package: retrying cannot make it appear.
+    if (result.notFound) {
+      auto availableVersions = systemInterface_->getLocalRepoBspRpmVersions(
+          *platformConfig_.bspKmodsRpmName());
+      throw std::runtime_error(
+          fmt::format(
+              "BSP rpm ({}) was not found in any enabled dnf repo. The "
+              "bspKmodsRpmVersion ({}) in the platform_manager config most "
+              "likely does not match any BSP built for kernel {}. Versions "
+              "available in {}: {}. Set bspKmodsRpmVersion to \"*\" to always "
+              "use the newest BSP present on the system.",
+              bspKmodsRpmName,
+              *platformConfig_.bspKmodsRpmVersion(),
+              systemInterface_->getHostKernelVersion(),
+              FLAGS_local_rpm_repo_path,
+              availableVersions.empty()
+                  ? std::string("none")
+                  : folly::join(", ", availableVersions)));
+    }
   }
-  if (exitStatus != 0) {
+  if (result.exitStatus != 0) {
     throw std::runtime_error(
         fmt::format(
             "Failed to install rpm ({}) with exit code {}",
             bspKmodsRpmName,
-            exitStatus));
+            result.exitStatus));
   }
+  int exitStatus{0};
   XLOG(INFO) << "Caching kernel modules dependencies";
   if (exitStatus = systemInterface_->depmod(); exitStatus != 0) {
     XLOG(ERR) << fmt::format("Failed to depmod with exit code {}", exitStatus);

--- a/fboss/platform/platform_manager/PkgManager.h
+++ b/fboss/platform/platform_manager/PkgManager.h
@@ -12,10 +12,24 @@
 DECLARE_bool(enable_pkg_mgmnt);
 DECLARE_bool(reload_kmods);
 DECLARE_string(local_rpm_path);
+DECLARE_string(local_rpm_repo_path);
 DECLARE_int32(kmod_unload_retries);
 DECLARE_int32(kmod_unload_retry_backoff_s);
 
 namespace facebook::fboss::platform::platform_manager {
+
+// bspKmodsRpmVersion value asking PM to use whichever BSP rpm the image happens
+// to ship, instead of a version pinned in the config.
+constexpr auto kBspKmodsRpmVersionWildcard = "*";
+
+// If config.bspKmodsRpmVersion() is the wildcard, rewrites it in-place with the
+// newest BSP version available in the local rpm repo for the running kernel, so
+// that everything downstream (rpm name, ODS counters, thrift getBspVersion)
+// sees a concrete version. Throws if the wildcard cannot be resolved. No-op for
+// a pinned version.
+void resolveBspKmodsRpmVersion(
+    PlatformConfig& config,
+    const package_manager::SystemInterface& systemInterface);
 
 class PkgManager {
  public:

--- a/fboss/platform/platform_manager/SystemInterface.cpp
+++ b/fboss/platform/platform_manager/SystemInterface.cpp
@@ -4,6 +4,10 @@
 
 #include <sys/utsname.h>
 
+#include <algorithm>
+#include <array>
+#include <filesystem>
+
 #include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/String.h>
@@ -20,8 +24,22 @@ DEFINE_string(
     "",
     "Path to the local rpm file that needs to be installed on the system.");
 
-namespace facebook::fboss::platform::platform_manager {
-namespace package_manager {
+DEFINE_string(
+    local_rpm_repo_path,
+    "/usr/local/share/local_rpm_repo",
+    "Directory holding the rpms shipped with the image. Used to resolve "
+    "bspKmodsRpmVersion when it is set to '*', and to report which BSP "
+    "versions are available when an install fails.");
+
+namespace fs = std::filesystem;
+
+namespace facebook::fboss::platform::platform_manager::package_manager {
+namespace {
+// dnf's wording when the requested package exists in no enabled repo.
+constexpr std::array<std::string_view, 2> kRpmNotFoundMarkers = {
+    "Unable to find a match",
+    "No match for argument"};
+} // namespace
 
 std::optional<BspVersion> BspVersion::fromString(std::string_view version) {
   std::vector<std::string_view> parts;
@@ -60,18 +78,28 @@ bool SystemInterface::unloadKmod(const std::string& moduleName) const {
   return exitStatus == 0;
 }
 
-int SystemInterface::installRpm(
+RpmInstallResult SystemInterface::installRpm(
     const std::string& rpmFullName,
     const std::string& repoName) const {
-  int exitStatus{0};
-  std::string standardOut{};
+  // Redirect stderr into stdout: dnf reports "Unable to find a match" there,
+  // and execCommand only hands back stdout.
   auto cmd = fmt::format(
-      "dnf install {} --assumeyes --setopt=*.skip_if_unavailable=True {}",
+      "dnf install {} --assumeyes --setopt=*.skip_if_unavailable=True {} 2>&1",
       rpmFullName,
       repoName.empty() ? "" : "--disablerepo='*' --enablerepo=" + repoName);
   VLOG(1) << fmt::format("Running command ({})", cmd);
-  std::tie(exitStatus, standardOut) = platformUtils_->execCommand(cmd);
-  return exitStatus;
+  auto [exitStatus, standardOut] = platformUtils_->execCommand(cmd);
+  if (exitStatus == 0) {
+    return RpmInstallResult{};
+  }
+  XLOG(ERR) << standardOut;
+  bool notFound = std::any_of(
+      kRpmNotFoundMarkers.begin(),
+      kRpmNotFoundMarkers.end(),
+      [&standardOut](const auto& marker) {
+        return standardOut.find(marker) != std::string::npos;
+      });
+  return RpmInstallResult{exitStatus, notFound};
 }
 
 int SystemInterface::installLocalRpm() const {
@@ -194,5 +222,65 @@ std::optional<BspVersion> SystemInterface::getInstalledBspVersion(
   return std::nullopt;
 }
 
-} // namespace package_manager
-} // namespace facebook::fboss::platform::platform_manager
+std::vector<std::string> SystemInterface::getLocalRepoBspRpmVersions(
+    const std::string& rpmBaseName) const {
+  const auto kernelVersion = getHostKernelVersion();
+  if (kernelVersion.empty()) {
+    return {};
+  }
+  std::error_code errorCode;
+  if (!fs::is_directory(FLAGS_local_rpm_repo_path, errorCode)) {
+    XLOG(ERR) << fmt::format(
+        "Local rpm repo {} is not a directory", FLAGS_local_rpm_repo_path);
+    return {};
+  }
+  // A BSP kmods rpm file is named
+  //   {rpmBaseName}-{kernelVersion}-{version}-{release}-{version}-{release}.{arch}.rpm
+  // where {rpmBaseName}-{kernelVersion}-{version}-{release} is the package name
+  // (what dnf install takes) and the trailing {version}-{release}.{arch} is
+  // rpm's usual file suffix. Pinning the prefix on the running kernel skips
+  // rpms built for other kernels.
+  const auto prefix = fmt::format("{}-{}-", rpmBaseName, kernelVersion);
+  // {version, release, "{version}-{release}"}
+  std::vector<std::tuple<BspVersion, int, std::string>> candidates;
+  for (const auto& entry : fs::directory_iterator(
+           FLAGS_local_rpm_repo_path,
+           fs::directory_options::skip_permission_denied,
+           errorCode)) {
+    const auto filename = entry.path().filename().string();
+    if (!filename.ends_with(".rpm") || !filename.starts_with(prefix)) {
+      continue;
+    }
+    std::vector<std::string> tokens;
+    folly::split('-', filename.substr(prefix.size()), tokens);
+    if (tokens.size() < 2) {
+      continue;
+    }
+    auto bspVersion = BspVersion::fromString(tokens[0]);
+    if (!bspVersion) {
+      XLOG(WARNING) << fmt::format(
+          "Ignoring {}: unparseable BSP version '{}'", filename, tokens[0]);
+      continue;
+    }
+    auto release = folly::tryTo<int>(tokens[1]);
+    candidates.emplace_back(
+        *bspVersion,
+        release.hasValue() ? *release : 0,
+        fmt::format("{}-{}", tokens[0], tokens[1]));
+  }
+  // Newest version first, then newest release.
+  std::sort(
+      candidates.begin(),
+      candidates.end(),
+      [](const auto& lhs, const auto& rhs) { return lhs > rhs; });
+  std::vector<std::string> versions;
+  for (const auto& candidate : candidates) {
+    const auto& version = std::get<2>(candidate);
+    if (versions.empty() || versions.back() != version) {
+      versions.push_back(version);
+    }
+  }
+  return versions;
+}
+
+} // namespace facebook::fboss::platform::platform_manager::package_manager

--- a/fboss/platform/platform_manager/SystemInterface.h
+++ b/fboss/platform/platform_manager/SystemInterface.h
@@ -28,6 +28,14 @@ struct BspVersion {
   auto operator<=>(const BspVersion&) const = default;
 };
 
+// Outcome of an RPM install attempt. notFound distinguishes "no such package in
+// any enabled repo" -- a permanent failure, usually a wrong version in the
+// platform_manager config -- from transient failures worth retrying.
+struct RpmInstallResult {
+  int exitStatus{0};
+  bool notFound{false};
+};
+
 class SystemInterface {
  public:
   explicit SystemInterface(
@@ -36,7 +44,7 @@ class SystemInterface {
   virtual ~SystemInterface() = default;
   virtual bool loadKmod(const std::string& moduleName) const;
   virtual bool unloadKmod(const std::string& moduleName) const;
-  virtual int installRpm(
+  virtual RpmInstallResult installRpm(
       const std::string& rpmFullName,
       const std::string& repoName = "") const;
   virtual int depmod() const;
@@ -55,6 +63,13 @@ class SystemInterface {
   // the virtual host-state reads above, so tests drive it by faking
   // getHostKernelVersion() and getInstalledRpms().
   std::optional<BspVersion> getInstalledBspVersion(
+      const std::string& rpmBaseName) const;
+
+  // Returns the {version}-{release} tokens of the BSP kmods RPM files sitting
+  // in the local RPM repo (--local_rpm_repo_path) whose package name targets
+  // the running kernel, newest first. Empty when the repo directory is absent
+  // or holds nothing for this kernel.
+  virtual std::vector<std::string> getLocalRepoBspRpmVersions(
       const std::string& rpmBaseName) const;
 
  private:

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -912,7 +912,10 @@ struct PlatformConfig {
   // Number of transceivers in the platform.
   17: i16 numXcvrs;
 
-  // Name and version of the rpm containing the BSP kmods for this platform
+  // Name and version of the rpm containing the BSP kmods for this platform.
+  // bspKmodsRpmVersion can be "*", in which case PM installs the newest BSP rpm
+  // shipped in the image (the local rpm repo) for the running kernel. Useful for
+  // configs which are maintained outside of the image, e.g. manufacturing.
   21: string bspKmodsRpmName;
   22: string bspKmodsRpmVersion;
 

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -878,6 +878,9 @@ TEST(ConfigValidatorTest, BspRpm) {
   EXPECT_FALSE(ConfigValidator().isValidBspKmodsRpmVersion("5.4.6"));
   EXPECT_TRUE(ConfigValidator().isValidBspKmodsRpmVersion("5.4.6-1"));
   EXPECT_TRUE(ConfigValidator().isValidBspKmodsRpmVersion("11.44.63-14"));
+  // Wildcard: resolved at runtime to the newest BSP rpm in the image.
+  EXPECT_TRUE(ConfigValidator().isValidBspKmodsRpmVersion("*"));
+  EXPECT_FALSE(ConfigValidator().isValidBspKmodsRpmVersion("4.*"));
   EXPECT_FALSE(ConfigValidator().isValidBspKmodsRpmName(""));
   EXPECT_FALSE(ConfigValidator().isValidBspKmodsRpmName("fboss_bsp_kmod"));
   EXPECT_FALSE(ConfigValidator().isValidBspKmodsRpmName("invalid"));

--- a/fboss/platform/platform_manager/tests/PkgManagerTest.cpp
+++ b/fboss/platform/platform_manager/tests/PkgManagerTest.cpp
@@ -22,9 +22,14 @@ class MockSystemInterface : public package_manager::SystemInterface {
       (const));
   MOCK_METHOD(int, removeRpms, (const std::vector<std::string>&), (const));
   MOCK_METHOD(
-      int,
+      package_manager::RpmInstallResult,
       installRpm,
       (const std::string&, const std::string&),
+      (const));
+  MOCK_METHOD(
+      std::vector<std::string>,
+      getLocalRepoBspRpmVersions,
+      (const std::string&),
       (const));
   MOCK_METHOD(int, depmod, (), (const));
   MOCK_METHOD(std::set<std::string>, lsmod, (), (const));
@@ -203,7 +208,7 @@ TEST_F(PkgManagerTest, processRpms) {
               *platformConfig_.bspKmodsRpmName(),
               *platformConfig_.bspKmodsRpmVersion()),
           "kernel"))
-      .WillOnce(Return(0));
+      .WillOnce(Return(package_manager::RpmInstallResult{}));
   EXPECT_CALL(*mockSystemInterface_, depmod()).WillOnce(Return(0));
   EXPECT_NO_THROW(pkgManager_.processRpms());
   EXPECT_EQ(
@@ -232,7 +237,7 @@ TEST_F(PkgManagerTest, processRpms) {
               *platformConfig_.bspKmodsRpmName(),
               *platformConfig_.bspKmodsRpmVersion()),
           "kernel"))
-      .WillOnce(Return(0));
+      .WillOnce(Return(package_manager::RpmInstallResult{}));
   EXPECT_CALL(*mockSystemInterface_, depmod()).WillOnce(Return(0));
   EXPECT_NO_THROW(pkgManager_.processRpms());
   EXPECT_EQ(
@@ -278,7 +283,7 @@ TEST_F(PkgManagerTest, processRpms) {
               *platformConfig_.bspKmodsRpmName(),
               *platformConfig_.bspKmodsRpmVersion()),
           "kernel"))
-      .WillOnce(Return(0));
+      .WillOnce(Return(package_manager::RpmInstallResult{}));
   EXPECT_CALL(*mockSystemInterface_, depmod()).WillOnce(Return(1));
   EXPECT_NO_THROW(pkgManager_.processRpms());
   EXPECT_EQ(
@@ -306,7 +311,7 @@ TEST_F(PkgManagerTest, processRpms) {
               *platformConfig_.bspKmodsRpmVersion()),
           "kernel"))
       .Times(3)
-      .WillRepeatedly(Return(1));
+      .WillRepeatedly(Return(package_manager::RpmInstallResult{1, false}));
   EXPECT_THROW(pkgManager_.processRpms(), std::runtime_error);
   EXPECT_EQ(
       facebook::fb303::fbData->getCounter(PkgManager::kProcessRpmFailure), 1);
@@ -610,5 +615,55 @@ TEST_F(PkgManagerTest, isValidRpm) {
   // Empty file name
   FLAGS_local_rpm_path = "";
   EXPECT_FALSE(mockPkgManager_.isValidRpm());
+}
+
+TEST_F(PkgManagerTest, processRpmsRpmNotFound) {
+  EXPECT_CALL(*mockSystemInterface_, getHostKernelVersion())
+      .WillRepeatedly(Return("6.4.3-0_fbk1_755_ga25447393a1d"));
+  EXPECT_CALL(*mockPlatformFsUtils_, getStringFileContent(_))
+      .WillRepeatedly(Return(jsonBspKmodsFile_));
+  EXPECT_CALL(*mockSystemInterface_, lsmod())
+      .WillRepeatedly(Return(std::set<std::string>{}));
+  EXPECT_CALL(*mockSystemInterface_, getInstalledRpms(_))
+      .WillOnce(Return(std::vector<std::string>{}));
+  // A missing rpm is permanent, so there is exactly one install attempt.
+  EXPECT_CALL(*mockSystemInterface_, installRpm(_, "kernel"))
+      .Times(1)
+      .WillOnce(Return(package_manager::RpmInstallResult{1, true}));
+  EXPECT_CALL(
+      *mockSystemInterface_,
+      getLocalRepoBspRpmVersions(*platformConfig_.bspKmodsRpmName()))
+      .WillOnce(Return(std::vector<std::string>{"4.4.2-1", "4.3.0-1"}));
+  EXPECT_CALL(*mockSystemInterface_, depmod()).Times(0);
+  EXPECT_THROW(pkgManager_.processRpms(), std::runtime_error);
+  EXPECT_EQ(
+      facebook::fb303::fbData->getCounter(PkgManager::kProcessRpmFailure), 1);
+}
+
+TEST_F(PkgManagerTest, resolveBspKmodsRpmVersionWildcard) {
+  platformConfig_.bspKmodsRpmVersion() = kBspKmodsRpmVersionWildcard;
+  EXPECT_CALL(
+      *mockSystemInterface_,
+      getLocalRepoBspRpmVersions(*platformConfig_.bspKmodsRpmName()))
+      .WillOnce(Return(std::vector<std::string>{"4.4.2-1", "4.3.0-1"}));
+  resolveBspKmodsRpmVersion(platformConfig_, *mockSystemInterface_);
+  EXPECT_EQ(*platformConfig_.bspKmodsRpmVersion(), "4.4.2-1");
+}
+
+TEST_F(PkgManagerTest, resolveBspKmodsRpmVersionWildcardNoRpmAvailable) {
+  platformConfig_.bspKmodsRpmVersion() = kBspKmodsRpmVersionWildcard;
+  EXPECT_CALL(*mockSystemInterface_, getHostKernelVersion())
+      .WillRepeatedly(Return("6.4.3-0_fbk1_755_ga25447393a1d"));
+  EXPECT_CALL(*mockSystemInterface_, getLocalRepoBspRpmVersions(_))
+      .WillOnce(Return(std::vector<std::string>{}));
+  EXPECT_THROW(
+      resolveBspKmodsRpmVersion(platformConfig_, *mockSystemInterface_),
+      std::runtime_error);
+}
+
+TEST_F(PkgManagerTest, resolveBspKmodsRpmVersionPinned) {
+  EXPECT_CALL(*mockSystemInterface_, getLocalRepoBspRpmVersions(_)).Times(0);
+  resolveBspKmodsRpmVersion(platformConfig_, *mockSystemInterface_);
+  EXPECT_EQ(*platformConfig_.bspKmodsRpmVersion(), "11.44.63-14");
 }
 }; // namespace facebook::fboss::platform::platform_manager

--- a/fboss/platform/platform_manager/tests/SystemInterfaceTest.cpp
+++ b/fboss/platform/platform_manager/tests/SystemInterfaceTest.cpp
@@ -1,6 +1,8 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include <fmt/args.h>
+#include <filesystem>
+#include <fstream>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -132,6 +134,38 @@ TEST(SystemInterfaceTest, GetInstalledBspVersionUnparseableVersion) {
   fake.kernelVersion = "6.4.3-mock";
   fake.rpms = {"arista_bsp_kmods-6.4.3-mock-notaversion-1.x86_64"};
   EXPECT_FALSE(fake.getInstalledBspVersion("arista_bsp_kmods").has_value());
+}
+
+TEST(SystemInterfaceTest, GetLocalRepoBspRpmVersions) {
+  namespace fs = std::filesystem;
+  auto repoDir = fs::temp_directory_path() / "pm_local_rpm_repo_test";
+  fs::remove_all(repoDir);
+  fs::create_directories(repoDir);
+  FLAGS_local_rpm_repo_path = repoDir.string();
+  for (const auto& filename : std::vector<std::string>{
+           // Two BSPs for the running kernel; newest must come first.
+           "fboss_bsp_kmods-6.11.1-mock-4.3.0-1-4.3.0-1.x86_64.rpm",
+           "fboss_bsp_kmods-6.11.1-mock-4.4.2-1-4.4.2-1.x86_64.rpm",
+           // Different kernel, different rpm, and a non-rpm file: all ignored.
+           "fboss_bsp_kmods-6.9.9-other-9.9.9-1-9.9.9-1.x86_64.rpm",
+           "arista_bsp_kmods-6.11.1-mock-1.0.0-1-1.0.0-1.x86_64.rpm",
+           "README"}) {
+    std::ofstream{repoDir / filename} << "";
+  }
+  FakeBspSystemInterface fake;
+  fake.kernelVersion = "6.11.1-mock";
+  EXPECT_EQ(
+      fake.getLocalRepoBspRpmVersions("fboss_bsp_kmods"),
+      (std::vector<std::string>{"4.4.2-1", "4.3.0-1"}));
+  EXPECT_TRUE(fake.getLocalRepoBspRpmVersions("nexthop_bsp_kmods").empty());
+  fs::remove_all(repoDir);
+}
+
+TEST(SystemInterfaceTest, GetLocalRepoBspRpmVersionsMissingRepo) {
+  FLAGS_local_rpm_repo_path = "/does/not/exist";
+  FakeBspSystemInterface fake;
+  fake.kernelVersion = "6.11.1-mock";
+  EXPECT_TRUE(fake.getLocalRepoBspRpmVersions("fboss_bsp_kmods").empty());
 }
 
 }; // namespace facebook::fboss::platform::platform_manager


### PR DESCRIPTION
# Summary

During early stages of NPI when using a hand-maintained `platform_manager.json` for a new platform not yet officially supported by FBOSS,  a stale `bspKmodsRpmVersion` made `platform_manager` retry a non-existent rpm 3 times and then abort with an opaque error `Failed to install rpm ... exit code 1`.

- `installRpm` now captures `dnf`'s `stderr` and reports whether the package exists in no enabled repo. That case is permanent, so `platform_manager` no longer retries and the error names the likely cause plus the BSP versions the image actually ships.
- `bspKmodsRpmVersion` can now be `"*"`, resolved at startup to the newest BSP rpm in `/usr/local/share/local_rpm_repo` for the running kernel, which removes the need for constantly updating this hand-maintained `platform_manager.json` as the BSP version moves forward.

This small ergonomic improvement can help speed things up durnig NPI.

# Test Plan

New unit tests.