### PR TITLE
[Nexthop][m4062nhp] Add 4x200G-FR4 speed combination so qsfp_service can program FR4_2x400G optics

### DIFF
--- a/fboss/qsfp_service/if/transceiver.thrift
+++ b/fboss/qsfp_service/if/transceiver.thrift
@@ -245,6 +245,7 @@ enum MediaInterfaceCode {
   DR4_800G_GEARBOX = 35,
   // 8x800G over DR4: 4 banks, each a 2x800G-DR4
   DR4_8x800G = 36,
+  FR2_200G = 37,
 }
 
 // The extended specification compliance code of the transceiver module.
@@ -316,6 +317,7 @@ enum SMFMediaInterfaceCode {
   ZR_OROADM_FLEXO_4E_DO_400G = 0x64,
   ZR_OPENZRP_OFEC_400G = 0x36,
   FR4_800G = 0x79,
+  FR2_200G = 0xC0,
   FR2_400G = 0xC2,
   FR1_200G = 0xC4,
   ZR_VENDOR_CUSTOM = 0xF7,

--- a/fboss/qsfp_service/module/properties/TransceiverPropertiesDefault.h
+++ b/fboss/qsfp_service/module/properties/TransceiverPropertiesDefault.h
@@ -208,12 +208,22 @@ constexpr auto kDefaultTransceiverPropertiesJson = R"({
           "ports": [
             {"speed": 800000, "hostLanes": {"start": 0, "count": 8}, "mediaLanes": {"start": 0, "count": 8}, "mediaLaneCode": {"smfCode": 0xC1}, "mediaInterfaceCode": 15}
           ]
+        },
+        {
+          "combinationName": "4x200G-FR4",
+          "ports": [
+            {"speed": 200000, "hostLanes": {"start": 0, "count": 2}, "mediaLanes": {"start": 0, "count": 2}, "mediaLaneCode": {"smfCode": 0xC0}, "mediaInterfaceCode": 37},
+            {"speed": 200000, "hostLanes": {"start": 2, "count": 2}, "mediaLanes": {"start": 2, "count": 2}, "mediaLaneCode": {"smfCode": 0xC0}, "mediaInterfaceCode": 37},
+            {"speed": 200000, "hostLanes": {"start": 4, "count": 2}, "mediaLanes": {"start": 4, "count": 2}, "mediaLaneCode": {"smfCode": 0xC0}, "mediaInterfaceCode": 37},
+            {"speed": 200000, "hostLanes": {"start": 6, "count": 2}, "mediaLanes": {"start": 6, "count": 2}, "mediaLaneCode": {"smfCode": 0xC0}, "mediaInterfaceCode": 37}
+          ]
         }
       ],
       "speedChangeTransitions": [
         ["2x400G-FR4", "2x200G-FR4"],
         ["2x400G-FR4", "400G-FR4+200G-FR4"],
         ["2x400G-FR4", "200G-FR4+400G-FR4"],
+        ["2x400G-FR4", "4x200G-FR4"],
       ]
     },
     "13": {

--- a/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.cpp
+++ b/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.cpp
@@ -507,13 +507,15 @@ void HwTransceiverUtils::verify200gProfile(
         *mediaId.media()->smfCode() == SMFMediaInterfaceCode::LR4_200G ||
         *mediaId.media()->smfCode() == SMFMediaInterfaceCode::DR2_200G ||
         *mediaId.media()->smfCode() == SMFMediaInterfaceCode::DR1_200G ||
-        *mediaId.media()->smfCode() == SMFMediaInterfaceCode::FR1_200G);
+        *mediaId.media()->smfCode() == SMFMediaInterfaceCode::FR1_200G ||
+        *mediaId.media()->smfCode() == SMFMediaInterfaceCode::FR2_200G);
     EXPECT_TRUE(
         *mediaId.code() == MediaInterfaceCode::FR4_200G ||
         *mediaId.code() == MediaInterfaceCode::LR4_200G ||
         *mediaId.code() == MediaInterfaceCode::DR2_200G ||
         *mediaId.code() == MediaInterfaceCode::DR1_200G ||
-        *mediaId.code() == MediaInterfaceCode::FR1_200G);
+        *mediaId.code() == MediaInterfaceCode::FR1_200G ||
+        *mediaId.code() == MediaInterfaceCode::FR2_200G);
   }
 }
 


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Under 4x200G breakout (`PROFILE_200G_2_PAM4_RS544X2N_OPTICAL`, 200G on 2 host lanes), `qsfp_service` cannot program `FR4_2x400G` optics: the properties entry for media interface 11 declares 200G only on 4 host lanes, so application selection finds no candidate and every module fails with `Unsupported Application`, retrying forever at about 6/s. The modules do advertise a matching application (`200GAUI-2-L`, media code `0xC0`, 2 host lanes, host-assign `0x55`).

This adds the missing combination to entry `"11"` of `TransceiverPropertiesDefault.h`: four 200G ports on host/media lanes 0/2/4/6 with `mediaLaneCode` `0xC0`, plus the `2x400G-FR4` to `4x200G-FR4` speed-change transition. The byte gets a proper name, `SMFMediaInterfaceCode::FR2_200G = 0xC0`, alongside a new `MediaInterfaceCode::FR2_200G = 37` used as the combo's reporting code, and `verify200gProfile` in the hw_test utils accepts both. No logic touched, data and enum values only.

# Test Plan

Validated the exact JSON on an m4062nhp (INNOLIGHT T-OL8CNT-NFM optics) by loading it through the `--transceiver_properties_config` runtime override:

- Reproduced first: flipped cage 1 to 4x200G on stock defaults, got the ticket's `Unsupported Application` retry loop.
- With the new table: config loads (`Loaded transceiver properties config with 14 SMF entries`), modules program to app 5, all lanes `ACTIVATED`, `Current Media Interface: 192` (`0xC0`), zero errors.
- Regression: reverted the cage to 800G with the new table still loaded; module reprogrammed to app 6 (`FR8_800G`) cleanly. Box restored to its original config, all 128 links up.
