### PR TITLE
[Celestica] Tahansb800bc: Config: Change CPU i801 bus name to CPU_BUS@0 for Kernel 6.16.1

### DIFF
--- a/fboss/platform/configs/tahansb800bc/platform_manager.json
+++ b/fboss/platform/configs/tahansb800bc/platform_manager.json
@@ -6,7 +6,7 @@
     "MCB_SLOT": {
       "numOutgoingI2cBuses": 0,
       "idpromConfig": {
-        "busName": "SMBus I801 adapter at 5000",
+        "busName": "CPU_BUS@0",
         "address": "0x53",
         "kernelDeviceName": "24c02"
       },
@@ -41,7 +41,7 @@
     }
   },
   "i2cAdaptersFromCpu": [
-    "SMBus I801 adapter at 5000"
+    "CPU_BUS@0"
   ],
   "versionedPmUnitConfigs": {
     "NETLAKE": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="979" height="292" alt="image" src="https://github.com/user-attachments/assets/b2cb16a2-ec21-4b42-9a7e-092b2dff1b46" />



# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
This PR updates the bus name of CPU i801 bus as "CPU_BUS@0" in platform_manager.json 

# Motivation

Linux Kernel 6.16.1 renames the host i801 SMBus adapter from “SMBus I801 adapter at 5000” to “SMBus I801 adapter at 0000:00:1f.4“. Configuring the CPU bus name with a hardcoded string is no longer compatible across various kernel versions. Therefore, this PR updates the configuration using a compatible method, i.e., naming it with the virtual name CPU_BUS@0, which was introduced by commit : [https://github.com/facebook/fboss/commit/aad42d744564248a266f17bdff346d1fe3530066](https://github.com/facebook/fboss/commit/aad42d744564248a266f17bdff346d1fe3530066)

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

1.Passed the config validation 
2.Run platform_manager/sensor_service/fan_service/data_corral_service on the Tahansb800bc devices with Kernel 6.11.1 and 6.16.1 successfully, 
<img width="1269" height="70" alt="image" src="https://github.com/user-attachments/assets/b28e9c1a-48c2-4305-ae4b-ca7cdb15f950" />

<img width="1058" height="45" alt="image" src="https://github.com/user-attachments/assets/9ecbb64f-ce13-4dfb-9f20-7a03a536e362" />


Pls refer the full logs: 
[PM Services(Kernel 6.16.1).zip](https://github.com/user-attachments/files/31286583/PM.Services.Kernel.6.16.1.zip)
[PM Services(Kernel 6.11.1).zip](https://github.com/user-attachments/files/31286608/PM.Services.Kernel.6.11.1.zip)

3.Run all hw_test cases, passed.
Pls refer the full : 
[HwTest(Kernel 6.16.1).zip](https://github.com/user-attachments/files/31286616/HwTest.Kernel.6.16.1.zip)
[HwTest(Kernel 6.11.1).zip](https://github.com/user-attachments/files/31286620/HwTest.Kernel.6.11.1.zip)


<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
