### PR TITLE
[Celestica] Leh800bcls: Config: Update sensors according to the latest HW spec

### DIFF
--- a/fboss/configs/platforms/celestica/leh800bcls/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/leh800bcls/platform_stack/platform_manager.json
@@ -733,13 +733,13 @@
           "busName": "SMB_L_MUX_3@0",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_OUTLET_TH6_TSENSOR"
+          "pmUnitScopedName": "SMB_L_INLET_TSENSOR1"
         },
         {
           "busName": "SMB_L_MUX_3@1",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_INLET_TSENSOR"
+          "pmUnitScopedName": "SMB_L_OUTLET_TSENSOR2"
         },
         {
           "busName": "SMB_L_MUX_3@2",
@@ -914,7 +914,7 @@
           "busName": "SMB_L_MUX_4@7",
           "address": "0x4a",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_INLET_SMB_TSENSOR"
+          "pmUnitScopedName": "SMB_L_INLET_TSENSOR3"
         }
       ]
     },
@@ -1066,13 +1066,13 @@
           "busName": "SMB_R_MUX_3@0",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_OUTLET_TH6_TSENSOR"
+          "pmUnitScopedName": "SMB_R_INLET_TSENSOR1"
         },
         {
           "busName": "SMB_R_MUX_3@1",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_INLET_TSENSOR"
+          "pmUnitScopedName": "SMB_R_OUTLET_TSENSOR2"
         },
         {
           "busName": "SMB_R_MUX_3@2",
@@ -1247,7 +1247,7 @@
           "busName": "SMB_R_MUX_4@7",
           "address": "0x4a",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_INLET_SMB_TSENSOR"
+          "pmUnitScopedName": "SMB_R_INLET_TSENSOR3"
         }
       ]
     },
@@ -1662,8 +1662,8 @@
     "/run/devmap/sensors/SMB_L_RTM_ADC7_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC7_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC8_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC8_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC9_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC9_SENSOR]",
-    "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_OUTLET_TH6_TSENSOR]",
-    "/run/devmap/sensors/SMB_L_INLET_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_INLET_TSENSOR1": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR1]",
+    "/run/devmap/sensors/SMB_L_OUTLET_TSENSOR2": "/SMB_L_SLOT@0/[SMB_L_OUTLET_TSENSOR2]",
     "/run/devmap/sensors/SMB_L_ADC1_SENSOR": "/SMB_L_SLOT@0/[SMB_L_ADC1_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC10_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC10_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC11_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC11_SENSOR]",
@@ -1673,7 +1673,7 @@
     "/run/devmap/sensors/SMB_L_RTM_ADC2_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC3_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC3_SENSOR]",
     "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_2": "/SMB_L_SLOT@0/[SMB_L_TH6_SENSOR_TMP432_2]",
-    "/run/devmap/sensors/SMB_L_INLET_SMB_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_INLET_SMB_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_INLET_TSENSOR3": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR3]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_0_1]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0_2": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_0_2]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_1]",
@@ -1690,8 +1690,8 @@
     "/run/devmap/sensors/SMB_R_RTM_ADC7_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC7_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC8_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC8_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC9_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC9_SENSOR]",
-    "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_OUTLET_TH6_TSENSOR]",
-    "/run/devmap/sensors/SMB_R_INLET_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_R_INLET_TSENSOR1": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR1]",
+    "/run/devmap/sensors/SMB_R_OUTLET_TSENSOR2": "/SMB_R_SLOT@0/[SMB_R_OUTLET_TSENSOR2]",
     "/run/devmap/sensors/SMB_R_ADC1_SENSOR": "/SMB_R_SLOT@0/[SMB_R_ADC1_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC10_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC10_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC11_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC11_SENSOR]",
@@ -1701,7 +1701,7 @@
     "/run/devmap/sensors/SMB_R_RTM_ADC2_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC3_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC3_SENSOR]",
     "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_2": "/SMB_R_SLOT@0/[SMB_R_TH6_SENSOR_TMP432_2]",
-    "/run/devmap/sensors/SMB_R_INLET_SMB_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_INLET_SMB_TSENSOR]"
+    "/run/devmap/sensors/SMB_R_INLET_TSENSOR3": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR3]"
   },
   "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
   "numXcvrs": 2,

