### PR TITLE
[Celestica] Leh800bcls: Implement HwFlowletStats readback via ARS NextHopGroup attributes on Tomahawk 6

### DIFF
--- a/fboss/agent/hw/sai/api/NextHopGroupApi.h
+++ b/fboss/agent/hw/sai/api/NextHopGroupApi.h
@@ -133,6 +133,22 @@ struct SaiNextHopGroupTraits {
         sai_uint32_t,
         AttributeArsNextHopGroupMetaData,
         SaiIntDefault<sai_uint32_t>>;
+
+    struct AttributeArsFailPktCount {
+      std::optional<sai_attr_id_t> operator()();
+    };
+    using ArsFailPktCount = SaiExtensionAttribute<
+        sai_uint64_t,
+        AttributeArsFailPktCount,
+        SaiIntDefault<sai_uint64_t>>;
+
+    struct AttributeArsNhReassignCount {
+      std::optional<sai_attr_id_t> operator()();
+    };
+    using ArsNhReassignCount = SaiExtensionAttribute<
+        sai_uint64_t,
+        AttributeArsNhReassignCount,
+        SaiIntDefault<sai_uint64_t>>;
   };
 
   using AdapterKey = NextHopGroupSaiId;
@@ -161,6 +177,8 @@ SAI_ATTRIBUTE_NAME(NextHopGroup, HashAlgorithm)
 SAI_ATTRIBUTE_NAME(NextHopGroup, HierarchicalNextHop)
 #endif
 SAI_ATTRIBUTE_NAME(NextHopGroup, ArsNextHopGroupMetaData)
+SAI_ATTRIBUTE_NAME(NextHopGroup, ArsFailPktCount)
+SAI_ATTRIBUTE_NAME(NextHopGroup, ArsNhReassignCount)
 
 struct SaiNextHopGroupMemberTraits {
   static constexpr sai_object_type_t ObjectType =

--- a/fboss/agent/hw/sai/api/bcm/NextHopGroupApi.cpp
+++ b/fboss/agent/hw/sai/api/bcm/NextHopGroupApi.cpp
@@ -18,4 +18,22 @@ std::optional<sai_attr_id_t> SaiNextHopGroupTraits::Attributes::
 #endif
 }
 
+std::optional<sai_attr_id_t>
+SaiNextHopGroupTraits::Attributes::AttributeArsFailPktCount::operator()() {
+#if defined(BRCM_SAI_SDK_GTE_14_0)
+  return SAI_NEXT_HOP_GROUP_ATTR_ARS_FAIL_PKT_COUNT;
+#else
+  return std::nullopt;
+#endif
+}
+
+std::optional<sai_attr_id_t>
+SaiNextHopGroupTraits::Attributes::AttributeArsNhReassignCount::operator()() {
+#if defined(BRCM_SAI_SDK_GTE_14_0)
+  return SAI_NEXT_HOP_GROUP_ATTR_ARS_NH_REASSIGN_COUNT;
+#else
+  return std::nullopt;
+#endif
+}
+
 } // namespace facebook::fboss

