### PR TITLE
[Nexthop][qsfp_service] Support AOC modules in the qsfp hw test media checks

### DIFF
--- a/cmake/QsfpServiceTestHwTest.cmake
+++ b/cmake/QsfpServiceTestHwTest.cmake
@@ -26,6 +26,7 @@ target_link_libraries(hw_transceiver_utils
   Folly::folly
   fboss_error
   platform_mapping
+  port_test_utils
   switch_config_cpp2
   transceiver_cpp2
   transceiver_manager

--- a/fboss/qsfp_service/test/hw_test/BUCK
+++ b/fboss/qsfp_service/test/hw_test/BUCK
@@ -23,6 +23,7 @@ cpp_library(
         "fbsource//third-party/fmt:fmt",
         "fbsource//third-party/googletest:gtest",
         "//fboss/agent:fboss-error",
+        "//fboss/agent/test/utils:port_test_utils",
         "//fboss/lib/config:fboss_config_utils",
         "//fboss/qsfp_service:transceiver-manager",
         "//fboss/qsfp_service/module/properties:transceiver-properties-manager",

--- a/fboss/qsfp_service/test/hw_test/HwI2cSelectTest.cpp
+++ b/fboss/qsfp_service/test/hw_test/HwI2cSelectTest.cpp
@@ -4,8 +4,8 @@
 
 #include "fboss/qsfp_service/test/hw_test/HwPortUtils.h"
 #include "fboss/qsfp_service/test/hw_test/HwQsfpEnsemble.h"
+#include "fboss/qsfp_service/test/hw_test/HwTransceiverUtils.h"
 
-#include <folly/gen/Base.h>
 #include <folly/logging/xlog.h>
 
 namespace facebook::fboss {
@@ -68,21 +68,23 @@ TEST_F(HwTest, i2cUniqueSerialNumbers) {
     if (snIds.find(sn) == snIds.end()) {
       snIds[sn] = tcvrId;
     } else {
-      // Found duplicated serial numbers, module must be DAC and connected to
-      // another DAC on the other end
+      // Found duplicated serial numbers, module must be a single cable
+      // assembly (DAC/AEC/AOC) connected back to itself on the other end
       auto neighborId = snIds[sn];
       CHECK(cabledNames.find(tcvrId) != cabledNames.end());
       CHECK(cabledNames.find(neighborId) != cabledNames.end());
       EXPECT_EQ(cabledNames[tcvrId].first, cabledNames[neighborId].second);
       EXPECT_EQ(cabledNames[tcvrId].second, cabledNames[neighborId].first);
 
-      auto transmitterTech =
-          *(transceiverInfo[tcvrId].tcvrState()->cable()->transmitterTech());
-      EXPECT_EQ(TransmitterTechnology::COPPER, transmitterTech);
-
-      transmitterTech = *(
-          transceiverInfo[neighborId].tcvrState()->cable()->transmitterTech());
-      EXPECT_EQ(TransmitterTechnology::COPPER, transmitterTech);
+      for (auto id : {tcvrId, neighborId}) {
+        const auto& tcvrState = *transceiverInfo[id].tcvrState();
+        auto transmitterTech = *(tcvrState.cable()->transmitterTech());
+        EXPECT_TRUE(
+            transmitterTech == TransmitterTechnology::COPPER ||
+            utility::HwTransceiverUtils::isAoc(tcvrState))
+            << "Transceiver " << id
+            << " shares a serial number but is neither copper nor AOC";
+      }
     }
   }
 }

--- a/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.cpp
+++ b/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.cpp
@@ -9,6 +9,7 @@
  */
 #include "fboss/qsfp_service/test/hw_test/HwTransceiverUtils.h"
 
+#include <algorithm>
 #include <set>
 
 #include <fmt/format.h>
@@ -18,8 +19,10 @@
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/gen-cpp2/switch_config_types.h"
 #include "fboss/agent/platforms/common/PlatformMapping.h"
+#include "fboss/agent/test/utils/PortTestUtils.h"
 #include "fboss/lib/config/PlatformConfigUtils.h"
 #include "fboss/qsfp_service/TransceiverManager.h"
+#include "fboss/qsfp_service/module/cmis/CmisHelper.h"
 #include "fboss/qsfp_service/module/properties/TransceiverPropertiesManager.h"
 
 namespace facebook::fboss::utility {
@@ -354,6 +357,14 @@ void HwTransceiverUtils::verifyMediaInterfaceCompliance(
     mediaInterfaces.push_back(allMediaInterfaces[mediaLane]);
   }
 
+  if (isAoc(tcvrState)) {
+    // An AOC programs like an active cable regardless of the profile's
+    // copper/optical suffix, so the per-profile verifiers below (which
+    // read smfCode or expect a copper transmitter) don't apply.
+    verifyActiveOpticalCableProfile(mgmtInterface, mediaInterfaces, profile);
+    return;
+  }
+
   switch (profile) {
     case cfg::PortProfileID::PROFILE_10G_1_NRZ_NOFEC_OPTICAL:
       verify10gProfile(tcvrState, mgmtInterface, mediaInterfaces);
@@ -648,6 +659,41 @@ void HwTransceiverUtils::verifyCopper800gProfile(
           *mediaId.media()->activeCuCode() ==
           ActiveCuHostInterfaceCode::AUI_PAM4_8S_800G);
     }
+  }
+}
+
+bool HwTransceiverUtils::isAoc(const TcvrState& tcvrState) {
+  return TransceiverManager::activeCable(tcvrState) &&
+      *tcvrState.cable()->transmitterTech() == TransmitterTechnology::OPTICAL;
+}
+
+void HwTransceiverUtils::verifyActiveOpticalCableProfile(
+    const TransceiverManagementInterface mgmtInterface,
+    const std::vector<MediaInterfaceId>& mediaInterfaces,
+    cfg::PortProfileID profile) {
+  EXPECT_EQ(mgmtInterface, TransceiverManagementInterface::CMIS);
+
+  const auto& speedApplications = CmisHelper::getActiveSpeedApplication();
+  auto expectedCodesIt = speedApplications.find(utility::getSpeed(profile));
+  if (expectedCodesIt == speedApplications.end()) {
+    throw FbossError(
+        "No active cable application for profile ",
+        apache::thrift::util::enumNameSafe(profile));
+  }
+  const auto& expectedCodes = expectedCodesIt->second;
+  const auto& activeMediaMap = CmisHelper::getActiveMediaInterfaceMapping();
+
+  for (const auto& mediaId : mediaInterfaces) {
+    auto activeCuCode = *mediaId.media()->activeCuCode();
+    EXPECT_TRUE(
+        std::find(expectedCodes.begin(), expectedCodes.end(), activeCuCode) !=
+        expectedCodes.end())
+        << "Unexpected activeCuCode "
+        << apache::thrift::util::enumNameSafe(activeCuCode) << " for profile "
+        << apache::thrift::util::enumNameSafe(profile);
+    auto mediaCodeIt = activeMediaMap.find(activeCuCode);
+    ASSERT_TRUE(mediaCodeIt != activeMediaMap.end());
+    EXPECT_EQ(*mediaId.code(), mediaCodeIt->second);
   }
 }
 

--- a/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.h
+++ b/fboss/qsfp_service/test/hw_test/HwTransceiverUtils.h
@@ -50,7 +50,16 @@ class HwTransceiverUtils {
       time_t timeReference,
       bool expectedReset);
 
+  // Active optical cable: reports ACTIVE_CABLES media type encoding like an
+  // AEC, but an optical transmitter. Its media interface union carries
+  // activeCuCode, not smfCode.
+  static bool isAoc(const TcvrState& tcvrState);
+
  private:
+  static void verifyActiveOpticalCableProfile(
+      TransceiverManagementInterface mgmtInterface,
+      const std::vector<MediaInterfaceId>& mediaInterfaces,
+      cfg::PortProfileID profile);
   static void verifyOpticsSettings(
       const TcvrState& tcvrState,
       const std::string& portName,


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

AOCs report ACTIVE_CABLES with an OPTICAL transmitter and publish
activeCuCode, so the media compliance checks either crashed reading
smfCode or failed the COPPER transmitter assert on AOC ports.

Make the test expectations AOC-aware instead:

- New HwTransceiverUtils::isAoc routes AOC ports to
  verifyActiveOpticalCableProfile, which checks activeCuCode and the
  media interface code against the CmisHelper tables the product
  programs active cables from.
- i2cUniqueSerialNumbers accepts AOCs: duplicate serials mean one cable
  assembly (DAC, AEC, or AOC).

Test code only; product code unchanged.

# Test Plan

Full t0 and t1 qsfp suites with a locally built qsfp_hw_test:

| platform | modules | t0 | t1 |
| --- | --- | --- | --- |
| m4062nhp | 17x 800G AOC | PASS 7/7 | PASS 14/14 |
| wedge800cact | FR4 optics | PASS 7/7 | PASS 14/14 |
| nh4010f | 7x 800G DAC + 2x 800G AOC | PASS 7/7 | PASS 14/14 |

Zero failures, zero skips. The previously failing AOC cases
(HwStateMachineTest.*, resetTranscieverAndDetectStateChanged,
i2cUniqueSerialNumbers) pass cold and warm boot; optics and DAC paths
are unchanged.
