### PR TITLE
[Cisco] Prevent loopback re-entry in queue watermark accuracy test

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
@@ -10,6 +10,7 @@
 #include "fboss/agent/test/EcmpSetupHelper.h"
 #include "fboss/agent/test/TestUtils.h"
 #include "fboss/agent/test/agent_hw_tests/AgentTestAddressConstants.h"
+#include "fboss/agent/test/utils/AclTestUtils.h"
 #include "fboss/agent/test/utils/AqmTestUtils.h"
 #include "fboss/agent/test/utils/ConfigUtils.h"
 #include "fboss/agent/test/utils/CoppTestUtils.h"
@@ -515,7 +516,24 @@ TEST_F(AgentWatermarkTest, VerifyDeviceWatermarkHigherThanQueueWatermark) {
 }
 
 TEST_F(AgentWatermarkTest, VerifyQueueWatermarkAccuracy) {
-  auto setup = [this]() { _setup(false); };
+  auto setup = [this]() {
+    // A packet that egresses the congested port, loops back on the MAC and
+    // re-enters the same queue is counted as TXed while still occupying a
+    // buffer. sendPacketsWithQueueBuildup() then compensates for it and the
+    // queue peaks above kNumberOfPacketsToSend. Deny ingress on the egress
+    // port so each packet gets exactly one pass through the queue.
+    auto config = getAgentEnsemble()->getCurrentConfig();
+    const PortID kEgressPort = masterLogicalInterfacePortIds()[0];
+    cfg::AclEntry acl;
+    acl.name() = "verifyQueueWatermarkAccuracy-egress-rx-disable";
+    acl.srcPort() = kEgressPort;
+    acl.actionType() = cfg::AclActionType::DENY;
+    utility::addAclEntry(&config, acl, utility::kDefaultAclTable());
+    applyNewConfig(config);
+    XLOG(DBG0) << "Disabled egress port ingress via ACL on port "
+               << kEgressPort;
+    _setup(false);
+  };
   auto verify = [this]() {
     for (const auto& switchId : switchIdsUnderTest()) {
       const auto asic = getSw()->getHwAsicTable()->getHwAsic(switchId);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

`VerifyQueueWatermarkAccuracy` expects a predictable queue depth after building up traffic with egress transmission disabled.

The queue-buildup helper assumes packets counted as transmitted have permanently left the congested queue. A packet returning through MAC loopback can be counted as transmitted while re-entering the queue. The helper may then send an unnecessary replacement packet, causing the watermark to exceed the expected value by one packet buffer.

This change adds an ingress ACL on the congested egress port during test setup. It drops packets returning through that port before they can re-enter the queue.

The initial traffic path remains unaffected because test packets are injected through a different port. This is limited to test configuration and does not affect production forwarding behavior.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

Manually ran VerifyQueueWatermarkAccuracy on HW and test Passed

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
