### PR TITLE
[Nexthop][m4062nhp] Add DPM sensors

### DIFF
--- a/fboss/platform/configs/m4062nhp/sensor_service.json
+++ b/fboss/platform/configs/m4062nhp/sensor_service.json
@@ -6,22 +6,218 @@
       "pmUnitName": "SCM",
       "sensors": [
         {
-          "name": "DPM_VIN",
+          "name": "DPM_POS12V",
           "sysfsPath": "/run/devmap/sensors/DPM/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 10.2
           },
           "compute": "@/1000.0"
         },
         {
-          "name": "DPM_2_VIN",
+          "name": "DPM_2_POS12V",
           "sysfsPath": "/run/devmap/sensors/DPM_2/in1_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 14,
-            "lowerCriticalVal": 9
+            "maxAlarmVal": 13.2,
+            "minAlarmVal": 10.8,
+            "upperCriticalVal": 13.8,
+            "lowerCriticalVal": 10.2
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS5V0",
+          "sysfsPath": "/run/devmap/sensors/DPM/in2_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.5,
+            "minAlarmVal": 4.5,
+            "upperCriticalVal": 5.75,
+            "lowerCriticalVal": 4.25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS2V0_PHY",
+          "sysfsPath": "/run/devmap/sensors/DPM/in3_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 2.104,
+            "minAlarmVal": 1.911,
+            "upperCriticalVal": 2.207,
+            "lowerCriticalVal": 1.822
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS5V0_S0",
+          "sysfsPath": "/run/devmap/sensors/DPM/in4_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 5.5,
+            "minAlarmVal": 4.5,
+            "upperCriticalVal": 5.75,
+            "lowerCriticalVal": 4.25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V0_A7",
+          "sysfsPath": "/run/devmap/sensors/DPM/in5_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.05,
+            "minAlarmVal": 0.9,
+            "upperCriticalVal": 1.1,
+            "lowerCriticalVal": 0.85
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V8_A7",
+          "sysfsPath": "/run/devmap/sensors/DPM/in6_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.62,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.53
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS3V3",
+          "sysfsPath": "/run/devmap/sensors/DPM/in7_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 2.97,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS0V74_PHY",
+          "sysfsPath": "/run/devmap/sensors/DPM/in8_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.785,
+            "minAlarmVal": 0.71,
+            "upperCriticalVal": 0.83,
+            "lowerCriticalVal": 0.681
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V2_A7",
+          "sysfsPath": "/run/devmap/sensors/DPM/in9_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.26,
+            "minAlarmVal": 1.08,
+            "upperCriticalVal": 1.32,
+            "lowerCriticalVal": 1.02
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS0V75_S5",
+          "sysfsPath": "/run/devmap/sensors/DPM/in10_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 0.785,
+            "minAlarmVal": 0.711,
+            "upperCriticalVal": 0.822,
+            "lowerCriticalVal": 0.674
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V8_S5",
+          "sysfsPath": "/run/devmap/sensors/DPM/in11_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.62,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.53
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS3V3_S5",
+          "sysfsPath": "/run/devmap/sensors/DPM/in12_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 2.97,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.805
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V1_S0",
+          "sysfsPath": "/run/devmap/sensors/DPM/in13_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.155,
+            "minAlarmVal": 0.99,
+            "upperCriticalVal": 1.2,
+            "lowerCriticalVal": 0.935
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V5_SWT",
+          "sysfsPath": "/run/devmap/sensors/DPM/in14_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.658,
+            "minAlarmVal": 1.441,
+            "upperCriticalVal": 1.766,
+            "lowerCriticalVal": 1.333
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V15_SWT",
+          "sysfsPath": "/run/devmap/sensors/DPM/in15_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.203,
+            "minAlarmVal": 1.087,
+            "upperCriticalVal": 1.261,
+            "lowerCriticalVal": 1.043
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS1V8_S0",
+          "sysfsPath": "/run/devmap/sensors/DPM/in16_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 1.89,
+            "minAlarmVal": 1.62,
+            "upperCriticalVal": 1.98,
+            "lowerCriticalVal": 1.53
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "DPM_POS3V3_S0",
+          "sysfsPath": "/run/devmap/sensors/DPM/in17_input",
+          "type": 1,
+          "thresholds": {
+            "maxAlarmVal": 3.465,
+            "minAlarmVal": 2.97,
+            "upperCriticalVal": 3.63,
+            "lowerCriticalVal": 2.805
           },
           "compute": "@/1000.0"
         }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Monitor all 17 voltage rails of the CPU card power sequencer (ADM1266 DPM at 0x41) instead of only the 12V input. The adm1266 driver maps VH1-4 to in1-in4 and VP1-13 to in5-in17. Rail names and thresholds match the limits programmed in the sequencer itself as read from a live unit via sysfs (in*_lcrit/min/max/crit).

