### PR TITLE
[sai] Adopt pre-existing port serdes on SAI_STATUS_ITEM_ALREADY_EXISTS

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
@@ -5,6 +5,7 @@
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/hw/HwPortFb303Stats.h"
 #include "fboss/agent/hw/gen-cpp2/hardware_stats_constants.h"
+#include "fboss/agent/hw/sai/api/SaiApiError.h"
 #include "fboss/agent/hw/sai/store/SaiStore.h"
 #include "fboss/agent/hw/sai/switch/ConcurrentIndices.h"
 #include "fboss/agent/hw/sai/switch/SaiBridgeManager.h"
@@ -1341,6 +1342,30 @@ void SaiPortManager::programSerdes(
       swPort->getZeroPreemphasis()) {
     createSerdesWithZeroPreemphasis(portHandle, swPort->getPinConfigs());
   }
+  // Adopt existing serdes on ITEM_ALREADY_EXISTS (XGS keeps it on recreate).
+  auto setSerdesObject =
+      [&](const SaiPortSerdesTraits::CreateAttributes& serdesCreateAttributes) {
+        try {
+          return store.setObject(serdesKey, serdesCreateAttributes);
+        } catch (const SaiApiError& e) {
+          if (e.getSaiStatus() != SAI_STATUS_ITEM_ALREADY_EXISTS) {
+            throw;
+          }
+          std::optional<SaiPortTraits::Attributes::SerdesId> serdesIdAttr{};
+          auto serdesId = SaiApiTable::getInstance()->portApi().getAttribute(
+              saiPort->adapterKey(), serdesIdAttr);
+          if (!serdesId.has_value() || serdesId.value() == SAI_NULL_OBJECT_ID) {
+            // Nothing to adopt; surface the original error.
+            throw;
+          }
+          XLOG(WARNING) << "Port serdes already exists for port "
+                        << swPort->getID()
+                        << "; adopting existing serdes object "
+                        << serdesId.value();
+          store.reloadObject(static_cast<PortSerdesSaiId>(serdesId.value()));
+          return store.setObject(serdesKey, serdesCreateAttributes);
+        }
+      };
   if (platform_->getAsic()->getAsicType() ==
           cfg::AsicType::ASIC_TYPE_TOMAHAWK5 ||
       platform_->getAsic()->getAsicType() ==
@@ -1380,13 +1405,13 @@ void SaiPortManager::programSerdes(
       txPost1.resize(numLanes, 0);
       std::get<std::optional<SaiPortSerdesTraits::Attributes::TxFirPost1>>(
           attributes) = txPost1;
-      portHandle->serdes = store.setObject(serdesKey, attributes);
+      portHandle->serdes = setSerdesObject(attributes);
     } else {
       XLOG(DBG2) << "No tx main setting for port " << swPort->getID();
     }
   }
   // create if serdes doesn't exist or update existing serdes
-  portHandle->serdes = store.setObject(serdesKey, serdesAttributes);
+  portHandle->serdes = setSerdesObject(serdesAttributes);
 
   // Set RX Reach if ASIC supports and platform mapping has a rxReach
   // setting


### PR DESCRIPTION
## Summary

On cold-boot config apply, `SaiPortManager` may recreate a port via
`changePortByRecreate()` when a create-only attribute (e.g. lane or speed)
differs from the port the SAI switch created by default. The recreate removes
the old SAI port and adds a new one, which programs a new port serdes.

Some SAI implementations do not remove the port serdes object when its parent
port is removed. On the subsequent recreate,
`programSerdes()` -> `store.setObject()` -> `create_port_serdes` then fails with
`SAI_STATUS_ITEM_ALREADY_EXISTS`. Because the `SaiObjectStore` holds no handle
for the serdes (on XGS the serdes is not reloaded from the adapter beforehand),
the error propagates as an uncaught `SaiApiError` and aborts the HW agent during
initialization.

## Fix

When the serdes create returns `SAI_STATUS_ITEM_ALREADY_EXISTS`, adopt the
pre-existing hardware serdes: reload it into the store from the port's
`SerdesId` and re-apply the desired attributes. This reuses the
`getAttribute(SerdesId)` + `reloadObject()` idiom already used in
`programSerdes()` on the non-XGS reload path. On implementations that remove the
serdes together with its port, create never returns `ITEM_ALREADY_EXISTS`, so
there is no behavior change. Both serdes create sites go through a small
`setSerdesObject()` helper.

## Test Plan

Reproduced on a xgs platform running the agent HW test in `multi_switch`
mode: the HW agent aborted during init in
`SaiPortManager::programSerdes()` -> `changePortByRecreate()` with
`[port] Failed to create sai entity PortSerdes...: ITEM ALREADY EXISTS`. With
this change the existing serdes is adopted instead of aborting.
