### PR TITLE
[agent] Use std::_Exit() to avoid EventBase double-drive on HwAgent exit

### DIFF
--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -36,6 +36,7 @@
 #include "fboss/agent/hw/test/HwTestThriftHandler.h"
 
 #include <chrono>
+#include <cstdlib>
 
 FOLLY_INIT_LOGGING_CONFIG("fboss=DBG2; default:async=true");
 
@@ -155,7 +156,8 @@ void SplitHwAgentSignalHandler::signalReceived(int /*signum*/) noexcept {
     XLOG(INFO) << "[Exit] Delay complete, exiting now";
   }
 
-  exit(0);
+  // _Exit: skip global dtors that re-drive the live EventBase on warmboot exit.
+  std::_Exit(0);
 }
 
 int hwAgentMain(


### PR DESCRIPTION
## Summary

`SplitHwAgentSignalHandler::signalReceived()` performs a graceful shutdown (unregister callbacks, stop oper-delta sync, stop services, `gracefulExit()` which writes warm-boot state) and then calls `exit(0)`.

`exit(0)` runs global/atexit destructors. During a warm-boot shutdown those destructors can re-enter and drive the still-live thrift `folly::EventBase` — the one `hwAgentMain()` is driving in `server->serve()` on the main thread — from the signal-handler thread. Two threads then drive the same EventBase, tripping folly's check in `EventBase.cpp`:

```
Check failed: expected == prevLoopTid
Driving an EventBase (in thread X) while it is already being driven (in thread Y) is forbidden.
```

The process aborts before the oper-delta ack is sent, so the peer SW agent waits out `oper_delta_ack_timeout` (600s) and the warm-boot iteration fails on timeout. Cold-boot exit takes the `hwAgent_.reset()` branch and does not hit this, which is why only warm boot is affected.

## Fix

Replace `exit(0)` with `std::_Exit(0)`. All required graceful cleanup (warm-boot state write via `gracefulExit()`, service/syncer shutdown) has already completed earlier in the handler, so the global/atexit destructors add nothing here; skipping them avoids the second EventBase drive and the resulting abort. This mirrors the existing `std::_Exit(rc)` usage in `fboss/agent/hw/test/Main.cpp`.

## Test Plan

- On hardware, forcing the HW-agent exit to bypass the atexit/global-destructor path (the behavior this change makes permanent) does not reproduce the folly EventBase "already being driven" abort on warm-boot shutdown; the agent exits cleanly and the warm-boot oper-delta ack is delivered.
- `gracefulExit()` persists warm-boot state before the exit call, so `std::_Exit()` loses no state.
- Cold-boot exit (the `hwAgent_.reset()` path) and the `agent_exit_delay_s` delay path are unchanged.

### Runtime workaround, not a fix: `agent_exit_delay_s`

For anyone who can't pick up this patch yet, the same warm-boot abort can be mitigated at runtime without a rebuild via the existing `agent_exit_delay_s` gflag (`AgentFeatures.cpp`). It sleeps right before the `exit(0)` in this handler — after `gracefulExit()` has already persisted warm-boot state — giving the main thread's `server->serve()` loop time to unwind before the atexit/global destructors run. It can be set via the agent config's `defaultCommandLineArgs` (both agents read it), e.g. `"agent_exit_delay_s": "5"` (bump to `"10"` if needed).

Caveats:
- **Non-deterministic** — the delay only widens the timing window; it does not remove the double-drive, so the test can still be flaky (a larger delay may help but isn't guaranteed). `std::_Exit()` in this PR is the deterministic fix.