--- a/fboss/configs/platforms/celestica/leh800bcls/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/leh800bcls/platform_stack/sensor_service.json
@@ -2980,8 +2980,8 @@
           "compute": "@/1000000.0"
         },
         {
-          "name": "SMB_L_U7_LM75B_SMB_OUTLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR/temp1_input",
+          "name": "SMB_L_U7_LM75B_OUTLET2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_OUTLET_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -2992,8 +2992,8 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_L_U17_LM75B_SMB_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_SMB_TSENSOR/temp1_input",
+          "name": "SMB_L_U17_LM75B_INLET3",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR3/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -3004,8 +3004,8 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_L_U8_LM75B_TH6_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR/temp1_input",
+          "name": "SMB_L_U8_LM75B_INLET1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -7093,8 +7093,8 @@
           "compute": "@/1000000.0"
         },
         {
-          "name": "SMB_R_U7_LM75B_SMB_OUTLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR/temp1_input",
+          "name": "SMB_R_U7_LM75B_OUTLET2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_OUTLET_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 90,
@@ -7105,8 +7105,20 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_R_U8_LM75B_TH6_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR/temp1_input",
+          "name": "SMB_R_U17_LM75B_INLET3",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": -20,
+            "upperCriticalVal": 90,
+            "lowerCriticalVal": -25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U8_LM75B_INLET1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 90,
@@ -7353,18 +7365,6 @@
             "minAlarmVal": 1.62,
             "upperCriticalVal": 2.07,
             "lowerCriticalVal": 1.53
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "SMB_R_U17_LM75B_SMB_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_SMB_TSENSOR/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "maxAlarmVal": 85,
-            "minAlarmVal": -20,
-            "upperCriticalVal": 90,
-            "lowerCriticalVal": -25
           },
           "compute": "@/1000.0"
         },

--- a/fboss/configs/platforms/celestica/leh800bcls/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/leh800bcls/platform_stack/sensor_service.json
@@ -323,7 +323,7 @@
             "maxAlarmVal": 115,
             "upperCriticalVal": 120
           },
-          "compute": "2.4*@/1000.0"
+          "compute": "3*@/1000.0"
         },
         {
           "name": "HSCB_UP1_XP48R0V_HOTSWAP_TEMP",

--- a/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/platform_manager.json
@@ -728,13 +728,13 @@
           "busName": "SMB_L_MUX_3@0",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_OUTLET_TH6_TSENSOR"
+          "pmUnitScopedName": "SMB_L_INLET_TSENSOR1"
         },
         {
           "busName": "SMB_L_MUX_3@1",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_INLET_TSENSOR"
+          "pmUnitScopedName": "SMB_L_OUTLET_TSENSOR2"
         },
         {
           "busName": "SMB_L_MUX_3@2",
@@ -909,7 +909,7 @@
           "busName": "SMB_L_MUX_4@7",
           "address": "0x4a",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_L_INLET_SMB_TSENSOR"
+          "pmUnitScopedName": "SMB_L_INLET_TSENSOR3"
         }
       ]
     },
@@ -1061,13 +1061,13 @@
           "busName": "SMB_R_MUX_3@0",
           "address": "0x48",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_OUTLET_TH6_TSENSOR"
+          "pmUnitScopedName": "SMB_R_INLET_TSENSOR1"
         },
         {
           "busName": "SMB_R_MUX_3@1",
           "address": "0x49",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_INLET_TSENSOR"
+          "pmUnitScopedName": "SMB_R_OUTLET_TSENSOR2"
         },
         {
           "busName": "SMB_R_MUX_3@2",
@@ -1242,7 +1242,7 @@
           "busName": "SMB_R_MUX_4@7",
           "address": "0x4a",
           "kernelDeviceName": "lm75b",
-          "pmUnitScopedName": "SMB_R_INLET_SMB_TSENSOR"
+          "pmUnitScopedName": "SMB_R_INLET_TSENSOR3"
         }
       ]
     },
@@ -1657,8 +1657,8 @@
     "/run/devmap/sensors/SMB_L_RTM_ADC7_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC7_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC8_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC8_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC9_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC9_SENSOR]",
-    "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_OUTLET_TH6_TSENSOR]",
-    "/run/devmap/sensors/SMB_L_INLET_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_INLET_TSENSOR1": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR1]",
+    "/run/devmap/sensors/SMB_L_OUTLET_TSENSOR2": "/SMB_L_SLOT@0/[SMB_L_OUTLET_TSENSOR2]",
     "/run/devmap/sensors/SMB_L_ADC1_SENSOR": "/SMB_L_SLOT@0/[SMB_L_ADC1_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC10_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC10_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC11_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC11_SENSOR]",
