### PR TITLE
[Cisco] Rate limit QSFP port state machine update log

### DIFF
--- a/fboss/qsfp_service/PortManager.cpp
+++ b/fboss/qsfp_service/PortManager.cpp
@@ -1776,7 +1776,7 @@ void PortManager::handlePendingUpdates() {
   // Pending updates are stored within each PortStateMachineController, so this
   // function asks each StateMachineController to execute a single pending
   // update if possible.
-  PORTMGR_SM_LOG(INFO) << "Trying to update all PortStateMachines";
+  XLOG_EVERY_MS(DBG2, 30000) << "[SM] Trying to update all PortStateMachines";
 
   // To expedite all these different ports state update, use Future
   std::vector<folly::Future<folly::Unit>> stateUpdateTasks;


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`PortManager::handlePendingUpdates()` logs that it is trying to update every port state machine on each periodic update pass, even when there is no noteworthy state change. On a 64-port system this single message accounted for more than 10,000 lines in a 100,000-line `qsfp_service` log sample.

Log the periodic message at `DBG2` at most once every 30 seconds. The existing `[SM]` prefix is preserved.

# Test Plan

- Ran the upstream pre-commit hooks against `fboss/qsfp_service/PortManager.cpp`; clang-format and all applicable checks passed.
- Rebuilt `qsfp_service` with this change and hot-swapped the binary on a live Cisco C8501 (`MORGAN800CC`). The service remained active and the standard FBOSS service and routing health checks remained clean.
- Compared 100,000-line `qsfp_service` log samples before and after the change. Occurrences of this message fell from 10,797 to 16.
