### PR TITLE
[Nexthop][m4062nhp] Wire FPGA info ROMs into fw_util

### DIFF
--- a/fboss/platform/configs/m4062nhp/fw_util.json
+++ b/fboss/platform/configs/m4062nhp/fw_util.json
@@ -5,6 +5,27 @@
         "versionType": "sysfs",
         "path": "/sys/devices/virtual/dmi/id/bios_version"
       }
+    },
+    "SCM_IOB": {
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/SCM_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
+    "SMB0_IOB": {
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/SMB0_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
+    "SMB1_IOB": {
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/SMB1_IOB_INFO_ROM/fw_ver"
+      },
+      "priority": 2
     }
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
Report the SCM and both SMB IOB FPGA versions via fw_util by reading the info ROM fw_ver sysfs nodes exposed by platform_manager.

Depends on the platform_manager infoRomConfigs for m4062nhp (facebook/fboss#1437) for backing sysfs path.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

example when running fw_util:
```
I0727 22:10:35.937963  4105 PlatformNameLib.cpp:103] Platform name read from cache: M4062NHP
I0727 22:10:35.938060  4105 PlatformNameLib.cpp:103] Platform name read from cache: M4062NHP
bios : BM-fboss-nosb-0.2
SCM_IOB : 0.8
SMB0_IOB : 3.3
SMB1_IOB : 3.5
```

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
