### PR TITLE
[Accton][minipack3n] Update SMB VRM voltage sensor thresholds

### DIFF
--- a/fboss/configs/platforms/accton/minipack3n/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/accton/minipack3n/platform_stack/sensor_service.json
@@ -2019,10 +2019,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.88875,
+            "upperCriticalVal": 0.905375,
             "maxAlarmVal": 0.80625,
-            "minAlarmVal": 0.64125,
-            "lowerCriticalVal": 0.55875
+            "minAlarmVal": 0.608,
+            "lowerCriticalVal": 0.508875
           },
           "compute": "@/1000"
         },
@@ -2175,10 +2175,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM3/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2347,7 +2347,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "SMB_VDD_T2_3_VRM_VOUT",
+          "name": "SMB_VDD_T2_VRM_VOUT",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM5/in2_input",
           "type": 1,
           "thresholds": {
@@ -2651,10 +2651,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM8/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2663,10 +2663,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM8/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2739,10 +2739,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM9/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2751,10 +2751,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM9/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2827,10 +2827,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM10/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2839,10 +2839,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM10/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2915,10 +2915,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM11/in2_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },
@@ -2927,10 +2927,10 @@
           "sysfsPath": "/run/devmap/sensors/SMB_VRM11/in3_input",
           "type": 1,
           "thresholds": {
-            "upperCriticalVal": 0.9935,
+            "upperCriticalVal": 1.01725,
             "maxAlarmVal": 0.903,
-            "minAlarmVal": 0.722,
-            "lowerCriticalVal": 0.6315
+            "minAlarmVal": 0.6745,
+            "lowerCriticalVal": 0.56025
           },
           "compute": "@/1000"
         },


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

## Summary
Update SMB VRM output voltage sensor thresholds for Minipack3n platform to widen the acceptable operating range based on latest hardware characterization data.

## Changes
1. **Threshold adjustments for SMB VRM voltage outputs (VRM1, VRM3, VRM8~VRM11):**
   - Raised `upperCriticalVal` slightly (e.g. 0.9935 → 1.01725, 0.88875 → 0.905375)
   - Lowered `minAlarmVal` (e.g. 0.722 → 0.6745, 0.64125 → 0.608)
   - Lowered `lowerCriticalVal` (e.g. 0.6315 → 0.56025, 0.55875 → 0.508875)
2. **Sensor rename:**
   - `SMB_VDD_T2_3_VRM_VOUT` → `SMB_VDD_T2_VRM_VOUT` (corrected naming on SMB_VRM5)

## Test Plan
Ran the following commands on DUT and verified sensor readings are within updated thresholds:
- `Sensor_service`
[mp3n_sensor_service.txt](https://github.com/user-attachments/files/31254156/mp3n_sensor_service.txt)
- `Sensor_service_hw_test`
[mp3n_sensor_service_hw_test.txt](https://github.com/user-attachments/files/31254166/mp3n_sensor_service_hw_test.txt)
- `sensor_service_client`
[mp3n_sensor_service_client.txt](https://github.com/user-attachments/files/31254171/mp3n_sensor_service_client.txt)