@@ -1668,7 +1668,7 @@
     "/run/devmap/sensors/SMB_L_RTM_ADC2_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_L_RTM_ADC3_SENSOR": "/SMB_L_SLOT@0/[SMB_L_RTM_ADC3_SENSOR]",
     "/run/devmap/sensors/SMB_L_TH6_SENSOR_TMP432_2": "/SMB_L_SLOT@0/[SMB_L_TH6_SENSOR_TMP432_2]",
-    "/run/devmap/sensors/SMB_L_INLET_SMB_TSENSOR": "/SMB_L_SLOT@0/[SMB_L_INLET_SMB_TSENSOR]",
+    "/run/devmap/sensors/SMB_L_INLET_TSENSOR3": "/SMB_L_SLOT@0/[SMB_L_INLET_TSENSOR3]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_0_1]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_0_2": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_0_2]",
     "/run/devmap/sensors/SMB_R_ASIC_VOLTAGE_1": "/SMB_R_SLOT@0/[SMB_R_ASIC_VOLTAGE_1]",
@@ -1685,8 +1685,8 @@
     "/run/devmap/sensors/SMB_R_RTM_ADC7_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC7_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC8_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC8_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC9_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC9_SENSOR]",
-    "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_OUTLET_TH6_TSENSOR]",
-    "/run/devmap/sensors/SMB_R_INLET_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR]",
+    "/run/devmap/sensors/SMB_R_INLET_TSENSOR1": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR1]",
+    "/run/devmap/sensors/SMB_R_OUTLET_TSENSOR2": "/SMB_R_SLOT@0/[SMB_R_OUTLET_TSENSOR2]",
     "/run/devmap/sensors/SMB_R_ADC1_SENSOR": "/SMB_R_SLOT@0/[SMB_R_ADC1_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC10_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC10_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC11_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC11_SENSOR]",
@@ -1696,7 +1696,7 @@
     "/run/devmap/sensors/SMB_R_RTM_ADC2_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_R_RTM_ADC3_SENSOR": "/SMB_R_SLOT@0/[SMB_R_RTM_ADC3_SENSOR]",
     "/run/devmap/sensors/SMB_R_TH6_SENSOR_TMP432_2": "/SMB_R_SLOT@0/[SMB_R_TH6_SENSOR_TMP432_2]",
-    "/run/devmap/sensors/SMB_R_INLET_SMB_TSENSOR": "/SMB_R_SLOT@0/[SMB_R_INLET_SMB_TSENSOR]"
+    "/run/devmap/sensors/SMB_R_INLET_TSENSOR3": "/SMB_R_SLOT@0/[SMB_R_INLET_TSENSOR3]"
   },
   "chassisEepromDevicePath": "/[CHASSIS_EEPROM]",
   "numXcvrs": 2,

--- a/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
@@ -286,8 +286,8 @@
           "sysfsPath": "/run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input",
           "type": 2,
           "thresholds": {
-            "maxAlarmVal": 10,
-            "upperCriticalVal": 15
+            "maxAlarmVal": 16,
+            "upperCriticalVal": 20
           },
           "compute": "0.274*@/1000.0"
         },
@@ -2794,8 +2794,8 @@
           "compute": "@/1000000.0"
         },
         {
-          "name": "SMB_L_U7_LM75B_SMB_OUTLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR/temp1_input",
+          "name": "SMB_L_U7_LM75B_OUTLET2",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_OUTLET_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -2806,8 +2806,8 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_L_U17_LM75B_SMB_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_SMB_TSENSOR/temp1_input",
+          "name": "SMB_L_U17_LM75B_INLET3",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR3/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -2818,8 +2818,8 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_L_U8_LM75B_TH6_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_L_OUTLET_TH6_TSENSOR/temp1_input",
+          "name": "SMB_L_U8_LM75B_INLET1",
+          "sysfsPath": "/run/devmap/sensors/SMB_L_INLET_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 85,
@@ -6907,8 +6907,8 @@
           "compute": "@/1000000.0"
         },
         {
-          "name": "SMB_R_U7_LM75B_SMB_OUTLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR/temp1_input",
+          "name": "SMB_R_U7_LM75B_OUTLET2",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_OUTLET_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 90,
@@ -6919,8 +6919,20 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "SMB_R_U8_LM75B_TH6_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_OUTLET_TH6_TSENSOR/temp1_input",
+          "name": "SMB_R_U17_LM75B_INLET3",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR3/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 85,
+            "minAlarmVal": -20,
+            "upperCriticalVal": 90,
+            "lowerCriticalVal": -25
+          },
+          "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_R_U8_LM75B_INLET1",
+          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
             "maxAlarmVal": 90,
