### PR TITLE
[Nexthop][distro] Update minipack3 default agent.conf

### DIFF
--- a/fboss/oss/scripts/run_configs/default_configs/minipack3/agent.conf
+++ b/fboss/oss/scripts/run_configs/default_configs/minipack3/agent.conf
@@ -1,15 +1,18 @@
 {
   "defaultCommandLineArgs": {
     "check_wb_handles": "true",
+    "cleanup_probed_kernel_data": "true",
     "counter_refresh_interval": "0",
-    "disable_neighbor_updates": "true",
+    "disable_neighbor_updates": "false",
     "ecmp_width": "320",
+    "enable_1to1_intf_route_table_mapping": "true",
+    "enable_acl_table_group": "true",
     "enable_replayer": "true",
     "log_variable_name": "true",
-    "sai_configure_six_tap": "true",
     "multi_switch": "true",
     "publish_state_to_fsdb": "true",
     "publish_stats_to_fsdb": "true",
+    "sai_configure_six_tap": "true",
     "use_full_dlb_scale": "true"
   },
   "sw": {
@@ -17,4572 +20,1472 @@
     "ports": [
       {
         "logicalID": 9,
+        "name": "eth1/1/1",
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2001,
-        "speed": 800000,
-        "name": "eth1/1/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/5/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 39,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 1,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2003,
-        "speed": 200000,
         "name": "eth1/2/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/6/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 5,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2004,
-        "speed": 200000,
-        "name": "eth1/2/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/6/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 11,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2005,
-        "speed": 400000,
         "name": "eth1/3/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/3/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 15,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2006,
-        "speed": 400000,
-        "name": "eth1/3/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/3/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 19,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2007,
-        "speed": 400000,
         "name": "eth1/4/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/4/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 20,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2008,
-        "speed": 400000,
-        "name": "eth1/4/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/4/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 30,
+        "name": "eth1/5/1",
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2009,
-        "speed": 800000,
-        "name": "eth1/5/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/1/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 39,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 22,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2011,
-        "speed": 200000,
         "name": "eth1/6/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/2/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 26,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2012,
-        "speed": 200000,
-        "name": "eth1/6/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/2/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 33,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2013,
-        "speed": 400000,
         "name": "eth1/7/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 37,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2014,
-        "speed": 400000,
-        "name": "eth1/7/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 41,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2015,
-        "speed": 400000,
         "name": "eth1/8/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 42,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2016,
-        "speed": 400000,
-        "name": "eth1/8/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 52,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2017,
-        "speed": 400000,
         "name": "eth1/9/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 53,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2018,
-        "speed": 400000,
-        "name": "eth1/9/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 44,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2019,
-        "speed": 100000,
         "name": "eth1/10/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/14/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 23,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 48,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2020,
-        "speed": 100000,
-        "name": "eth1/10/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/14/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 23,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 55,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2021,
-        "speed": 400000,
         "name": "eth1/11/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 59,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2022,
-        "speed": 400000,
-        "name": "eth1/11/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 63,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2023,
-        "speed": 400000,
         "name": "eth1/12/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/16/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 64,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2024,
-        "speed": 400000,
-        "name": "eth1/12/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/16/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 74,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2025,
-        "speed": 400000,
         "name": "eth1/13/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 75,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2026,
-        "speed": 400000,
-        "name": "eth1/13/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 66,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2027,
-        "speed": 100000,
         "name": "eth1/14/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/10/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 23,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 70,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2028,
-        "speed": 100000,
-        "name": "eth1/14/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/10/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 23,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 77,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2029,
-        "speed": 400000,
         "name": "eth1/15/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 81,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2030,
-        "speed": 400000,
-        "name": "eth1/15/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 85,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2031,
-        "speed": 400000,
         "name": "eth1/16/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/12/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 86,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2032,
-        "speed": 400000,
-        "name": "eth1/16/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/12/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 96,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2033,
-        "speed": 400000,
         "name": "eth1/17/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 97,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2034,
-        "speed": 400000,
-        "name": "eth1/17/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 88,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2035,
-        "speed": 400000,
         "name": "eth1/18/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/22/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 92,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2036,
-        "speed": 400000,
-        "name": "eth1/18/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/22/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 99,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2037,
-        "speed": 400000,
         "name": "eth1/19/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 103,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2038,
-        "speed": 400000,
-        "name": "eth1/19/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 107,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2039,
-        "speed": 200000,
         "name": "eth1/20/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/24/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 108,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2040,
-        "speed": 400000,
-        "name": "eth1/20/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/24/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 118,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2041,
-        "speed": 400000,
         "name": "eth1/21/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 119,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2042,
-        "speed": 400000,
-        "name": "eth1/21/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 110,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2043,
-        "speed": 400000,
         "name": "eth1/22/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/18/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 114,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2044,
-        "speed": 400000,
-        "name": "eth1/22/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/18/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 121,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2045,
-        "speed": 400000,
         "name": "eth1/23/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 125,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2046,
-        "speed": 400000,
-        "name": "eth1/23/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 129,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2047,
-        "speed": 200000,
         "name": "eth1/24/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/20/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 130,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2048,
-        "speed": 400000,
-        "name": "eth1/24/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/20/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 140,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2049,
-        "speed": 400000,
         "name": "eth1/25/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 141,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2050,
-        "speed": 400000,
-        "name": "eth1/25/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 132,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2051,
-        "speed": 100000,
         "name": "eth1/26/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/26/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 47,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 136,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2052,
-        "speed": 100000,
-        "name": "eth1/26/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/26/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 47,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 143,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2053,
-        "speed": 400000,
         "name": "eth1/27/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/32/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 147,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2054,
-        "speed": 400000,
-        "name": "eth1/27/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/32/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 151,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2055,
-        "speed": 400000,
         "name": "eth1/28/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 152,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2056,
-        "speed": 400000,
-        "name": "eth1/28/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 162,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2057,
-        "speed": 400000,
         "name": "eth1/29/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 163,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2058,
-        "speed": 400000,
-        "name": "eth1/29/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 154,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2059,
-        "speed": 400000,
         "name": "eth1/30/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/30/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 158,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2060,
-        "speed": 400000,
-        "name": "eth1/30/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/30/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 165,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2061,
-        "speed": 400000,
         "name": "eth1/31/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 169,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2062,
-        "speed": 400000,
-        "name": "eth1/31/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 173,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2063,
-        "speed": 400000,
         "name": "eth1/32/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/27/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 174,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2064,
-        "speed": 400000,
-        "name": "eth1/32/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/27/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 184,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2065,
-        "speed": 400000,
         "name": "eth1/33/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 185,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2066,
-        "speed": 400000,
-        "name": "eth1/33/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 176,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2067,
-        "speed": 400000,
         "name": "eth1/34/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 180,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2068,
-        "speed": 400000,
-        "name": "eth1/34/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 187,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2069,
-        "speed": 400000,
         "name": "eth1/35/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 191,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2070,
-        "speed": 400000,
-        "name": "eth1/35/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 195,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2071,
-        "speed": 400000,
         "name": "eth1/36/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 196,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2072,
-        "speed": 400000,
-        "name": "eth1/36/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 206,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2073,
-        "speed": 400000,
         "name": "eth1/37/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 207,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2074,
-        "speed": 400000,
-        "name": "eth1/37/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 198,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2075,
-        "speed": 400000,
         "name": "eth1/38/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 202,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2076,
-        "speed": 400000,
-        "name": "eth1/38/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 209,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2077,
-        "speed": 400000,
         "name": "eth1/39/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 213,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2078,
-        "speed": 400000,
-        "name": "eth1/39/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 217,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2079,
-        "speed": 400000,
         "name": "eth1/40/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/40/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 218,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2080,
-        "speed": 400000,
-        "name": "eth1/40/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/40/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 228,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2081,
-        "speed": 400000,
         "name": "eth1/41/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/42/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 229,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2082,
-        "speed": 400000,
-        "name": "eth1/41/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/42/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 220,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2083,
-        "speed": 400000,
         "name": "eth1/42/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/41/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 224,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2084,
-        "speed": 400000,
-        "name": "eth1/42/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/41/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 231,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2085,
-        "speed": 200000,
         "name": "eth1/43/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/44/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 235,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2086,
-        "speed": 400000,
-        "name": "eth1/43/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/44/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 239,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2087,
-        "speed": 200000,
         "name": "eth1/44/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/43/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 240,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2088,
-        "speed": 400000,
-        "name": "eth1/44/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/43/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 250,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2089,
-        "speed": 200000,
         "name": "eth1/45/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/49/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 251,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2090,
-        "speed": 400000,
-        "name": "eth1/45/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/49/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 242,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2091,
-        "speed": 400000,
         "name": "eth1/46/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 246,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2092,
-        "speed": 400000,
-        "name": "eth1/46/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 253,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2093,
-        "speed": 400000,
         "name": "eth1/47/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 257,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2094,
-        "speed": 400000,
-        "name": "eth1/47/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 261,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2095,
-        "speed": 400000,
         "name": "eth1/48/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 262,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2096,
-        "speed": 400000,
-        "name": "eth1/48/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 272,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2097,
-        "speed": 200000,
         "name": "eth1/49/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/45/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 25,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 273,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2098,
-        "speed": 400000,
-        "name": "eth1/49/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/45/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 264,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2099,
-        "speed": 400000,
         "name": "eth1/50/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 268,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2100,
-        "speed": 400000,
-        "name": "eth1/50/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 275,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2101,
-        "speed": 400000,
         "name": "eth1/51/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 279,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2102,
-        "speed": 400000,
-        "name": "eth1/51/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 283,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2103,
-        "speed": 400000,
         "name": "eth1/52/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 284,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2104,
-        "speed": 400000,
-        "name": "eth1/52/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 294,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2105,
-        "speed": 400000,
         "name": "eth1/53/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 295,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2106,
-        "speed": 400000,
-        "name": "eth1/53/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 286,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2107,
-        "speed": 400000,
         "name": "eth1/54/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 290,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2108,
-        "speed": 400000,
-        "name": "eth1/54/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 297,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2109,
-        "speed": 400000,
         "name": "eth1/55/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 301,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2110,
-        "speed": 400000,
-        "name": "eth1/55/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 305,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2111,
-        "speed": 400000,
         "name": "eth1/56/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 306,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2112,
-        "speed": 400000,
-        "name": "eth1/56/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 316,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2113,
-        "speed": 400000,
         "name": "eth1/57/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 317,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2114,
-        "speed": 400000,
-        "name": "eth1/57/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 308,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2115,
-        "speed": 400000,
         "name": "eth1/58/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/59/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 312,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2116,
-        "speed": 400000,
-        "name": "eth1/58/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/59/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 319,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2117,
-        "speed": 400000,
         "name": "eth1/59/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/58/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 323,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2118,
-        "speed": 400000,
-        "name": "eth1/59/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/58/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 327,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2119,
-        "speed": 400000,
         "name": "eth1/60/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 328,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2120,
-        "speed": 400000,
-        "name": "eth1/60/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 338,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2121,
-        "speed": 400000,
         "name": "eth1/61/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/61/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 339,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2122,
-        "speed": 400000,
-        "name": "eth1/61/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/61/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 330,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2123,
-        "speed": 400000,
         "name": "eth1/62/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 334,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2124,
-        "speed": 400000,
-        "name": "eth1/62/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 341,
-        "state": 1,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2125,
-        "speed": 400000,
         "name": "eth1/63/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 345,
-        "state": 1,
+        "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2126,
-        "speed": 400000,
-        "name": "eth1/63/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
       },
       {
         "logicalID": 349,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2127,
-        "speed": 400000,
         "name": "eth1/64/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/64/5"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
-        "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 350,
         "state": 2,
+        "speed": 800000,
+        "profileID": 39,
         "minFrameSize": 64,
         "maxFrameSize": 9412,
         "parserType": 1,
         "routable": true,
-        "ingressVlan": 2128,
-        "speed": 400000,
-        "name": "eth1/64/5",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
+        "ingressVlan": 4094,
         "pause": {
-          "tx": false,
-          "rx": false
+          "rx": false,
+          "tx": false
         },
         "sFlowIngressRate": 0,
         "sFlowEgressRate": 0,
         "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/64/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 38,
         "portType": 0,
-        "expectedNeighborReachability": [
-
-        ],
-        "drainState": 0,
-        "scope": 0,
-        "conditionalEntropyRehash": false
-      },
-      {
-        "logicalID": 351,
-        "state": 2,
-        "minFrameSize": 64,
-        "maxFrameSize": 9412,
-        "parserType": 1,
-        "routable": true,
-        "ingressVlan": 2200,
-        "speed": 100000,
-        "name": "eth1/65/1",
-        "description": "",
-        "queues_DEPRECATED": [
-
-        ],
-        "pause": {
-          "tx": false,
-          "rx": false
-        },
-        "sFlowIngressRate": 0,
-        "sFlowEgressRate": 0,
-        "loopbackMode": 0,
-        "expectedLLDPValues": {
-          "2": "eth1/65/1"
-        },
-        "lookupClasses": [
-
-        ],
-        "profileID": 23,
-        "portType": 4,
-        "expectedNeighborReachability": [
-
-        ],
         "drainState": 0,
         "scope": 0,
         "conditionalEntropyRehash": false
@@ -4594,3719 +1497,732 @@
         "id": 10,
         "recordStats": true,
         "routable": true,
-        "ipAddresses": [
-
-        ]
+        "ipAddresses": []
       },
       {
         "name": "default",
         "id": 4094,
         "recordStats": true,
         "routable": false,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2001",
-        "id": 2001,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2003",
-        "id": 2003,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2004",
-        "id": 2004,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2005",
-        "id": 2005,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2006",
-        "id": 2006,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2007",
-        "id": 2007,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2008",
-        "id": 2008,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2009",
-        "id": 2009,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2011",
-        "id": 2011,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2012",
-        "id": 2012,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2013",
-        "id": 2013,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2014",
-        "id": 2014,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2015",
-        "id": 2015,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2016",
-        "id": 2016,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2017",
-        "id": 2017,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2018",
-        "id": 2018,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2019",
-        "id": 2019,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2020",
-        "id": 2020,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2021",
-        "id": 2021,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2022",
-        "id": 2022,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2023",
-        "id": 2023,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2024",
-        "id": 2024,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2025",
-        "id": 2025,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2026",
-        "id": 2026,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2027",
-        "id": 2027,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2028",
-        "id": 2028,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2029",
-        "id": 2029,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2030",
-        "id": 2030,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2031",
-        "id": 2031,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2032",
-        "id": 2032,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2033",
-        "id": 2033,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2034",
-        "id": 2034,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2035",
-        "id": 2035,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2036",
-        "id": 2036,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2037",
-        "id": 2037,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2038",
-        "id": 2038,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2039",
-        "id": 2039,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2040",
-        "id": 2040,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2041",
-        "id": 2041,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2042",
-        "id": 2042,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2043",
-        "id": 2043,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2044",
-        "id": 2044,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2045",
-        "id": 2045,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2046",
-        "id": 2046,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2047",
-        "id": 2047,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2048",
-        "id": 2048,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2049",
-        "id": 2049,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2050",
-        "id": 2050,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2051",
-        "id": 2051,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2052",
-        "id": 2052,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2053",
-        "id": 2053,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2054",
-        "id": 2054,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2055",
-        "id": 2055,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2056",
-        "id": 2056,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2057",
-        "id": 2057,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2058",
-        "id": 2058,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2059",
-        "id": 2059,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2060",
-        "id": 2060,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2061",
-        "id": 2061,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2062",
-        "id": 2062,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2063",
-        "id": 2063,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2064",
-        "id": 2064,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2065",
-        "id": 2065,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2066",
-        "id": 2066,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2067",
-        "id": 2067,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2068",
-        "id": 2068,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2069",
-        "id": 2069,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2070",
-        "id": 2070,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2071",
-        "id": 2071,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2072",
-        "id": 2072,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2073",
-        "id": 2073,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2074",
-        "id": 2074,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2075",
-        "id": 2075,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2076",
-        "id": 2076,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2077",
-        "id": 2077,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2078",
-        "id": 2078,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2079",
-        "id": 2079,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2080",
-        "id": 2080,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2081",
-        "id": 2081,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2082",
-        "id": 2082,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2083",
-        "id": 2083,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2084",
-        "id": 2084,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2085",
-        "id": 2085,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2086",
-        "id": 2086,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2087",
-        "id": 2087,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2088",
-        "id": 2088,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2089",
-        "id": 2089,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2090",
-        "id": 2090,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2091",
-        "id": 2091,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2092",
-        "id": 2092,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2093",
-        "id": 2093,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2094",
-        "id": 2094,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2095",
-        "id": 2095,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2096",
-        "id": 2096,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2097",
-        "id": 2097,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2098",
-        "id": 2098,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2099",
-        "id": 2099,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2100",
-        "id": 2100,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2101",
-        "id": 2101,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2102",
-        "id": 2102,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2103",
-        "id": 2103,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2104",
-        "id": 2104,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2105",
-        "id": 2105,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2106",
-        "id": 2106,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2107",
-        "id": 2107,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2108",
-        "id": 2108,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2109",
-        "id": 2109,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2110",
-        "id": 2110,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2111",
-        "id": 2111,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2112",
-        "id": 2112,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2113",
-        "id": 2113,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2114",
-        "id": 2114,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2115",
-        "id": 2115,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2116",
-        "id": 2116,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2117",
-        "id": 2117,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2118",
-        "id": 2118,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2119",
-        "id": 2119,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2120",
-        "id": 2120,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2121",
-        "id": 2121,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2122",
-        "id": 2122,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2123",
-        "id": 2123,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2124",
-        "id": 2124,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2125",
-        "id": 2125,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2126",
-        "id": 2126,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2127",
-        "id": 2127,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2128",
-        "id": 2128,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
-      },
-      {
-        "name": "vlan2200",
-        "id": 2200,
-        "recordStats": true,
-        "routable": true,
-        "ipAddresses": [
-
-        ]
+        "ipAddresses": []
       }
     ],
-    "vlanPorts": [
-      {
-        "vlanID": 2001,
-        "logicalPort": 9,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2003,
-        "logicalPort": 1,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2004,
-        "logicalPort": 5,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2005,
-        "logicalPort": 11,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2006,
-        "logicalPort": 15,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2007,
-        "logicalPort": 19,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2008,
-        "logicalPort": 20,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2009,
-        "logicalPort": 30,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2011,
-        "logicalPort": 22,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2012,
-        "logicalPort": 26,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2013,
-        "logicalPort": 33,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2014,
-        "logicalPort": 37,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2015,
-        "logicalPort": 41,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2016,
-        "logicalPort": 42,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2017,
-        "logicalPort": 52,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2018,
-        "logicalPort": 53,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2019,
-        "logicalPort": 44,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2020,
-        "logicalPort": 48,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2021,
-        "logicalPort": 55,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2022,
-        "logicalPort": 59,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2023,
-        "logicalPort": 63,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2024,
-        "logicalPort": 64,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2025,
-        "logicalPort": 74,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2026,
-        "logicalPort": 75,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2027,
-        "logicalPort": 66,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2028,
-        "logicalPort": 70,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2029,
-        "logicalPort": 77,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2030,
-        "logicalPort": 81,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2031,
-        "logicalPort": 85,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2032,
-        "logicalPort": 86,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2033,
-        "logicalPort": 96,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2034,
-        "logicalPort": 97,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2035,
-        "logicalPort": 88,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2036,
-        "logicalPort": 92,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2037,
-        "logicalPort": 99,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2038,
-        "logicalPort": 103,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2039,
-        "logicalPort": 107,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2040,
-        "logicalPort": 108,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2041,
-        "logicalPort": 118,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2042,
-        "logicalPort": 119,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2043,
-        "logicalPort": 110,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2044,
-        "logicalPort": 114,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2045,
-        "logicalPort": 121,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2046,
-        "logicalPort": 125,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2047,
-        "logicalPort": 129,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2048,
-        "logicalPort": 130,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2049,
-        "logicalPort": 140,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2050,
-        "logicalPort": 141,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2051,
-        "logicalPort": 132,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2052,
-        "logicalPort": 136,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2053,
-        "logicalPort": 143,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2054,
-        "logicalPort": 147,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2055,
-        "logicalPort": 151,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2056,
-        "logicalPort": 152,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2057,
-        "logicalPort": 162,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2058,
-        "logicalPort": 163,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2059,
-        "logicalPort": 154,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2060,
-        "logicalPort": 158,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2061,
-        "logicalPort": 165,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2062,
-        "logicalPort": 169,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2063,
-        "logicalPort": 173,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2064,
-        "logicalPort": 174,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2065,
-        "logicalPort": 184,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2066,
-        "logicalPort": 185,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2067,
-        "logicalPort": 176,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2068,
-        "logicalPort": 180,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2069,
-        "logicalPort": 187,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2070,
-        "logicalPort": 191,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2071,
-        "logicalPort": 195,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2072,
-        "logicalPort": 196,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2073,
-        "logicalPort": 206,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2074,
-        "logicalPort": 207,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2075,
-        "logicalPort": 198,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2076,
-        "logicalPort": 202,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2077,
-        "logicalPort": 209,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2078,
-        "logicalPort": 213,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2079,
-        "logicalPort": 217,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2080,
-        "logicalPort": 218,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2081,
-        "logicalPort": 228,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2082,
-        "logicalPort": 229,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2083,
-        "logicalPort": 220,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2084,
-        "logicalPort": 224,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2085,
-        "logicalPort": 231,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2086,
-        "logicalPort": 235,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2087,
-        "logicalPort": 239,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2088,
-        "logicalPort": 240,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2089,
-        "logicalPort": 250,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2090,
-        "logicalPort": 251,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2091,
-        "logicalPort": 242,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2092,
-        "logicalPort": 246,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2093,
-        "logicalPort": 253,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2094,
-        "logicalPort": 257,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2095,
-        "logicalPort": 261,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2096,
-        "logicalPort": 262,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2097,
-        "logicalPort": 272,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2098,
-        "logicalPort": 273,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2099,
-        "logicalPort": 264,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2100,
-        "logicalPort": 268,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2101,
-        "logicalPort": 275,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2102,
-        "logicalPort": 279,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2103,
-        "logicalPort": 283,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2104,
-        "logicalPort": 284,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2105,
-        "logicalPort": 294,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2106,
-        "logicalPort": 295,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2107,
-        "logicalPort": 286,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2108,
-        "logicalPort": 290,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2109,
-        "logicalPort": 297,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2110,
-        "logicalPort": 301,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2111,
-        "logicalPort": 305,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2112,
-        "logicalPort": 306,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2113,
-        "logicalPort": 316,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2114,
-        "logicalPort": 317,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2115,
-        "logicalPort": 308,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2116,
-        "logicalPort": 312,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2117,
-        "logicalPort": 319,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2118,
-        "logicalPort": 323,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2119,
-        "logicalPort": 327,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2120,
-        "logicalPort": 328,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2121,
-        "logicalPort": 338,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2122,
-        "logicalPort": 339,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2123,
-        "logicalPort": 330,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2124,
-        "logicalPort": 334,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2125,
-        "logicalPort": 341,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2126,
-        "logicalPort": 345,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2127,
-        "logicalPort": 349,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2128,
-        "logicalPort": 350,
-        "spanningTreeState": 2,
-        "emitTags": false
-      },
-      {
-        "vlanID": 2200,
-        "logicalPort": 351,
-        "spanningTreeState": 2,
-        "emitTags": false
-      }
-    ],
+    "vlanPorts": [],
     "defaultVlan": 4094,
     "interfaces": [
       {
+        "intfID": 10,
+        "routerID": 0,
+        "vlanID": 10,
+        "ipAddresses": [],
+        "mtu": 9412,
+        "isVirtual": true,
+        "isStateSyncDisabled": false,
+        "type": 1,
+        "scope": 0
+      },
+      {
         "intfID": 2001,
         "routerID": 0,
-        "vlanID": 2001,
-        "ipAddresses": [
-          "2400::/64",
-          "10.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 9,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
+        "scope": 0
+      },
+      {
+        "intfID": 2002,
+        "routerID": 0,
+        "portID": 1,
+        "ipAddresses": [],
+        "mtu": 9412,
+        "isVirtual": false,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2003,
         "routerID": 0,
-        "vlanID": 2003,
-        "ipAddresses": [
-          "2401::/64",
-          "11.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 11,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2004,
         "routerID": 0,
-        "vlanID": 2004,
-        "ipAddresses": [
-          "2402::/64",
-          "12.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 19,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2005,
         "routerID": 0,
-        "vlanID": 2005,
-        "ipAddresses": [
-          "2403::/64",
-          "13.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 30,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2006,
         "routerID": 0,
-        "vlanID": 2006,
-        "ipAddresses": [
-          "2404::/64",
-          "14.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 22,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2007,
         "routerID": 0,
-        "vlanID": 2007,
-        "ipAddresses": [
-          "2405::/64",
-          "15.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 33,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2008,
         "routerID": 0,
-        "vlanID": 2008,
-        "ipAddresses": [
-          "2406::/64",
-          "16.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 41,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2009,
         "routerID": 0,
-        "vlanID": 2009,
-        "ipAddresses": [
-          "2407::/64",
-          "17.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 52,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
+        "scope": 0
+      },
+      {
+        "intfID": 2010,
+        "routerID": 0,
+        "portID": 44,
+        "ipAddresses": [],
+        "mtu": 9412,
+        "isVirtual": false,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2011,
         "routerID": 0,
-        "vlanID": 2011,
-        "ipAddresses": [
-          "2408::/64",
-          "18.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 55,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2012,
         "routerID": 0,
-        "vlanID": 2012,
-        "ipAddresses": [
-          "2409::/64",
-          "19.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 63,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2013,
         "routerID": 0,
-        "vlanID": 2013,
-        "ipAddresses": [
-          "2410::/64",
-          "20.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 74,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2014,
         "routerID": 0,
-        "vlanID": 2014,
-        "ipAddresses": [
-          "2411::/64",
-          "21.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 66,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2015,
         "routerID": 0,
-        "vlanID": 2015,
-        "ipAddresses": [
-          "2412::/64",
-          "22.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 77,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2016,
         "routerID": 0,
-        "vlanID": 2016,
-        "ipAddresses": [
-          "2413::/64",
-          "23.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 85,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2017,
         "routerID": 0,
-        "vlanID": 2017,
-        "ipAddresses": [
-          "2414::/64",
-          "24.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 96,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2018,
         "routerID": 0,
-        "vlanID": 2018,
-        "ipAddresses": [
-          "2415::/64",
-          "25.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 88,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2019,
         "routerID": 0,
-        "vlanID": 2019,
-        "ipAddresses": [
-          "2416::/64",
-          "26.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 99,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2020,
         "routerID": 0,
-        "vlanID": 2020,
-        "ipAddresses": [
-          "2417::/64",
-          "27.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 107,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2021,
         "routerID": 0,
-        "vlanID": 2021,
-        "ipAddresses": [
-          "2418::/64",
-          "28.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 118,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2022,
         "routerID": 0,
-        "vlanID": 2022,
-        "ipAddresses": [
-          "2419::/64",
-          "29.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 110,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2023,
         "routerID": 0,
-        "vlanID": 2023,
-        "ipAddresses": [
-          "2420::/64",
-          "30.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 121,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2024,
         "routerID": 0,
-        "vlanID": 2024,
-        "ipAddresses": [
-          "2421::/64",
-          "31.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 129,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2025,
         "routerID": 0,
-        "vlanID": 2025,
-        "ipAddresses": [
-          "2422::/64",
-          "32.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 140,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2026,
         "routerID": 0,
-        "vlanID": 2026,
-        "ipAddresses": [
-          "2423::/64",
-          "33.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 132,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2027,
         "routerID": 0,
-        "vlanID": 2027,
-        "ipAddresses": [
-          "2424::/64",
-          "34.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 143,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2028,
         "routerID": 0,
-        "vlanID": 2028,
-        "ipAddresses": [
-          "2425::/64",
-          "35.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 151,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2029,
         "routerID": 0,
-        "vlanID": 2029,
-        "ipAddresses": [
-          "2426::/64",
-          "36.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 162,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2030,
         "routerID": 0,
-        "vlanID": 2030,
-        "ipAddresses": [
-          "2427::/64",
-          "37.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 154,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2031,
         "routerID": 0,
-        "vlanID": 2031,
-        "ipAddresses": [
-          "2428::/64",
-          "38.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 165,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2032,
         "routerID": 0,
-        "vlanID": 2032,
-        "ipAddresses": [
-          "2429::/64",
-          "39.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 173,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2033,
         "routerID": 0,
-        "vlanID": 2033,
-        "ipAddresses": [
-          "2430::/64",
-          "40.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 184,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2034,
         "routerID": 0,
-        "vlanID": 2034,
-        "ipAddresses": [
-          "2431::/64",
-          "41.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 176,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2035,
         "routerID": 0,
-        "vlanID": 2035,
-        "ipAddresses": [
-          "2432::/64",
-          "42.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 187,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2036,
         "routerID": 0,
-        "vlanID": 2036,
-        "ipAddresses": [
-          "2433::/64",
-          "43.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 195,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2037,
         "routerID": 0,
-        "vlanID": 2037,
-        "ipAddresses": [
-          "2434::/64",
-          "44.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 206,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2038,
         "routerID": 0,
-        "vlanID": 2038,
-        "ipAddresses": [
-          "2435::/64",
-          "45.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 198,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2039,
         "routerID": 0,
-        "vlanID": 2039,
-        "ipAddresses": [
-          "2436::/64",
-          "46.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 209,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2040,
         "routerID": 0,
-        "vlanID": 2040,
-        "ipAddresses": [
-          "2437::/64",
-          "47.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 217,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2041,
         "routerID": 0,
-        "vlanID": 2041,
-        "ipAddresses": [
-          "2438::/64",
-          "48.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 228,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2042,
         "routerID": 0,
-        "vlanID": 2042,
-        "ipAddresses": [
-          "2439::/64",
-          "49.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 220,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2043,
         "routerID": 0,
-        "vlanID": 2043,
-        "ipAddresses": [
-          "2440::/64",
-          "50.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 231,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2044,
         "routerID": 0,
-        "vlanID": 2044,
-        "ipAddresses": [
-          "2441::/64",
-          "51.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 239,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2045,
         "routerID": 0,
-        "vlanID": 2045,
-        "ipAddresses": [
-          "2442::/64",
-          "52.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 250,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2046,
         "routerID": 0,
-        "vlanID": 2046,
-        "ipAddresses": [
-          "2443::/64",
-          "53.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 242,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2047,
         "routerID": 0,
-        "vlanID": 2047,
-        "ipAddresses": [
-          "2444::/64",
-          "54.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 253,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2048,
         "routerID": 0,
-        "vlanID": 2048,
-        "ipAddresses": [
-          "2445::/64",
-          "55.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 261,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2049,
         "routerID": 0,
-        "vlanID": 2049,
-        "ipAddresses": [
-          "2446::/64",
-          "56.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 272,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2050,
         "routerID": 0,
-        "vlanID": 2050,
-        "ipAddresses": [
-          "2447::/64",
-          "57.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 264,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2051,
         "routerID": 0,
-        "vlanID": 2051,
-        "ipAddresses": [
-          "2448::/64",
-          "58.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 275,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2052,
         "routerID": 0,
-        "vlanID": 2052,
-        "ipAddresses": [
-          "2449::/64",
-          "59.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 283,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2053,
         "routerID": 0,
-        "vlanID": 2053,
-        "ipAddresses": [
-          "2450::/64",
-          "60.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 294,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2054,
         "routerID": 0,
-        "vlanID": 2054,
-        "ipAddresses": [
-          "2451::/64",
-          "61.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 286,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2055,
         "routerID": 0,
-        "vlanID": 2055,
-        "ipAddresses": [
-          "2452::/64",
-          "62.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 297,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2056,
         "routerID": 0,
-        "vlanID": 2056,
-        "ipAddresses": [
-          "2453::/64",
-          "63.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 305,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2057,
         "routerID": 0,
-        "vlanID": 2057,
-        "ipAddresses": [
-          "2454::/64",
-          "64.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 316,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2058,
         "routerID": 0,
-        "vlanID": 2058,
-        "ipAddresses": [
-          "2455::/64",
-          "65.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 308,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2059,
         "routerID": 0,
-        "vlanID": 2059,
-        "ipAddresses": [
-          "2456::/64",
-          "66.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 319,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2060,
         "routerID": 0,
-        "vlanID": 2060,
-        "ipAddresses": [
-          "2457::/64",
-          "67.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 327,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2061,
         "routerID": 0,
-        "vlanID": 2061,
-        "ipAddresses": [
-          "2458::/64",
-          "68.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 338,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2062,
         "routerID": 0,
-        "vlanID": 2062,
-        "ipAddresses": [
-          "2459::/64",
-          "69.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 330,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2063,
         "routerID": 0,
-        "vlanID": 2063,
-        "ipAddresses": [
-          "2460::/64",
-          "70.0.0.0/24"
-        ],
-        "mtu": 9000,
+        "portID": 341,
+        "ipAddresses": [],
+        "mtu": 9412,
         "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       },
       {
         "intfID": 2064,
         "routerID": 0,
-        "vlanID": 2064,
-        "ipAddresses": [
-          "2461::/64",
-          "71.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2065,
-        "routerID": 0,
-        "vlanID": 2065,
-        "ipAddresses": [
-          "2462::/64",
-          "72.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2066,
-        "routerID": 0,
-        "vlanID": 2066,
-        "ipAddresses": [
-          "2463::/64",
-          "73.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2067,
-        "routerID": 0,
-        "vlanID": 2067,
-        "ipAddresses": [
-          "2464::/64",
-          "74.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2068,
-        "routerID": 0,
-        "vlanID": 2068,
-        "ipAddresses": [
-          "2465::/64",
-          "75.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2069,
-        "routerID": 0,
-        "vlanID": 2069,
-        "ipAddresses": [
-          "2466::/64",
-          "76.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2070,
-        "routerID": 0,
-        "vlanID": 2070,
-        "ipAddresses": [
-          "2467::/64",
-          "77.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2071,
-        "routerID": 0,
-        "vlanID": 2071,
-        "ipAddresses": [
-          "2468::/64",
-          "78.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2072,
-        "routerID": 0,
-        "vlanID": 2072,
-        "ipAddresses": [
-          "2469::/64",
-          "79.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2073,
-        "routerID": 0,
-        "vlanID": 2073,
-        "ipAddresses": [
-          "2470::/64",
-          "80.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2074,
-        "routerID": 0,
-        "vlanID": 2074,
-        "ipAddresses": [
-          "2471::/64",
-          "81.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2075,
-        "routerID": 0,
-        "vlanID": 2075,
-        "ipAddresses": [
-          "2472::/64",
-          "82.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2076,
-        "routerID": 0,
-        "vlanID": 2076,
-        "ipAddresses": [
-          "2473::/64",
-          "83.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2077,
-        "routerID": 0,
-        "vlanID": 2077,
-        "ipAddresses": [
-          "2474::/64",
-          "84.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2078,
-        "routerID": 0,
-        "vlanID": 2078,
-        "ipAddresses": [
-          "2475::/64",
-          "85.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2079,
-        "routerID": 0,
-        "vlanID": 2079,
-        "ipAddresses": [
-          "2476::/64",
-          "86.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2080,
-        "routerID": 0,
-        "vlanID": 2080,
-        "ipAddresses": [
-          "2477::/64",
-          "87.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2081,
-        "routerID": 0,
-        "vlanID": 2081,
-        "ipAddresses": [
-          "2478::/64",
-          "88.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2082,
-        "routerID": 0,
-        "vlanID": 2082,
-        "ipAddresses": [
-          "2479::/64",
-          "89.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2083,
-        "routerID": 0,
-        "vlanID": 2083,
-        "ipAddresses": [
-          "2480::/64",
-          "90.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2084,
-        "routerID": 0,
-        "vlanID": 2084,
-        "ipAddresses": [
-          "2481::/64",
-          "91.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2085,
-        "routerID": 0,
-        "vlanID": 2085,
-        "ipAddresses": [
-          "2482::/64",
-          "92.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2086,
-        "routerID": 0,
-        "vlanID": 2086,
-        "ipAddresses": [
-          "2483::/64",
-          "93.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2087,
-        "routerID": 0,
-        "vlanID": 2087,
-        "ipAddresses": [
-          "2484::/64",
-          "94.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2088,
-        "routerID": 0,
-        "vlanID": 2088,
-        "ipAddresses": [
-          "2485::/64",
-          "95.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2089,
-        "routerID": 0,
-        "vlanID": 2089,
-        "ipAddresses": [
-          "2486::/64",
-          "96.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2090,
-        "routerID": 0,
-        "vlanID": 2090,
-        "ipAddresses": [
-          "2487::/64",
-          "97.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2091,
-        "routerID": 0,
-        "vlanID": 2091,
-        "ipAddresses": [
-          "2488::/64",
-          "98.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2092,
-        "routerID": 0,
-        "vlanID": 2092,
-        "ipAddresses": [
-          "2489::/64",
-          "99.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2093,
-        "routerID": 0,
-        "vlanID": 2093,
-        "ipAddresses": [
-          "2490::/64",
-          "100.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2094,
-        "routerID": 0,
-        "vlanID": 2094,
-        "ipAddresses": [
-          "2491::/64",
-          "101.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2095,
-        "routerID": 0,
-        "vlanID": 2095,
-        "ipAddresses": [
-          "2492::/64",
-          "102.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2096,
-        "routerID": 0,
-        "vlanID": 2096,
-        "ipAddresses": [
-          "2493::/64",
-          "103.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2097,
-        "routerID": 0,
-        "vlanID": 2097,
-        "ipAddresses": [
-          "2494::/64",
-          "104.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2098,
-        "routerID": 0,
-        "vlanID": 2098,
-        "ipAddresses": [
-          "2495::/64",
-          "105.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2099,
-        "routerID": 0,
-        "vlanID": 2099,
-        "ipAddresses": [
-          "2496::/64",
-          "106.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2100,
-        "routerID": 0,
-        "vlanID": 2100,
-        "ipAddresses": [
-          "2497::/64",
-          "107.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2101,
-        "routerID": 0,
-        "vlanID": 2101,
-        "ipAddresses": [
-          "2498::/64",
-          "108.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2102,
-        "routerID": 0,
-        "vlanID": 2102,
-        "ipAddresses": [
-          "2499::/64",
-          "109.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2103,
-        "routerID": 0,
-        "vlanID": 2103,
-        "ipAddresses": [
-          "2500::/64",
-          "110.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2104,
-        "routerID": 0,
-        "vlanID": 2104,
-        "ipAddresses": [
-          "2501::/64",
-          "111.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2105,
-        "routerID": 0,
-        "vlanID": 2105,
-        "ipAddresses": [
-          "2502::/64",
-          "112.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2106,
-        "routerID": 0,
-        "vlanID": 2106,
-        "ipAddresses": [
-          "2503::/64",
-          "113.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2107,
-        "routerID": 0,
-        "vlanID": 2107,
-        "ipAddresses": [
-          "2504::/64",
-          "114.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2108,
-        "routerID": 0,
-        "vlanID": 2108,
-        "ipAddresses": [
-          "2505::/64",
-          "115.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2109,
-        "routerID": 0,
-        "vlanID": 2109,
-        "ipAddresses": [
-          "2506::/64",
-          "116.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2110,
-        "routerID": 0,
-        "vlanID": 2110,
-        "ipAddresses": [
-          "2507::/64",
-          "117.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2111,
-        "routerID": 0,
-        "vlanID": 2111,
-        "ipAddresses": [
-          "2508::/64",
-          "118.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2112,
-        "routerID": 0,
-        "vlanID": 2112,
-        "ipAddresses": [
-          "2509::/64",
-          "119.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2113,
-        "routerID": 0,
-        "vlanID": 2113,
-        "ipAddresses": [
-          "2510::/64",
-          "120.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2114,
-        "routerID": 0,
-        "vlanID": 2114,
-        "ipAddresses": [
-          "2511::/64",
-          "121.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2115,
-        "routerID": 0,
-        "vlanID": 2115,
-        "ipAddresses": [
-          "2512::/64",
-          "122.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2116,
-        "routerID": 0,
-        "vlanID": 2116,
-        "ipAddresses": [
-          "2513::/64",
-          "123.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2117,
-        "routerID": 0,
-        "vlanID": 2117,
-        "ipAddresses": [
-          "2514::/64",
-          "124.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2118,
-        "routerID": 0,
-        "vlanID": 2118,
-        "ipAddresses": [
-          "2515::/64",
-          "125.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2119,
-        "routerID": 0,
-        "vlanID": 2119,
-        "ipAddresses": [
-          "2516::/64",
-          "126.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2120,
-        "routerID": 0,
-        "vlanID": 2120,
-        "ipAddresses": [
-          "2517::/64",
-          "127.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2121,
-        "routerID": 0,
-        "vlanID": 2121,
-        "ipAddresses": [
-          "2518::/64",
-          "128.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2122,
-        "routerID": 0,
-        "vlanID": 2122,
-        "ipAddresses": [
-          "2519::/64",
-          "129.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2123,
-        "routerID": 0,
-        "vlanID": 2123,
-        "ipAddresses": [
-          "2520::/64",
-          "130.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2124,
-        "routerID": 0,
-        "vlanID": 2124,
-        "ipAddresses": [
-          "2521::/64",
-          "131.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2125,
-        "routerID": 0,
-        "vlanID": 2125,
-        "ipAddresses": [
-          "2522::/64",
-          "132.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2126,
-        "routerID": 0,
-        "vlanID": 2126,
-        "ipAddresses": [
-          "2523::/64",
-          "133.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2127,
-        "routerID": 0,
-        "vlanID": 2127,
-        "ipAddresses": [
-          "2524::/64",
-          "134.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2128,
-        "routerID": 0,
-        "vlanID": 2128,
-        "ipAddresses": [
-          "2525::/64",
-          "135.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": false,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 2200,
-        "routerID": 0,
-        "vlanID": 2200,
-        "ipAddresses": [
-          "2526::/64",
-          "136.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": true,
-        "isStateSyncDisabled": true,
-        "type": 1,
-        "scope": 0
-      },
-      {
-        "intfID": 10,
-        "routerID": 0,
-        "vlanID": 10,
-        "ipAddresses": [
-          "2527::/64",
-          "137.0.0.0/24"
-        ],
-        "mtu": 9000,
-        "isVirtual": true,
-        "isStateSyncDisabled": true,
-        "type": 1,
+        "portID": 349,
+        "ipAddresses": [],
+        "mtu": 9412,
+        "isVirtual": false,
+        "isStateSyncDisabled": false,
+        "type": 3,
         "scope": 0
       }
     ],
@@ -8314,129 +2230,30 @@
     "arpRefreshSeconds": 20,
     "arpAgerInterval": 5,
     "proactiveArp": false,
-    "staticRoutesWithNhops": [
-
-    ],
-    "staticRoutesToNull": [
-
-    ],
-    "staticRoutesToCPU": [
-
-    ],
-    "acls": [
-      {
-        "dscp": 48,
-        "name": "cpuPolicing-high-NetworkControl-dstLocalIp6",
-        "actionType": 1,
-        "lookupClassNeighbor": 2
-      },
-      {
-        "dscp": 48,
-        "name": "cpuPolicing-high-NetworkControl-dstLocalIp4",
-        "actionType": 1,
-        "lookupClassNeighbor": 1
-      },
-      {
-        "dstIp": "ff02::/16",
-        "srcPort": 0,
-        "name": "cpuPolicing-CPU-Port-Mcast-v6",
-        "actionType": 1
-      },
-      {
-        "dstIp": "fe80::/10",
-        "dscp": 48,
-        "name": "cpuPolicing-high-NetworkControl-linkLocal-v6",
-        "actionType": 1
-      },
-      {
-        "dstIp": "ff02::/16",
-        "dscp": 48,
-        "name": "cpuPolicing-high-NetworkControl-ff02::/16",
-        "actionType": 1
-      },
-      {
-        "dstIp": "fe80::/10",
-        "name": "cpuPolicing-mid-linkLocal-v6",
-        "actionType": 1
-      },
-      {
-        "dstIp": "ff02::/16",
-        "name": "cpuPolicing-mid-ff02::/16",
-        "actionType": 1
-      },
-      {
-        "srcIp": "2401:db00::/32",
-        "proto": 6,
-        "name": "ttld-prod-private",
-        "actionType": 1,
-        "ttl": {
-          "value": 128,
-          "mask": 128
-        },
-        "ipType": 3
-      },
-      {
-        "srcIp": "2a03:2880::/32",
-        "proto": 6,
-        "name": "ttld-prod-public",
-        "actionType": 1,
-        "ttl": {
-          "value": 128,
-          "mask": 128
-        },
-        "ipType": 3
-      },
-      {
-        "srcIp": "2803:6080::/29",
-        "proto": 6,
-        "name": "ttld-ip-per-task",
-        "actionType": 1,
-        "ttl": {
-          "value": 128,
-          "mask": 128
-        },
-        "ipType": 3
-      },
-      {
-        "srcIp": "2a03:83e0::/32",
-        "proto": 6,
-        "name": "ttld-onavo-infra",
-        "actionType": 1,
-        "ttl": {
-          "value": 128,
-          "mask": 128
-        },
-        "ipType": 3
-      },
-      {
-        "srcIp": "2620:0000:1c00::/40",
-        "proto": 6,
-        "name": "ttld-interconnect",
-        "actionType": 1,
-        "ttl": {
-          "value": 128,
-          "mask": 128
-        },
-        "ipType": 3
-      }
-    ],
     "maxNeighborProbes": 300,
     "staleEntryInterval": 10,
-    "aggregatePorts": [
-
+    "staticRoutesWithNhops": [],
+    "staticRoutesToNull": [],
+    "staticRoutesToCPU": [],
+    "acls": [],
+    "aclTableGroups": [
+      {
+        "name": "acl-table-group-ingress",
+        "aclTables": [
+          {
+            "name": "AclTable1",
+            "priority": 0,
+            "aclEntries": [],
+            "actionTypes": [],
+            "qualifiers": [],
+            "udfGroups": []
+          }
+        ],
+        "stage": 0
+      }
     ],
-    "clientIdToAdminDistance": {
-      "0": 20,
-      "1": 1,
-      "2": 0,
-      "3": 0,
-      "4": 0,
-      "700": 255,
-      "786": 10
-    },
-    "sFlowCollectors": [
-
-    ],
+    "aggregatePorts": [],
+    "sFlowCollectors": [],
     "cpuQueues": [
       {
         "id": 9,
@@ -8476,105 +2293,6 @@
       }
     ],
     "cpuTrafficPolicy": {
-      "trafficPolicy": {
-        "matchToAction": [
-          {
-            "matcher": "cpuPolicing-high-NetworkControl-dstLocalIp6",
-            "action": {
-              "sendToQueue": {
-                "queueId": 9
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 9
-              },
-              "userDefinedTrap": {
-                "queueId": 9
-              }
-            }
-          },
-          {
-            "matcher": "cpuPolicing-high-NetworkControl-dstLocalIp4",
-            "action": {
-              "sendToQueue": {
-                "queueId": 9
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 9
-              },
-              "userDefinedTrap": {
-                "queueId": 9
-              }
-            }
-          },
-          {
-            "matcher": "cpuPolicing-CPU-Port-Mcast-v6",
-            "action": {
-            }
-          },
-          {
-            "matcher": "cpuPolicing-high-NetworkControl-linkLocal-v6",
-            "action": {
-              "sendToQueue": {
-                "queueId": 9
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 9
-              },
-              "userDefinedTrap": {
-                "queueId": 9
-              }
-            }
-          },
-          {
-            "matcher": "cpuPolicing-high-NetworkControl-ff02::/16",
-            "action": {
-              "sendToQueue": {
-                "queueId": 9
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 9
-              },
-              "userDefinedTrap": {
-                "queueId": 9
-              }
-            }
-          },
-          {
-            "matcher": "cpuPolicing-mid-linkLocal-v6",
-            "action": {
-              "sendToQueue": {
-                "queueId": 2
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 2
-              },
-              "userDefinedTrap": {
-                "queueId": 2
-              }
-            }
-          },
-          {
-            "matcher": "cpuPolicing-mid-ff02::/16",
-            "action": {
-              "sendToQueue": {
-                "queueId": 2
-              },
-              "toCpuAction": 0,
-              "setTc": {
-                "tcValue": 2
-              },
-              "userDefinedTrap": {
-                "queueId": 2
-              }
-            }
-          }
-        ]
-      },
       "rxReasonToQueueOrderedList": [
         {
           "rxReason": 8,
@@ -8646,12 +2364,8 @@
             1,
             2
           ],
-          "mplsFields": [
-
-          ],
-          "udfGroups": [
-
-          ]
+          "mplsFields": [],
+          "udfGroups": []
         },
         "algorithm": 1
       },
@@ -8666,179 +2380,183 @@
             1,
             2
           ],
-          "transportFields": [
-
-          ],
-          "mplsFields": [
-
-          ],
-          "udfGroups": [
-
-          ]
+          "transportFields": [],
+          "mplsFields": [],
+          "udfGroups": []
         },
         "algorithm": 1
       }
     ],
-    "dataPlaneTrafficPolicy": {
-      "matchToAction": [
-        {
-          "matcher": "ttld-prod-private",
-          "action": {
-            "counter": "ttld-prod-private"
-          }
-        },
-        {
-          "matcher": "ttld-prod-public",
-          "action": {
-            "counter": "ttld-prod-public"
-          }
-        },
-        {
-          "matcher": "ttld-ip-per-task",
-          "action": {
-            "counter": "ttld-ip-per-task"
-          }
-        },
-        {
-          "matcher": "ttld-onavo-infra",
-          "action": {
-            "counter": "ttld-onavo-infra"
-          }
-        },
-        {
-          "matcher": "ttld-interconnect",
-          "action": {
-            "counter": "ttld-interconnect"
+    "mirrors": [],
+    "trafficCounters": [],
+    "qosPolicies": [
+      {
+        "name": "default",
+        "qosMap": {
+          "dscpMaps": [
+            {
+              "internalTrafficClass": 0,
+              "fromDscpToTrafficClass": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+              ]
+            },
+            {
+              "internalTrafficClass": 1,
+              "fromDscpToTrafficClass": [
+                8,
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15
+              ]
+            },
+            {
+              "internalTrafficClass": 2,
+              "fromDscpToTrafficClass": [
+                16,
+                17,
+                18,
+                19,
+                20,
+                21,
+                22,
+                23
+              ]
+            },
+            {
+              "internalTrafficClass": 3,
+              "fromDscpToTrafficClass": [
+                24,
+                25,
+                26,
+                27,
+                28,
+                29,
+                30,
+                31
+              ]
+            },
+            {
+              "internalTrafficClass": 4,
+              "fromDscpToTrafficClass": [
+                32,
+                33,
+                34,
+                35,
+                36,
+                37,
+                38,
+                39
+              ]
+            },
+            {
+              "internalTrafficClass": 5,
+              "fromDscpToTrafficClass": [
+                40,
+                41,
+                42,
+                43,
+                44,
+                45,
+                46,
+                47
+              ]
+            },
+            {
+              "internalTrafficClass": 6,
+              "fromDscpToTrafficClass": [
+                48,
+                49,
+                50,
+                51,
+                52,
+                53,
+                54,
+                55
+              ]
+            },
+            {
+              "internalTrafficClass": 7,
+              "fromDscpToTrafficClass": [
+                56,
+                57,
+                58,
+                59,
+                60,
+                61,
+                62,
+                63
+              ]
+            }
+          ],
+          "expMaps": [],
+          "trafficClassToQueueId": {
+            "0": 0,
+            "1": 1,
+            "2": 2,
+            "3": 3,
+            "4": 4,
+            "5": 5,
+            "6": 6,
+            "7": 7
           }
         }
-      ]
-    },
-    "mirrors": [
-
-    ],
-    "trafficCounters": [
-      {
-        "name": "ttld-prod-private",
-        "types": [
-          0,
-          1
-        ]
-      },
-      {
-        "name": "ttld-prod-public",
-        "types": [
-          0,
-          1
-        ]
-      },
-      {
-        "name": "ttld-ip-per-task",
-        "types": [
-          0,
-          1
-        ]
-      },
-      {
-        "name": "ttld-onavo-infra",
-        "types": [
-          0,
-          1
-        ]
-      },
-      {
-        "name": "ttld-interconnect",
-        "types": [
-          0,
-          1
-        ]
       }
     ],
-    "qosPolicies": [
-
-    ],
-    "defaultPortQueues": [
-
-    ],
-    "staticMplsRoutesWithNhops": [
-
-    ],
-    "staticMplsRoutesToNull": [
-
-    ],
-    "staticMplsRoutesToCPU": [
-
-    ],
-    "staticIp2MplsRoutes": [
-
-    ],
-    "portQueueConfigs": {
-
-    },
+    "defaultPortQueues": [],
+    "staticMplsRoutesWithNhops": [],
+    "staticMplsRoutesToNull": [],
+    "staticMplsRoutesToCPU": [],
+    "staticIp2MplsRoutes": [],
+    "portQueueConfigs": {},
     "switchSettings": {
       "l2LearningMode": 0,
       "qcmEnable": false,
       "ptpTcEnable": false,
       "l2AgeTimerSeconds": 300,
       "maxRouteCounterIDs": 0,
-      "blockNeighbors": [
-
-      ],
-      "macAddrsToBlock": [
-
-      ],
+      "blockNeighbors": [],
+      "macAddrsToBlock": [],
       "switchType": 0,
-      "exactMatchTableConfigs": [
-
-      ],
-      "switchIdToSwitchType_DEPRECATED": {
-
-      },
+      "exactMatchTableConfigs": [],
       "switchDrainState": 0,
       "switchIdToSwitchInfo": {
         "0": {
-            "switchType": 0,
-            "asicType": 13,
-            "switchIndex": 0,
-            "portIdRange": {
-              "minimum": 0,
-              "maximum": 2047
-            },
-            "firmwareNameToFirmwareInfo": {
-
-            }
+          "switchType": 0,
+          "asicType": 13,
+          "switchIndex": 0,
+          "portIdRange": {
+            "minimum": 0,
+            "maximum": 2047
+          },
+          "firmwareNameToFirmwareInfo": {}
         }
       },
-      "vendorMacOuis": [
-
-      ],
-      "metaMacOuis": [
-
-      ]
+      "vendorMacOuis": [],
+      "metaMacOuis": [],
+      "needL2EntryForNeighbor": true
     },
-    "sdkVersion": {
-      "asicSdk": "sdk",
-      "saiSdk": "sai"
-    },
-    "dsfNodes": {
-
-    },
-    "defaultVoqConfig": [
-
-    ],
-    "mirrorOnDropReports": [
-
-    ]
+    "dsfNodes": {},
+    "defaultVoqConfig": [],
+    "mirrorOnDropReports": []
   },
   "platform": {
     "chip": {
       "asicConfig": {
         "common": {
-          "yamlConfig": "---\ndevice:\n  0:\n    PC_PM_CORE:\n      ?\n        PC_PM_ID: 1\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x8C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFF\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 2\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x55\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 3\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23016745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x33\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x00\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 4\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x52701634\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAA\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 5\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74305612\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21640357\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF7\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x59\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 6\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x03562147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x29\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 7\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x14567302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 8\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x67315024\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217034\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x53\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 9\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x21403765\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20543176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x48\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 10\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x53062147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x69\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 11\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54067312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 12\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65304721\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x56\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 13\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x21403765\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20543176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x48\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 14\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x53062147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x69\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 15\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54067312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 16\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65304721\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x56\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 17\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65274130\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x87\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 18\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47306521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 19\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02731456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x99\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x07\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 20\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x30472165\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21543076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 21\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45376120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 22\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x40376521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 23\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02731456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x99\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x07\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 24\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x30472165\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21543076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 25\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45376120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 26\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x40376521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 27\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x03762514\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDE\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x03\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 28\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x67125403\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x12470356\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x63\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xB2\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 29\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x22\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 30\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCC\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x00\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 31\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x05371426\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x65\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 32\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23016745\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x9C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFF\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 33\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x46751032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106754\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x55\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 34\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54721036\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x22\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 35\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x63410725\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x93\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 36\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107645\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x77\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 37\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74260351\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13064257\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD8\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x21\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 38\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10573246\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x99\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 39\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47356120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 40\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54217630\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x58\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 41\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01736524\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20365174\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x96\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x52\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 42\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10573246\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xD9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 43\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47356120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 44\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54217630\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x58\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 45\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01746523\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20365174\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x86\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x52\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 46\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10576423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xD9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 47\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x46357102\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 48\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54216703\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x54\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 49\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 50\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 51\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x60\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 52\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01572346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21560347\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 53\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 54\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 55\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x60\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 56\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01572346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21560347\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 57\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 58\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 59\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x20\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 60\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x64207531\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23671045\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0B\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xBB\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 61\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x51740362\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB1\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 62\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23016745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x66\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 63\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x00\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 64\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23016745\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 65\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x3210\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x3210\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x00\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x0F\n        TX_POLARITY_FLIP_AUTO: 0\n...\n---\ndevice:\n  0:\n    PC_PORT_PHYS_MAP:\n      ?\n        PORT_ID: 1\n      :\n        PC_PHYS_PORT_ID: 1\n      ?\n        PORT_ID: 5\n      :\n        PC_PHYS_PORT_ID: 5\n      ?\n        PORT_ID: 9\n      :\n        PC_PHYS_PORT_ID: 9\n      ?\n        PORT_ID: 10\n      :\n        PC_PHYS_PORT_ID: 13\n      ?\n        PORT_ID: 11\n      :\n        PC_PHYS_PORT_ID: 17\n      ?\n        PORT_ID: 15\n      :\n        PC_PHYS_PORT_ID: 21\n      ?\n        PORT_ID: 19\n      :\n        PC_PHYS_PORT_ID: 25\n      ?\n        PORT_ID: 20\n      :\n        PC_PHYS_PORT_ID: 29\n      ?\n        PORT_ID: 22\n      :\n        PC_PHYS_PORT_ID: 33\n      ?\n        PORT_ID: 26\n      :\n        PC_PHYS_PORT_ID: 37\n      ?\n        PORT_ID: 30\n      :\n        PC_PHYS_PORT_ID: 41\n      ?\n        PORT_ID: 31\n      :\n        PC_PHYS_PORT_ID: 45\n      ?\n        PORT_ID: 33\n      :\n        PC_PHYS_PORT_ID: 49\n      ?\n        PORT_ID: 37\n      :\n        PC_PHYS_PORT_ID: 53\n      ?\n        PORT_ID: 41\n      :\n        PC_PHYS_PORT_ID: 57\n      ?\n        PORT_ID: 42\n      :\n        PC_PHYS_PORT_ID: 61\n      ?\n        PORT_ID: 44\n      :\n        PC_PHYS_PORT_ID: 65\n      ?\n        PORT_ID: 48\n      :\n        PC_PHYS_PORT_ID: 69\n      ?\n        PORT_ID: 52\n      :\n        PC_PHYS_PORT_ID: 73\n      ?\n        PORT_ID: 53\n      :\n        PC_PHYS_PORT_ID: 77\n      ?\n        PORT_ID: 55\n      :\n        PC_PHYS_PORT_ID: 81\n      ?\n        PORT_ID: 59\n      :\n        PC_PHYS_PORT_ID: 85\n      ?\n        PORT_ID: 63\n      :\n        PC_PHYS_PORT_ID: 89\n      ?\n        PORT_ID: 64\n      :\n        PC_PHYS_PORT_ID: 93\n      ?\n        PORT_ID: 66\n      :\n        PC_PHYS_PORT_ID: 97\n      ?\n        PORT_ID: 70\n      :\n        PC_PHYS_PORT_ID: 101\n      ?\n        PORT_ID: 74\n      :\n        PC_PHYS_PORT_ID: 105\n      ?\n        PORT_ID: 75\n      :\n        PC_PHYS_PORT_ID: 109\n      ?\n        PORT_ID: 77\n      :\n        PC_PHYS_PORT_ID: 113\n      ?\n        PORT_ID: 81\n      :\n        PC_PHYS_PORT_ID: 117\n      ?\n        PORT_ID: 85\n      :\n        PC_PHYS_PORT_ID: 121\n      ?\n        PORT_ID: 86\n      :\n        PC_PHYS_PORT_ID: 125\n      ?\n        PORT_ID: 88\n      :\n        PC_PHYS_PORT_ID: 129\n      ?\n        PORT_ID: 92\n      :\n        PC_PHYS_PORT_ID: 133\n      ?\n        PORT_ID: 96\n      :\n        PC_PHYS_PORT_ID: 137\n      ?\n        PORT_ID: 97\n      :\n        PC_PHYS_PORT_ID: 141\n      ?\n        PORT_ID: 99\n      :\n        PC_PHYS_PORT_ID: 145\n      ?\n        PORT_ID: 103\n      :\n        PC_PHYS_PORT_ID: 149\n      ?\n        PORT_ID: 107\n      :\n        PC_PHYS_PORT_ID: 153\n      ?\n        PORT_ID: 108\n      :\n        PC_PHYS_PORT_ID: 157\n      ?\n        PORT_ID: 110\n      :\n        PC_PHYS_PORT_ID: 161\n      ?\n        PORT_ID: 114\n      :\n        PC_PHYS_PORT_ID: 165\n      ?\n        PORT_ID: 118\n      :\n        PC_PHYS_PORT_ID: 169\n      ?\n        PORT_ID: 119\n      :\n        PC_PHYS_PORT_ID: 173\n      ?\n        PORT_ID: 121\n      :\n        PC_PHYS_PORT_ID: 177\n      ?\n        PORT_ID: 125\n      :\n        PC_PHYS_PORT_ID: 181\n      ?\n        PORT_ID: 129\n      :\n        PC_PHYS_PORT_ID: 185\n      ?\n        PORT_ID: 130\n      :\n        PC_PHYS_PORT_ID: 189\n      ?\n        PORT_ID: 132\n      :\n        PC_PHYS_PORT_ID: 193\n      ?\n        PORT_ID: 136\n      :\n        PC_PHYS_PORT_ID: 197\n      ?\n        PORT_ID: 140\n      :\n        PC_PHYS_PORT_ID: 201\n      ?\n        PORT_ID: 141\n      :\n        PC_PHYS_PORT_ID: 205\n      ?\n        PORT_ID: 143\n      :\n        PC_PHYS_PORT_ID: 209\n      ?\n        PORT_ID: 147\n      :\n        PC_PHYS_PORT_ID: 213\n      ?\n        PORT_ID: 151\n      :\n        PC_PHYS_PORT_ID: 217\n      ?\n        PORT_ID: 152\n      :\n        PC_PHYS_PORT_ID: 221\n      ?\n        PORT_ID: 154\n      :\n        PC_PHYS_PORT_ID: 225\n      ?\n        PORT_ID: 158\n      :\n        PC_PHYS_PORT_ID: 229\n      ?\n        PORT_ID: 162\n      :\n        PC_PHYS_PORT_ID: 233\n      ?\n        PORT_ID: 163\n      :\n        PC_PHYS_PORT_ID: 237\n      ?\n        PORT_ID: 165\n      :\n        PC_PHYS_PORT_ID: 241\n      ?\n        PORT_ID: 169\n      :\n        PC_PHYS_PORT_ID: 245\n      ?\n        PORT_ID: 173\n      :\n        PC_PHYS_PORT_ID: 249\n      ?\n        PORT_ID: 174\n      :\n        PC_PHYS_PORT_ID: 253\n      ?\n        PORT_ID: 176\n      :\n        PC_PHYS_PORT_ID: 257\n      ?\n        PORT_ID: 180\n      :\n        PC_PHYS_PORT_ID: 261\n      ?\n        PORT_ID: 184\n      :\n        PC_PHYS_PORT_ID: 265\n      ?\n        PORT_ID: 185\n      :\n        PC_PHYS_PORT_ID: 269\n      ?\n        PORT_ID: 187\n      :\n        PC_PHYS_PORT_ID: 273\n      ?\n        PORT_ID: 191\n      :\n        PC_PHYS_PORT_ID: 277\n      ?\n        PORT_ID: 195\n      :\n        PC_PHYS_PORT_ID: 281\n      ?\n        PORT_ID: 196\n      :\n        PC_PHYS_PORT_ID: 285\n      ?\n        PORT_ID: 198\n      :\n        PC_PHYS_PORT_ID: 289\n      ?\n        PORT_ID: 202\n      :\n        PC_PHYS_PORT_ID: 293\n      ?\n        PORT_ID: 206\n      :\n        PC_PHYS_PORT_ID: 297\n      ?\n        PORT_ID: 207\n      :\n        PC_PHYS_PORT_ID: 301\n      ?\n        PORT_ID: 209\n      :\n        PC_PHYS_PORT_ID: 305\n      ?\n        PORT_ID: 213\n      :\n        PC_PHYS_PORT_ID: 309\n      ?\n        PORT_ID: 217\n      :\n        PC_PHYS_PORT_ID: 313\n      ?\n        PORT_ID: 218\n      :\n        PC_PHYS_PORT_ID: 317\n      ?\n        PORT_ID: 220\n      :\n        PC_PHYS_PORT_ID: 321\n      ?\n        PORT_ID: 224\n      :\n        PC_PHYS_PORT_ID: 325\n      ?\n        PORT_ID: 228\n      :\n        PC_PHYS_PORT_ID: 329\n      ?\n        PORT_ID: 229\n      :\n        PC_PHYS_PORT_ID: 333\n      ?\n        PORT_ID: 231\n      :\n        PC_PHYS_PORT_ID: 337\n      ?\n        PORT_ID: 235\n      :\n        PC_PHYS_PORT_ID: 341\n      ?\n        PORT_ID: 239\n      :\n        PC_PHYS_PORT_ID: 345\n      ?\n        PORT_ID: 240\n      :\n        PC_PHYS_PORT_ID: 349\n      ?\n        PORT_ID: 242\n      :\n        PC_PHYS_PORT_ID: 353\n      ?\n        PORT_ID: 246\n      :\n        PC_PHYS_PORT_ID: 357\n      ?\n        PORT_ID: 250\n      :\n        PC_PHYS_PORT_ID: 361\n      ?\n        PORT_ID: 251\n      :\n        PC_PHYS_PORT_ID: 365\n      ?\n        PORT_ID: 253\n      :\n        PC_PHYS_PORT_ID: 369\n      ?\n        PORT_ID: 257\n      :\n        PC_PHYS_PORT_ID: 373\n      ?\n        PORT_ID: 261\n      :\n        PC_PHYS_PORT_ID: 377\n      ?\n        PORT_ID: 262\n      :\n        PC_PHYS_PORT_ID: 381\n      ?\n        PORT_ID: 264\n      :\n        PC_PHYS_PORT_ID: 385\n      ?\n        PORT_ID: 268\n      :\n        PC_PHYS_PORT_ID: 389\n      ?\n        PORT_ID: 272\n      :\n        PC_PHYS_PORT_ID: 393\n      ?\n        PORT_ID: 273\n      :\n        PC_PHYS_PORT_ID: 397\n      ?\n        PORT_ID: 275\n      :\n        PC_PHYS_PORT_ID: 401\n      ?\n        PORT_ID: 279\n      :\n        PC_PHYS_PORT_ID: 405\n      ?\n        PORT_ID: 283\n      :\n        PC_PHYS_PORT_ID: 409\n      ?\n        PORT_ID: 284\n      :\n        PC_PHYS_PORT_ID: 413\n      ?\n        PORT_ID: 286\n      :\n        PC_PHYS_PORT_ID: 417\n      ?\n        PORT_ID: 290\n      :\n        PC_PHYS_PORT_ID: 421\n      ?\n        PORT_ID: 294\n      :\n        PC_PHYS_PORT_ID: 425\n      ?\n        PORT_ID: 295\n      :\n        PC_PHYS_PORT_ID: 429\n      ?\n        PORT_ID: 297\n      :\n        PC_PHYS_PORT_ID: 433\n      ?\n        PORT_ID: 301\n      :\n        PC_PHYS_PORT_ID: 437\n      ?\n        PORT_ID: 305\n      :\n        PC_PHYS_PORT_ID: 441\n      ?\n        PORT_ID: 306\n      :\n        PC_PHYS_PORT_ID: 445\n      ?\n        PORT_ID: 308\n      :\n        PC_PHYS_PORT_ID: 449\n      ?\n        PORT_ID: 312\n      :\n        PC_PHYS_PORT_ID: 453\n      ?\n        PORT_ID: 316\n      :\n        PC_PHYS_PORT_ID: 457\n      ?\n        PORT_ID: 317\n      :\n        PC_PHYS_PORT_ID: 461\n      ?\n        PORT_ID: 319\n      :\n        PC_PHYS_PORT_ID: 465\n      ?\n        PORT_ID: 323\n      :\n        PC_PHYS_PORT_ID: 469\n      ?\n        PORT_ID: 327\n      :\n        PC_PHYS_PORT_ID: 473\n      ?\n        PORT_ID: 328\n      :\n        PC_PHYS_PORT_ID: 477\n      ?\n        PORT_ID: 330\n      :\n        PC_PHYS_PORT_ID: 481\n      ?\n        PORT_ID: 334\n      :\n        PC_PHYS_PORT_ID: 485\n      ?\n        PORT_ID: 338\n      :\n        PC_PHYS_PORT_ID: 489\n      ?\n        PORT_ID: 339\n      :\n        PC_PHYS_PORT_ID: 493\n      ?\n        PORT_ID: 341\n      :\n        PC_PHYS_PORT_ID: 497\n      ?\n        PORT_ID: 345\n      :\n        PC_PHYS_PORT_ID: 501\n      ?\n        PORT_ID: 349\n      :\n        PC_PHYS_PORT_ID: 505\n      ?\n        PORT_ID: 350\n      :\n        PC_PHYS_PORT_ID: 509\n      ?\n        PORT_ID: 0\n      :\n        PC_PHYS_PORT_ID: 0\n      ?\n        PORT_ID: 76\n      :\n        PC_PHYS_PORT_ID: 513\n...\n---\ndevice:\n  0:\n    PC_PORT:\n      ?\n        PORT_ID: 0\n      :\n        ENABLE: 1\n        SPEED: 10000\n        NUM_LANES: 1\n      ?\n        PORT_ID: [[1, 1], [5, 5], [9, 9], [10, 10], [11, 11], [15, 15], [19, 19],\n        [20, 20], [22, 22], [26, 26], [30, 30], [31, 31], [33, 33], [37, 37], [41,\n        41], [42, 42], [44, 44], [48, 48], [52, 52], [53, 53], [55, 55], [59, 59],\n        [63, 63], [64, 64], [66, 66], [70, 70], [74, 74], [75, 75], [77, 77], [81,\n        81], [85, 85], [86, 86], [88, 88], [92, 92], [96, 96], [97, 97], [99, 99],\n        [103, 103], [107, 107], [108, 108], [110, 110], [114, 114], [118, 118], [119,\n        119], [121, 121], [125, 125], [129, 129], [130, 130], [132, 132], [136, 136],\n        [140, 140], [141, 141], [143, 143], [147, 147], [151, 151], [152, 152], [154,\n        154], [158, 158], [162, 162], [163, 163], [165, 165], [169, 169], [173, 173],\n        [174, 174], [176, 176], [180, 180], [184, 184], [185, 185], [187, 187], [191,\n        191], [195, 195], [196, 196], [198, 198], [202, 202], [206, 206], [207, 207],\n        [209, 209], [213, 213], [217, 217], [218, 218], [220, 220], [224, 224], [228,\n        228], [229, 229], [231, 231], [235, 235], [239, 239], [240, 240], [242, 242],\n        [246, 246], [250, 250], [251, 251], [253, 253], [257, 257], [261, 261], [262,\n        262], [264, 264], [268, 268], [272, 272], [273, 273], [275, 275], [279, 279],\n        [283, 283], [284, 284], [286, 286], [290, 290], [294, 294], [295, 295], [297,\n        297], [301, 301], [305, 305], [306, 306], [308, 308], [312, 312], [316, 316],\n        [317, 317], [319, 319], [323, 323], [327, 327], [328, 328], [330, 330], [334,\n        334], [338, 338], [339, 339], [341, 341], [345, 345], [349, 349], [350, 350]]\n      :\n        ENABLE: 0\n        SPEED: 400000\n        NUM_LANES: 4\n        FEC_MODE: PC_FEC_RS544_2XN\n        MAX_FRAME_SIZE: 9416\n      ?\n        PORT_ID: 76\n      :\n        ENABLE: 0\n        SPEED: 100000\n        NUM_LANES: 4\n        FEC_MODE: PC_FEC_RS528\n        MAX_FRAME_SIZE: 9416\n...\n---\ndevice:\n  0:\n    PORT_CONFIG:\n      PORT_SYSTEM_PROFILE_OPERMODE_PIPEUNIQUE: 1\n...\n---\nbcm_device:\n  0:\n    global:\n      l3_alpm_template: 1\n      l3_alpm_hit_mode: 1\n      ipv6_lpm_128b_enable: 1\n      pktio_driver_type: 1\n      qos_map_multi_get_mode: 1\n      rx_cosq_mapping_management_mode: 0\n      l3_iif_reservation_skip: 0\n      pcie_host_intf_timeout_purge_enable: 0\n      macro_flow_hash_shuffle_random_seed: 34345645\n      bcm_linkscan_interval: 25000\n      sai_common_hash_crc: 0x1\n      sai_disable_srcmacqedstmac_ctrl: 0x1\n      sai_acl_qset_optimization: 0x1\n      sai_optimized_mmu: 0x1\n      sai_pkt_rx_custom_cfg: 1\n      sai_pkt_rx_pkt_size: 16512\n      sai_pkt_rx_cfg_ppc: 16\n      sai_async_fdb_nbr_enable: 0x1\n      sai_pfc_defaults_disable: 0x1\n      sai_ifp_enable_on_cpu_tx: 0x1\n      sai_vfp_smac_drop_filter_disable: 1\n      sai_macro_flow_based_hash: 1\n      sai_mmu_qgroups_default: 1\n      sai_dis_ctr_incr_on_port_ln_dn: 0\n      custom_feature_mesh_topology_sync_mode: 1\n      sai_ecmp_group_members_increment: 1\n      sai_field_group_auto_prioritize: 1\n      bcm_tunnel_term_compatible_mode: 1\n      sai_l2_cpu_fdb_event_suppress: 1\n      sai_port_phy_time_sync_en: 1\n      sai_stats_support_mask: 0x802\n      sai_disable_internal_port_serdes: 1\n      stat_custom_receive0_management_mode: 1\n      sai_stats_disable_mask: 0x800\n      global_flexctr_ing_action_num_reserved: 20\n      global_flexctr_ing_pool_num_reserved: 8\n      global_flexctr_ing_op_profile_num_reserved: 20\n      global_flexctr_ing_group_num_reserved: 2\n      global_flexctr_egr_action_num_reserved: 8\n      global_flexctr_egr_pool_num_reserved: 5\n      global_flexctr_egr_op_profile_num_reserved: 10\n      global_flexctr_egr_group_num_reserved: 1\n      sai_uncached_port_stats: 0x1\n      ecmp_dlb_port_speeds: 1\n      l3_ecmp_member_secondary_mem_size: 4096\n      sai_rdma_udf_disable: 1\n      sai_l3_byte1_udf_disable: 1\n...\n---\ndevice:\n  0:\n    TM_THD_CONFIG:\n      THRESHOLD_MODE: LOSSY\n...\n---\ndevice:\n  0:\n    PORT:\n      ?\n        PORT_ID: [[1, 1], [5, 5], [9, 9], [10, 10], [11, 11], [15, 15], [19, 19],\n        [20, 20], [22, 22], [26, 26], [30, 30], [31, 31], [33, 33], [37, 37], [41,\n        41], [42, 42], [44, 44], [48, 48], [52, 52], [53, 53], [55, 55], [59, 59],\n        [63, 63], [64, 64], [66, 66], [70, 70], [74, 74], [75, 75], [77, 77], [81,\n        81], [85, 85], [86, 86], [88, 88], [92, 92], [96, 96], [97, 97], [99, 99],\n        [103, 103], [107, 107], [108, 108], [110, 110], [114, 114], [118, 118], [119,\n        119], [121, 121], [125, 125], [129, 129], [130, 130], [132, 132], [136, 136],\n        [140, 140], [141, 141], [143, 143], [147, 147], [151, 151], [152, 152], [154,\n        154], [158, 158], [162, 162], [163, 163], [165, 165], [169, 169], [173, 173],\n        [174, 174], [176, 176], [180, 180], [184, 184], [185, 185], [187, 187], [191,\n        191], [195, 195], [196, 196], [198, 198], [202, 202], [206, 206], [207, 207],\n        [209, 209], [213, 213], [217, 217], [218, 218], [220, 220], [224, 224], [228,\n        228], [229, 229], [231, 231], [235, 235], [239, 239], [240, 240], [242, 242],\n        [246, 246], [250, 250], [251, 251], [253, 253], [257, 257], [261, 261], [262,\n        262], [264, 264], [268, 268], [272, 272], [273, 273], [275, 275], [279, 279],\n        [283, 283], [284, 284], [286, 286], [290, 290], [294, 294], [295, 295], [297,\n        297], [301, 301], [305, 305], [306, 306], [308, 308], [312, 312], [316, 316],\n        [317, 317], [319, 319], [323, 323], [327, 327], [328, 328], [330, 330], [334,\n        334], [338, 338], [339, 339], [341, 341], [345, 345], [349, 349], [350, 350]]\n      :\n        MTU: 9416\n        MTU_CHECK: 1\n...\n---\ndevice:\n  0:\n    DEVICE_CONFIG:\n      AUTOLOAD_BOARD_SETTINGS: 0\n      CORE_CLK_FREQ: CLK_1125MHZ\n      PP_CLK_FREQ: CLK_675MHZ\n...\n---\ndevice:\n  0:\n    FP_CONFIG:\n      FP_ING_OPERMODE: GLOBAL_PIPE_AWARE\n...\n---\ndevice:\n  0:\n    CTR_EFLEX_CONFIG:\n      CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n...\n"
+          "yamlConfig": "---\ndevice:\n  0:\n    PC_PM_CORE:\n      ?\n        PC_PM_ID: 1\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x8C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFF\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 2\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x55\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 3\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23016745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x33\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x00\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 4\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x52701634\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAA\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 5\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74305612\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21640357\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF7\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x59\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 6\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x03562147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x29\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 7\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x14567302\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 8\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x67315024\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217034\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x53\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 9\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x21403765\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20543176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x48\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 10\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x53062147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x69\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 11\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54067312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 12\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65304721\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x56\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 13\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x21403765\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20543176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x48\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 14\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x53062147\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30742165\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x48\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x69\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 15\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54067312\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56712430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xAF\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 16\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65304721\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56217430\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDD\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x56\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 17\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x65274130\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x87\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 18\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47306521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 19\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02731456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x99\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x07\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 20\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x30472165\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21543076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 21\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45376120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 22\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x40376521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 23\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x02731456\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x99\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x07\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 24\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x30472165\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21543076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x6C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAD\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 25\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x45376120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56207431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA7\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 26\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x40376521\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x76305412\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x3C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x86\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 27\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x03762514\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21345076\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xDE\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x03\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 28\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x67125403\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x12470356\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x63\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xB2\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 29\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x22\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 30\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107654\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xCC\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x00\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 31\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x05371426\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x65\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 32\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x56741032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23016745\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x9C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xFF\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 33\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x46751032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32106754\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x55\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 34\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54721036\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x22\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 35\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x63410725\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x93\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 36\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32107645\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x77\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xCC\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 37\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x74260351\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x13064257\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD8\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x21\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 38\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10573246\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x99\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 39\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47356120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 40\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54217630\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x58\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 41\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01736524\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20365174\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x96\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x52\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 42\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10573246\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xD9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 43\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x47356120\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 44\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54217630\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x58\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 45\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01746523\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20365174\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x86\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x52\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 46\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x10576423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x30762145\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC6\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xD9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 47\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x46357102\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x56702431\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x2D\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x8F\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 48\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75016423\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54216703\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xC9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x54\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 49\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 50\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 51\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x60\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 52\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01572346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21560347\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 53\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 54\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 55\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x60\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 56\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x01572346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x21560347\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0C\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xA9\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 57\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x57032146\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54702631\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xED\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 58\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x75102346\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x74305612\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xF3\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 59\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x32610754\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x20345176\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x95\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x20\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 60\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x64207531\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23671045\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x0B\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xBB\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 61\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x51740362\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xB1\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 62\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x23016745\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x54761032\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x66\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 63\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x32107654\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x00\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x66\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 64\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x54761032\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x23016745\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0xD9\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0xAA\n        TX_POLARITY_FLIP_AUTO: 0\n      ?\n        PC_PM_ID: 65\n        CORE_INDEX: 0\n      :\n        RX_LANE_MAP: 0x3210\n        RX_LANE_MAP_AUTO: 0\n        TX_LANE_MAP: 0x3210\n        TX_LANE_MAP_AUTO: 0\n        RX_POLARITY_FLIP: 0x00\n        RX_POLARITY_FLIP_AUTO: 0\n        TX_POLARITY_FLIP: 0x0F\n        TX_POLARITY_FLIP_AUTO: 0\n...\n---\ndevice:\n  0:\n    PC_PORT_PHYS_MAP:\n      ?\n        PORT_ID: 1\n      :\n        PC_PHYS_PORT_ID: 1\n      ?\n        PORT_ID: 5\n      :\n        PC_PHYS_PORT_ID: 5\n      ?\n        PORT_ID: 9\n      :\n        PC_PHYS_PORT_ID: 9\n      ?\n        PORT_ID: 10\n      :\n        PC_PHYS_PORT_ID: 13\n      ?\n        PORT_ID: 11\n      :\n        PC_PHYS_PORT_ID: 17\n      ?\n        PORT_ID: 15\n      :\n        PC_PHYS_PORT_ID: 21\n      ?\n        PORT_ID: 19\n      :\n        PC_PHYS_PORT_ID: 25\n      ?\n        PORT_ID: 20\n      :\n        PC_PHYS_PORT_ID: 29\n      ?\n        PORT_ID: 22\n      :\n        PC_PHYS_PORT_ID: 33\n      ?\n        PORT_ID: 26\n      :\n        PC_PHYS_PORT_ID: 37\n      ?\n        PORT_ID: 30\n      :\n        PC_PHYS_PORT_ID: 41\n      ?\n        PORT_ID: 31\n      :\n        PC_PHYS_PORT_ID: 45\n      ?\n        PORT_ID: 33\n      :\n        PC_PHYS_PORT_ID: 49\n      ?\n        PORT_ID: 37\n      :\n        PC_PHYS_PORT_ID: 53\n      ?\n        PORT_ID: 41\n      :\n        PC_PHYS_PORT_ID: 57\n      ?\n        PORT_ID: 42\n      :\n        PC_PHYS_PORT_ID: 61\n      ?\n        PORT_ID: 44\n      :\n        PC_PHYS_PORT_ID: 65\n      ?\n        PORT_ID: 48\n      :\n        PC_PHYS_PORT_ID: 69\n      ?\n        PORT_ID: 52\n      :\n        PC_PHYS_PORT_ID: 73\n      ?\n        PORT_ID: 53\n      :\n        PC_PHYS_PORT_ID: 77\n      ?\n        PORT_ID: 55\n      :\n        PC_PHYS_PORT_ID: 81\n      ?\n        PORT_ID: 59\n      :\n        PC_PHYS_PORT_ID: 85\n      ?\n        PORT_ID: 63\n      :\n        PC_PHYS_PORT_ID: 89\n      ?\n        PORT_ID: 64\n      :\n        PC_PHYS_PORT_ID: 93\n      ?\n        PORT_ID: 66\n      :\n        PC_PHYS_PORT_ID: 97\n      ?\n        PORT_ID: 70\n      :\n        PC_PHYS_PORT_ID: 101\n      ?\n        PORT_ID: 74\n      :\n        PC_PHYS_PORT_ID: 105\n      ?\n        PORT_ID: 75\n      :\n        PC_PHYS_PORT_ID: 109\n      ?\n        PORT_ID: 77\n      :\n        PC_PHYS_PORT_ID: 113\n      ?\n        PORT_ID: 81\n      :\n        PC_PHYS_PORT_ID: 117\n      ?\n        PORT_ID: 85\n      :\n        PC_PHYS_PORT_ID: 121\n      ?\n        PORT_ID: 86\n      :\n        PC_PHYS_PORT_ID: 125\n      ?\n        PORT_ID: 88\n      :\n        PC_PHYS_PORT_ID: 129\n      ?\n        PORT_ID: 92\n      :\n        PC_PHYS_PORT_ID: 133\n      ?\n        PORT_ID: 96\n      :\n        PC_PHYS_PORT_ID: 137\n      ?\n        PORT_ID: 97\n      :\n        PC_PHYS_PORT_ID: 141\n      ?\n        PORT_ID: 99\n      :\n        PC_PHYS_PORT_ID: 145\n      ?\n        PORT_ID: 103\n      :\n        PC_PHYS_PORT_ID: 149\n      ?\n        PORT_ID: 107\n      :\n        PC_PHYS_PORT_ID: 153\n      ?\n        PORT_ID: 108\n      :\n        PC_PHYS_PORT_ID: 157\n      ?\n        PORT_ID: 110\n      :\n        PC_PHYS_PORT_ID: 161\n      ?\n        PORT_ID: 114\n      :\n        PC_PHYS_PORT_ID: 165\n      ?\n        PORT_ID: 118\n      :\n        PC_PHYS_PORT_ID: 169\n      ?\n        PORT_ID: 119\n      :\n        PC_PHYS_PORT_ID: 173\n      ?\n        PORT_ID: 121\n      :\n        PC_PHYS_PORT_ID: 177\n      ?\n        PORT_ID: 125\n      :\n        PC_PHYS_PORT_ID: 181\n      ?\n        PORT_ID: 129\n      :\n        PC_PHYS_PORT_ID: 185\n      ?\n        PORT_ID: 130\n      :\n        PC_PHYS_PORT_ID: 189\n      ?\n        PORT_ID: 132\n      :\n        PC_PHYS_PORT_ID: 193\n      ?\n        PORT_ID: 136\n      :\n        PC_PHYS_PORT_ID: 197\n      ?\n        PORT_ID: 140\n      :\n        PC_PHYS_PORT_ID: 201\n      ?\n        PORT_ID: 141\n      :\n        PC_PHYS_PORT_ID: 205\n      ?\n        PORT_ID: 143\n      :\n        PC_PHYS_PORT_ID: 209\n      ?\n        PORT_ID: 147\n      :\n        PC_PHYS_PORT_ID: 213\n      ?\n        PORT_ID: 151\n      :\n        PC_PHYS_PORT_ID: 217\n      ?\n        PORT_ID: 152\n      :\n        PC_PHYS_PORT_ID: 221\n      ?\n        PORT_ID: 154\n      :\n        PC_PHYS_PORT_ID: 225\n      ?\n        PORT_ID: 158\n      :\n        PC_PHYS_PORT_ID: 229\n      ?\n        PORT_ID: 162\n      :\n        PC_PHYS_PORT_ID: 233\n      ?\n        PORT_ID: 163\n      :\n        PC_PHYS_PORT_ID: 237\n      ?\n        PORT_ID: 165\n      :\n        PC_PHYS_PORT_ID: 241\n      ?\n        PORT_ID: 169\n      :\n        PC_PHYS_PORT_ID: 245\n      ?\n        PORT_ID: 173\n      :\n        PC_PHYS_PORT_ID: 249\n      ?\n        PORT_ID: 174\n      :\n        PC_PHYS_PORT_ID: 253\n      ?\n        PORT_ID: 176\n      :\n        PC_PHYS_PORT_ID: 257\n      ?\n        PORT_ID: 180\n      :\n        PC_PHYS_PORT_ID: 261\n      ?\n        PORT_ID: 184\n      :\n        PC_PHYS_PORT_ID: 265\n      ?\n        PORT_ID: 185\n      :\n        PC_PHYS_PORT_ID: 269\n      ?\n        PORT_ID: 187\n      :\n        PC_PHYS_PORT_ID: 273\n      ?\n        PORT_ID: 191\n      :\n        PC_PHYS_PORT_ID: 277\n      ?\n        PORT_ID: 195\n      :\n        PC_PHYS_PORT_ID: 281\n      ?\n        PORT_ID: 196\n      :\n        PC_PHYS_PORT_ID: 285\n      ?\n        PORT_ID: 198\n      :\n        PC_PHYS_PORT_ID: 289\n      ?\n        PORT_ID: 202\n      :\n        PC_PHYS_PORT_ID: 293\n      ?\n        PORT_ID: 206\n      :\n        PC_PHYS_PORT_ID: 297\n      ?\n        PORT_ID: 207\n      :\n        PC_PHYS_PORT_ID: 301\n      ?\n        PORT_ID: 209\n      :\n        PC_PHYS_PORT_ID: 305\n      ?\n        PORT_ID: 213\n      :\n        PC_PHYS_PORT_ID: 309\n      ?\n        PORT_ID: 217\n      :\n        PC_PHYS_PORT_ID: 313\n      ?\n        PORT_ID: 218\n      :\n        PC_PHYS_PORT_ID: 317\n      ?\n        PORT_ID: 220\n      :\n        PC_PHYS_PORT_ID: 321\n      ?\n        PORT_ID: 224\n      :\n        PC_PHYS_PORT_ID: 325\n      ?\n        PORT_ID: 228\n      :\n        PC_PHYS_PORT_ID: 329\n      ?\n        PORT_ID: 229\n      :\n        PC_PHYS_PORT_ID: 333\n      ?\n        PORT_ID: 231\n      :\n        PC_PHYS_PORT_ID: 337\n      ?\n        PORT_ID: 235\n      :\n        PC_PHYS_PORT_ID: 341\n      ?\n        PORT_ID: 239\n      :\n        PC_PHYS_PORT_ID: 345\n      ?\n        PORT_ID: 240\n      :\n        PC_PHYS_PORT_ID: 349\n      ?\n        PORT_ID: 242\n      :\n        PC_PHYS_PORT_ID: 353\n      ?\n        PORT_ID: 246\n      :\n        PC_PHYS_PORT_ID: 357\n      ?\n        PORT_ID: 250\n      :\n        PC_PHYS_PORT_ID: 361\n      ?\n        PORT_ID: 251\n      :\n        PC_PHYS_PORT_ID: 365\n      ?\n        PORT_ID: 253\n      :\n        PC_PHYS_PORT_ID: 369\n      ?\n        PORT_ID: 257\n      :\n        PC_PHYS_PORT_ID: 373\n      ?\n        PORT_ID: 261\n      :\n        PC_PHYS_PORT_ID: 377\n      ?\n        PORT_ID: 262\n      :\n        PC_PHYS_PORT_ID: 381\n      ?\n        PORT_ID: 264\n      :\n        PC_PHYS_PORT_ID: 385\n      ?\n        PORT_ID: 268\n      :\n        PC_PHYS_PORT_ID: 389\n      ?\n        PORT_ID: 272\n      :\n        PC_PHYS_PORT_ID: 393\n      ?\n        PORT_ID: 273\n      :\n        PC_PHYS_PORT_ID: 397\n      ?\n        PORT_ID: 275\n      :\n        PC_PHYS_PORT_ID: 401\n      ?\n        PORT_ID: 279\n      :\n        PC_PHYS_PORT_ID: 405\n      ?\n        PORT_ID: 283\n      :\n        PC_PHYS_PORT_ID: 409\n      ?\n        PORT_ID: 284\n      :\n        PC_PHYS_PORT_ID: 413\n      ?\n        PORT_ID: 286\n      :\n        PC_PHYS_PORT_ID: 417\n      ?\n        PORT_ID: 290\n      :\n        PC_PHYS_PORT_ID: 421\n      ?\n        PORT_ID: 294\n      :\n        PC_PHYS_PORT_ID: 425\n      ?\n        PORT_ID: 295\n      :\n        PC_PHYS_PORT_ID: 429\n      ?\n        PORT_ID: 297\n      :\n        PC_PHYS_PORT_ID: 433\n      ?\n        PORT_ID: 301\n      :\n        PC_PHYS_PORT_ID: 437\n      ?\n        PORT_ID: 305\n      :\n        PC_PHYS_PORT_ID: 441\n      ?\n        PORT_ID: 306\n      :\n        PC_PHYS_PORT_ID: 445\n      ?\n        PORT_ID: 308\n      :\n        PC_PHYS_PORT_ID: 449\n      ?\n        PORT_ID: 312\n      :\n        PC_PHYS_PORT_ID: 453\n      ?\n        PORT_ID: 316\n      :\n        PC_PHYS_PORT_ID: 457\n      ?\n        PORT_ID: 317\n      :\n        PC_PHYS_PORT_ID: 461\n      ?\n        PORT_ID: 319\n      :\n        PC_PHYS_PORT_ID: 465\n      ?\n        PORT_ID: 323\n      :\n        PC_PHYS_PORT_ID: 469\n      ?\n        PORT_ID: 327\n      :\n        PC_PHYS_PORT_ID: 473\n      ?\n        PORT_ID: 328\n      :\n        PC_PHYS_PORT_ID: 477\n      ?\n        PORT_ID: 330\n      :\n        PC_PHYS_PORT_ID: 481\n      ?\n        PORT_ID: 334\n      :\n        PC_PHYS_PORT_ID: 485\n      ?\n        PORT_ID: 338\n      :\n        PC_PHYS_PORT_ID: 489\n      ?\n        PORT_ID: 339\n      :\n        PC_PHYS_PORT_ID: 493\n      ?\n        PORT_ID: 341\n      :\n        PC_PHYS_PORT_ID: 497\n      ?\n        PORT_ID: 345\n      :\n        PC_PHYS_PORT_ID: 501\n      ?\n        PORT_ID: 349\n      :\n        PC_PHYS_PORT_ID: 505\n      ?\n        PORT_ID: 350\n      :\n        PC_PHYS_PORT_ID: 509\n      ?\n        PORT_ID: 0\n      :\n        PC_PHYS_PORT_ID: 0\n      ?\n        PORT_ID: 76\n      :\n        PC_PHYS_PORT_ID: 513\n...\n---\ndevice:\n  0:\n    PC_PORT:\n      ?\n        PORT_ID: 0\n      :\n        ENABLE: 1\n        SPEED: 10000\n        NUM_LANES: 1\n      ?\n        PORT_ID: [[1, 1], [5, 5], [9, 9], [10, 10], [11, 11], [15, 15], [19, 19],\n        [20, 20], [22, 22], [26, 26], [30, 30], [31, 31], [33, 33], [37, 37], [41,\n        41], [42, 42], [44, 44], [48, 48], [52, 52], [53, 53], [55, 55], [59, 59],\n        [63, 63], [64, 64], [66, 66], [70, 70], [74, 74], [75, 75], [77, 77], [81,\n        81], [85, 85], [86, 86], [88, 88], [92, 92], [96, 96], [97, 97], [99, 99],\n        [103, 103], [107, 107], [108, 108], [110, 110], [114, 114], [118, 118], [119,\n        119], [121, 121], [125, 125], [129, 129], [130, 130], [132, 132], [136, 136],\n        [140, 140], [141, 141], [143, 143], [147, 147], [151, 151], [152, 152], [154,\n        154], [158, 158], [162, 162], [163, 163], [165, 165], [169, 169], [173, 173],\n        [174, 174], [176, 176], [180, 180], [184, 184], [185, 185], [187, 187], [191,\n        191], [195, 195], [196, 196], [198, 198], [202, 202], [206, 206], [207, 207],\n        [209, 209], [213, 213], [217, 217], [218, 218], [220, 220], [224, 224], [228,\n        228], [229, 229], [231, 231], [235, 235], [239, 239], [240, 240], [242, 242],\n        [246, 246], [250, 250], [251, 251], [253, 253], [257, 257], [261, 261], [262,\n        262], [264, 264], [268, 268], [272, 272], [273, 273], [275, 275], [279, 279],\n        [283, 283], [284, 284], [286, 286], [290, 290], [294, 294], [295, 295], [297,\n        297], [301, 301], [305, 305], [306, 306], [308, 308], [312, 312], [316, 316],\n        [317, 317], [319, 319], [323, 323], [327, 327], [328, 328], [330, 330], [334,\n        334], [338, 338], [339, 339], [341, 341], [345, 345], [349, 349], [350, 350]]\n      :\n        ENABLE: 0\n        SPEED: 400000\n        NUM_LANES: 4\n        FEC_MODE: PC_FEC_RS544_2XN\n        MAX_FRAME_SIZE: 9416\n      ?\n        PORT_ID: 76\n      :\n        ENABLE: 0\n        SPEED: 100000\n        NUM_LANES: 4\n        FEC_MODE: PC_FEC_RS528\n        MAX_FRAME_SIZE: 9416\n...\n---\ndevice:\n  0:\n    PORT_CONFIG:\n      PORT_SYSTEM_PROFILE_OPERMODE_PIPEUNIQUE: 1\n...\n---\nbcm_device:\n  0:\n    global:\n      l3_alpm_template: 1\n      l3_alpm_hit_mode: 1\n      ipv6_lpm_128b_enable: 1\n      pktio_driver_type: 1\n      qos_map_multi_get_mode: 1\n      rx_cosq_mapping_management_mode: 0\n      l3_iif_reservation_skip: 0\n      pcie_host_intf_timeout_purge_enable: 0\n      macro_flow_hash_shuffle_random_seed: 34345645\n      bcm_linkscan_interval: 25000\n      sai_common_hash_crc: 0x1\n      sai_disable_srcmacqedstmac_ctrl: 0x1\n      sai_acl_qset_optimization: 0x1\n      sai_optimized_mmu: 0x1\n      sai_pkt_rx_custom_cfg: 1\n      sai_pkt_rx_pkt_size: 16512\n      sai_pkt_rx_cfg_ppc: 16\n      sai_async_fdb_nbr_enable: 0x1\n      sai_pfc_defaults_disable: 0x1\n      sai_ifp_enable_on_cpu_tx: 0x1\n      sai_vfp_smac_drop_filter_disable: 1\n      sai_macro_flow_based_hash: 1\n      sai_mmu_qgroups_default: 1\n      sai_dis_ctr_incr_on_port_ln_dn: 0\n      custom_feature_mesh_topology_sync_mode: 1\n      sai_ecmp_group_members_increment: 1\n      sai_field_group_auto_prioritize: 1\n      bcm_tunnel_term_compatible_mode: 1\n      sai_l2_cpu_fdb_event_suppress: 1\n      sai_port_phy_time_sync_en: 1\n      sai_stats_support_mask: 0x802\n      sai_disable_internal_port_serdes: 1\n      stat_custom_receive0_management_mode: 1\n      sai_stats_disable_mask: 0x800\n      global_flexctr_ing_action_num_reserved: 20\n      global_flexctr_ing_pool_num_reserved: 8\n      global_flexctr_ing_op_profile_num_reserved: 20\n      global_flexctr_ing_group_num_reserved: 2\n      global_flexctr_egr_action_num_reserved: 8\n      global_flexctr_egr_pool_num_reserved: 5\n      global_flexctr_egr_op_profile_num_reserved: 10\n      global_flexctr_egr_group_num_reserved: 1\n      sai_uncached_port_stats: 0x1\n      ecmp_dlb_port_speeds: 1\n      l3_ecmp_member_secondary_mem_size: 4096\n      sai_eapol_trap_use_bcast_mac: 1\n      sai_rdma_udf_disable: 1\n      sai_l3_byte1_udf_disable: 1\n...\n---\ndevice:\n  0:\n    TM_THD_CONFIG:\n      THRESHOLD_MODE: LOSSY\n...\n---\ndevice:\n  0:\n    PORT:\n      ?\n        PORT_ID: [[1, 1], [5, 5], [9, 9], [10, 10], [11, 11], [15, 15], [19, 19],\n        [20, 20], [22, 22], [26, 26], [30, 30], [31, 31], [33, 33], [37, 37], [41,\n        41], [42, 42], [44, 44], [48, 48], [52, 52], [53, 53], [55, 55], [59, 59],\n        [63, 63], [64, 64], [66, 66], [70, 70], [74, 74], [75, 75], [77, 77], [81,\n        81], [85, 85], [86, 86], [88, 88], [92, 92], [96, 96], [97, 97], [99, 99],\n        [103, 103], [107, 107], [108, 108], [110, 110], [114, 114], [118, 118], [119,\n        119], [121, 121], [125, 125], [129, 129], [130, 130], [132, 132], [136, 136],\n        [140, 140], [141, 141], [143, 143], [147, 147], [151, 151], [152, 152], [154,\n        154], [158, 158], [162, 162], [163, 163], [165, 165], [169, 169], [173, 173],\n        [174, 174], [176, 176], [180, 180], [184, 184], [185, 185], [187, 187], [191,\n        191], [195, 195], [196, 196], [198, 198], [202, 202], [206, 206], [207, 207],\n        [209, 209], [213, 213], [217, 217], [218, 218], [220, 220], [224, 224], [228,\n        228], [229, 229], [231, 231], [235, 235], [239, 239], [240, 240], [242, 242],\n        [246, 246], [250, 250], [251, 251], [253, 253], [257, 257], [261, 261], [262,\n        262], [264, 264], [268, 268], [272, 272], [273, 273], [275, 275], [279, 279],\n        [283, 283], [284, 284], [286, 286], [290, 290], [294, 294], [295, 295], [297,\n        297], [301, 301], [305, 305], [306, 306], [308, 308], [312, 312], [316, 316],\n        [317, 317], [319, 319], [323, 323], [327, 327], [328, 328], [330, 330], [334,\n        334], [338, 338], [339, 339], [341, 341], [345, 345], [349, 349], [350, 350]]\n      :\n        MTU: 9416\n        MTU_CHECK: 1\n...\n---\ndevice:\n  0:\n    DEVICE_CONFIG:\n      AUTOLOAD_BOARD_SETTINGS: 0\n      CORE_CLK_FREQ: CLK_1125MHZ\n      PP_CLK_FREQ: CLK_675MHZ\n...\n---\ndevice:\n  0:\n    FP_CONFIG:\n      FP_ING_OPERMODE: GLOBAL_PIPE_AWARE\n...\n---\ndevice:\n  0:\n    CTR_EFLEX_CONFIG:\n      CTR_ING_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_ING_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPEUNIQUE: 1\n      CTR_EGR_EFLEX_OPERMODE_PIPE_INSTANCE_UNIQUE: 1\n...\n"
         }
       }
     }
-  },
-  "thriftApiToRateLimitInQps": {
-
   }
 }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Sync the minipack3 default agent.conf used by the OSS run scripts with the
current canonical config. Replaces the legacy VLAN-per-port config with a
64x800G VLAN-less port-router config, adds aclTableGroups, and enables
neighbor updates.

# Test Plan

Config parses and validates against the agent thrift schema; all referenced
gflags exist in the agent.
