### PR TITLE
[Nexthop] [fboss2] don't stage a config session from read-only commands

### DIFF
--- a/fboss/cli/fboss2/commands/config/history/CmdConfigHistory.cpp
+++ b/fboss/cli/fboss2/commands/config/history/CmdConfigHistory.cpp
@@ -40,7 +40,9 @@ std::string formatTime(int64_t timeSec) {
 
 CmdConfigHistoryTraits::RetType CmdConfigHistory::queryClient(
     const HostInfo& /* hostInfo */) {
-  auto& session = ConfigSession::getInstance();
+  // Read-only: reporting committed history must never stage a session.
+  auto& session =
+      ConfigSession::getInstance(ConfigSession::SessionInit::ReadOnly);
   auto& git = session.getGit();
 
   // Get the commit history from Git for the CLI config file

--- a/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.cpp
+++ b/fboss/cli/fboss2/commands/config/session/CmdConfigSessionDiff.cpp
@@ -182,7 +182,9 @@ void appendSection(
 CmdConfigSessionDiffTraits::RetType CmdConfigSessionDiff::queryClient(
     const HostInfo& /* hostInfo */,
     const utils::RevisionList& revisions) {
-  auto& session = ConfigSession::getInstance();
+  // Diffing must never stage a session.
+  auto& session =
+      ConfigSession::getInstance(ConfigSession::SessionInit::ReadOnly);
   auto& git = session.getGit();
   auto domains = allDomains(session);
 

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -281,7 +281,7 @@ std::string ConfigSession::readCommandLineFromProc() const {
   return folly::join(" ", args);
 }
 
-ConfigSession::ConfigSession() {
+ConfigSession::ConfigSession(SessionInit init) {
   username_ = getUsername();
   std::string homeDir = getHomeDirectory();
 
@@ -295,17 +295,18 @@ ConfigSession::ConfigSession() {
   sessionConfigDir_ = homeDir + "/.fboss2";
   systemConfigDir_ = coopDir;
   git_ = std::make_unique<Git>(coopDir);
-  initializeSession();
+  initializeSession(init);
 }
 
 ConfigSession::ConfigSession(
     std::string sessionConfigDir,
-    std::string systemConfigDir)
+    std::string systemConfigDir,
+    SessionInit init)
     : sessionConfigDir_(std::move(sessionConfigDir)),
       systemConfigDir_(std::move(systemConfigDir)),
       username_(getUsername()),
       git_(std::make_unique<Git>(systemConfigDir_)) {
-  initializeSession();
+  initializeSession(init);
 }
 
 ConfigSession::ConfigSession(
@@ -328,10 +329,10 @@ std::unique_ptr<ConfigSession>& getInstancePtr() {
 }
 } // namespace
 
-ConfigSession& ConfigSession::getInstance() {
+ConfigSession& ConfigSession::getInstance(SessionInit init) {
   auto& instance = getInstancePtr();
   if (!instance) {
-    instance = std::make_unique<ConfigSession>();
+    instance = std::make_unique<ConfigSession>(init);
   }
   return *instance;
 }
@@ -445,6 +446,7 @@ void ConfigSession::saveConfig(
     throw std::runtime_error("No config loaded to save");
   }
 
+<<<<<<< HEAD
   // We need to do a round-trip through serialize -> parse -> toPrettyJson
   // because SimpleJSONSerializer handles Thrift maps with integer keys
   // (like clientIdToAdminDistance) by converting them to strings.
@@ -455,6 +457,10 @@ void ConfigSession::saveConfig(
       apache::thrift::SimpleJSONSerializer::serialize<std::string>(
           agentConfig_);
   std::string prettyJson = folly::toPrettyJson(folly::parseJson(json));
+=======
+  // May not exist yet if this session was constructed ReadOnly.
+  ensureDirectoryExists(sessionConfigDir_);
+>>>>>>> 2b69b192fa (NOS-13484: don't stage a config session from read-only commands (#1634))
 
   // Use folly::writeFileAtomic with sync to avoid race conditions when multiple
   // threads/processes write to the same session file. WITH_SYNC ensures data
@@ -659,6 +665,8 @@ void ConfigSession::loadMetadata() {
 
 void ConfigSession::saveMetadata() {
   std::string metadataPath = getMetadataPath();
+  // May not exist yet if this session was constructed ReadOnly.
+  ensureDirectoryExists(sessionConfigDir_);
 
   // Build Thrift metadata struct and serialize to JSON with symbolic enum names
   // Using PORTABLE format for human-readable enum names instead of integers
@@ -780,7 +788,8 @@ void ConfigSession::loadConfig() {
   // If session file doesn't exist (e.g., after a commit), re-initialize
   // the session by copying from system config.
   if (!sessionExists()) {
-    initializeSession();
+    // Force materialization even if constructed ReadOnly.
+    initializeSession(SessionInit::CreateIfAbsent);
   }
 
   std::string configJson;
@@ -802,7 +811,8 @@ void ConfigSession::loadConfig() {
   configLoaded_ = true;
 }
 
-void ConfigSession::initializeSession() {
+void ConfigSession::initializeSession(SessionInit init) {
+  // Bootstraps /etc/coop, not ~/.fboss2, so this runs regardless of `init`.
   initializeGit();
   // Resume an existing session if EITHER an agent (agent.conf) or a BGP
   // (bgp_config.json) session is staged. Keying only on the agent session file
@@ -816,6 +826,10 @@ void ConfigSession::initializeSession() {
     commands_.clear();
     requiredActions_.clear();
     configLoaded_ = false;
+
+    if (init == SessionInit::ReadOnly) {
+      return; // leave ~/.fboss2 alone
+    }
 
     // Ensure the session config directory exists
     ensureDirectoryExists(sessionConfigDir_);

--- a/fboss/cli/fboss2/session/ConfigSession.cpp
+++ b/fboss/cli/fboss2/session/ConfigSession.cpp
@@ -281,7 +281,7 @@ std::string ConfigSession::readCommandLineFromProc() const {
   return folly::join(" ", args);
 }
 
-ConfigSession::ConfigSession() {
+ConfigSession::ConfigSession(SessionInit init) {
   username_ = getUsername();
   std::string homeDir = getHomeDirectory();
 
@@ -295,17 +295,18 @@ ConfigSession::ConfigSession() {
   sessionConfigDir_ = homeDir + "/.fboss2";
   systemConfigDir_ = coopDir;
   git_ = std::make_unique<Git>(coopDir);
-  initializeSession();
+  initializeSession(init);
 }
 
 ConfigSession::ConfigSession(
     std::string sessionConfigDir,
-    std::string systemConfigDir)
+    std::string systemConfigDir,
+    SessionInit init)
     : sessionConfigDir_(std::move(sessionConfigDir)),
       systemConfigDir_(std::move(systemConfigDir)),
       username_(getUsername()),
       git_(std::make_unique<Git>(systemConfigDir_)) {
-  initializeSession();
+  initializeSession(init);
 }
 
 ConfigSession::ConfigSession(
@@ -328,10 +329,10 @@ std::unique_ptr<ConfigSession>& getInstancePtr() {
 }
 } // namespace
 
-ConfigSession& ConfigSession::getInstance() {
+ConfigSession& ConfigSession::getInstance(SessionInit init) {
   auto& instance = getInstancePtr();
   if (!instance) {
-    instance = std::make_unique<ConfigSession>();
+    instance = std::make_unique<ConfigSession>(init);
   }
   return *instance;
 }
@@ -455,6 +456,9 @@ void ConfigSession::saveConfig(
       apache::thrift::SimpleJSONSerializer::serialize<std::string>(
           agentConfig_);
   std::string prettyJson = folly::toPrettyJson(folly::parseJson(json));
+
+  // May not exist yet if this session was constructed ReadOnly.
+  ensureDirectoryExists(sessionConfigDir_);
 
   // Use folly::writeFileAtomic with sync to avoid race conditions when multiple
   // threads/processes write to the same session file. WITH_SYNC ensures data
@@ -659,6 +663,8 @@ void ConfigSession::loadMetadata() {
 
 void ConfigSession::saveMetadata() {
   std::string metadataPath = getMetadataPath();
+  // May not exist yet if this session was constructed ReadOnly.
+  ensureDirectoryExists(sessionConfigDir_);
 
   // Build Thrift metadata struct and serialize to JSON with symbolic enum names
   // Using PORTABLE format for human-readable enum names instead of integers
@@ -780,7 +786,8 @@ void ConfigSession::loadConfig() {
   // If session file doesn't exist (e.g., after a commit), re-initialize
   // the session by copying from system config.
   if (!sessionExists()) {
-    initializeSession();
+    // Force materialization even if constructed ReadOnly.
+    initializeSession(SessionInit::CreateIfAbsent);
   }
 
   std::string configJson;
@@ -802,7 +809,8 @@ void ConfigSession::loadConfig() {
   configLoaded_ = true;
 }
 
-void ConfigSession::initializeSession() {
+void ConfigSession::initializeSession(SessionInit init) {
+  // Bootstraps /etc/coop, not ~/.fboss2, so this runs regardless of `init`.
   initializeGit();
   // Resume an existing session if EITHER an agent (agent.conf) or a BGP
   // (bgp_config.json) session is staged. Keying only on the agent session file
@@ -816,6 +824,10 @@ void ConfigSession::initializeSession() {
     commands_.clear();
     requiredActions_.clear();
     configLoaded_ = false;
+
+    if (init == SessionInit::ReadOnly) {
+      return; // leave ~/.fboss2 alone
+    }
 
     // Ensure the session config directory exists
     ensureDirectoryExists(sessionConfigDir_);

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -85,12 +85,19 @@ namespace facebook::fboss {
  */
 class ConfigSession {
  public:
-  ConfigSession();
+  // ReadOnly skips seeding ~/.fboss2 when no session exists; used by commands
+  // (history, session diff) that must not stage one.
+  enum class SessionInit { CreateIfAbsent, ReadOnly };
+
+  explicit ConfigSession(SessionInit init = SessionInit::CreateIfAbsent);
+
   virtual ~ConfigSession() = default;
 
-  // Get or create the current config session
-  // If no session exists, copies /etc/coop/agent.conf to ~/.fboss2/agent.conf
-  static ConfigSession& getInstance();
+  // Get or create the current config session.
+  // If no session exists, copies /etc/coop/agent.conf to ~/.fboss2/agent.conf,
+  // unless init == ReadOnly.
+  static ConfigSession& getInstance(
+      SessionInit init = SessionInit::CreateIfAbsent);
 
   // Reset the singleton (for testing only).
   // Destroys the current instance so the next getInstance() creates a fresh
@@ -244,7 +251,10 @@ class ConfigSession {
 
  protected:
   // Constructor for testing with custom paths
-  ConfigSession(std::string sessionConfigDir, std::string systemConfigDir);
+  ConfigSession(
+      std::string sessionConfigDir,
+      std::string systemConfigDir,
+      SessionInit init = SessionInit::CreateIfAbsent);
 
   // Constructor for testing with custom paths and mock FbossServiceUtil
   ConfigSession(
@@ -339,8 +349,9 @@ class ConfigSession {
   // multi-switch state via Thrift, rather than reading the config file.
   virtual void ensureFbossServiceUtil(const HostInfo& hostInfo);
 
-  // Initialize the session (creates session config file if it doesn't exist)
-  void initializeSession();
+  // Initialize the session. With CreateIfAbsent, creates the session config
+  // file if it doesn't exist; with ReadOnly, leaves ~/.fboss2 untouched.
+  void initializeSession(SessionInit init);
   void copySystemConfigToSession() const;
   void loadConfig();
 

--- a/fboss/cli/fboss2/session/ConfigSession.h
+++ b/fboss/cli/fboss2/session/ConfigSession.h
@@ -85,12 +85,24 @@ namespace facebook::fboss {
  */
 class ConfigSession {
  public:
+<<<<<<< HEAD
   ConfigSession();
   virtual ~ConfigSession() = default;
+=======
+  // ReadOnly skips seeding ~/.fboss2 when no session exists; used by commands
+  // (history, session diff) that must not stage one.
+  enum class SessionInit { CreateIfAbsent, ReadOnly };
 
-  // Get or create the current config session
-  // If no session exists, copies /etc/coop/agent.conf to ~/.fboss2/agent.conf
-  static ConfigSession& getInstance();
+  explicit ConfigSession(SessionInit init = SessionInit::CreateIfAbsent);
+
+  virtual ~ConfigSession();
+>>>>>>> 2b69b192fa (NOS-13484: don't stage a config session from read-only commands (#1634))
+
+  // Get or create the current config session.
+  // If no session exists, copies /etc/coop/agent.conf to ~/.fboss2/agent.conf,
+  // unless init == ReadOnly.
+  static ConfigSession& getInstance(
+      SessionInit init = SessionInit::CreateIfAbsent);
 
   // Reset the singleton (for testing only).
   // Destroys the current instance so the next getInstance() creates a fresh
@@ -244,7 +256,10 @@ class ConfigSession {
 
  protected:
   // Constructor for testing with custom paths
-  ConfigSession(std::string sessionConfigDir, std::string systemConfigDir);
+  ConfigSession(
+      std::string sessionConfigDir,
+      std::string systemConfigDir,
+      SessionInit init = SessionInit::CreateIfAbsent);
 
   // Constructor for testing with custom paths and mock FbossServiceUtil
   ConfigSession(
@@ -339,8 +354,9 @@ class ConfigSession {
   // multi-switch state via Thrift, rather than reading the config file.
   virtual void ensureFbossServiceUtil(const HostInfo& hostInfo);
 
-  // Initialize the session (creates session config file if it doesn't exist)
-  void initializeSession();
+  // Initialize the session. With CreateIfAbsent, creates the session config
+  // file if it doesn't exist; with ReadOnly, leaves ~/.fboss2 untouched.
+  void initializeSession(SessionInit init);
   void copySystemConfigToSession() const;
   void loadConfig();
 

--- a/fboss/cli/fboss2/test/TestableConfigSession.h
+++ b/fboss/cli/fboss2/test/TestableConfigSession.h
@@ -26,9 +26,12 @@ class TestableConfigSession : public ConfigSession {
  public:
   TestableConfigSession(
       std::string sessionConfigDir,
-      std::string systemConfigDir)
-      : ConfigSession(std::move(sessionConfigDir), std::move(systemConfigDir)) {
-  }
+      std::string systemConfigDir,
+      SessionInit init = SessionInit::CreateIfAbsent)
+      : ConfigSession(
+            std::move(sessionConfigDir),
+            std::move(systemConfigDir),
+            init) {}
 
   // Constructor with mock FbossServiceUtil
   TestableConfigSession(

--- a/fboss/cli/fboss2/test/config/CmdConfigHistoryTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigHistoryTest.cpp
@@ -3,8 +3,10 @@
 #include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
 
 #include <gtest/gtest.h>
+#include <filesystem>
 
 #include "fboss/cli/fboss2/commands/config/history/CmdConfigHistory.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
 
 using namespace ::testing;
 
@@ -178,6 +180,48 @@ TEST_F(CmdConfigHistoryTestFixture, historyMultipleCommits) {
   auto pos_initial = result.find("Initial commit");
   EXPECT_LT(pos_6, pos_5);
   EXPECT_LT(pos_5, pos_initial);
+}
+
+TEST_F(CmdConfigHistoryTestFixture, historyDoesNotCreateSessionFiles) {
+  setupReadOnlyTestableConfigSession();
+
+  std::filesystem::path sessionDir = getTestHomeDir() / ".fboss2";
+  ASSERT_FALSE(std::filesystem::exists(sessionDir));
+
+  auto cmd = CmdConfigHistory();
+  auto result = cmd.queryClient(localhost());
+
+  EXPECT_NE(result.find("Initial commit"), std::string::npos);
+  EXPECT_FALSE(std::filesystem::exists(getSessionConfigPath()));
+  EXPECT_FALSE(std::filesystem::exists(sessionDir / "cli_metadata.json"));
+  EXPECT_FALSE(std::filesystem::exists(sessionDir / "bgp_config.json"));
+  EXPECT_FALSE(ConfigSession::getInstance().hasActiveSession());
+}
+
+TEST_F(CmdConfigHistoryTestFixture, historyLeavesExistingSessionUntouched) {
+  const std::string staged =
+      R"({"sw": {"ports": [{"logicalID": 1, "name": "eth1/1/1", "state": 2, "speed": 400000}]}})";
+  std::filesystem::create_directories(getSessionConfigPath().parent_path());
+  createTestConfig(getSessionConfigPath(), staged);
+
+  setupReadOnlyTestableConfigSession();
+
+  auto cmd = CmdConfigHistory();
+  auto result = cmd.queryClient(localhost());
+
+  EXPECT_NE(result.find("Initial commit"), std::string::npos);
+  EXPECT_TRUE(std::filesystem::exists(getSessionConfigPath()));
+  EXPECT_EQ(readFile(getSessionConfigPath()), staged);
+  EXPECT_TRUE(ConfigSession::getInstance().hasActiveSession());
+}
+
+TEST_F(CmdConfigHistoryTestFixture, defaultSessionStillCreatesSessionFile) {
+  ASSERT_FALSE(std::filesystem::exists(getSessionConfigPath()));
+
+  setupTestableConfigSession();
+
+  EXPECT_TRUE(std::filesystem::exists(getSessionConfigPath()));
+  EXPECT_TRUE(ConfigSession::getInstance().hasActiveSession());
 }
 
 TEST_F(CmdConfigHistoryTestFixture, printOutput) {

--- a/fboss/cli/fboss2/test/config/CmdConfigSessionDiffTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigSessionDiffTest.cpp
@@ -298,6 +298,63 @@ TEST_F(CmdConfigSessionDiffTestFixture, printOutput) {
   EXPECT_NE(output.find("+new"), std::string::npos);
 }
 
+TEST_F(
+    CmdConfigSessionDiffTestFixture,
+    diffNoSessionDoesNotCreateSessionFiles) {
+  setupReadOnlyTestableConfigSession();
+
+  std::filesystem::path sessionDir = getTestHomeDir() / ".fboss2";
+  ASSERT_FALSE(std::filesystem::exists(sessionDir));
+
+  auto cmd = CmdConfigSessionDiff();
+  utils::RevisionList emptyRevisions(std::vector<std::string>{});
+  auto result = cmd.queryClient(localhost(), emptyRevisions);
+
+  EXPECT_EQ(result, "No config session exists. Make a config change first.");
+  EXPECT_FALSE(std::filesystem::exists(getSessionConfigPath()));
+  EXPECT_FALSE(std::filesystem::exists(sessionDir / "cli_metadata.json"));
+  EXPECT_FALSE(std::filesystem::exists(sessionDir / "bgp_config.json"));
+}
+
+TEST_F(
+    CmdConfigSessionDiffTestFixture,
+    diffTwoRevisionsDoesNotCreateSessionFiles) {
+  auto commits = git().log((getCliConfigDir() / "agent.conf").string());
+  std::string firstCommit = commits.back().sha1;
+
+  std::filesystem::path cliConfigPath = getCliConfigDir() / "agent.conf";
+  createTestConfig(
+      cliConfigPath,
+      R"({"sw": {"ports": [{"logicalID": 1, "name": "eth1/1/1", "state": 2, "speed": 200000}]}})");
+  std::string secondCommit = git().commit({"cli/agent.conf"}, "Second commit");
+
+  setupReadOnlyTestableConfigSession();
+
+  auto cmd = CmdConfigSessionDiff();
+  utils::RevisionList revisions(
+      std::vector<std::string>{firstCommit, secondCommit});
+  auto result = cmd.queryClient(localhost(), revisions);
+
+  EXPECT_NE(result.find("200000"), std::string::npos);
+  EXPECT_FALSE(std::filesystem::exists(getTestHomeDir() / ".fboss2"));
+}
+
+TEST_F(CmdConfigSessionDiffTestFixture, diffReadOnlyStillSeesStagedSession) {
+  const std::string staged =
+      R"({"sw": {"ports": [{"logicalID": 1, "name": "eth1/1/1", "state": 2, "speed": 400000}]}})";
+  std::filesystem::create_directories(getSessionConfigPath().parent_path());
+  createTestConfig(getSessionConfigPath(), staged);
+
+  setupReadOnlyTestableConfigSession();
+
+  auto cmd = CmdConfigSessionDiff();
+  utils::RevisionList emptyRevisions(std::vector<std::string>{});
+  auto result = cmd.queryClient(localhost(), emptyRevisions);
+
+  EXPECT_NE(result.find("400000"), std::string::npos);
+  EXPECT_EQ(readFile(getSessionConfigPath()), staged);
+}
+
 TEST_F(CmdConfigSessionDiffTestFixture, printOutputNoDifferences) {
   auto cmd = CmdConfigSessionDiff();
   std::string noDiffMessage =

--- a/fboss/cli/fboss2/test/config/CmdConfigTestBase.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigTestBase.cpp
@@ -105,6 +105,14 @@ void CmdConfigTestBase::setupTestableConfigSession() {
           (testEtcDir_ / "coop").string()));
 }
 
+void CmdConfigTestBase::setupReadOnlyTestableConfigSession() {
+  TestableConfigSession::setInstance(
+      std::make_unique<TestableConfigSession>(
+          (testHomeDir_ / ".fboss2").string(),
+          (testEtcDir_ / "coop").string(),
+          ConfigSession::SessionInit::ReadOnly));
+}
+
 void CmdConfigTestBase::setupTestableConfigSession(
     const std::string& cmdPrefix,
     const std::string& cmdArgs) {

--- a/fboss/cli/fboss2/test/config/CmdConfigTestBase.h
+++ b/fboss/cli/fboss2/test/config/CmdConfigTestBase.h
@@ -52,6 +52,8 @@ class CmdConfigTestBase : public CmdHandlerTestBase {
 
   // For now, we only support one command line per TestableConfigSession
   void setupTestableConfigSession();
+  // Installs a SessionInit::ReadOnly session, as read-only commands do.
+  void setupReadOnlyTestableConfigSession();
   void setupTestableConfigSession(
       const std::string& cmdPrefix,
       const std::string& cmdArgs);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

[Slack thread](https://nexthopai.slack.com/archives/D0AMDB6A92M/p1785991859035259)

# Summary

`fboss2-dev config history` and `fboss2-dev config session diff` are purely informational, but both create a config session as a side effect.

Both call `ConfigSession::getInstance()`, which lazily default-constructs the singleton, whose constructor unconditionally runs `initializeSession()`. With nothing staged, that takes the "starting a new session" branch: `ensureDirectoryExists(~/.fboss2)`, `copySystemConfigToSession()` (seeding `~/.fboss2/agent.conf` from the live `/etc/coop/agent.conf`), `base_ = git HEAD`, and `saveMetadata()` (writing `~/.fboss2/cli_metadata.json`).

Consequences:

- Running `config history` on a clean box silently starts a config session. `config session diff`/`commit` afterwards behave as if the user has an edit in flight.
- `session diff`'s own `"No config session exists. Make a config change first."` message is checked *after* `getInstance()` has already created the session — the message is false by the time it is printed.

## Fix

Add a `ConfigSession::SessionInit { CreateIfAbsent, ReadOnly }` mode, threaded through the constructors into `initializeSession()`:

- `ReadOnly` returns before the "start a new session" branch, so **nothing under `~/.fboss2` is written**. The git handle, path getters, `configDomains()` and `readStagedContent()` all still work, which is everything these two commands actually use.
- `CreateIfAbsent` remains the default, so every editing command is byte-for-byte unchanged.
- `loadConfig()` — the entry point of every editing command — now calls `initializeSession(CreateIfAbsent)` explicitly, so even a `ReadOnly`-constructed singleton materializes a session the moment someone genuinely reads the agent config.
- Call sites: `CmdConfigHistory` and `CmdConfigSessionDiff` pass `SessionInit::ReadOnly`.

Two deliberate choices worth reviewing:

1. **`initializeGit()` still runs in `ReadOnly` mode.** It only bootstraps the *system* config repo under `/etc/coop` (never `~/.fboss2`), it is idempotent once the repo exists, and both read commands need a usable repo to report anything at all. Skipping it would make `history` fail with a raw git error on a fresh device instead of showing the baseline commit. Happy to tighten this further if reviewers prefer.
2. **`~/.fboss2` is now ensured in `saveConfig()` and `saveMetadata()`** rather than only at construction, since the directory is no longer guaranteed to have been created up front. This also removes a pre-existing latent failure in the `rollback()` path, which calls `saveMetadata()` unconditionally.

A "delete the files on exit" approach was considered and rejected: it races against a concurrent `config session start`/edit in another terminal, and does a pointless copy-then-delete on every invocation. Not creating the file at all is strictly better.

# Test Plan

New unit tests (all use a new `CmdConfigTestBase::setupReadOnlyTestableConfigSession()` helper that installs a `SessionInit::ReadOnly` session, mirroring how the commands construct theirs):

`CmdConfigHistoryTest.cpp`
- `historyDoesNotCreateSessionFiles` — asserts `~/.fboss2` does not exist beforehand, runs the command, asserts the output still lists `Initial commit`, and that `agent.conf`, `cli_metadata.json`, `bgp_config.json` and `hasActiveSession()` are all still absent/false.
- `historyLeavesExistingSessionUntouched` — with a session already staged, the command still works and the staged content is byte-identical afterwards.
- `defaultSessionStillCreatesSessionFile` — regression guard that the default `CreateIfAbsent` editing path still seeds `~/.fboss2/agent.conf`.

`CmdConfigSessionDiffTest.cpp`
- `diffNoSessionDoesNotCreateSessionFiles` — the "No config session exists" message is now true when printed; no session files created.
- `diffTwoRevisionsDoesNotCreateSessionFiles` — the revision-vs-revision mode never consults the session, and no longer stages one.
- `diffReadOnlyStillSeesStagedSession` — a real staged session is still diffed correctly and left untouched.

Existing `CmdConfigHistoryTest`/`CmdConfigSessionDiffTest`/`CmdConfigSessionTest`/`ConfigSessionSystemdTest` cases exercise the unchanged `CreateIfAbsent` path.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
