### PR TITLE
[Celestica] Tahansb800bc: showtech: Add CPLD registers dump and ASIC power state in showtech

### DIFF
--- a/fboss/platform/configs/tahansb800bc/rma_showtech.json
+++ b/fboss/platform/configs/tahansb800bc/rma_showtech.json
@@ -1,3 +1,20 @@
 {
-  "i2cBusIgnore": []
+  "i2cBusIgnore": [],
+  "i2cDumpDevices": [
+    "/run/devmap/cplds/MCB_CPLD",
+    "/run/devmap/cplds/SCM_CPLD",
+    "/run/devmap/cplds/SMB_CPLD"
+  ],
+  "scPowerGood": {
+    "sysfsAttributes": [
+      {
+        "name": "SMB_POWERGOOD",
+        "path": "/run/devmap/cplds/MCB_CPLD/smb_pg"
+      },
+      {
+        "name": "ASIC_POWERSTATE",
+        "path": "/run/devmap/cplds/SMB_CPLD/th6_pwr_en"
+      }
+    ]
+  }
 }

--- a/fboss/platform/configs/tahansb800bcm/rma_showtech.json
+++ b/fboss/platform/configs/tahansb800bcm/rma_showtech.json
@@ -1,3 +1,20 @@
 {
-  "i2cBusIgnore": []
+  "i2cBusIgnore": [],
+  "i2cDumpDevices": [
+    "/run/devmap/cplds/MCB_CPLD",
+    "/run/devmap/cplds/SCM_CPLD",
+    "/run/devmap/cplds/SMB_CPLD"
+  ],
+  "scPowerGood": {
+    "sysfsAttributes": [
+      {
+        "name": "SMB_POWERGOOD",
+        "path": "/run/devmap/cplds/MCB_CPLD/smb_pg"
+      },
+      {
+        "name": "ASIC_POWERSTATE",
+        "path": "/run/devmap/cplds/SMB_CPLD/th6_pwr_en"
+      }
+    ]
+  }
 }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="486" height="149" alt="image" src="https://github.com/user-attachments/assets/5d6dcf94-0ad0-4133-b9d9-e3f8bfe9f732" />

# Summary

CPLD information and ASIC power state is very important for issue debug. So add the CPLD registers dump and ASIC power state in the showtech. Dump MCB_CPLD, SCM_CPLD and SMB_CPLD info. Add SMB power good info "smb_pg" and TH6 ASIC power state info "th6_pwr_en".

# Test Plan

showtech log:
<img width="422" height="881" alt="image" src="https://github.com/user-attachments/assets/f7fbd000-daf0-4ba2-a20e-9013ada2b7a8" />
<img width="257" height="73" alt="image" src="https://github.com/user-attachments/assets/998beaa0-29b4-4dc7-ae9c-feb308f1e081" />