@@ -7167,18 +7179,6 @@
             "minAlarmVal": 1.62,
             "upperCriticalVal": 2.07,
             "lowerCriticalVal": 1.53
-          },
-          "compute": "@/1000.0"
-        },
-        {
-          "name": "SMB_R_U17_LM75B_SMB_INLET",
-          "sysfsPath": "/run/devmap/sensors/SMB_R_INLET_SMB_TSENSOR/temp1_input",
-          "type": 3,
-          "thresholds": {
-            "maxAlarmVal": 85,
-            "minAlarmVal": -20,
-            "upperCriticalVal": 90,
-            "lowerCriticalVal": -25
           },
           "compute": "@/1000.0"
         },

--- a/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/leh800bclsm/platform_stack/sensor_service.json
@@ -323,7 +323,7 @@
             "maxAlarmVal": 115,
             "upperCriticalVal": 120
           },
-          "compute": "2.4*@/1000.0"
+          "compute": "3*@/1000.0"
         },
         {
           "name": "HSCB_UP1_XP48R0V_HOTSWAP_TEMP",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`
```bash
  clang-format.........................................(no files to check)Skipped
  shellcheck...........................................(no files to check)Skipped
  shfmt................................................(no files to check)Skipped
  trim trailing whitespace.................................................Passed
  fix end of files.........................................................Passed
  check yaml...........................................(no files to check)Skipped
  check json...............................................................Passed
  check for merge conflicts................................................Passed
  ruff check...........................................(no files to check)Skipped
  ruff format..........................................(no files to check)Skipped
  Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

This PR is to update sensors according to the latest HW spec.

1. Update `INLET` and `OUTLET` sensors of `SMB`
2. Update `MCB_UP15_XP12R0V_COME_IIN` thresholds for Netlake2.0
3. Update compute coefficient of `HSCB_UP1_XP48R0V_HOTSWAP_IOUT` according to the HW design

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

* SMB
```
| SMB_L_U17_LM75B_INLET3                  | 32.75 | PASS   | [-25.00, 90.00]  | [-20.00, 85.00]  | 2s ago      | /run/devmap/sensors/SMB_L_INLET_TSENSOR3/temp1_input      |
| SMB_L_U7_LM75B_OUTLET2                  | 38.50 | PASS   | [-25.00, 90.00]  | [-20.00, 85.00]  | 2s ago      | /run/devmap/sensors/SMB_L_OUTLET_TSENSOR2/temp1_input     |
| SMB_L_U8_LM75B_INLET1                   | 35.12 | PASS   | [-25.00, 90.00]  | [-20.00, 85.00]  | 2s ago      | /run/devmap/sensors/SMB_L_INLET_TSENSOR1/temp1_input      |
| SMB_R_U17_LM75B_INLET3                  | 33.88 | PASS   | [-25.00, 90.00]  | [-20.00, 85.00]  | 2s ago      | /run/devmap/sensors/SMB_R_INLET_TSENSOR3/temp1_input      |
| SMB_R_U7_LM75B_OUTLET2                  | 37.00 | PASS   | [-25.00, 95.00]  | [-20.00, 90.00]  | 2s ago      | /run/devmap/sensors/SMB_R_OUTLET_TSENSOR2/temp1_input     |
| SMB_R_U8_LM75B_INLET1                   | 29.50 | PASS   | [-25.00, 95.00]  | [-20.00, 90.00]  | 2s ago      | /run/devmap/sensors/SMB_R_INLET_TSENSOR1/temp1_input      |
```

* MCB_UP15_XP12R0V_COME_IIN

Netlake1.0

```
| MCB_UP15_XP12R0V_COME_IIN     | 2.56    | PASS   | [, 15.00]        | [, 10.00]        | 4s ago      | /run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input       |
```

Netlake2.0

```
| MCB_UP15_XP12R0V_COME_IIN     | 1.41   | PASS   | [, 20.00]        | [, 16.00]        | 3s ago      | /run/devmap/sensors/LOAD_SWITCH_MONITOR/curr1_input       |
```

* HSCB_UP1_XP48R0V_HOTSWAP_IOUT

before
```
V0824 06:02:18.575778 226048 SensorServiceImpl.cpp:360] HSCB_UP1_XP48R0V_HOTSWAP_IOUT (/run/devmap/sensors/48V_HSC_MONITOR/curr1_input) : 26.8584
```

after
```
V0824 10:28:39.470780 234082 SensorServiceImpl.cpp:360] HSCB_UP1_XP48R0V_HOTSWAP_IOUT (/run/devmap/sensors/48V_HSC_MONITOR/curr1_input) : 33.591
```
