### PR TITLE
Fix stale branch reference in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ possible.
 
 ## Pull Requests
 We actively welcome your pull requests.
-1. Fork the repo and create your branch from `master`. 
+1. Fork the repo and create your branch from `main`. 
 2. If you've added code that should be tested, add tests
 3. If you've changed APIs, update the documentation. 
 4. Ensure the test suite passes. 


### PR DESCRIPTION
## Problem
CONTRIBUTING.md instructs contributors to create their branch from `master`, but the repository's default branch is `main`. Following the current instruction leads to branching off a stale or non-existent branch.

## Change
Update the instruction to reference `main`, matching the actual default branch.

## Why this is safe
Documentation-only change; no code or behavior is affected.

## Verification
Confirmed via the GitHub API that the repository's `default_branch` is `main`.