### PR TITLE
[Celestica] Leh800bcls: Fix AgentTrunkTest crash in multi-NPU environment by passing platform type in config generation

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentTrunkTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentTrunkTests.cpp
@@ -2,6 +2,7 @@
 
 #include "fboss/agent/test/AgentHwTest.h"
 #include "fboss/agent/test/EcmpSetupHelper.h"
+#include "fboss/agent/test/TestUtils.h"
 #include "fboss/agent/test/TrunkUtils.h"
 #include "fboss/agent/test/utils/ConfigUtils.h"
 #include "fboss/agent/test/utils/PacketTestUtils.h"
@@ -16,10 +17,15 @@ class AgentTrunkTest : public AgentHwTest {
  protected:
   cfg::SwitchConfig initialConfig(
       const AgentEnsemble& ensemble) const override {
+    auto asic = checkSameAndGetAsicForTesting(ensemble.getL3Asics());
     return utility::oneL3IntfTwoPortConfig(
-        ensemble.getSw(),
+        ensemble.getSw()->getPlatformMapping(),
+        asic,
         ensemble.masterLogicalPortIds()[0],
-        ensemble.masterLogicalPortIds()[1]);
+        ensemble.masterLogicalPortIds()[1],
+        ensemble.getSw()->getPlatformSupportsAddRemovePort(),
+        asic->desiredLoopbackModes(),
+        ensemble.getSw()->getPlatformType());
   }
 
   std::vector<ProductionFeature> getProductionFeaturesVerified()


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary
Fixes a crash in fboss_hw_agent during AgentTrunkTest cases in multi-NPU (Split Agent) environments. fboss_hw_agent0 crashed with 'counter_get() failed(Invalid unit)' during initialization.
```
Error: counter_get() failed(Invalid unit).
E0810 15:02:20.451190 1978187 SaiApiError.h:67] [switch] Failed to create sai entity SwitchSaiId(17947989248409862144): (InitSwitch: true, HwInfo: [], SrcMac: 66:f6:4d:d1:59:fd, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, MacAgingTime: 300, nullopt, nullopt, nullopt, nullopt
, UseEcnThresholds: true, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt
, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, PfcTcDldTimerGranularityInterval: [(mapping: key: 0, value: 10), (mapping: key: 1, value: 10), (mapping: key: 2, value: 10), (mapping: key: 3, value: 10), (mapping: key: 4, va
lue: 10), (mapping: key: 5, value: 10), (mapping: key: 6, value: 10), (mapping: key: 7, value: 10)], nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt, nullopt): FAILURE
```
# Root Cause
 In `AgentTrunkTest::initialConfig()`, the configuration was generated by calling `utility::oneL3IntfTwoPortConfig()` without passing the `platformType`. In multi-NPU environments, omitting the platform type causes the configuration generator to fall back to a single-NPU configuration. 

# Solution
In `utility::oneL3IntfTwoPortConfig()` to explicitly pass the `platformType` (retrieved via `ensemble.getSw()->getPlatformType()`).

# Test Plan
Successfully ran and verified all Trunk tests on Leh800bcls platform (NPU0 and NPU1):
- NPU0
```
Running all tests took 0:05:53.619048 between 2026-08-10 16:08:21.121951 and 2026-08-10 16:14:14.740999
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCreateHighLowKeyIds (21927 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCreateHighLowKeyIds (12099 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCheckIngressPktAggPort (21715 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCheckIngressPktAggPort (11247 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkMemberPortDownMinLinksViolated (21853 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkMemberPortDownMinLinksViolated (12202 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkPortStats (25375 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkPortStats (15034 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCapacityUpdatesOnMemberDown (26950 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCapacityUpdatesOnMemberDown (16058 ms)
Summary:
   PASSED : 10
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
- NPU1
```
Running all tests took 0:05:50.088523 between 2026-08-10 16:16:37.923524 and 2026-08-10 16:22:28.012047
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCreateHighLowKeyIds (20600 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCreateHighLowKeyIds (10205 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCheckIngressPktAggPort (21644 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCheckIngressPktAggPort (11171 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkMemberPortDownMinLinksViolated (22897 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkMemberPortDownMinLinksViolated (12236 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkPortStats (25240 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkPortStats (16088 ms)
[ PASSED ] cold_boot.AgentTrunkTest.TrunkCapacityUpdatesOnMemberDown (26488 ms)
[ PASSED ] warm_boot.AgentTrunkTest.TrunkCapacityUpdatesOnMemberDown (15404 ms)
Summary:
   PASSED : 10
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```