### PR TITLE
[Nexthop] Fix baseline stats retrieval for ACL queue per host tests

### DIFF
--- a/cmake/AgentTestUtils.cmake
+++ b/cmake/AgentTestUtils.cmake
@@ -21,6 +21,7 @@ target_link_libraries(acl_test_utils
   switch_config_cpp2
   switch_state_cpp2
   asic_test_utils
+  common_utils
 )
 
 add_library(copp_test_utils

--- a/fboss/agent/hw/HwFb303Stats.h
+++ b/fboss/agent/hw/HwFb303Stats.h
@@ -22,7 +22,7 @@ namespace facebook::fboss {
 
 struct HwFb303Counter {
   facebook::stats::MonotonicCounter fb303Counter;
-  int64_t cumulativeValue;
+  int64_t cumulativeValue{0};
   explicit HwFb303Counter(facebook::stats::MonotonicCounter counter)
       : fb303Counter(std::move(counter)) {}
 };

--- a/fboss/agent/test/agent_hw_tests/AgentAclTableGroupTrafficTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentAclTableGroupTrafficTests.cpp
@@ -224,7 +224,8 @@ class AgentAclTableGroupTrafficTest : public AgentHwTest {
 
     auto ttlCounterName = utility::getQueuePerHostTtlCounterName();
 
-    auto statBefore = utility::getAclInOutPackets(getSw(), ttlCounterName);
+    auto statBefore =
+        utility::waitForAndGetAclInOutPackets(getSw(), ttlCounterName);
 
     const auto beforePortStats =
         this->getLatestPortStats(this->masterLogicalPortIds()[0]);

--- a/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentQueuePerHostL2Tests.cpp
@@ -52,7 +52,8 @@ class AgentQueuePerHostL2Test : public AgentHwTest {
     auto ttlAclName = utility::getQueuePerHostTtlAclName();
     auto ttlCounterName = utility::getQueuePerHostTtlCounterName();
 
-    auto statBefore = utility::getAclInOutPackets(getSw(), ttlCounterName);
+    auto statBefore =
+        utility::waitForAndGetAclInOutPackets(getSw(), ttlCounterName);
 
     std::map<int, int64_t> beforeQueueOutPkts;
     for (const auto& queueId : utility::kQueuePerhostQueueIds()) {

--- a/fboss/agent/test/agent_hw_tests/AgentQueuePerHostTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentQueuePerHostTests.cpp
@@ -280,7 +280,8 @@ class AgentQueuePerHostTest : public AgentHwTest {
     auto ttlAclName = utility::getQueuePerHostTtlAclName();
     auto ttlCounterName = utility::getQueuePerHostTtlCounterName();
 
-    auto statBefore = utility::getAclInOutPackets(getSw(), ttlCounterName);
+    auto statBefore =
+        utility::waitForAndGetAclInOutPackets(getSw(), ttlCounterName);
 
     std::map<int, int64_t> beforeQueueOutPkts;
     for (const auto& queueId : utility::kQueuePerhostQueueIds()) {
@@ -441,10 +442,11 @@ class AgentQueuePerHostTest : public AgentHwTest {
     auto ttlCounterName = utility::getQueuePerHostTtlCounterName();
 
     for (bool frontPanel : {false, true}) {
-      auto packetsBefore = utility::getAclInOutPackets(getSw(), ttlCounterName);
+      auto packetsBefore =
+          utility::waitForAndGetAclInOutPackets(getSw(), ttlCounterName);
 
       auto bytesBefore =
-          utility::getAclInOutPackets(getSw(), ttlCounterName, true);
+          utility::waitForAndGetAclInOutPackets(getSw(), ttlCounterName, true);
 
       auto dstIP = getIpToMacAndClassID<AddrT>().begin()->first;
       sendPacket(dstIP, frontPanel, 64 /* ttl < 128 */);

--- a/fboss/agent/test/utils/AclTestUtils.cpp
+++ b/fboss/agent/test/utils/AclTestUtils.cpp
@@ -10,11 +10,14 @@
 
 #include "fboss/agent/test/utils/AclTestUtils.h"
 
+#include <chrono>
 #include <memory>
+#include <optional>
 
 #include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/SwSwitch.h"
+#include "fboss/lib/CommonUtils.h"
 
 DECLARE_bool(enable_acl_table_group);
 
@@ -675,21 +678,46 @@ std::vector<cfg::CounterType> getAclCounterTypes(
   }
 }
 
-uint64_t getAclInOutPackets(
+std::optional<uint64_t> getAclInOutPacketsIf(
     const SwSwitch* sw,
     const std::string& statName,
     bool bytes) {
   auto statStr = bytes ? statName + ".bytes" : statName + ".packets";
   auto hwSwitchStatsMap = sw->getHwSwitchStatsExpensive();
-  int64_t statValue = 0;
+  std::optional<uint64_t> statValue;
   for (const auto& [switchIndex, hwswitchStats] : hwSwitchStatsMap) {
     auto aclStats = hwswitchStats.aclStats();
     auto entry = aclStats->statNameToCounterMap()->find(statStr);
     if (entry != aclStats->statNameToCounterMap()->end()) {
-      statValue += entry->second;
+      statValue = statValue.value_or(0) + entry->second;
     }
   }
   return statValue;
+}
+
+uint64_t getAclInOutPackets(
+    const SwSwitch* sw,
+    const std::string& statName,
+    bool bytes) {
+  return getAclInOutPacketsIf(sw, statName, bytes).value_or(0);
+}
+
+uint64_t waitForAndGetAclInOutPackets(
+    const SwSwitch* sw,
+    const std::string& statName,
+    bool bytes,
+    int numRetries,
+    std::chrono::milliseconds retryInterval) {
+  std::optional<uint64_t> statValue;
+  checkWithRetry(
+      [&]() {
+        statValue = getAclInOutPacketsIf(sw, statName, bytes);
+        return statValue.has_value();
+      },
+      numRetries,
+      retryInterval,
+      folly::to<std::string>("fetch acl stat ", statName));
+  return *statValue;
 }
 
 uint64_t getAclInOutPackets(

--- a/fboss/agent/test/utils/AclTestUtils.h
+++ b/fboss/agent/test/utils/AclTestUtils.h
@@ -10,6 +10,9 @@
 
 #pragma once
 
+#include <chrono>
+#include <optional>
+
 #include "fboss/agent/HwSwitch.h"
 #include "fboss/agent/gen-cpp2/switch_config_types.h"
 #include "fboss/agent/hw/switch_asics/HwAsic.h"
@@ -188,6 +191,25 @@ uint64_t getAclInOutPackets(
     const SwSwitch* sw,
     const std::string& statName,
     bool bytes = false);
+
+// nullopt if no HwSwitch has reported this counter yet, as opposed to a
+// reported value of 0.
+std::optional<uint64_t> getAclInOutPacketsIf(
+    const SwSwitch* sw,
+    const std::string& statName,
+    bool bytes = false);
+
+// Waits for the counter to appear in SwSwitch's async HwSwitchStats. Use for
+// baseline snapshots taken outside WITH_RETRIES: right after a warm boot the
+// counter is absent until the HwSwitch re-programs its ACLs, and
+// getAclInOutPackets() reports absent as 0 while the hardware counter has kept
+// its pre-warmboot value.
+uint64_t waitForAndGetAclInOutPackets(
+    const SwSwitch* sw,
+    const std::string& statName,
+    bool bytes = false,
+    int numRetries = 120,
+    std::chrono::milliseconds retryInterval = std::chrono::milliseconds(1000));
 
 uint64_t getAclInOutPackets(
     const HwSwitch* hw,

--- a/fboss/agent/test/utils/BUCK
+++ b/fboss/agent/test/utils/BUCK
@@ -61,6 +61,7 @@ cpp_library(
         "//fboss/agent:switch_config-cpp2-types",
         "//fboss/agent/hw/switch_asics:switch_asics",
         "//fboss/agent/state:state",
+        "//fboss/lib:common_utils",
     ],
 )
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

The test expects to run as follows:

1. Read the counter before (baseline) -> `statBefore`
2. Send packets
3. Read the counter after -> `statAfter`
4. Check `statAfter - statBefore` is expected value

**Problem**:

The HW agent process polls the ACL counters and pushes them to the SW agent every 1s.  Until the first push lands, the SW agent's cached stats map is empty - and the old `getAclInOutPackets` couldn't distinguish "no `HwSwitch` has reported this coutner yet" from "the counter reports 0". It returned 0 for both.

Across a warm boot the hardware counter keeps it pre-warmboot value (20). But if the baseline is read before the first stats push arrives, `statBefore` gets 0 instead of 20, so the delta comes out as the full accumulated count:

```
  08:57:07.837500 AgentQueuePerHostTests.cpp:231] Verify class id for 1.0.0.14 ...   <- baseline read here
  08:57:07.877734 MultiSwitchThriftHandler.cpp:378] Got stats event from switchIndex 0  <- stats polled
  08:57:10.840604 AgentQueuePerHostTests.cpp:349]  Acl stats : 25                    <- 25-0 != 5, fails 30s
  08:57:41.849150 AgentQueuePerHostTests.cpp:349]  Acl stats : 30                    <- next sub-phase passes
```

Since `statBefore` is not in `WITH_RETRIES` loop, it stays 0 for full 30s until timeout.

**Fix**:

`getAclInOutPacketsIf` returns `nullopt` when no HwSwitch has reported the counter, and 0 only when 0 is genuinely reported. `getLatestAclInOutPackets` wraps it to wait until the counter is present, mirroring how `getLatestPortStats` waits for port stats. Only the baseline snapshot switch to it - `getAclInOutPackets` keeps its existing absent-is-0 behavior, so other tests are unchanged.

As a side fix, also make sure `HwFb303Counter::cumulativeValue` is explicitly inited to 0.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
[ PASSED ] cold_boot.AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (17887 ms)
[ PASSED ] warm_boot.AgentQueuePerHostL2Test.VerifyHostToQueueMappingClassID (8544 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsAfterResolve (20091 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsAfterResolve (12629 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsAfterResolveBlock (16187 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsAfterResolveBlock (4755 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsWithResolve (21140 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsWithResolve (12542 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsWithResolveBlock (16035 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.VerifyHostToQueueMappingClassIDsWithResolveBlock (4705 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.VerifyTtldCounter (20290 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.VerifyTtldCounter (8604 ms)
[ PASSED ] cold_boot.AgentQueuePerHostTest.RemovePendingNeighborDoesNotCrash (16035 ms)
[ PASSED ] warm_boot.AgentQueuePerHostTest.RemovePendingNeighborDoesNotCrash (4700 ms)
[ PASSED ] cold_boot.AgentQueuePerHostRouteTest.VerifyHostToQueueMappingClassID (33005 ms)
[ PASSED ] warm_boot.AgentQueuePerHostRouteTest.VerifyHostToQueueMappingClassID (13857 ms)
[ PASSED ] cold_boot.AgentQueuePerHostRouteTest.VerifyHostToQueueMappingClassIDBlock (29143 ms)
[ PASSED ] warm_boot.AgentQueuePerHostRouteTest.VerifyHostToQueueMappingClassIDBlock (9886 ms)
Summary:
   PASSED : 18
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
