### PR TITLE
[Celestica] Leh800bcls: Config: Support Netlake2.0 third source

### DIFF
--- a/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/platform_manager.json
@@ -106,6 +106,56 @@
           ]
         },
         "productSubVersion": 2
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_HWMON1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_HWMON2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_HWMON3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_OUTLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_INLET_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 3
       }
     ]
   },

--- a/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
@@ -783,6 +783,148 @@
         {
           "sensors": [
             {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 1
+        },
+        {
+          "sensors": [
+            {
               "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
               "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
               "type": 1,
@@ -1063,6 +1205,148 @@
           "productionState": 1,
           "productionSubState": 3,
           "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_SOC_POUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_SOC_VOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_SOC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU1_RAA229641_PVDDCR_SOC_IOUT2",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_RAA229641_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 13.22,
+                "minAlarmVal": 10.82,
+                "upperCriticalVal": 13.35,
+                "lowerCriticalVal": 10.7
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_RAA229641_PVDD_MISC_POUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000.0"
+            },
+            {
+              "name": "COME_PU37_RAA229641_PVDD_MISC_VOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_RAA229641_PVDD_MISC_TEMP1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "upperCriticalVal": 100
+              },
+              "compute": "@/1000.0"
+            },
+            {
+              "name": "COME_PU37_RAA229641_PVDD_MISC_IOUT1",
+              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000.0"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 3
         }
       ]
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```bash
  clang-format.........................................(no files to check)Skipped
  shellcheck...........................................(no files to check)Skipped
  shfmt................................................(no files to check)Skipped
  trim trailing whitespace.................................................Passed
  fix end of files.........................................................Passed
  check yaml...........................................(no files to check)Skipped
  check json...............................................................Passed
  check for merge conflicts................................................Passed
  ruff check...........................................(no files to check)Skipped
  ruff format..........................................(no files to check)Skipped
  Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR is to support Netlake2.0 third source.

1. Netlake2.0 COME has used Renesas+ADI
2. Add `versionedPmUnitConfigs` in `platform_manager.json`
3. Add `versionedSensors` in `sensor_service.json`

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
I0222 20:08:43.529809 41095 DataStore.cpp:132] At SlotPath /COMESE_SLOT@0, updating PmUnit eepromProductName: NETLAKE20
I0222 20:08:43.529811 41095 PlatformExplorer.cpp:464] Found ProductionState `3` ProductionSubState `1` RespinVariantIndicator `3` in IDPROM /sys/bus/i2c/devices/21-0056/eeprom at /COMESE_SLOT@0
I0222 20:08:43.529813 41095 DataStore.cpp:117] At SlotPath /COMESE_SLOT@0, updating to PmUnit `` with ProductionState 3, ProductionSubState 1, RespinVariantIndicator 3
I0222 20:08:43.529815 41095 PlatformExplorer.cpp:511] Found PmUnit name `NETLAKE20` in IDPROM /sys/bus/i2c/devices/21-0056/eeprom at /COMESE_SLOT@0
I0222 20:08:43.529816 41095 DataStore.cpp:109] At SlotPath /COMESE_SLOT@0, updating to PmUnit with name: NETLAKE20
I0222 20:08:43.529819 41095 DataStore.cpp:187] Resolved /COMESE_SLOT@0 to versioned PmUnitConfig of NETLAKE20 with version 3.1.3
```
[platform_manager.log](https://github.com/user-attachments/files/31205012/platform_manager.log)
[sensor_service.log](https://github.com/user-attachments/files/31205017/sensor_service.log)

