### PR TITLE
[Nexthop][m4062nhp] Expand PSU sensor coverage

### DIFF
--- a/fboss/platform/configs/m4062nhp/sensor_service.json
+++ b/fboss/platform/configs/m4062nhp/sensor_service.json
@@ -260,6 +260,81 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "PSU1_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1/in3_input",
+          "type": 1,
+          "thresholds": {
+            "lowerCriticalVal": 11.589,
+            "upperCriticalVal": 12.808
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU1/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 18
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 265,
+            "upperCriticalVal": 330
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU1/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 2700
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU1_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU1/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU1/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU1/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 106,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU1_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU1/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "lowerCriticalVal": 1000
+          }
+        },
+        {
           "name": "PSU2_PIN",
           "sysfsPath": "/run/devmap/sensors/PSU2/power1_input",
           "type": 0,
@@ -276,6 +351,81 @@
             "upperCriticalVal": 300
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2/in3_input",
+          "type": 1,
+          "thresholds": {
+            "lowerCriticalVal": 11.589,
+            "upperCriticalVal": 12.808
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU2/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 18
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 265,
+            "upperCriticalVal": 330
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU2/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 2700
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU2_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU2/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU2/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU2/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 106,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU2_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU2/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "lowerCriticalVal": 1000
+          }
         },
         {
           "name": "PSU3_PIN",
@@ -296,6 +446,81 @@
           "compute": "@/1000.0"
         },
         {
+          "name": "PSU3_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3/in3_input",
+          "type": 1,
+          "thresholds": {
+            "lowerCriticalVal": 11.589,
+            "upperCriticalVal": 12.808
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU3/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 18
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 265,
+            "upperCriticalVal": 330
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU3/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 2700
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU3_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU3/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU3/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 106,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU3_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU3/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "lowerCriticalVal": 1000
+          }
+        },
+        {
           "name": "PSU4_PIN",
           "sysfsPath": "/run/devmap/sensors/PSU4/power1_input",
           "type": 0,
@@ -312,6 +537,81 @@
             "upperCriticalVal": 300
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_VOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU4/in3_input",
+          "type": 1,
+          "thresholds": {
+            "lowerCriticalVal": 11.589,
+            "upperCriticalVal": 12.808
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_IIN",
+          "sysfsPath": "/run/devmap/sensors/PSU4/curr1_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 18
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_IOUT",
+          "sysfsPath": "/run/devmap/sensors/PSU4/curr2_input",
+          "type": 2,
+          "thresholds": {
+            "maxAlarmVal": 265,
+            "upperCriticalVal": 330
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_POUT",
+          "sysfsPath": "/run/devmap/sensors/PSU4/power2_input",
+          "type": 0,
+          "thresholds": {
+            "upperCriticalVal": 2700
+          },
+          "compute": "@/1000000"
+        },
+        {
+          "name": "PSU4_TEMP1",
+          "sysfsPath": "/run/devmap/sensors/PSU4/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 61,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_TEMP2",
+          "sysfsPath": "/run/devmap/sensors/PSU4/temp2_input",
+          "type": 3,
+          "thresholds": {
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_TEMP3",
+          "sysfsPath": "/run/devmap/sensors/PSU4/temp3_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 106,
+            "upperCriticalVal": 123
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "PSU4_FAN1_RPM",
+          "sysfsPath": "/run/devmap/sensors/PSU4/fan1_input",
+          "type": 4,
+          "thresholds": {
+            "lowerCriticalVal": 1000
+          }
         }
       ]
     }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Expand PSU monitoring on m4062nhp from 2 channels per PSU (PIN, VIN) to 10, adding VOUT, IIN, IOUT, POUT, TEMP1-3, and FAN1_RPM for each of the four PSUs. Thresholds match the limits programmed in the PSU's own PMBus registers as read from a real unit.

No platform_manager changes needed.

# Test Plan

Ran sensor_service_client on a test device and verified all new PSU channels report values with PASS status.

```
| PSU1_IIN          | 1.44     | PASS   | [, ]                  | [, 18.00]  | 4s ago      | /run/devmap/sensors/PSU1/curr1_input                    |
| PSU1_IOUT         | 22.62    | PASS   | [, 330.00]            | [, 265.00] | 4s ago      | /run/devmap/sensors/PSU1/curr2_input                    |
| PSU1_PIN          | 287.50   | PASS   | [, 1,000.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU1/power1_input                   |
| PSU1_POUT         | 276.50   | PASS   | [, 2,700.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU1/power2_input                   |
| PSU1_TEMP1        | 27.38    | PASS   | [, 123.00]            | [, 61.00]  | 4s ago      | /run/devmap/sensors/PSU1/temp1_input                    |
| PSU1_TEMP2        | 39.38    | PASS   | [, 123.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU1/temp2_input                    |
| PSU1_TEMP3        | 36.88    | PASS   | [, 123.00]            | [, 106.00] | 4s ago      | /run/devmap/sensors/PSU1/temp3_input                    |
| PSU1_VIN          | 205.25   | PASS   | [, 300.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU1/in1_input                      |
| PSU1_VOUT         | 12.24    | PASS   | [11.59, 12.81]        | [, ]       | 4s ago      | /run/devmap/sensors/PSU1/in3_input                      |
| PSU2_FAN1_RPM     | 7,776.00 | PASS   | [1,000.00, ]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/fan1_input                     |
| PSU2_IIN          | 1.45     | PASS   | [, ]                  | [, 18.00]  | 4s ago      | /run/devmap/sensors/PSU2/curr1_input                    |
| PSU2_IOUT         | 22.69    | PASS   | [, 330.00]            | [, 265.00] | 4s ago      | /run/devmap/sensors/PSU2/curr2_input                    |
| PSU2_PIN          | 283.00   | PASS   | [, 1,000.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/power1_input                   |
| PSU2_POUT         | 277.00   | PASS   | [, 2,700.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/power2_input                   |
| PSU2_TEMP1        | 26.75    | PASS   | [, 123.00]            | [, 61.00]  | 4s ago      | /run/devmap/sensors/PSU2/temp1_input                    |
| PSU2_TEMP2        | 37.62    | PASS   | [, 123.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/temp2_input                    |
| PSU2_TEMP3        | 37.88    | PASS   | [, 123.00]            | [, 106.00] | 4s ago      | /run/devmap/sensors/PSU2/temp3_input                    |
| PSU2_VIN          | 205.50   | PASS   | [, 300.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/in1_input                      |
| PSU2_VOUT         | 12.22    | PASS   | [11.59, 12.81]        | [, ]       | 4s ago      | /run/devmap/sensors/PSU2/in3_input                      |
| PSU3_FAN1_RPM     | 7,776.00 | PASS   | [1,000.00, ]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/fan1_input                     |
| PSU3_IIN          | 1.45     | PASS   | [, ]                  | [, 18.00]  | 4s ago      | /run/devmap/sensors/PSU3/curr1_input                    |
| PSU3_IOUT         | 22.44    | PASS   | [, 330.00]            | [, 265.00] | 4s ago      | /run/devmap/sensors/PSU3/curr2_input                    |
| PSU3_PIN          | 290.50   | PASS   | [, 1,000.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/power1_input                   |
| PSU3_POUT         | 274.00   | PASS   | [, 2,700.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/power2_input                   |
| PSU3_TEMP1        | 27.25    | PASS   | [, 123.00]            | [, 61.00]  | 4s ago      | /run/devmap/sensors/PSU3/temp1_input                    |
| PSU3_TEMP2        | 39.50    | PASS   | [, 123.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/temp2_input                    |
| PSU3_TEMP3        | 38.12    | PASS   | [, 123.00]            | [, 106.00] | 4s ago      | /run/devmap/sensors/PSU3/temp3_input                    |
| PSU3_VIN          | 205.25   | PASS   | [, 300.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/in1_input                      |
| PSU3_VOUT         | 12.23    | PASS   | [11.59, 12.81]        | [, ]       | 4s ago      | /run/devmap/sensors/PSU3/in3_input                      |
| PSU4_FAN1_RPM     | 8,000.00 | PASS   | [1,000.00, ]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/fan1_input                     |
| PSU4_IIN          | 1.45     | PASS   | [, ]                  | [, 18.00]  | 4s ago      | /run/devmap/sensors/PSU4/curr1_input                    |
| PSU4_IOUT         | 23.06    | PASS   | [, 330.00]            | [, 265.00] | 4s ago      | /run/devmap/sensors/PSU4/curr2_input                    |
| PSU4_PIN          | 294.50   | PASS   | [, 1,000.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/power1_input                   |
| PSU4_POUT         | 282.00   | PASS   | [, 2,700.00]          | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/power2_input                   |
| PSU4_TEMP1        | 25.50    | PASS   | [, 123.00]            | [, 61.00]  | 4s ago      | /run/devmap/sensors/PSU4/temp1_input                    |
| PSU4_TEMP2        | 38.88    | PASS   | [, 123.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/temp2_input                    |
| PSU4_TEMP3        | 38.62    | PASS   | [, 123.00]            | [, 106.00] | 4s ago      | /run/devmap/sensors/PSU4/temp3_input                    |
| PSU4_VIN          | 205.25   | PASS   | [, 300.00]            | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/in1_input                      |
| PSU4_VOUT         | 12.23    | PASS   | [11.59, 12.81]        | [, ]       | 4s ago      | /run/devmap/sensors/PSU4/in3_input                      |
```
