### PR TITLE
[Accton][minipack3bta] Support TU1 UDF ANY match encoding

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiUdfManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiUdfManager.cpp
@@ -10,8 +10,10 @@
 
 #include "fboss/agent/hw/sai/switch/SaiUdfManager.h"
 #include "fboss/agent/hw/sai/store/SaiStore.h"
+#include "fboss/agent/hw/switch_asics/HwAsic.h"
 #include "fboss/agent/packet/Ethertype.h"
 #include "fboss/agent/packet/IPProto.h"
+#include "fboss/agent/platforms/sai/SaiPlatform.h"
 
 namespace facebook::fboss {
 
@@ -181,6 +183,10 @@ std::pair<uint16_t, uint16_t> SaiUdfManager::cfgL3MatchTypeToSai(
     cfg::UdfMatchL3Type cfgType) const {
   switch (cfgType) {
     case cfg::UdfMatchL3Type::UDF_L3_PKT_TYPE_ANY:
+      if (platform_->getAsic()->useAllOnesForUdfL2TypeAny()) {
+        return std::make_pair(
+            static_cast<uint16_t>(kMaskAny), static_cast<uint16_t>(kMaskAny));
+      }
       return std::make_pair(0, kMaskDontCare);
     case cfg::UdfMatchL3Type::UDF_L3_PKT_TYPE_IPV4:
       return std::make_pair(

--- a/fboss/agent/hw/switch_asics/HwAsic.h
+++ b/fboss/agent/hw/switch_asics/HwAsic.h
@@ -604,6 +604,11 @@ class HwAsic {
       std::optional<HwAsic::FabricNodeRole> fabricNodeRole);
 
   virtual bool isSupported(Feature) const = 0;
+  // Some SAI implementations encode an ANY UDF L2 type match with all-ones
+  // data and mask instead of the standard don't-care value and mask.
+  virtual bool useAllOnesForUdfL2TypeAny() const {
+    return false;
+  }
   virtual cfg::AsicType getAsicType() const = 0;
   std::string getAsicTypeStr() const;
   virtual AsicVendor getAsicVendor() const = 0;

--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.cpp
@@ -5,6 +5,10 @@
 
 namespace facebook::fboss {
 
+bool TomahawkUltra1Asic::useAllOnesForUdfL2TypeAny() const {
+  return true;
+}
+
 bool TomahawkUltra1Asic::isSupported(Feature feature) const {
   switch (feature) {
     case HwAsic::Feature::SPAN:

--- a/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.h
+++ b/fboss/agent/hw/switch_asics/TomahawkUltra1Asic.h
@@ -10,6 +10,7 @@ class TomahawkUltra1Asic : public BroadcomXgsAsic {
  public:
   using BroadcomXgsAsic::BroadcomXgsAsic;
   bool isSupported(Feature) const override;
+  bool useAllOnesForUdfL2TypeAny() const override;
   cfg::AsicType getAsicType() const override {
     return cfg::AsicType::ASIC_TYPE_TOMAHAWKULTRA1;
   }


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

## Summary
- Preserve the standard UDF ANY match encoding of 0/0 by default.
- Use 0xffff/0xffff for Tomahawk Ultra 1 through an HwAsic property.
- Keep SaiUdfManager free of ASIC-type checks.

## Test Plan
PASS on Tomahawk Ultra 1 with SAI 15.4 GA:

Cold boot:
- cold_boot.AgentHwUdfTest.checkUdfHashConfiguration
- cold_boot.AgentHwUdfTest.checkUdfAclConfiguration
- cold_boot.AgentHwUdfTest.deleteUdfHashConfig
- cold_boot.AgentHwUdfTest.deleteUdfAclConfig
- cold_boot.AgentHwUdfTest.checkUdfHashAclConfiguration

Warm boot:
- warm_boot.AgentHwUdfTest.checkUdfHashConfiguration
- warm_boot.AgentHwUdfTest.checkUdfAclConfiguration
- warm_boot.AgentHwUdfTest.deleteUdfHashConfig
- warm_boot.AgentHwUdfTest.deleteUdfAclConfig
- warm_boot.AgentHwUdfTest.checkUdfHashAclConfiguration

log: [t0_agent_20260819_182615_.zip](https://github.com/user-attachments/files/31220222/t0_agent_20260819_182615_.zip)
