### PR TITLE
[Cisco] Support SAMPLE_PACKET in show hw-object

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiSwitch.cpp
+++ b/fboss/agent/hw/sai/switch/SaiSwitch.cpp
@@ -5228,6 +5228,9 @@ std::string SaiSwitch::listObjects(
         objTypes.push_back(SAI_OBJECT_TYPE_MY_SID_ENTRY);
 #endif
         break;
+      case HwObjectType::SAMPLE_PACKET:
+        objTypes.push_back(SAI_OBJECT_TYPE_SAMPLEPACKET);
+        break;
     }
   }
   FineGrainedLockPolicy policy(saiSwitchMutex_);

--- a/fboss/agent/if/ctrl.thrift
+++ b/fboss/agent/if/ctrl.thrift
@@ -769,6 +769,7 @@ enum HwObjectType {
   FIRMWARE = 26,
   SRV6 = 27,
   NEXT_HOP_GROUP_MEMBER = 28,
+  SAMPLE_PACKET = 29,
 }
 
 exception FbossFibUpdateError {

--- a/fboss/cli/fboss2/commands/show/hwobject/CmdShowHwObject.cpp
+++ b/fboss/cli/fboss2/commands/show/hwobject/CmdShowHwObject.cpp
@@ -54,7 +54,7 @@ void CmdShowHwObject::printOutput(
 }
 
 std::string_view CmdShowHwObjectTraits::description() {
-  return "Displays the raw SAI hardware-object state for a given object type. Requires an object-type argument, one of: PORT, LAG, VIRTUAL_ROUTER, NEXT_HOP, NEXT_HOP_GROUP, ROUTER_INTERFACE, CPU_TRAP, HASH, MIRROR, QOS_MAP, QUEUE, SCHEDULER, L2_ENTRY, NEIGHBOR_ENTRY, ROUTE_ENTRY, VLAN, BRIDGE, BUFFER, ACL, DEBUG_COUNTER, TELEMETRY, LABEL_ENTRY, MACSEC, SAI_MANAGED_OBJECTS, IPTUNNEL, SYSTEM_PORT, FIRMWARE, SRV6 (the HwObjectType enum). The output format is specific to each object type. Use it for low-level SAI/ASIC debugging.";
+  return "Displays the raw SAI hardware-object state for a given object type. Requires an object-type argument, one of: PORT, LAG, VIRTUAL_ROUTER, NEXT_HOP, NEXT_HOP_GROUP, ROUTER_INTERFACE, CPU_TRAP, HASH, MIRROR, QOS_MAP, QUEUE, SCHEDULER, L2_ENTRY, NEIGHBOR_ENTRY, ROUTE_ENTRY, VLAN, BRIDGE, BUFFER, ACL, DEBUG_COUNTER, TELEMETRY, LABEL_ENTRY, MACSEC, SAI_MANAGED_OBJECTS, IPTUNNEL, SYSTEM_PORT, FIRMWARE, SRV6, NEXT_HOP_GROUP_MEMBER, SAMPLE_PACKET (the HwObjectType enum). The output format is specific to each object type. Use it for low-level SAI/ASIC debugging.";
 }
 
 CmdShowHwObject::RetType CmdShowHwObject::sampleModel() {

--- a/fboss/cli/fboss2/test/CmdArgsTest.cpp
+++ b/fboss/cli/fboss2/test/CmdArgsTest.cpp
@@ -144,6 +144,10 @@ TEST(CmdArgsTest, HwObjectList) {
   EXPECT_THAT(
       utils::HwObjectList({"LAG", "MIRROR"}).data(),
       ElementsAre(HwObjectType::LAG, HwObjectType::MIRROR));
+  ASSERT_NO_THROW(utils::HwObjectList({"SAMPLE_PACKET"}));
+  EXPECT_THAT(
+      utils::HwObjectList({"SAMPLE_PACKET"}).data(),
+      ElementsAre(HwObjectType::SAMPLE_PACKET));
 
   // test invalid arguments
   ASSERT_THROW(utils::HwObjectList({"M"}), std::out_of_range);


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

`fboss2 show hw-object SAMPLE_PACKET` fails during argument parsing because `SAMPLE_PACKET` is missing from `HwObjectType`, even though FBOSS already creates and programs SAI sample-packet objects.

Add `SAMPLE_PACKET` to `HwObjectType` and map it to `SAI_OBJECT_TYPE_SAMPLEPACKET` in `SaiSwitch::listObjects()`. This enables both cached and uncached queries to display the sample-packet attributes, including the programmed sample rate. Also include the new type in the CLI help and argument parser coverage.

# Test Plan

- Ran `pre-commit run --from-ref upstream/main --to-ref HEAD`; all applicable checks passed.
- Rebuilt the FBOSS forwarding stack with this change, zero failures.
- Tested the updated `fboss2` and SAI hardware agent binaries on a live Cisco C8501 (`MORGAN800CC`) and configured an ingress sFlow sample rate of 90,000. Both cached and uncached queries returned the programmed sample rate:

```console
$ fboss2 show hw-object SAMPLE_PACKET
Object type: sample-packet
SamplePacketSaiId(540431955284459521): (SampleRate: 90000, Type: 0, Mode: 0)

$ fboss2 show hw-object SAMPLE_PACKET uncached
Object type: sample-packet
SamplePacketSaiId(540431955284459521): (SampleRate: 90000, Type: 0, Mode: 0)
```
