### PR TITLE
[Cisco]  Fix FBOSS mirror DSCP encoding

### DIFF
--- a/fboss/agent/hw/sai/hw_test/HwTestMirrorUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestMirrorUtils.cpp
@@ -94,7 +94,7 @@ static void verifyResolvedErspanMirror(
   auto tos = SaiApiTable::getInstance()->mirrorApi().getAttribute(
       mirrorHandle->adapterKey(),
       SaiEnhancedRemoteMirrorTraits::Attributes::Tos());
-  EXPECT_EQ(tos, mirror->getDscp());
+  EXPECT_EQ(tos, static_cast<uint8_t>(mirror->getDscp() << 2));
 
   const auto& tunnel = mirror->getMirrorTunnel();
 
@@ -146,7 +146,7 @@ static void verifyResolvedSflowMirror(
   // TOS
   auto tos = SaiApiTable::getInstance()->mirrorApi().getAttribute(
       mirrorHandle->adapterKey(), SaiSflowMirrorTraits::Attributes::Tos());
-  EXPECT_EQ(tos, mirror->getDscp());
+  EXPECT_EQ(tos, static_cast<uint8_t>(mirror->getDscp() << 2));
 
   const auto& tunnel = mirror->getMirrorTunnel();
 

--- a/fboss/agent/hw/sai/hw_test/HwTestMirrorUtilsThriftHandler.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestMirrorUtilsThriftHandler.cpp
@@ -87,9 +87,11 @@ bool verifyResolvedMirror(
   auto tos = SaiApiTable::getInstance()->mirrorApi().getAttribute(
       mirrorHandle->adapterKey(),
       SaiEnhancedRemoteMirrorTraits::Attributes::Tos());
-  if (tos != folly::copy(mirror.dscp().value())) {
+  const auto expectedTos =
+      static_cast<uint8_t>(folly::copy(mirror.dscp().value()) << 2);
+  if (tos != expectedTos) {
     XLOG(ERR) << "verifyResolvedMirror: TOS mismatch, expected "
-              << (int)mirror.dscp().value() << " got " << (int)tos;
+              << (int)expectedTos << " got " << (int)tos;
     return false;
   }
 

--- a/fboss/agent/hw/sai/switch/SaiMirrorManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiMirrorManager.cpp
@@ -56,7 +56,7 @@ SaiMirrorHandle::SaiMirror SaiMirrorManager::addNodeErSpan(
       SAI_MIRROR_SESSION_TYPE_ENHANCED_REMOTE,
       monitorPort,
       SAI_ERSPAN_ENCAPSULATION_TYPE_MIRROR_L3_GRE_TUNNEL,
-      mirror->getDscp(),
+      static_cast<uint8_t>(mirror->getDscp() << 2),
       mirrorTunnel.srcIp,
       mirrorTunnel.dstIp,
       mirrorTunnel.srcMac,
@@ -92,7 +92,7 @@ SaiMirrorHandle::SaiMirror SaiMirrorManager::addNodeSflow(
   SaiSflowMirrorTraits::CreateAttributes attributes{
       SAI_MIRROR_SESSION_TYPE_SFLOW,
       monitorPort,
-      mirror->getDscp(),
+      static_cast<uint8_t>(mirror->getDscp() << 2),
       mirrorTunnel.srcIp,
       mirrorTunnel.dstIp,
       mirrorTunnel.srcMac,

--- a/fboss/agent/hw/sai/switch/tests/MirrorManagerTest.cpp
+++ b/fboss/agent/hw/sai/switch/tests/MirrorManagerTest.cpp
@@ -122,7 +122,7 @@ class MirrorManagerTest : public ManagerTestBase {
     EXPECT_EQ(gotDstMac, dstMac);
     auto gotTos = mirrorApi.getAttribute(
         mirrorSaiId, SaiEnhancedRemoteMirrorTraits::Attributes::Tos{});
-    EXPECT_EQ(gotTos, tos);
+    EXPECT_EQ(gotTos, static_cast<uint8_t>(tos << 2));
     auto gotTtl = mirrorApi.getAttribute(
         mirrorSaiId, SaiEnhancedRemoteMirrorTraits::Attributes::Ttl{});
     EXPECT_EQ(gotTtl, ttl);
@@ -164,7 +164,7 @@ class MirrorManagerTest : public ManagerTestBase {
     EXPECT_EQ(gotDstMac, dstMac);
     auto gotTos = mirrorApi.getAttribute(
         mirrorSaiId, SaiSflowMirrorTraits::Attributes::Tos{});
-    EXPECT_EQ(gotTos, tos);
+    EXPECT_EQ(gotTos, static_cast<uint8_t>(tos << 2));
     auto gotTtl = mirrorApi.getAttribute(
         mirrorSaiId, SaiSflowMirrorTraits::Attributes::Ttl{});
     EXPECT_EQ(gotTtl, ttl);


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
FBOSS passed the configured 6-bit mirror DSCP directly to the SAI 8-bit TOS attribute. This caused DSCP 42 to produce an on-wire DSCP of 10.

Convert DSCP to TOS using `DSCP << 2` for sFlow and ERSPAN mirror sessions, and update the associated mirror verification tests.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
- Built `fboss-forwarding-stack` successfully.
- Deployed the updated HW agent on fboss dut.
- Verified through the SAI replay log that configured DSCP 42 programs TOS 168 (`0xA8`).
- Verified the dut sFlow mirror is active and resolved.
- Verified in Ixia packets capture that exported sFlow packets have Traffic Class `0xA8`, corresponding to DSCP 42 and ECN 0.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
