### PR TITLE
[Nexthop][m4062nhp] Add embedded sensors

### DIFF
--- a/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/platform_manager.json
@@ -74,6 +74,18 @@
         {
           "pmUnitScopedName": "DIMM2_TEMP",
           "sysfsPath": "/run/nexthop_bsp/sensors/DIMM2_TEMP"
+        },
+        {
+          "pmUnitScopedName": "CPU_TEMP",
+          "sysfsPath": "/sys/bus/pci/drivers/k10temp/0000:00:18.3"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "NIC_TEMP",
+          "sysfsPath": "/sys/bus/pci/devices/0000:02:00.0"
         }
       ],
       "outgoingSlotConfigs": {
@@ -442,6 +454,9 @@
     "/run/devmap/sensors/DPM_2": "/[DPM_2]",
     "/run/devmap/sensors/DIMM1_TEMP": "/[DIMM1_TEMP]",
     "/run/devmap/sensors/DIMM2_TEMP": "/[DIMM2_TEMP]",
+    "/run/devmap/sensors/CPU_TEMP": "/[CPU_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/NIC_TEMP": "/[NIC_TEMP]",
     "/run/devmap/sensors/SWITCH_CARD_TEMP_SENSOR": "/SMB_SLOT@0/[SWITCH_CARD_TEMP_SENSOR]",
     "/run/devmap/fpgas/SCM_IOB": "/[SCM_IOB]",
     "/run/devmap/inforoms/SCM_IOB_INFO_ROM": "/[SCM_IOB_INFO_ROM]",

--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -59,6 +59,20 @@
           "isEeprom": true
         }
       ],
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "CPU_TEMP",
+          "sysfsPath": "/sys/bus/pci/drivers/k10temp/0000:00:18.3"
+        },
+        {
+          "pmUnitScopedName": "NVME_TEMP",
+          "sysfsPath": "/sys/class/nvme/nvme0"
+        },
+        {
+          "pmUnitScopedName": "NIC_TEMP",
+          "sysfsPath": "/sys/bus/pci/devices/0000:02:00.0"
+        }
+      ],
       "outgoingSlotConfigs": {
         "SMB_SLOT@0": {
           "slotType": "SMB_SLOT"
@@ -430,6 +444,9 @@
     "/run/devmap/eeproms/PSU4_EEPROM": "/SMB_SLOT@0/[PSU4_EEPROM]",
     "/run/devmap/sensors/DPM": "/[DPM]",
     "/run/devmap/sensors/DPM_2": "/[DPM_2]",
+    "/run/devmap/sensors/CPU_TEMP": "/[CPU_TEMP]",
+    "/run/devmap/sensors/NVME_TEMP": "/[NVME_TEMP]",
+    "/run/devmap/sensors/NIC_TEMP": "/[NIC_TEMP]",
     "/run/devmap/sensors/SWITCH_CARD_TEMP_SENSOR": "/SMB_SLOT@0/[SWITCH_CARD_TEMP_SENSOR]",
     "/run/devmap/fpgas/SCM_IOB": "/[SCM_IOB]",
     "/run/devmap/i2c-busses/SCM_IOB_I2C_0": "/[SCM_IOB_I2C_0]",

--- a/fboss/platform/configs/m4062nhp/sensor_service.json
+++ b/fboss/platform/configs/m4062nhp/sensor_service.json
@@ -24,6 +24,66 @@
             "lowerCriticalVal": 9
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCTL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCCD1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCCD2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NIC_PHY_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NIC_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NIC_MAC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NIC_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
         }
       ]
     },

--- a/fboss/platform/configs/m4062nhp/sensor_service.json
+++ b/fboss/platform/configs/m4062nhp/sensor_service.json
@@ -240,6 +240,66 @@
             "upperCriticalVal": 95
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCTL_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCCD1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "CPU_TCCD2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/CPU_TEMP/temp4_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 95,
+            "upperCriticalVal": 120
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NVME_COMPOSITE_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NVME_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 90,
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NIC_PHY_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NIC_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "NIC_MAC_TEMP",
+          "sysfsPath": "/run/devmap/sensors/NIC_TEMP/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 110
+          },
+          "compute": "@/1000.0"
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add the embedded temperature sensor devices on the m4062nhp SCM (CPU TCTL/TCCD, NVMe composite, NIC PHY/MAC) to platform_manager and sensor_service, with thresholds from the hardware thermal spec.

# Test Plan

Loaded the image on a test device and verified that the new sensors appear in the PlatformManager device map and report values via sensor_service_client.

```
# ./bin/sensor_service_client

Sensor Service Output:

Slot Path: /:

+---------------------+-------+--------+---------------+------------+-------------+-------------------------------------------+
| name                | value | status | criticalRange | alarmRange | lastUpdated | sysfsPath                                 |
+---------------------+-------+--------+---------------+------------+-------------+-------------------------------------------+
| CPU_TCCD1_TEMP      | 45.88 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp3_input  |
| CPU_TCCD2_TEMP      | 44.25 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp4_input  |
| CPU_TCTL_TEMP       | 68.38 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp1_input  |
| DPM_2_VIN           | 12.21 | PASS   | [9.00, 14.00] | [, ]       | 2s ago      | /run/devmap/sensors/DPM_2/in1_input       |
| DPM_VIN             | 12.20 | PASS   | [9.00, 14.00] | [, ]       | 2s ago      | /run/devmap/sensors/DPM/in1_input         |
| NIC_MAC_TEMP        | 40.00 | PASS   | [, 110.00]    | [, 100.00] | 2s ago      | /run/devmap/sensors/NIC_TEMP/temp2_input  |
| NIC_PHY_TEMP        | 40.00 | PASS   | [, 110.00]    | [, 100.00] | 2s ago      | /run/devmap/sensors/NIC_TEMP/temp1_input  |
| NVME_COMPOSITE_TEMP | 23.85 | PASS   | [, 95.00]     | [, 90.00]  | 2s ago      | /run/devmap/sensors/NVME_TEMP/temp1_input |
+---------------------+-------+--------+---------------+------------+-------------+-------------------------------------------+
```