### PR TITLE
[Nexthop] Define TAJO_SDK for cmake builds with SAI_TAJO_IMPL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(SAI_TAJO_IMPL "Build SAI api with tajo extensions" OFF)
 if ($ENV{SAI_TAJO_IMPL})
   message(STATUS "ENV SAI_TAJO_IMPL is set")
   set (SAI_TAJO_IMPL ON)
+  add_definitions (-DTAJO_SDK)
 endif()
 
 option(SAI_BRCM_IMPL "Build SAI api with BRCM-SAI extensions" OFF)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

## Issue

The `AgentAclTableGroupTrafficTest.VerifyDscpMarkingAndTtlAclTable` agent_hw test would fail this equality check:

```
/src/fboss/agent/test/agent_hw_tests/AgentAclTableGroupTrafficTests.cpp:363: Failure
Expected equality of these values:
  dscpAclPkts - beforeAclPkts.first
    Which is: 0
  (1 * 2 * 2 * (utility::kUdpPorts().size() + utility::kTcpPorts().size()))
    Which is: 40
```

## Cause

The OSS cmake build never defined the `TAJO_SDK` macro, which fbcode supplies from its tp2 SAI config. FBOSS uses that macro to gate Tajo-specific SAI attribute mappings, so cmake-built binaries were compiling the generic (non-Tajo) code paths on Tajo hardware.

The visible symptom was `AgentAclTableGroupTrafficTest.VerifyDscpMarkingAndTtlAclTable` failing on `wedge800cact`: `SaiAclTableManager` advertised `SAI_ACL_TABLE_ATTR_FIELD_IPV6_NEXT_HEADER` in the ACL table's key profile while the entries only set `IP_PROTOCOL_NUMBER`. That mismatch meant the marking entries never matched: traffic flowed, but ACL hit counters read 0.

## Solution

This adds `add_definitions (-DTAJO_SDK)` to the `SAI_TAJO_IMPL` block, mirroring the existing `CHENAB_SAI_SDK` handling in the same file.

# Test Plan

After incorporating this change, I ran the test on a Wedge800cact unit using this command:

```
./run_test.py sai_agent --config ./hw_test_configs/wedge800cact.agent.materialized_JSON --skip-known-bad-tests leaba/25.11.4210/25.11.4210/graphene202x --enable-production-features g202x --agent-run-mode=multi_switch --filter=*AgentAclTableGroupTrafficTest.VerifyDscpMarkingAndTtlAclTable*
```

which produced these results:

```
[ PASSED ] cold_boot.AgentAclTableGroupTrafficTest.VerifyDscpMarkingAndTtlAclTable (20390 ms)
[ PASSED ] warm_boot.AgentAclTableGroupTrafficTest.VerifyDscpMarkingAndTtlAclTable (8717 ms)
Summary:
   PASSED : 2
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```