### PR TITLE
[Cisco] Build rma-showtech with platform services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1427,6 +1427,7 @@ add_dependencies(fboss_agent_benchmark_libs
 )
 add_custom_target(fboss_platform_services)
 add_dependencies(fboss_platform_services
+  rma-showtech
   # Services
   sensor_service
   fan_service


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add `rma-showtech` to the `fboss_platform_services` aggregate CMake target so FBOSS platform-stack builds include the show-tech support binary by default.

This makes `/opt/fboss/bin/rma-showtech` available in the generated FBOSS image without requiring the binary to be copied to the switch separately.

Having the tool available by default provides a consistent way for operators to collect the relevant FBOSS and platform-service diagnostics when an issue occurs. This reduces manual log collection, speeds up troubleshooting and RMA analysis, and makes it easier to capture support data while the problem is still present.

# Test Plan

- Built the `fboss-platform-stack` component and verified that `bin/rma-showtech` was packaged.
- Ran `/opt/fboss/bin/rma-showtech --details logs` on a live MORGAN800CC FBOSS switch.
- Verified that show-tech collection completed successfully.
- Verified that all FBOSS services remained active after collection.
