### PR TITLE
[Cisco] Use checksum-matched FBOSS builder image on cache hit

### DIFF
--- a/fboss-image/distro_cli/lib/docker/image.py
+++ b/fboss-image/distro_cli/lib/docker/image.py
@@ -204,6 +204,20 @@ def build_fboss_builder_image() -> None:
     should_build, checksum, reason = _should_build_image(root_dir)
 
     if not should_build:
+        try:
+            subprocess.run(
+                [
+                    "docker",
+                    "tag",
+                    f"{FBOSS_BUILDER_IMAGE}:{checksum}",
+                    f"{FBOSS_BUILDER_IMAGE}:latest",
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            raise RuntimeError(
+                f"Failed to activate cached {FBOSS_BUILDER_IMAGE} image: {e}"
+            ) from e
         logger.info(
             f"{FBOSS_BUILDER_IMAGE} image with checksum {checksum[:12]} "
             f"{reason}, skipping build"

--- a/fboss-image/distro_cli/tests/docker_image_test.py
+++ b/fboss-image/distro_cli/tests/docker_image_test.py
@@ -1,11 +1,12 @@
 """Tests for Docker image management utilities."""
 
 import os
+import subprocess
 import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from distro_cli.lib.docker.image import _should_build_image
+from distro_cli.lib.docker.image import _should_build_image, build_fboss_builder_image
 
 
 class TestShouldBuildImage(unittest.TestCase):
@@ -87,6 +88,39 @@ class TestShouldBuildImage(unittest.TestCase):
         self.assertEqual(checksum, "abc123")
         self.assertIn("expired", reason)
         self.assertIn("48", reason)
+
+
+class TestBuildFbossBuilderImage(unittest.TestCase):
+    @patch("distro_cli.lib.docker.image.get_abs_path")
+    @patch("distro_cli.lib.docker.image._should_build_image")
+    @patch("distro_cli.lib.docker.image.subprocess.run")
+    def test_cached_checksum_image_becomes_latest(
+        self, mock_run, mock_should_build, mock_get_abs_path
+    ):
+        mock_get_abs_path.return_value = Path(__file__)
+        mock_should_build.return_value = (False, "abc123", "exists")
+
+        build_fboss_builder_image()
+
+        mock_run.assert_called_once_with(
+            ["docker", "tag", "fboss_builder:abc123", "fboss_builder:latest"],
+            check=True,
+        )
+
+    @patch("distro_cli.lib.docker.image.get_abs_path")
+    @patch("distro_cli.lib.docker.image._should_build_image")
+    @patch("distro_cli.lib.docker.image.subprocess.run")
+    def test_cached_checksum_activation_failure_raises_runtime_error(
+        self, mock_run, mock_should_build, mock_get_abs_path
+    ):
+        mock_get_abs_path.return_value = Path(__file__)
+        mock_should_build.return_value = (False, "abc123", "exists")
+        mock_run.side_effect = subprocess.CalledProcessError(1, ["docker", "tag"])
+
+        with self.assertRaisesRegex(
+            RuntimeError, "Failed to activate cached fboss_builder image"
+        ):
+            build_fboss_builder_image()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`build_fboss_builder_image()` checks for a valid builder image using its dependency checksum tag, but subsequent builds run the unqualified `fboss_builder` image, which resolves to `latest`. When switching between dependency trees or restoring a cached checksum image, the matching image can exist while `latest` still points to a different builder.

Retag the selected checksum image as `latest` before returning from the cache-hit path. A tag activation failure is reported as a `RuntimeError` instead of continuing with the wrong builder image.

# Test Plan

- Ran the upstream pre-commit hooks against the modified files; all applicable checks passed.
- Ran `PYTHONPATH=fboss-image python3 -m unittest distro_cli.tests.docker_image_test`; all six tests passed.
- Added unit coverage for successful checksum-tag activation and activation failure handling.