--- a/fboss/agent/hw/sai/hw_test/HwTestFlowletUtilsThriftHandler.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestFlowletUtilsThriftHandler.cpp
@@ -8,7 +8,7 @@
 namespace facebook::fboss::utility {
 
 void HwTestThriftHandler::updateFlowletStats() {
-  throw FbossError("Flowlet stats are not supported in SaiSwitch.");
+  hwSwitch_->getHwFlowletStats();
 }
 
 cfg::SwitchingMode HwTestThriftHandler::getFwdSwitchingMode(

--- a/fboss/agent/hw/sai/switch/SaiNextHopGroupManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiNextHopGroupManager.cpp
@@ -926,4 +926,53 @@ std::string SaiNextHopGroupChildGroupMember::toString() const {
       nextHopGroupMemberIdStr);
 }
 
+HwFlowletStats SaiNextHopGroupManager::getHwFlowletStats() const {
+  HwFlowletStats stats;
+  uint64_t totalFailPktCount = 0;
+  uint64_t totalNhReassignCount = 0;
+
+  for (const auto& [key, handleWeak] : handles_) {
+    auto handle = handleWeak.lock();
+    if (!handle || !handle->nextHopGroup) {
+      continue;
+    }
+    auto nexthopGroupId = handle->nextHopGroup->adapterKey();
+
+    // 1. Get ARS Fail Pkt Count
+    uint64_t failPktCount = 0;
+    try {
+      failPktCount = SaiApiTable::getInstance()->nextHopGroupApi().getAttribute(
+          nexthopGroupId, SaiNextHopGroupTraits::Attributes::ArsFailPktCount{});
+    } catch (const SaiApiError& e) {
+      XLOG_EVERY_MS(WARNING, 5000)
+          << "Failed to get ArsFailPktCount for NextHopGroup: "
+          << nexthopGroupId << ", error: " << e.what();
+    }
+    totalFailPktCount += failPktCount;
+
+    // 2. Get ARS NH Reassign Count
+    uint64_t nhReassignCount = 0;
+    try {
+      nhReassignCount =
+          SaiApiTable::getInstance()->nextHopGroupApi().getAttribute(
+              nexthopGroupId,
+              SaiNextHopGroupTraits::Attributes::ArsNhReassignCount{});
+    } catch (const SaiApiError& e) {
+      XLOG_EVERY_MS(WARNING, 5000)
+          << "Failed to get ArsNhReassignCount for NextHopGroup: "
+          << nexthopGroupId << ", error: " << e.what();
+    }
+    totalNhReassignCount += nhReassignCount;
+
+    XLOG_EVERY_MS(INFO, 1000)
+        << "getHwFlowletStats: NextHopGroup OID: " << nexthopGroupId
+        << ", ArsFailPktCount: " << failPktCount
+        << ", ArsNhReassignCount: " << nhReassignCount;
+  }
+
+  stats.l3EcmpDlbFailPackets() = totalFailPktCount;
+  stats.l3EcmpDlbPortReassignmentCount() = totalNhReassignCount;
+  return stats;
+}
+
 } // namespace facebook::fboss

