### PR TITLE
[Celestica] Leh800bcls: Fix AgentEcmpTrunkTest initialization and crash on multi-NPU platforms

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentEcmpTrunkTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentEcmpTrunkTests.cpp
@@ -26,7 +26,12 @@ class AgentEcmpTrunkTest : public AgentHwTest {
         ensemble.getL3Asics().front(),
         ensemble.masterLogicalPortIds(),
         ensemble.getSw()->getPlatformSupportsAddRemovePort(),
-        ensemble.getL3Asics().front()->desiredLoopbackModes());
+        ensemble.getL3Asics().front()->desiredLoopbackModes(),
+        true, /* interfaceHasSubnet */
+        utility::kBaseVlanId, /* baseVlanId */
+        true, /* optimizePortProfile */
+        true, /* setInterfaceMac */
+        ensemble.getSw()->getPlatformType());
     addAggPort(kAggId, getTrunkMemberPorts(ensemble), &config);
     return config;
   }


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```
# Summary
When running the test agent case AgentEcmpTrunkTest.*, fboss_hw_agent crashes. The error is:
```
Error: counter_get() failed(Invalid unit).
E0809 02:37:08.710696 659482 SaiApiError.h:67] [switch] Failed to create sai entity SwitchSaiId(17947989248409862144): (InitSwitch: true, HwInfo: [], SrcMac: 66:f6:4d:d1:59:fd, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, 
```
# Root Cause
The overridden initialConfig() method in AgentEcmpTrunkTests.cpp called utility::oneL3IntfNPortConfig without specifying the optional final parameter platformType (falling back to default std::nullopt).
Lacking a valid PlatformType, the config generator genPortVlanCfg fallback to single-NPU generation, producing a switchIdToSwitchInfo dictionary that only contained Switch ID 0 with an empty connectionHandle.

# Solution
Modified initialConfig() in  class AgentEcmpTrunkTest in fboss/agent/test/agent_hw_tests/AgentEcmpTrunkTests.cpp to pass the ensemble.getSw()->getPlatformType() platformType parameter, ensuring the correct configuration is generated for multi-switch platforms.

# Test Plan
Verified on leh800bcls platform that all 6 tests in AgentEcmpTrunkTest successfully pass on both Npu0 and Npu1:
```
[root@localhost log]# grep " OK " AgentTxNpu[01]/mu*.log
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpBeforeReinit-20260809_035738.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpBeforeReinit (30752 ms)
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpThenStateUp-20260809_035625.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpThenStateUp (29894 ms)
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkDownThenUpThenStateUp-20260809_035701.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkDownThenUpThenStateUp (29197 ms)
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkUpDownUpBeforeReinit-20260809_035816.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkUpDownUpBeforeReinit (30862 ms)
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkMemberRemoveWithRouteTest-20260809_035548.log:[       OK ] AgentEcmpTrunkTest.TrunkMemberRemoveWithRouteTest (28986 ms)
AgentTxNpu0/multi_switch_agent-AgentEcmpTrunkTest.TrunkNotRemovedFromEcmpWithMinLinks-20260809_035512.log:[       OK ] AgentEcmpTrunkTest.TrunkNotRemovedFromEcmpWithMinLinks (29102 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpBeforeReinit-20260809_040120.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpBeforeReinit (30618 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpThenStateUp-20260809_040007.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkAndLACPDownThenUpThenStateUp (29722 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkDownThenUpThenStateUp-20260809_040044.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkDownThenUpThenStateUp (29634 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkUpDownUpBeforeReinit-20260809_040158.log:[       OK ] AgentEcmpTrunkTest.TrunkL2ResolveNhopThenLinkUpDownUpBeforeReinit (30250 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkMemberRemoveWithRouteTest-20260809_035929.log:[       OK ] AgentEcmpTrunkTest.TrunkMemberRemoveWithRouteTest (30179 ms)
AgentTxNpu1/multi_switch_agent-AgentEcmpTrunkTest.TrunkNotRemovedFromEcmpWithMinLinks-20260809_035854.log:[       OK ] AgentEcmpTrunkTest.TrunkNotRemovedFromEcmpWithMinLinks (28852 ms)

```