### PR TITLE
[Celestica] Tahansb800bc: Fix HwInitAndExitBenchmark test cases for TH6

### DIFF
--- a/fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp
+++ b/fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp
@@ -146,6 +146,7 @@ utility::RouteDistributionGenerator::ThriftRouteChunks getRoutes(
       asicType == cfg::AsicType::ASIC_TYPE_JERICHO3 ||
       asicType == cfg::AsicType::ASIC_TYPE_RAMON ||
       asicType == cfg::AsicType::ASIC_TYPE_TOMAHAWK5 ||
+      asicType == cfg::AsicType::ASIC_TYPE_TOMAHAWK6 ||
       asicType == cfg::AsicType::ASIC_TYPE_G202X) {
     return utility::HgridUuRouteScaleGenerator(
                swSwitch->getState(), swSwitch->needL2EntryForNeighbor())


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
[INFO] Restored changes from /root/.cache/pre-commit/patch1785809914-1657611.
```
# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Several HwInitAndExitbenchmark related cased failed:
```
HwInitAndExit40Gx10GBenchmark: FAILED
HwInitAndExit100Gx10GBenchmark: FAILED
HwInitAndExit100Gx25GBenchmark: FAILED
HwInitAndExit100Gx50GBenchmark: FAILED
HwInitAndExit100Gx100GBenchmark: FAILED
HwInitAndExit400Gx400GBenchmark: FAILED
```
Log:
``` [stderr] F20260803 09:38:45.357613 236013 HwInitAndExitBenchmarkHelper.cpp:158] Check failed: false Invalid asic type for route scale ```

Root cause is getRoutes() function in fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp didn't handle the TH6.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Use below command to rerun the failed benchmark test cases:
```
sai_all_benchmarks-sai_impl --config tahansb800bc.agent.materialized_JSON --bm_regex <test case name>
```

All passed:

```
============================================================================
[...]rks/HwInitAndExit40Gx10GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit40Gx10GBenchmark                               26.67s    37.50m
{
  "cpu_time_usec": 54105424,
  "max_rss": 2262204
}

============================================================================
[...]ks/HwInitAndExit100Gx10GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit100Gx10GBenchmark                              28.01s    35.71m
{
  "cpu_time_usec": 57786885,
  "max_rss": 2276404
}
[root@localhost 0803_benchmark]#


============================================================================
[...]ks/HwInitAndExit100Gx25GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit100Gx25GBenchmark                              27.13s    36.87m
{
  "cpu_time_usec": 54671803,
  "max_rss": 2263488
}
[root@localhost 0803_benchmark]#


on-running SwSwitchUpdateEventBase FbossEventBase.
============================================================================
[...]ks/HwInitAndExit100Gx50GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit100Gx50GBenchmark                              28.12s    35.56m
{
  "cpu_time_usec": 55843060,
  "max_rss": 2275984
}
[root@localhost 0803_benchmark]#

============================================================================
[...]s/HwInitAndExit100Gx100GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit100Gx100GBenchmark                             28.29s    35.35m
{
  "cpu_time_usec": 57070284,
  "max_rss": 2276356
}
[root@localhost 0803_benchmark]#

============================================================================
[...]s/HwInitAndExit400Gx400GBenchmark.cpp     relative  time/iter   iters/s
============================================================================
HwInitAndExit400Gx400GBenchmark                             26.97s    37.08m
{
  "cpu_time_usec": 55603562,
  "max_rss": 2262764
}
[root@localhost 0803_benchmark]#
```