--- a/fboss/agent/hw/sai/switch/SaiNextHopGroupManager.h
+++ b/fboss/agent/hw/sai/switch/SaiNextHopGroupManager.h
@@ -339,6 +339,8 @@ class SaiNextHopGroupManager {
 
   std::vector<EcmpDetails> getAllEcmpDetails() const;
 
+  HwFlowletStats getHwFlowletStats() const;
+
  private:
   bool isFixedWidthNextHopGroup(
       const RouteNextHopEntry::NextHopSet& swNextHops) const;

--- a/fboss/agent/hw/sai/switch/SaiSwitch.cpp
+++ b/fboss/agent/hw/sai/switch/SaiSwitch.cpp
@@ -5601,8 +5601,8 @@ TeFlowStats SaiSwitch::getTeFlowStats() const {
 }
 
 HwFlowletStats SaiSwitch::getHwFlowletStats() const {
-  // not implemented in SAI. Return empty stats
-  return HwFlowletStats{};
+  std::lock_guard<std::mutex> lk(saiSwitchMutex_);
+  return managerTable_->nextHopGroupManager().getHwFlowletStats();
 }
 
 std::vector<EcmpDetails> SaiSwitch::getAllEcmpDetails() const {


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary
During benchmark testing on Broadcom Tomahawk6 (TH6) SAI platforms (e.g., Npu0), the HwFlowletStatsCollection benchmark fails and crashes the test harness process with the following error:
```
[stderr] E20260802 09:20:46.997387 919033 ExceptionTracer.cpp:263] exception stack complete
[stderr] terminate called after throwing an instance of 'apache::thrift::TApplicationException'
[stderr]   what():  facebook::fboss::FbossError: Flowlet stats are not supported in SaiSwitch.
[stderr] *** Aborted at 1785676846 (Unix time, try 'date -d @1785676846') ***

```
The symptom occurs because the Thrift client (sai_multi_switch_all_benchmarks) makes synchronous RPC calls to sync_updateFlowletStats(), which bubbles up an unhandled FbossError exception across the RPC boundary, triggering an immediate process abort.

# Root Cause
HwTestThriftHandler::updateFlowletStats() by throwing a hard FbossError("Flowlet stats are not supported in SaiSwitch.").

# Solution
During our hardware validation on the `leh800bcls` TH6 platform under Broadcom SAI SDK 14.2.0.0, we identified that TH6's runtime support for ARS-related next-hop group attributes is selective:
1. `SAI_NEXT_HOP_GROUP_ATTR_ARS_FAIL_PKT_COUNT` is fully supported and reads back successfully.
2. `SAI_NEXT_HOP_GROUP_ATTR_ARS_NH_REASSIGN_COUNT` is defined in headers but returns `SAI_STATUS_ATTR_NOT_SUPPORTED` at runtime.

Directly calling getAttribute on both fields without safety guards would result in a fatal `SaiApiError` which crashes the entire hardware agent process. 

To resolve this:
- We mapped both `ArsFailPktCount` and `ArsNhReassignCount` extension attributes, gated under `#if defined(BRCM_SAI_SDK_GTE_14_0)`.
- We introduced individual `try-catch` exception blocks inside `SaiNextHopGroupManager::getHwFlowletStats()` to safely query these attributes. If an attribute returns `ATTR_NOT_SUPPORTED` at runtime, the agent logs a rate-limited warning and gracefully falls back to `0`, preventing any crash.

# Test Plan
The benchmark test case HwFlowletStatsCollection passed on both NPU0 and NPU1.
- NPU0
```
########## Benchmark HwFlowletStatsCollection completed
  >> WARNING: no benchmark threshold defined for HwFlowletStatsCollection on brcm/14.2.0.0_odp/tomahawk6/multi_switch; this benchmark WILL ALWAYS PASS until thresholds are added.

########## Benchmark results written to: benchmark_results_20260828_161051.csv

================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
HwFlowletStatsCollection: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x

```

- NPU1
```
########## Benchmark HwFlowletStatsCollection completed
  >> WARNING: no benchmark threshold defined for HwFlowletStatsCollection on brcm/14.2.0.0_odp/tomahawk6/multi_switch; this benchmark WILL ALWAYS PASS until thresholds are added.

########## Benchmark results written to: benchmark_results_20260828_161300.csv

================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
HwFlowletStatsCollection: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x

```
- fboss_hw_agent-sai_impl related log:
```
[root@localhost log]# grep NextHopGroup fboss_hw_agent_oss0.log  | grep Ars
Aug 28 16:10:48 localhost.localdomain fboss_hw_agent_oss@0[112769]: W0828 16:10:48.508731 113095 SaiNextHopGroupManager.cpp:961] Failed to get ArsNhReassignCount for NextHopGroup: 21475040448, error: [nhop-group] Failed to get sai attribute: NextHopGroupSaiId(21475040448): ArsNhReassignCount: 0: ATTR NOT SUPPORTED 0
Aug 28 16:10:48 localhost.localdomain fboss_hw_agent_oss@0[112769]: I0828 16:10:48.508741 113095 SaiNextHopGroupManager.cpp:967] getHwFlowletStats: NextHopGroup OID: 21475040448, ArsFailPktCount: 0, ArsNhReassignCount: 0
Aug 28 16:10:49 localhost.localdomain fboss_hw_agent_oss@0[112769]: I0828 16:10:49.508196 113095 SaiNextHopGroupManager.cpp:967] getHwFlowletStats: NextHopGroup OID: 21475040448, ArsFailPktCount: 0, ArsNhReassignCount: 0
[root@localhost log]# grep NextHopGroup fboss_hw_agent_oss1.log  | grep Ars
Aug 28 16:12:58 localhost.localdomain fboss_hw_agent_oss@1[113612]: W0828 16:12:58.315268 113970 SaiNextHopGroupManager.cpp:961] Failed to get ArsNhReassignCount for NextHopGroup: 21475040448, error: [nhop-group] Failed to get sai attribute: NextHopGroupSaiId(21475040448): ArsNhReassignCount: 0: ATTR NOT SUPPORTED 0
Aug 28 16:12:58 localhost.localdomain fboss_hw_agent_oss@1[113612]: I0828 16:12:58.315279 113970 SaiNextHopGroupManager.cpp:967] getHwFlowletStats: NextHopGroup OID: 21475040448, ArsFailPktCount: 0, ArsNhReassignCount: 0
Aug 28 16:12:59 localhost.localdomain fboss_hw_agent_oss@1[113612]: I0828 16:12:59.315192 113970 SaiNextHopGroupManager.cpp:967] getHwFlowletStats: NextHopGroup OID: 21475040448, ArsFailPktCount: 0, ArsNhReassignCount: 0
[root@localhost log]#

```
