### PR TITLE
[Nexthop][m4062nhp] Use stable paths for DIMM temp sensors

### DIFF
--- a/fboss/platform/configs/m4062nhp/platform_manager.json
+++ b/fboss/platform/configs/m4062nhp/platform_manager.json
@@ -69,11 +69,11 @@
       "embeddedSensorConfigs": [
         {
           "pmUnitScopedName": "DIMM1_TEMP",
-          "sysfsPath": "/sys/bus/i2c/devices/1-0050"
+          "sysfsPath": "/run/nexthop_bsp/sensors/DIMM1_TEMP"
         },
         {
           "pmUnitScopedName": "DIMM2_TEMP",
-          "sysfsPath": "/sys/bus/i2c/devices/1-0051"
+          "sysfsPath": "/run/nexthop_bsp/sensors/DIMM2_TEMP"
         }
       ],
       "outgoingSlotConfigs": {


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The DDR5 SPD hubs are auto-instantiated by the kernel and the i2c paths may change depending on the module load order. Resolve the DIMM temp sensor to a stable path provided by the BSP.

# Test Plan

Verified on hardware.
