### PR TITLE
[Nexthop] Use real timestamps from retrieved port stats for port line rate calculation

### DIFF
--- a/fboss/agent/hw/test/HwSwitchEnsemble.cpp
+++ b/fboss/agent/hw/test/HwSwitchEnsemble.cpp
@@ -892,8 +892,15 @@ bool HwSwitchEnsemble::waitForRateOnPort(
     // interpacket gap. Account for that in linerate.
     auto packetPaddingBytes = (curPortPackets - prevPortPackets) * 20;
     auto curPortBytes = *curPortStats.outBytes_() + packetPaddingBytes;
+    // Port stats are sampled asynchronously by the stats thread, so the
+    // real interval between two samples can differ from the requested
+    // sleep duration. Use the actual timestamp delta when available.
+    const int elapsedSec = static_cast<int>(
+        *curPortStats.timestamp_() - *prevPortStats.timestamp_());
+    const int rateDurationSec =
+        elapsedSec > 0 ? elapsedSec : secondsToWaitPerIteration;
     auto rate = static_cast<uint64_t>((curPortBytes - prevPortBytes) * 8) /
-        secondsToWaitPerIteration;
+        rateDurationSec;
     if (desiredBps == 0 && rate == desiredBps) {
       XLOG(DBG0) << "Expect no traffic: Current rate " << rate << " bps!";
       return true;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Port stats are sampled asynchronously by the stats thread, so the real interval between two samples can differ from the requested sleep duration. Use the actual timestamp delta when available.

This is a change similar to the one found in https://github.com/facebook/fboss/commit/21c4e2a9fccaadc1acb22013b485ebd1df422260 which did the same fix for AgentPortBandWidthTests.cpp and will help reduce the flakiness in the tests that depend on this function.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Ran `AgentOlympicQosSchedulerTest.VerifyWRRAndNC` which depends on this function and it still passes with the change.