Also align the existing DPM_VIN (in1, POS12V) thresholds with the same programmed limits: warning 10.8/13.2, critical 10.2/13.8, replacing the previous 9/14 placeholders.

# Test Plan

Ran sensor_service_client on a test device and verified all DPM rail sensors report values with PASS status.

```
# bin/sensor_service_client

Sensor Service Output:

Slot Path: /:

+---------------------+-------+--------+----------------+----------------+-------------+-------------------------------------------+
| name                | value | status | criticalRange  | alarmRange     | lastUpdated | sysfsPath                                 |
+---------------------+-------+--------+----------------+----------------+-------------+-------------------------------------------+
...
| DPM_2_POS12V        | 12.37 | PASS   | [10.20, 13.80] | [10.80, 13.20] | 2s ago      | /run/devmap/sensors/DPM_2/in1_input       |
| DPM_POS0V74_PHY     | 0.74  | PASS   | [0.68, 0.83]   | [0.71, 0.79]   | 2s ago      | /run/devmap/sensors/DPM/in8_input         |
| DPM_POS0V75_S5      | 0.75  | PASS   | [0.67, 0.82]   | [0.71, 0.79]   | 2s ago      | /run/devmap/sensors/DPM/in10_input        |
| DPM_POS12V          | 12.38 | PASS   | [10.20, 13.80] | [10.80, 13.20] | 2s ago      | /run/devmap/sensors/DPM/in1_input         |
| DPM_POS1V0_A7       | 1.00  | PASS   | [0.85, 1.10]   | [0.90, 1.05]   | 2s ago      | /run/devmap/sensors/DPM/in5_input         |
| DPM_POS1V15_SWT     | 1.15  | PASS   | [1.04, 1.26]   | [1.09, 1.20]   | 2s ago      | /run/devmap/sensors/DPM/in15_input        |
| DPM_POS1V1_S0       | 1.10  | PASS   | [0.94, 1.20]   | [0.99, 1.16]   | 2s ago      | /run/devmap/sensors/DPM/in13_input        |
| DPM_POS1V2_A7       | 1.20  | PASS   | [1.02, 1.32]   | [1.08, 1.26]   | 2s ago      | /run/devmap/sensors/DPM/in9_input         |
| DPM_POS1V5_SWT      | 1.50  | PASS   | [1.33, 1.77]   | [1.44, 1.66]   | 2s ago      | /run/devmap/sensors/DPM/in14_input        |
| DPM_POS1V8_A7       | 1.81  | PASS   | [1.53, 1.98]   | [1.62, 1.89]   | 2s ago      | /run/devmap/sensors/DPM/in6_input         |
| DPM_POS1V8_S0       | 1.81  | PASS   | [1.53, 1.98]   | [1.62, 1.89]   | 2s ago      | /run/devmap/sensors/DPM/in16_input        |
| DPM_POS1V8_S5       | 1.79  | PASS   | [1.53, 1.98]   | [1.62, 1.89]   | 2s ago      | /run/devmap/sensors/DPM/in11_input        |
| DPM_POS2V0_PHY      | 2.02  | PASS   | [1.82, 2.21]   | [1.91, 2.10]   | 2s ago      | /run/devmap/sensors/DPM/in3_input         |
| DPM_POS3V3          | 3.32  | PASS   | [2.81, 3.63]   | [2.97, 3.46]   | 2s ago      | /run/devmap/sensors/DPM/in7_input         |
| DPM_POS3V3_S0       | 3.33  | PASS   | [2.81, 3.63]   | [2.97, 3.46]   | 2s ago      | /run/devmap/sensors/DPM/in17_input        |
| DPM_POS3V3_S5       | 3.31  | PASS   | [2.81, 3.63]   | [2.97, 3.46]   | 2s ago      | /run/devmap/sensors/DPM/in12_input        |
| DPM_POS5V0          | 5.03  | PASS   | [4.25, 5.75]   | [4.50, 5.50]   | 2s ago      | /run/devmap/sensors/DPM/in2_input         |
| DPM_POS5V0_S0       | 5.06  | PASS   | [4.25, 5.75]   | [4.50, 5.50]   | 2s ago      | /run/devmap/sensors/DPM/in4_input         |
...
+---------------------+-------+--------+----------------+----------------+-------------+-------------------------------------------+
```