### PR TITLE
[Celestica] Ladakh800bcls: Agent Test: A VLAN left with no ports must be dropped; otherwise it diverges between cold boot and warmboot.

### DIFF
--- a/fboss/agent/test/TrunkUtils.cpp
+++ b/fboss/agent/test/TrunkUtils.cpp
@@ -26,6 +26,64 @@ cfg::AggregatePortMember makePortMember(int32_t port, cfg::LacpPortRate rate) {
   return aggMember;
 }
 
+namespace {
+// A VLAN left with no ports must be dropped; otherwise it diverges between cold
+// boot and warmboot.
+void removeUnreferencedVlans(
+    cfg::SwitchConfig* config,
+    const std::set<int32_t>& memberOldVlans,
+    int32_t aggVlan) {
+  // TODO:remove this once cisco fixes the LAG vlan removal issue
+  bool isCiscoAsic = false;
+  for (const auto& [_, switchInfo] :
+       *config->switchSettings()->switchIdToSwitchInfo()) {
+    auto asicType = *switchInfo.asicType();
+    if (asicType == cfg::AsicType::ASIC_TYPE_EBRO ||
+        asicType == cfg::AsicType::ASIC_TYPE_YUBA ||
+        asicType == cfg::AsicType::ASIC_TYPE_P200 ||
+        asicType == cfg::AsicType::ASIC_TYPE_GARONNE ||
+        asicType == cfg::AsicType::ASIC_TYPE_G202X) {
+      isCiscoAsic = true;
+      break;
+    }
+  }
+  if (isCiscoAsic) {
+    return;
+  }
+
+  std::set<int32_t> stillReferenced;
+  for (const auto& vlanPort : *config->vlanPorts()) {
+    stillReferenced.insert(vlanPort.vlanID().value());
+  }
+
+  for (auto oldVlan : memberOldVlans) {
+    if (oldVlan == aggVlan || stillReferenced.contains(oldVlan) ||
+        (oldVlan == *config->defaultVlan())) {
+      continue;
+    }
+
+    auto& vlans = *config->vlans();
+    vlans.erase(
+        std::remove_if(
+            vlans.begin(),
+            vlans.end(),
+            [&](const auto& v) { return v.id().value() == oldVlan; }),
+        vlans.end());
+
+    auto& intfs = *config->interfaces();
+    intfs.erase(
+        std::remove_if(
+            intfs.begin(),
+            intfs.end(),
+            [&](const auto& i) {
+              return i.type().value() == cfg::InterfaceType::VLAN &&
+                  i.vlanID().value() == oldVlan;
+            }),
+        intfs.end());
+  }
+}
+} // namespace
+
 void addAggPort(
     int key,
     const std::vector<int32_t>& ports,
@@ -54,13 +112,20 @@ void addAggPort(
   // Set VLAN for all members to be the same
   std::set<uint32_t> memberPorts(ports.begin(), ports.end());
   std::optional<int32_t> aggVlan;
+  std::set<int32_t> memberOldVlans;
   for (auto& vlanPort : *config->vlanPorts()) {
     if (memberPorts.contains(vlanPort.logicalPort().value())) {
+      int32_t oldVlan = vlanPort.vlanID().value();
+      memberOldVlans.insert(oldVlan);
       if (!aggVlan) {
-        aggVlan = vlanPort.vlanID().value();
+        aggVlan = oldVlan;
       }
       vlanPort.vlanID() = *aggVlan;
     }
+  }
+
+  if (aggVlan.has_value()) {
+    removeUnreferencedVlans(config, memberOldVlans, *aggVlan);
   }
 
   if (aggregatePortType == cfg::AggregatePortType::LAG_PORT) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

# Summary

Issue Summary

On multi-NPU hardware platforms, the AgentTrunkLoadBalancerTest suite was experiencing a fatal warmboot failure, The failure manifested as a no sai vlan for VlanID 2001 error

Root Cause Analysis

after debugging ,
1: I found in AgentTrunkLoadBalancerTests config call onePortPerInterfaceConfig
2: then addAggPort 3 ports, before that logical port 1(vlan2000) 2(2001) 3(2002), then changed to
port 1(vlan2000) 2(2000) 3(2000), vlan/vlaninterface 2001 2002 empty member ports
3: then new config goto ApplyThriftConfig.cpp new_->resetVlans(
toMultiSwitchMap(newVlans, scopeResolver_));
const HwSwitchMatcher SwitchIdScopeResolver::scope(
const std::shared_ptr& vlan)
if (vlan->getPortsInfo().empty())
// Return the first switchId.
// TODO: Remove this after scope resolution is updated to return single
// switchId based on virtual interface and switchId configuration.
return HwSwitchMatcher(
std::unordered_set(
{*allSwitchMatcher().switchIds().begin()}));
debug log : SwitchIdScopeResolver.cpp:253] willtest Vlan 2001 has no ports, scoping to first switch ID: 1
4: since vlan 2001 scope to switch id 1, when thrift config send to agent , delta will remove vlan 2001,
5: after cold boot test, then enter warmboot restoring the environment , in high level config there are vlan 2001, but in agent sai , there is no vlan sai 2001 handler, so this case fail on npu0 warmboot,
why this case issue doesn't happen on other cases which call addAggPort , Because several conditions need to be met. (onePortPerInterfaceConfig ,addAggPort more then one ports) trunk/LAG/SRv6/MPLS/MAC/copp tests they do not.

Solution Implemented

In void addAggPort(

When adding a port to agg, check which vlan it is previously part of another vlan and if that vlan does not have any remaining ports, then delete the vlan from the config if vlan==defaultvlan or asic type cisco skip delete process
 


# Test Plan

cold_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacLinkDownNeighborResolve,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/2.learnMacLinkDownNeighborResolve,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacAndProgramNeighbors,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacAndProgramNeighbors,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndAgeMac,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndAgeMac,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndUpdateMac,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndUpdateMac,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.flapMacAndNeighbors,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.flapMacAndNeighbors,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndMove,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacProgramNeighborsAndMove,PASSED
cold_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacLinkDownNeighborResolve,PASSED
warm_boot.AgentMacLearningAndNeighborResolutionTest/3.learnMacLinkDownNeighborResolve,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X3WideTrunksCpuTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X3WideTrunksCpuTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X2WideTrunksCpuTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalfHash4X2WideTrunksCpuTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksFrontPanelTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X3WideTrunksFrontPanelTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksFrontPanelTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPFullTrunkHalf4X2WideTrunksFrontPanelTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X3WideTrunksCpuTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X3WideTrunksCpuTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X2WideTrunksCpuTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFullHash4X2WideTrunksCpuTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksFrontPanelTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X3WideTrunksFrontPanelTraffic,PASSED
cold_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksFrontPanelTraffic,PASSED
warm_boot.AgentTrunkLoadBalancerTest.ECMPHalfTrunkFull4X2WideTrunksFrontPanelTraffic,PASSED
cold_boot.AgentEcmpSpilloverTest.VerifyEcmpSpillover,TIMEOUT
cold_boot.AgentEcmpSpilloverTest.VerifyEcmpDecompress,PASSED
warm_boot.AgentEcmpSpilloverTest.VerifyEcmpDecompress,PASSED
cold_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollback,PASSED
warm_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollback,PASSED
cold_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollbackPartial,PASSED
warm_boot.AgentEcmpSpilloverTest.VerifyEcmpSpilloverForcedRollbackPartial,PASSED

