### PR TITLE
[Nexthop][m4062nhp] Add DIMM temperature sensors

### DIFF
--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -59,6 +59,16 @@
           "isEeprom": true
         }
       ],
+      "embeddedSensorConfigs": [
+        {
+          "pmUnitScopedName": "DIMM1_TEMP",
+          "sysfsPath": "/sys/bus/i2c/devices/1-0050"
+        },
+        {
+          "pmUnitScopedName": "DIMM2_TEMP",
+          "sysfsPath": "/sys/bus/i2c/devices/1-0051"
+        }
+      ],
       "outgoingSlotConfigs": {
         "SMB_SLOT@0": {
           "slotType": "SMB_SLOT"
@@ -430,6 +440,8 @@
     "/run/devmap/eeproms/PSU4_EEPROM": "/SMB_SLOT@0/[PSU4_EEPROM]",
     "/run/devmap/sensors/DPM": "/[DPM]",
     "/run/devmap/sensors/DPM_2": "/[DPM_2]",
+    "/run/devmap/sensors/DIMM1_TEMP": "/[DIMM1_TEMP]",
+    "/run/devmap/sensors/DIMM2_TEMP": "/[DIMM2_TEMP]",
     "/run/devmap/sensors/SWITCH_CARD_TEMP_SENSOR": "/SMB_SLOT@0/[SWITCH_CARD_TEMP_SENSOR]",
     "/run/devmap/fpgas/SCM_IOB": "/[SCM_IOB]",
     "/run/devmap/i2c-busses/SCM_IOB_I2C_0": "/[SCM_IOB_I2C_0]",
@@ -724,6 +736,8 @@
   "bspKmodsRpmVersion": "1.0.0-1",
   "nonBspKmodsToLoad": [
     "i2c_i801",
+    "i2c_piix4",
+    "spd5118",
     "i2c_mux",
     "fbiob_pci",
     "nh_fpga_i2c",

--- a/fboss/platform/configs/m4062nhp/sensor_service.json
+++ b/fboss/platform/configs/m4062nhp/sensor_service.json
@@ -24,6 +24,26 @@
             "lowerCriticalVal": 9
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "DIMM1_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM1_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DIMM2_TEMP",
+          "sysfsPath": "/run/devmap/sensors/DIMM2_TEMP/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "upperCriticalVal": 95
+          },
+          "compute": "@/1000.0"
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Add the two DDR5 on-DIMM temperature sensors on the m4062nhp SCM, which register via the spd5118 hwmon driver on the SMBus at i2c addresses 0x50 and 0x51:

- `DIMM1_TEMP`: `/sys/bus/i2c/devices/1-0050`
- `DIMM2_TEMP`: `/sys/bus/i2c/devices/1-0051`

Also add `i2c_piix4` and `spd5118` to `nonBspKmodsToLoad` so the SMBus adapter and DIMM sensors are detected before symlink resolution. Thresholds are from the hardware thermal spec.

# Test Plan

Verified on a test device that both `DIMM1_TEMP` and `DIMM2_TEMP` appear in the PlatformManager device map and report correct values via sensor_service_client.

```
# bin/sensor_service_client

Sensor Service Output:

Slot Path: /:

+---------------------+-------+--------+---------------+------------+-------------+--------------------------------------------+
| name                | value | status | criticalRange | alarmRange | lastUpdated | sysfsPath                                  |
+---------------------+-------+--------+---------------+------------+-------------+--------------------------------------------+
| CPU_TCCD1_TEMP      | 29.62 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp3_input   |
| CPU_TCCD2_TEMP      | 29.75 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp4_input   |
| CPU_TCTL_TEMP       | 45.25 | PASS   | [, 120.00]    | [, 95.00]  | 2s ago      | /run/devmap/sensors/CPU_TEMP/temp1_input   |
| DIMM1_TEMP          | 22.25 | PASS   | [, 95.00]     | [, 85.00]  | 2s ago      | /run/devmap/sensors/DIMM1_TEMP/temp1_input |
| DIMM2_TEMP          | 21.75 | PASS   | [, 95.00]     | [, 85.00]  | 2s ago      | /run/devmap/sensors/DIMM2_TEMP/temp1_input |
| DPM_2_VIN           | 12.38 | PASS   | [9.00, 14.00] | [, ]       | 2s ago      | /run/devmap/sensors/DPM_2/in1_input        |
| DPM_VIN             | 12.38 | PASS   | [9.00, 14.00] | [, ]       | 2s ago      | /run/devmap/sensors/DPM/in1_input          |
| NIC_MAC_TEMP        | 38.00 | PASS   | [, 110.00]    | [, 100.00] | 2s ago      | /run/devmap/sensors/NIC_TEMP/temp2_input   |
| NIC_PHY_TEMP        | 38.00 | PASS   | [, 110.00]    | [, 100.00] | 2s ago      | /run/devmap/sensors/NIC_TEMP/temp1_input   |
| NVME_COMPOSITE_TEMP | 23.85 | PASS   | [, 95.00]     | [, 90.00]  | 2s ago      | /run/devmap/sensors/NVME_TEMP/temp1_input  |
+---------------------+-------+--------+---------------+------------+-------------+--------------------------------------------+
```