### PR TITLE
[Nexthop][m4062nhp] Fix qsfp_service crash on graceful exit

### DIFF
--- a/fboss/qsfp_service/Main.cpp
+++ b/fboss/qsfp_service/Main.cpp
@@ -1,9 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <thrift/lib/cpp2/server/ThriftServer.h>
+#include <thrift/lib/cpp2/server/ThriftServer.h> // NOLINT(misc-include-cleaner)
+
+#include <unistd.h>
 
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/logging/Init.h>
+#include <folly/logging/LoggerDB.h>
 
 #include "fboss/qsfp_service/PortManager.h"
 #include "fboss/qsfp_service/QsfpServer.h"
@@ -111,5 +114,8 @@ int main(int argc, char** argv) {
   // Start the server loop
   doServerLoop(server, handler);
 
-  return 0;
+  // _exit(): skip global destructors, which re-drive still-live EventBases
+  // and abort. Exit 0 only if the signal-driven shutdown completed.
+  folly::LoggerDB::get().flushAllHandlers();
+  _exit(signalHandler.shutdownComplete() ? 0 : 1);
 }

--- a/fboss/qsfp_service/Main.cpp
+++ b/fboss/qsfp_service/Main.cpp
@@ -1,9 +1,12 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-#include <thrift/lib/cpp2/server/ThriftServer.h>
+#include <thrift/lib/cpp2/server/ThriftServer.h> // NOLINT(misc-include-cleaner)
+
+#include <unistd.h>
 
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/logging/Init.h>
+#include <folly/logging/LoggerDB.h>
 
 #include "fboss/qsfp_service/PortManager.h"
 #include "fboss/qsfp_service/QsfpServer.h"
@@ -112,5 +115,8 @@ int main(int argc, char** argv) {
   // Start the server loop
   doServerLoop(server, handler);
 
-  return 0;
+  // _exit(): skip global destructors, which re-drive still-live EventBases
+  // and abort. Exit 0 only if the signal-driven shutdown completed.
+  folly::LoggerDB::get().flushAllHandlers();
+  _exit(signalHandler.shutdownComplete() ? 0 : 1);
 }

--- a/fboss/qsfp_service/QsfpServiceSignalHandler.cpp
+++ b/fboss/qsfp_service/QsfpServiceSignalHandler.cpp
@@ -34,6 +34,12 @@ QsfpServiceSignalHandler::QsfpServiceSignalHandler(
 
 using namespace std::chrono;
 void QsfpServiceSignalHandler::signalReceived(int signum) noexcept {
+  if (exitSignalReceived_.exchange(true)) {
+    XLOG(WARNING)
+        << "[Exit] Signal received while shutdown already in progress, ignoring";
+    return;
+  }
+
   XLOG(INFO) << "[Exit] Signal received: " << signum;
   steady_clock::time_point begin = steady_clock::now();
 
@@ -64,6 +70,9 @@ void QsfpServiceSignalHandler::signalReceived(int signum) noexcept {
       << "[Exit] Total qsfp_service Exit time: "
       << duration_cast<duration<float>>(gracefulExitDone - begin).count();
 
-  exit(0);
+  // exit() here would re-drive this EventBase from its own teardown path
+  // and abort. Stop the loop instead; main() exits once it unwinds.
+  shutdownComplete_.store(true);
+  getEventBase()->terminateLoopSoon();
 }
 } // namespace facebook::fboss

--- a/fboss/qsfp_service/QsfpServiceSignalHandler.h
+++ b/fboss/qsfp_service/QsfpServiceSignalHandler.h
@@ -11,6 +11,8 @@
 
 #include <folly/io/async/AsyncSignalHandler.h>
 
+#include <atomic>
+
 namespace apache::thrift {
 class ThriftServer;
 }
@@ -31,15 +33,25 @@ class QsfpServiceSignalHandler : public folly::AsyncSignalHandler {
       std::shared_ptr<apache::thrift::ThriftServer> qsfpServer,
       std::shared_ptr<QsfpServiceHandler> qsfpServiceHandler);
 
-  void signalReceived(int signum) noexcept override;
-
- private:
-  // Forbidden copy constructor and assignment operator
   QsfpServiceSignalHandler(QsfpServiceSignalHandler const&) = delete;
   QsfpServiceSignalHandler& operator=(QsfpServiceSignalHandler const&) = delete;
 
+  void signalReceived(int signum) noexcept override;
+
+  // True once the shutdown in signalReceived() completed. Lets main()
+  // distinguish a signal-driven loop exit from any other cause.
+  bool shutdownComplete() const {
+    return shutdownComplete_.load();
+  }
+
+ private:
   folly::FunctionScheduler* functionScheduler_;
   std::shared_ptr<apache::thrift::ThriftServer> qsfpServer_;
   std::shared_ptr<QsfpServiceHandler> qsfpServiceHandler_;
+
+  // Guards against a second signal (e.g. SIGINT after SIGTERM) re-entering
+  // the shutdown sequence while it's already in progress.
+  std::atomic<bool> exitSignalReceived_{false};
+  std::atomic<bool> shutdownComplete_{false};
 };
 } // namespace facebook::fboss

--- a/fboss/qsfp_service/oss/QsfpServer.cpp
+++ b/fboss/qsfp_service/oss/QsfpServer.cpp
@@ -4,6 +4,7 @@
 #include "fboss/qsfp_service/QsfpServiceHandler.h"
 
 #include <folly/init/Init.h>
+#include <folly/logging/xlog.h>
 
 namespace facebook::fboss {
 
@@ -26,7 +27,14 @@ int doServerLoop(
 void stopQsfpServerGracefully(
     std::shared_ptr<apache::thrift::ThriftServer> thriftServer) {
   thriftServer->stopListening();
-  thriftServer->stop();
+  // stop() alone is async; use StopController so exit() in main() doesn't
+  // race still-running IO workers.
+  auto stopController = thriftServer->getStopController();
+  if (auto lockedPtr = stopController.lock()) {
+    lockedPtr->stop();
+  } else {
+    XLOG(WARNING) << "Unable to stop Thrift Server";
+  }
 }
 
 } // namespace facebook::fboss


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

qsfp_service aborted on SIGTERM/SIGINT: `exit()` was called from inside
`signalReceived()`, running global destructors that tore down EventBases
still in use.

The crash needs a thread to be inside an event loop when `exit()` runs.
A fully cabled m4062nhp has 128 transceivers, so the i2c refresh pass,
xphy stats, and thrift workers are almost always mid-flight when the
signal lands. Lightly populated boxes usually finish shutdown first.

Changes:
- `signalReceived()`: replace `exit()` with `terminateLoopSoon()`; `main()`
  unwinds naturally.
- `main()`: flush async log handlers, then `_exit(0)` to skip global
  destructors.
- Ignore a second signal while shutdown is in progress.
- `stopQsfpServerGracefully()`: use the ThriftServer `StopController`
  instead of the async `stop()`.
- Exit non-zero if the event loop ends without a completed signal-driven
  shutdown (can only happen if a new `terminateLoopSoon()` caller is added).

# Test Plan

qsfp_service used to crash consistently on a fully cabled m4062nhp when
running t0 link test. Tested on a live m4062nhp system, it now stays up.