### PR TITLE
[Nexthop][m4062nhp] Fix agent EventBase double-drive abort on graceful exit

### DIFF
--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -13,12 +13,9 @@
 #include <folly/logging/Init.h>
 #include <folly/logging/LoggerDB.h>
 #include <folly/logging/xlog.h>
-<<<<<<< HEAD
 #include "fboss/agent/AgentConfig.h"
-=======
 #include <gflags/gflags.h>
 #include "fboss/agent/InitHookRegistry.h"
->>>>>>> 178e092e05 (NOS-12717: Fix agent EventBase double-drive abort on graceful exit (#1593))
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"

--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -15,7 +15,6 @@
 #include <folly/logging/xlog.h>
 #include "fboss/agent/AgentConfig.h"
 #include <gflags/gflags.h>
-#include "fboss/agent/InitHookRegistry.h"
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"

--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -11,8 +11,14 @@
 #include <fb303/FollyLoggingHandler.h>
 #include <fb303/ServiceData.h>
 #include <folly/logging/Init.h>
+#include <folly/logging/LoggerDB.h>
 #include <folly/logging/xlog.h>
+<<<<<<< HEAD
 #include "fboss/agent/AgentConfig.h"
+=======
+#include <gflags/gflags.h>
+#include "fboss/agent/InitHookRegistry.h"
+>>>>>>> 178e092e05 (NOS-12717: Fix agent EventBase double-drive abort on graceful exit (#1593))
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"
@@ -79,6 +85,11 @@ void updateStats(
 namespace facebook::fboss {
 
 void SplitHwAgentSignalHandler::signalReceived(int /*signum*/) noexcept {
+  if (exitSignalReceived_.exchange(true)) {
+    XLOG(WARNING)
+        << "[Exit] Exit signal received while shutdown is already in progress, ignoring";
+    return;
+  }
   restart_time::mark(RestartEvent::SIGNAL_RECEIVED);
   XLOG(DBG2) << "[Exit] Signal received ";
   if (!hwAgent_->isInitialized()) {
@@ -155,8 +166,6 @@ void SplitHwAgentSignalHandler::signalReceived(int /*signum*/) noexcept {
     std::this_thread::sleep_for(std::chrono::seconds(FLAGS_agent_exit_delay_s));
     XLOG(INFO) << "[Exit] Delay complete, exiting now";
   }
-
-  exit(0);
 }
 
 int hwAgentMain(
@@ -313,7 +322,10 @@ int hwAgentMain(
   // @lint-ignore CLANGTIDY
   server->serve();
   server.reset();
-  return 0;
+  thriftSyncer.reset();
+  folly::LoggerDB::get().flushAllHandlers();
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  exit(signalHandler.exitSignalReceived() ? 0 : 1);
 }
 
 } // namespace facebook::fboss

--- a/fboss/agent/HwAgentMain.h
+++ b/fboss/agent/HwAgentMain.h
@@ -8,9 +8,8 @@
  *
  */
 #pragma once
+#include <atomic>
 #include <memory>
-
-#include <gflags/gflags.h>
 #include <string>
 
 #include "fboss/agent/CommonInit.h"
@@ -34,9 +33,14 @@ class SplitHwAgentSignalHandler : public SignalHandler {
 
   void signalReceived(int /*signum*/) noexcept override;
 
+  bool exitSignalReceived() const {
+    return exitSignalReceived_.load();
+  }
+
  private:
   std::unique_ptr<HwAgent> hwAgent_;
   SplitAgentThriftSyncer* syncer_;
+  std::atomic<bool> exitSignalReceived_{false};
 };
 
 void setSDKVersionInfo();

--- a/fboss/agent/HwSwitchConnectionStatusTable.cpp
+++ b/fboss/agent/HwSwitchConnectionStatusTable.cpp
@@ -70,7 +70,11 @@ bool HwSwitchConnectionStatusTable::disconnected(SwitchID switchId) {
                  << ": " << dirUtil->getHwColdBootOnceFile(switchIndex);
     }
 
-    std::exit(EXIT_SUCCESS);
+    // Schedule graceful teardown on the server's event base instead of exiting
+    // inline on this thrift stream cleanup thread.
+    lk.unlock();
+    sw_->requestGracefulShutdown();
+    return true;
   }
   if (FLAGS_exit_for_any_hw_disconnect) {
     XLOG(FATAL)

--- a/fboss/agent/SwAgentInitializer.cpp
+++ b/fboss/agent/SwAgentInitializer.cpp
@@ -268,6 +268,13 @@ int SwAgentInitializer::initAgent(
 
   swHandler->setSSLPolicy(server_->getSSLPolicy());
 
+  // Register before start() so an all-HwSwitches-disconnected teardown can be
+  // scheduled on the event base. skipWarmBootStateSave=true: this is a cold
+  // shutdown whose cold-boot-once markers are already written.
+  sw_->registerGracefulShutdownHandler(eventBase_, [this]() {
+    handleExitSignal(true /* gracefulExit */, true /* skipWarmBootStateSave */);
+  });
+
   // At this point, we are guaranteed no other agent process will initialize
   // the ASIC because such a process would have crashed attempting to bind to
   // the Thrift port 5909
@@ -314,6 +321,6 @@ int SwAgentInitializer::initAgent(
     serverStarted_ = false;
   }
   serverStopCV_.notify_one();
-  return 0;
+  return exitStatus_.load();
 }
 } // namespace facebook::fboss

--- a/fboss/agent/SwAgentInitializer.h
+++ b/fboss/agent/SwAgentInitializer.h
@@ -10,6 +10,7 @@
 #include "fboss/agent/SwSwitch.h"
 
 #include <gflags/gflags.h>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -96,7 +97,9 @@ class SwAgentInitializer : public AgentInitializer {
   std::unique_ptr<SwSwitch> sw_;
   std::unique_ptr<SwSwitchInitializer> initializer_;
   std::shared_ptr<PacketStreamHandler> packetStreamHandler_;
-  virtual void handleExitSignal(bool gracefulExit) = 0;
+  virtual void handleExitSignal(
+      bool gracefulExit,
+      bool skipWarmBootStateSave = false) = 0;
 
   void stopServer();
   /*
@@ -108,6 +111,10 @@ class SwAgentInitializer : public AgentInitializer {
    */
   virtual void stopServices();
   void waitForServerStopped();
+
+  // Exit status recorded by handleExitSignal() and returned by initAgent()
+  // once serve() unwinds.
+  std::atomic<int> exitStatus_{0};
 
  private:
   std::unique_ptr<apache::thrift::ThriftServer> server_;

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -901,10 +901,12 @@ state::WarmbootState SwSwitch::gracefulExitState() const {
   return thriftSwitchState;
 }
 
-void SwSwitch::gracefulExit() {
+void SwSwitch::gracefulExit(bool skipWarmBootStateSave) {
   if (isFullyInitialized()) {
     steady_clock::time_point begin = steady_clock::now();
-    XLOG(DBG2) << "[Exit] Starting SwSwitch graceful exit";
+    XLOG(DBG2) << "[Exit] Starting SwSwitch graceful exit"
+               << (skipWarmBootStateSave ? " (skipping warm boot state save)"
+                                         : "");
     ipv6_->floodNeighborAdvertisements();
     arp_->floodGratuituousArp();
     steady_clock::time_point neighborFloodDone = steady_clock::now();
@@ -920,22 +922,27 @@ void SwSwitch::gracefulExit() {
                       stopThreadsAndHandlersDone - neighborFloodDone)
                       .count();
 
-    state::WarmbootState thriftSwitchState;
-    std::thread swWarmbootStateThread([this,
-                                       &thriftSwitchState,
-                                       stopThreadsAndHandlersDone]() {
-      thriftSwitchState = gracefulExitState();
-      steady_clock::time_point switchStateToThriftDone = steady_clock::now();
-      XLOG(DBG2) << "[Exit] Switch state to thrift "
-                 << duration_cast<duration<float>>(
-                        switchStateToThriftDone - stopThreadsAndHandlersDone)
-                        .count();
-    });
-    // Cleanup if we ever initialized
-    stopHwSwitchHandler();
+    if (!skipWarmBootStateSave) {
+      state::WarmbootState thriftSwitchState;
+      std::thread swWarmbootStateThread([this,
+                                         &thriftSwitchState,
+                                         stopThreadsAndHandlersDone]() {
+        thriftSwitchState = gracefulExitState();
+        steady_clock::time_point switchStateToThriftDone = steady_clock::now();
+        XLOG(DBG2) << "[Exit] Switch state to thrift "
+                   << duration_cast<duration<float>>(
+                          switchStateToThriftDone - stopThreadsAndHandlersDone)
+                          .count();
+      });
+      // Cleanup if we ever initialized
+      stopHwSwitchHandler();
 
-    swWarmbootStateThread.join();
-    storeWarmBootState(thriftSwitchState);
+      swWarmbootStateThread.join();
+      storeWarmBootState(thriftSwitchState);
+    } else {
+      // Cleanup if we ever initialized
+      stopHwSwitchHandler();
+    }
     XLOG(DBG2)
         << "[Exit] SwSwitch Graceful Exit time "
         << duration_cast<duration<float>>(steady_clock::now() - begin).count();
@@ -1400,6 +1407,27 @@ void SwSwitch::invokeNeighborListener(
   if (neighborListener_ && !isExiting()) {
     neighborListener_(added, removed);
   }
+}
+
+void SwSwitch::registerGracefulShutdownHandler(
+    FbossEventBase* evb,
+    std::function<void()> handler) {
+  gracefulShutdownEvb_ = evb;
+  gracefulShutdownHandler_ = std::move(handler);
+}
+
+void SwSwitch::requestGracefulShutdown() {
+  if (!gracefulShutdownHandler_ || !gracefulShutdownEvb_) {
+    XLOG(ERR)
+        << "requestGracefulShutdown called but no graceful shutdown handler registered";
+    return;
+  }
+  // Run teardown on the registered event base, not the caller's thread;
+  // once_flag collapses concurrent requests into a single shutdown.
+  std::call_once(gracefulShutdownOnceFlag_, [this]() {
+    gracefulShutdownEvb_->runInEventBaseThread(
+        [handler = gracefulShutdownHandler_]() { handler(); });
+  });
 }
 
 void SwSwitch::exitFatal() const noexcept {

--- a/fboss/agent/SwSwitch.h
+++ b/fboss/agent/SwSwitch.h
@@ -848,8 +848,11 @@ class SwSwitch : public HwSwitchCallback {
   /*
    * Allow hardware to perform any cleanup needed to gracefully restart the
    * agent before we exit application.
+   *
+   * skipWarmBootStateSave: tear down without persisting warm-boot state or
+   * setting the can_warm_boot marker.
    */
-  void gracefulExit();
+  void gracefulExit(bool skipWarmBootStateSave = false);
 
   BootType getBootType() const {
     return bootType_;
@@ -878,6 +881,20 @@ class SwSwitch : public HwSwitchCallback {
   void invokeNeighborListener(
       const std::vector<std::string>& added,
       const std::vector<std::string>& deleted);
+
+  /*
+   * Register a graceful shutdown handler, run on the given event base when
+   * requestGracefulShutdown() is called.
+   */
+  void registerGracefulShutdownHandler(
+      FbossEventBase* evb,
+      std::function<void()> handler);
+
+  /*
+   * Schedule the registered graceful shutdown handler. Safe to call from any
+   * thread; the handler runs at most once.
+   */
+  void requestGracefulShutdown();
 
   std::string getConfigStr() const;
   cfg::SwitchConfig getConfig() const;
@@ -1265,6 +1282,11 @@ class SwSwitch : public HwSwitchCallback {
   bool supportsAddRemovePort_;
   const std::unique_ptr<PlatformProductInfo> platformProductInfo_;
   std::atomic<SwitchRunState> runState_{SwitchRunState::UNINITIALIZED};
+
+  std::function<void()> gracefulShutdownHandler_{nullptr};
+  FbossEventBase* gracefulShutdownEvb_{nullptr};
+  std::once_flag gracefulShutdownOnceFlag_;
+
   folly::ThreadLocalPtr<SwitchStats, SwSwitch> stats_;
   /**
    * The object to sync the interfaces to the system. This pointer could

--- a/fboss/agent/mnpu/SplitSwAgentInitializer.cpp
+++ b/fboss/agent/mnpu/SplitSwAgentInitializer.cpp
@@ -55,7 +55,15 @@ SplitSwAgentInitializer::getThrifthandlers() {
   return handlers;
 }
 
-void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
+void SplitSwAgentInitializer::handleExitSignal(
+    bool gracefulExit,
+    bool skipWarmBootStateSave) {
+  if (exitSignalReceived_.exchange(true)) {
+    XLOG(WARNING)
+        << "[Exit] Exit signal received while shutdown is already in progress, ignoring";
+    return;
+  }
+  exitStatus_ = gracefulExit ? 0 : 1;
   if (!sw_->isInitialized()) {
     XLOG(WARNING)
         << "[Exit] Signal received before initializing sw switch, waiting for initialization to finish.";
@@ -80,7 +88,7 @@ void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
   initializer_->stopFunctionScheduler();
   multiSwitchThriftHandler_->cancelEventSyncers();
   steady_clock::time_point switchGracefulExitBegin = steady_clock::now();
-  sw_->gracefulExit();
+  sw_->gracefulExit(skipWarmBootStateSave);
   steady_clock::time_point switchGracefulExitEnd = steady_clock::now();
   XLOG(DBG2) << "[Exit] Switch Graceful Exit time "
              << duration_cast<duration<float>>(
@@ -105,12 +113,6 @@ void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
 #endif
 #endif
   initializer_.reset();
-  this->waitForServerStopped();
-  if (gracefulExit) {
-    exit(0);
-  } else {
-    exit(1);
-  }
 }
 
 void SplitSwAgentInitializer::stopAgent(bool setupWarmboot, bool gracefulExit) {
@@ -130,6 +132,6 @@ void SplitSwAgentInitializer::exitForColdBoot() {
 }
 
 void SplitSwAgentInitializer::exitForWarmBoot(bool gracefulExit) {
-  handleExitSignal(gracefulExit);
+  handleExitSignal(gracefulExit, false /* skipWarmBootStateSave */);
 }
 } // namespace facebook::fboss

--- a/fboss/agent/mnpu/SplitSwAgentInitializer.h
+++ b/fboss/agent/mnpu/SplitSwAgentInitializer.h
@@ -5,7 +5,8 @@
 #include "fboss/agent/AgentDirectoryUtil.h"
 #include "fboss/agent/SwAgentInitializer.h"
 
-#include <folly/io/async/EventBase.h>
+#include <atomic>
+#include <vector>
 
 namespace facebook::fboss {
 
@@ -30,7 +31,7 @@ class SplitSwAgentInitializer : public SwAgentInitializer {
   std::vector<std::shared_ptr<apache::thrift::AsyncProcessorFactory>>
   getThrifthandlers() override;
 
-  void handleExitSignal(bool gracefulExit) override;
+  void handleExitSignal(bool gracefulExit, bool skipWarmBootStateSave) override;
 
   void stopAgent(bool setupWarmboot, bool gracefulExit) override;
 
@@ -39,6 +40,7 @@ class SplitSwAgentInitializer : public SwAgentInitializer {
   void exitForWarmBoot(bool gracefulExit);
   AgentDirectoryUtil agentDirectoryUtil_;
   MultiSwitchThriftHandler* multiSwitchThriftHandler_{nullptr};
+  std::atomic<bool> exitSignalReceived_{false};
 };
 
 } // namespace facebook::fboss

--- a/fboss/agent/single/MonolithicAgentInitializer.cpp
+++ b/fboss/agent/single/MonolithicAgentInitializer.cpp
@@ -110,7 +110,9 @@ void MonolithicAgentInitializer::createSwitch(
       sw_.get(), hwAgent_.get());
 }
 
-void MonolithicAgentInitializer::handleExitSignal(bool gracefulExit) {
+void MonolithicAgentInitializer::handleExitSignal(
+    bool gracefulExit,
+    bool skipWarmBootStateSave) {
   restart_time::mark(RestartEvent::SIGNAL_RECEIVED);
   XLOG(DBG2) << "[Exit] Signal received ";
   steady_clock::time_point begin = steady_clock::now();
@@ -132,7 +134,7 @@ void MonolithicAgentInitializer::handleExitSignal(bool gracefulExit) {
   steady_clock::time_point servicesStopped = steady_clock::now();
   XLOG(DBG2) << "[Exit] Services stop time "
              << duration_cast<duration<float>>(servicesStopped - begin).count();
-  sw_->gracefulExit();
+  sw_->gracefulExit(skipWarmBootStateSave);
   steady_clock::time_point switchGracefulExit = steady_clock::now();
   XLOG(DBG2)
       << "[Exit] Switch Graceful Exit time "

--- a/fboss/agent/single/MonolithicAgentInitializer.h
+++ b/fboss/agent/single/MonolithicAgentInitializer.h
@@ -69,7 +69,7 @@ class MonolithicAgentInitializer : public SwAgentInitializer {
    */
   virtual void setCmdLineFlagOverrides() const {}
 
-  void handleExitSignal(bool gracefulExit) override;
+  void handleExitSignal(bool gracefulExit, bool skipWarmBootStateSave) override;
 
   /*
    * MonoithicAgentInitializer overrides stopServices to stop the HwAgent first,

--- a/fboss/agent/test/AgentEnsemble.cpp
+++ b/fboss/agent/test/AgentEnsemble.cpp
@@ -3,6 +3,7 @@
 #include "fboss/agent/test/AgentEnsemble.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <map>
 #include <vector>
 
@@ -421,6 +422,12 @@ void AgentEnsemble::gracefulExit() {
   bool gracefulExit = !::testing::Test::HasFailure();
   initializer->stopAgent(
       true /* setupWarmboot */, gracefulExit /* gracefulExit */);
+  // handleExitSignal() now returns and lets serve() unwind on asyncInitThread_;
+  // join it then exit here to skip gtest TearDown() (which would tear down
+  // state the next warm boot depends on).
+  joinAsyncInitThread();
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  exit(gracefulExit ? 0 : 1);
 }
 
 void AgentEnsemble::applyNewState(

--- a/fboss/agent/test/SwSwitchTest.cpp
+++ b/fboss/agent/test/SwSwitchTest.cpp
@@ -10,7 +10,9 @@
 
 #include <gtest/gtest.h>
 
+#include "fboss/agent/AgentDirectoryUtil.h"
 #include "fboss/agent/ArpHandler.h"
+#include "fboss/agent/FbossEventBase.h"
 #include "fboss/agent/FbossHwUpdateError.h"
 #include "fboss/agent/MultiSwitchFb303Stats.h"
 #include "fboss/agent/NeighborUpdater.h"
@@ -26,12 +28,15 @@
 #include "fboss/agent/test/CounterCache.h"
 #include "fboss/agent/test/HwTestHandle.h"
 #include "fboss/agent/test/TestUtils.h"
+#include "fboss/lib/CommonFileUtils.h"
 
 #include <folly/IPAddressV4.h>
 #include <folly/IPAddressV6.h>
 #include <folly/MacAddress.h>
 
-#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
 
 using namespace facebook::fboss;
 using folly::IPAddressV4;
@@ -336,6 +341,38 @@ TEST_F(SwSwitchTest, gracefulExit) {
   sw->gracefulExit();
 }
 
+TEST_F(SwSwitchTest, gracefulExitSavesWarmBootState) {
+  auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
+    return bringAllPortsUp(state);
+  };
+  sw->updateStateBlocking("Bring Ports Up", bringPortsUpUpdateFn);
+
+  const auto* dirUtil = sw->getDirUtil();
+  auto canWarmBootFile = dirUtil->getSwSwitchCanWarmBootFile();
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+
+  // Persists warm-boot state and sets the can_warm_boot marker.
+  sw->gracefulExit();
+
+  EXPECT_TRUE(checkFileExists(canWarmBootFile));
+}
+
+TEST_F(SwSwitchTest, gracefulExitSkipWarmBootStateSave) {
+  auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
+    return bringAllPortsUp(state);
+  };
+  sw->updateStateBlocking("Bring Ports Up", bringPortsUpUpdateFn);
+
+  const auto* dirUtil = sw->getDirUtil();
+  auto canWarmBootFile = dirUtil->getSwSwitchCanWarmBootFile();
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+
+  // Cold shutdown: no warm-boot state persisted, so no can_warm_boot marker.
+  sw->gracefulExit(true /* skipWarmBootStateSave */);
+
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+}
+
 TEST_F(SwSwitchTest, overlappingUpdatesWithExit) {
   auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
     return bringAllPortsUp(state);
@@ -549,4 +586,37 @@ TEST_F(SwSwitchTest, FillFsdbStatsNullShelManager) {
   // Should not crash - shelManager_ is null on NPU switches
   // and the code must guard against that.
   EXPECT_NO_THROW(sw->fillFsdbStats());
+}
+
+TEST_F(SwSwitchTest, RequestGracefulShutdownUnregisteredIsNoOp) {
+  // No handler registered: must not crash.
+  EXPECT_NO_THROW(sw->requestGracefulShutdown());
+}
+
+TEST_F(SwSwitchTest, RequestGracefulShutdownRunsHandlerExactlyOnce) {
+  FbossEventBase evb("RequestGracefulShutdownTestEvb");
+  std::thread evbThread([&evb]() { evb.loopForever(); });
+  evb.waitUntilRunning();
+
+  std::atomic<int> callCount{0};
+  sw->registerGracefulShutdownHandler(
+      &evb, [&callCount]() { callCount.fetch_add(1); });
+
+  // Concurrent fires must collapse to a single handler invocation.
+  constexpr int kThreads = 8;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([this]() { sw->requestGracefulShutdown(); });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Flush the event base so the enqueued handler has run.
+  evb.runInFbossEventBaseThreadAndWait([]() {});
+  evb.terminateLoopSoon();
+  evbThread.join();
+
+  EXPECT_EQ(callCount.load(), 1);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The agent (both hw_agent and sw_agent) could abort with a `prevLoopTid` `LOG(FATAL)` ("Driving an EventBase while it is already being driven", `EventBase.cpp`) at the tail of shutdown. The abort happened because shutdown was terminated inline (`exit()` / `std::exit()`) from a thread whose event base was still live -- the thrift server's event base thread inside `serve()`, or a thrift stream-cleanup thread. Terminating there runs at-exit handlers that destroy folly's `EventBaseManager` and re-drive the still-live event base, tripping the CHECK and turning a clean exit into a SIGABRT/coredump. This fix makes every shutdown trigger (except if `FLAGS_exit_for_any_hw_disconnect` is set) converge on a single, thread-safe path: stop the services, return, let `serve()` unwind back to `main()`, and exit from the main thread once the thrift workers are joined  - never calling `exit()` from an event base thread. Note that we are only making this agent in split switch agent paths.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Ran `*AgentHwAcl*` tests. Without fix, saw multiple
crashes:

```
[root@wdg152 netops]# grep "Check failed: expected == prevLoopTid" /var/facebook/logs/fboss/wedge_agent.log
F20260806 19:16:47.595602  3407 EventBase.cpp:580] Check failed: expected == prevLoopTid (-2 vs. 2277) Driving an EventBase (in thread 3407) while it is already being driven (in thread 2277) is forbidden.
...
```

No crashes with fix.

Also wrote a script to be run on DUT which signals SIGTERM to sw and hw agents and also disconnects while the `serve()` is live. Verified that no crash is seen with fix. But seen without fix.

**With fix**:

```
[root@wdg152 netops]# ./repro.sh --path sigterm
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:sigterm] SIGTERM to SW agent while serve() is live ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 0
  create_port INVALID PARAMETER (must be 0): 0
  reached CONFIGURED                      : 1
  lone HW can_warm_boot_0 (asymmetric)    : 1
  graceful exit ran (warm boot saved)     : 1

[root@wdg152 netops]# ./repro.sh --path disconnect
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:disconnect] SIGKILL ALL hw agents; SW loses last connection ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 0
  create_port INVALID PARAMETER (must be 0): 0
  reached CONFIGURED                      : 0
  detected all-HW-lost (disconnect path)  : 1
  SW cold boot marker created             : 1
  HW cold boot marker(s) created          : 1
  graceful exit SKIPPING warm boot save   : 1
  handler-missing error (must be 0)       : 0
== [markers on disk] ==
-rw-r--r--. 1 root root 0 Aug  6 18:59 /dev/shm/fboss/warm_boot/hw_cold_boot_once_0

[root@wdg152 netops]# ./repro.sh --path hw-sigterm
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:hw-sigterm] SIGTERM to each hw agent while its serve() is live ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 0
  create_port INVALID PARAMETER (must be 0): 0
  [Exit] Signal received (DBG2)           : 2
  [Exit] Total graceful Exit (DBG2)       : 2
  [Exit] destroying hardware agent (HW)   : 0
  [Exit] Cold boot detected (HW,if marker): 0
== [HW cold-boot markers on disk] ==
  idx=0 /dev/shm/fboss/exit_hw_for_cold_boot_0 : absent
```

**Without fix**:

```
[root@wdg152 netops]# ./repro.sh --path sigterm
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:sigterm] SIGTERM to SW agent while serve() is live ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 2
  create_port INVALID PARAMETER (must be 0): 0
  reached CONFIGURED                      : 1
  lone HW can_warm_boot_0 (asymmetric)    : 1
  graceful exit ran (warm boot saved)     : 1


[root@wdg152 netops]# ./repro.sh --path disconnect
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:disconnect] SIGKILL ALL hw agents; SW loses last connection ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 1
  create_port INVALID PARAMETER (must be 0): 0
  reached CONFIGURED                      : 0
  detected all-HW-lost (disconnect path)  : 1
  SW cold boot marker created             : 1
  HW cold boot marker(s) created          : 1
  graceful exit SKIPPING warm boot save   : 0
  handler-missing error (must be 0)       : 0
== [markers on disk] ==
-rw-r--r--. 1 root root 0 Aug  6 19:19 /dev/shm/fboss/warm_boot/hw_cold_boot_once_0

[root@wdg152 netops]# ./repro.sh --path hw-sigterm
== [setup] clean cold boot: clear all warm/cold flags ==
   waiting 45s for CONFIGURED...
== [trigger:hw-sigterm] SIGTERM to each hw agent while its serve() is live ==
   waiting 60s for teardown + next boot...
== [result] (from this cycle only) ==
  EventBase double-drive (must be 0)      : 2
  create_port INVALID PARAMETER (must be 0): 0
  [Exit] Signal received (DBG2)           : 1
  [Exit] Total graceful Exit (DBG2)       : 1
  [Exit] destroying hardware agent (HW)   : 0
  [Exit] Cold boot detected (HW,if marker): 0
== [HW cold-boot markers on disk] ==
  idx=0 /dev/shm/fboss/exit_hw_for_cold_boot_0 : absent
```