### PR TITLE
[Nexthop] don't crash sw_agent in handlePendingUpdates when HwSwitch connections are lost

### DIFF
--- a/cmake/AgentTest.cmake
+++ b/cmake/AgentTest.cmake
@@ -89,6 +89,23 @@ target_link_libraries(async_logger_test
 
 gtest_discover_tests(async_logger_test)
 
+add_executable(switch_handler_test
+  fboss/util/oss/TestMain.cpp
+  fboss/agent/test/SwitchHandlerTest.cpp
+)
+
+target_link_libraries(switch_handler_test
+  agent_test_utils
+  core
+  multi_switch_hw_switch_handler
+  multiswitch_service
+  common_utils
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+)
+
+gtest_discover_tests(switch_handler_test)
+
 add_library(agent_test_lib
   fboss/agent/test/AgentTest.cpp
 )

--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -13,12 +13,9 @@
 #include <folly/logging/Init.h>
 #include <folly/logging/LoggerDB.h>
 #include <folly/logging/xlog.h>
-<<<<<<< HEAD
 #include "fboss/agent/AgentConfig.h"
-=======
 #include <gflags/gflags.h>
 #include "fboss/agent/InitHookRegistry.h"
->>>>>>> 178e092e05 (NOS-12717: Fix agent EventBase double-drive abort on graceful exit (#1593))
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"

--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -15,7 +15,6 @@
 #include <folly/logging/xlog.h>
 #include "fboss/agent/AgentConfig.h"
 #include <gflags/gflags.h>
-#include "fboss/agent/InitHookRegistry.h"
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"

--- a/fboss/agent/HwAgentMain.cpp
+++ b/fboss/agent/HwAgentMain.cpp
@@ -11,8 +11,14 @@
 #include <fb303/FollyLoggingHandler.h>
 #include <fb303/ServiceData.h>
 #include <folly/logging/Init.h>
+#include <folly/logging/LoggerDB.h>
 #include <folly/logging/xlog.h>
+<<<<<<< HEAD
 #include "fboss/agent/AgentConfig.h"
+=======
+#include <gflags/gflags.h>
+#include "fboss/agent/InitHookRegistry.h"
+>>>>>>> 178e092e05 (NOS-12717: Fix agent EventBase double-drive abort on graceful exit (#1593))
 #ifndef IS_OSS
 #include "common/fb303/cpp/DefaultControl.h"
 #include "common/fb303/cpp/DefaultMonitor.h"
@@ -79,6 +85,11 @@ void updateStats(
 namespace facebook::fboss {
 
 void SplitHwAgentSignalHandler::signalReceived(int /*signum*/) noexcept {
+  if (exitSignalReceived_.exchange(true)) {
+    XLOG(WARNING)
+        << "[Exit] Exit signal received while shutdown is already in progress, ignoring";
+    return;
+  }
   restart_time::mark(RestartEvent::SIGNAL_RECEIVED);
   XLOG(DBG2) << "[Exit] Signal received ";
   if (!hwAgent_->isInitialized()) {
@@ -155,8 +166,6 @@ void SplitHwAgentSignalHandler::signalReceived(int /*signum*/) noexcept {
     std::this_thread::sleep_for(std::chrono::seconds(FLAGS_agent_exit_delay_s));
     XLOG(INFO) << "[Exit] Delay complete, exiting now";
   }
-
-  exit(0);
 }
 
 int hwAgentMain(
@@ -313,7 +322,10 @@ int hwAgentMain(
   // @lint-ignore CLANGTIDY
   server->serve();
   server.reset();
-  return 0;
+  thriftSyncer.reset();
+  folly::LoggerDB::get().flushAllHandlers();
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  exit(signalHandler.exitSignalReceived() ? 0 : 1);
 }
 
 } // namespace facebook::fboss

--- a/fboss/agent/HwAgentMain.h
+++ b/fboss/agent/HwAgentMain.h
@@ -8,9 +8,8 @@
  *
  */
 #pragma once
+#include <atomic>
 #include <memory>
-
-#include <gflags/gflags.h>
 #include <string>
 
 #include "fboss/agent/CommonInit.h"
@@ -34,9 +33,14 @@ class SplitHwAgentSignalHandler : public SignalHandler {
 
   void signalReceived(int /*signum*/) noexcept override;
 
+  bool exitSignalReceived() const {
+    return exitSignalReceived_.load();
+  }
+
  private:
   std::unique_ptr<HwAgent> hwAgent_;
   SplitAgentThriftSyncer* syncer_;
+  std::atomic<bool> exitSignalReceived_{false};
 };
 
 void setSDKVersionInfo();

--- a/fboss/agent/HwSwitchConnectionStatusTable.cpp
+++ b/fboss/agent/HwSwitchConnectionStatusTable.cpp
@@ -122,4 +122,9 @@ int HwSwitchConnectionStatusTable::getConnectionStatus(SwitchID switchId) {
   return connectedSwitches_.find(switchId) != connectedSwitches_.end() ? 1 : 0;
 }
 
+bool HwSwitchConnectionStatusTable::hasActiveConnections() {
+  std::lock_guard<std::mutex> lk(hwSwitchConnectedMutex_);
+  return !connectedSwitches_.empty();
+}
+
 } // namespace facebook::fboss

--- a/fboss/agent/HwSwitchConnectionStatusTable.cpp
+++ b/fboss/agent/HwSwitchConnectionStatusTable.cpp
@@ -70,7 +70,11 @@ bool HwSwitchConnectionStatusTable::disconnected(SwitchID switchId) {
                  << ": " << dirUtil->getHwColdBootOnceFile(switchIndex);
     }
 
-    std::exit(EXIT_SUCCESS);
+    // Schedule graceful teardown on the server's event base instead of exiting
+    // inline on this thrift stream cleanup thread.
+    lk.unlock();
+    sw_->requestGracefulShutdown();
+    return true;
   }
   if (FLAGS_exit_for_any_hw_disconnect) {
     XLOG(FATAL)

--- a/fboss/agent/HwSwitchConnectionStatusTable.h
+++ b/fboss/agent/HwSwitchConnectionStatusTable.h
@@ -25,6 +25,7 @@ class HwSwitchConnectionStatusTable {
   bool waitUntilHwSwitchConnected();
   void cancelWait();
   int getConnectionStatus(SwitchID switchId);
+  bool hasActiveConnections();
 
  private:
   std::set<SwitchID> connectedSwitches_;

--- a/fboss/agent/MultiHwSwitchHandler.cpp
+++ b/fboss/agent/MultiHwSwitchHandler.cpp
@@ -273,6 +273,15 @@ bool MultiHwSwitchHandler::isHwSwitchConnected(const SwitchID& switchId) {
   return connectionStatusTable_.getConnectionStatus(switchId) == 1;
 }
 
+bool MultiHwSwitchHandler::hasActiveHwSwitchConnections() {
+  // for monolithic mode, we always return true, as we are not using
+  // connectionStatusTable_ in this case
+  if (sw_->isRunModeMonolithic()) {
+    return true;
+  }
+  return connectionStatusTable_.hasActiveConnections();
+}
+
 std::unique_ptr<TxPacket> MultiHwSwitchHandler::allocatePacket(uint32_t size) {
   // TODO - support with multiple switches
   CHECK_GE(hwSwitchSyncers_.size(), 1);

--- a/fboss/agent/MultiHwSwitchHandler.h
+++ b/fboss/agent/MultiHwSwitchHandler.h
@@ -124,6 +124,7 @@ class MultiHwSwitchHandler {
   }
 
   bool isHwSwitchConnected(const SwitchID& switchId);
+  bool hasActiveHwSwitchConnections();
   void fillHwAgentConnectionStatus(AgentStats& agentStats);
 
   state::SwitchState reconstructSwitchState(SwitchID id);

--- a/fboss/agent/SwAgentInitializer.cpp
+++ b/fboss/agent/SwAgentInitializer.cpp
@@ -268,6 +268,13 @@ int SwAgentInitializer::initAgent(
 
   swHandler->setSSLPolicy(server_->getSSLPolicy());
 
+  // Register before start() so an all-HwSwitches-disconnected teardown can be
+  // scheduled on the event base. skipWarmBootStateSave=true: this is a cold
+  // shutdown whose cold-boot-once markers are already written.
+  sw_->registerGracefulShutdownHandler(eventBase_, [this]() {
+    handleExitSignal(true /* gracefulExit */, true /* skipWarmBootStateSave */);
+  });
+
   // At this point, we are guaranteed no other agent process will initialize
   // the ASIC because such a process would have crashed attempting to bind to
   // the Thrift port 5909
@@ -314,6 +321,6 @@ int SwAgentInitializer::initAgent(
     serverStarted_ = false;
   }
   serverStopCV_.notify_one();
-  return 0;
+  return exitStatus_.load();
 }
 } // namespace facebook::fboss

--- a/fboss/agent/SwAgentInitializer.h
+++ b/fboss/agent/SwAgentInitializer.h
@@ -10,6 +10,7 @@
 #include "fboss/agent/SwSwitch.h"
 
 #include <gflags/gflags.h>
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -96,7 +97,9 @@ class SwAgentInitializer : public AgentInitializer {
   std::unique_ptr<SwSwitch> sw_;
   std::unique_ptr<SwSwitchInitializer> initializer_;
   std::shared_ptr<PacketStreamHandler> packetStreamHandler_;
-  virtual void handleExitSignal(bool gracefulExit) = 0;
+  virtual void handleExitSignal(
+      bool gracefulExit,
+      bool skipWarmBootStateSave = false) = 0;
 
   void stopServer();
   /*
@@ -108,6 +111,10 @@ class SwAgentInitializer : public AgentInitializer {
    */
   virtual void stopServices();
   void waitForServerStopped();
+
+  // Exit status recorded by handleExitSignal() and returned by initAgent()
+  // once serve() unwinds.
+  std::atomic<int> exitStatus_{0};
 
  private:
   std::unique_ptr<apache::thrift::ThriftServer> server_;

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -227,6 +227,8 @@ facebook::fboss::PortStatus fillInPortStatus(
 }
 
 auto constexpr kHwUpdateFailures = "hw_update_failures";
+auto constexpr kHwUpdateDroppedNoConnection =
+    "hwswitch_disconnected_update_drop";
 
 std::string getDrainStateChangedStr(
     const std::shared_ptr<facebook::fboss::SwitchState>& oldState,
@@ -2054,6 +2056,36 @@ void SwSwitch::handlePendingUpdates() {
           update->onError(ex);
         }
         return;
+      } else if (!multiHwSwitchHandler_->hasActiveHwSwitchConnections()) {
+        /*
+         * All HwSwitch connections are gone (e.g. hw_agent restarted right
+         * after sw_agent came up and the oper delta ack timed out or the
+         * stream disconnected). HwSwitchConnectionStatusTable::disconnected()
+         * has already created cold boot markers and scheduled a graceful
+         * shutdown, but the EXITING run state may not be set yet on this
+         * thread, so isExiting() can still be false here. Treat this like
+         * the exiting case instead of crashing: state will be resynced via
+         * the cold boot on restart.
+         *
+         * TODO: this connection-table check is a proxy for the
+         * HWSWITCH_STATE_UPDATE_CANCELLED status that
+         * MultiHwSwitchHandler::stateChanged computes per switch and then
+         * drops. It is correct only because both cancellation paths erase
+         * the connection-table entry before stateChanged returns to this
+         * thread. Propagating the aggregate update status out of
+         * MultiHwSwitchHandler::stateChanged would be exact, and would also
+         * let us handle partial cancellation (one of several HwSwitches
+         * cancelled) which today either still FATALs here or silently leaves
+         * the cancelled switch out of sync.
+         */
+        fb303::fbData->incrementCounter(kHwUpdateDroppedNoConnection);
+        XLOG(ERR) << "Failed to apply update to HW since all HwSwitch "
+                     "connections are lost; shutdown is in progress";
+        // Belt and braces: every path that empties the connection table
+        // already requests this (and call_once collapses the requests), but
+        // do not rely on that here - dropping updates without a pending
+        // teardown would leave a zombie agent acking updates forever.
+        requestGracefulShutdown();
       } else {
         XLOG(FATAL)
             << " Failed to apply update to HW and the update is not marked for "

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -901,10 +901,12 @@ state::WarmbootState SwSwitch::gracefulExitState() const {
   return thriftSwitchState;
 }
 
-void SwSwitch::gracefulExit() {
+void SwSwitch::gracefulExit(bool skipWarmBootStateSave) {
   if (isFullyInitialized()) {
     steady_clock::time_point begin = steady_clock::now();
-    XLOG(DBG2) << "[Exit] Starting SwSwitch graceful exit";
+    XLOG(DBG2) << "[Exit] Starting SwSwitch graceful exit"
+               << (skipWarmBootStateSave ? " (skipping warm boot state save)"
+                                         : "");
     ipv6_->floodNeighborAdvertisements();
     arp_->floodGratuituousArp();
     steady_clock::time_point neighborFloodDone = steady_clock::now();
@@ -920,22 +922,27 @@ void SwSwitch::gracefulExit() {
                       stopThreadsAndHandlersDone - neighborFloodDone)
                       .count();
 
-    state::WarmbootState thriftSwitchState;
-    std::thread swWarmbootStateThread([this,
-                                       &thriftSwitchState,
-                                       stopThreadsAndHandlersDone]() {
-      thriftSwitchState = gracefulExitState();
-      steady_clock::time_point switchStateToThriftDone = steady_clock::now();
-      XLOG(DBG2) << "[Exit] Switch state to thrift "
-                 << duration_cast<duration<float>>(
-                        switchStateToThriftDone - stopThreadsAndHandlersDone)
-                        .count();
-    });
-    // Cleanup if we ever initialized
-    stopHwSwitchHandler();
+    if (!skipWarmBootStateSave) {
+      state::WarmbootState thriftSwitchState;
+      std::thread swWarmbootStateThread([this,
+                                         &thriftSwitchState,
+                                         stopThreadsAndHandlersDone]() {
+        thriftSwitchState = gracefulExitState();
+        steady_clock::time_point switchStateToThriftDone = steady_clock::now();
+        XLOG(DBG2) << "[Exit] Switch state to thrift "
+                   << duration_cast<duration<float>>(
+                          switchStateToThriftDone - stopThreadsAndHandlersDone)
+                          .count();
+      });
+      // Cleanup if we ever initialized
+      stopHwSwitchHandler();
 
-    swWarmbootStateThread.join();
-    storeWarmBootState(thriftSwitchState);
+      swWarmbootStateThread.join();
+      storeWarmBootState(thriftSwitchState);
+    } else {
+      // Cleanup if we ever initialized
+      stopHwSwitchHandler();
+    }
     XLOG(DBG2)
         << "[Exit] SwSwitch Graceful Exit time "
         << duration_cast<duration<float>>(steady_clock::now() - begin).count();
@@ -1400,6 +1407,27 @@ void SwSwitch::invokeNeighborListener(
   if (neighborListener_ && !isExiting()) {
     neighborListener_(added, removed);
   }
+}
+
+void SwSwitch::registerGracefulShutdownHandler(
+    FbossEventBase* evb,
+    std::function<void()> handler) {
+  gracefulShutdownEvb_ = evb;
+  gracefulShutdownHandler_ = std::move(handler);
+}
+
+void SwSwitch::requestGracefulShutdown() {
+  if (!gracefulShutdownHandler_ || !gracefulShutdownEvb_) {
+    XLOG(ERR)
+        << "requestGracefulShutdown called but no graceful shutdown handler registered";
+    return;
+  }
+  // Run teardown on the registered event base, not the caller's thread;
+  // once_flag collapses concurrent requests into a single shutdown.
+  std::call_once(gracefulShutdownOnceFlag_, [this]() {
+    gracefulShutdownEvb_->runInEventBaseThread(
+        [handler = gracefulShutdownHandler_]() { handler(); });
+  });
 }
 
 void SwSwitch::exitFatal() const noexcept {

--- a/fboss/agent/SwSwitch.h
+++ b/fboss/agent/SwSwitch.h
@@ -848,8 +848,11 @@ class SwSwitch : public HwSwitchCallback {
   /*
    * Allow hardware to perform any cleanup needed to gracefully restart the
    * agent before we exit application.
+   *
+   * skipWarmBootStateSave: tear down without persisting warm-boot state or
+   * setting the can_warm_boot marker.
    */
-  void gracefulExit();
+  void gracefulExit(bool skipWarmBootStateSave = false);
 
   BootType getBootType() const {
     return bootType_;
@@ -878,6 +881,20 @@ class SwSwitch : public HwSwitchCallback {
   void invokeNeighborListener(
       const std::vector<std::string>& added,
       const std::vector<std::string>& deleted);
+
+  /*
+   * Register a graceful shutdown handler, run on the given event base when
+   * requestGracefulShutdown() is called.
+   */
+  void registerGracefulShutdownHandler(
+      FbossEventBase* evb,
+      std::function<void()> handler);
+
+  /*
+   * Schedule the registered graceful shutdown handler. Safe to call from any
+   * thread; the handler runs at most once.
+   */
+  void requestGracefulShutdown();
 
   std::string getConfigStr() const;
   cfg::SwitchConfig getConfig() const;
@@ -1265,6 +1282,11 @@ class SwSwitch : public HwSwitchCallback {
   bool supportsAddRemovePort_;
   const std::unique_ptr<PlatformProductInfo> platformProductInfo_;
   std::atomic<SwitchRunState> runState_{SwitchRunState::UNINITIALIZED};
+
+  std::function<void()> gracefulShutdownHandler_{nullptr};
+  FbossEventBase* gracefulShutdownEvb_{nullptr};
+  std::once_flag gracefulShutdownOnceFlag_;
+
   folly::ThreadLocalPtr<SwitchStats, SwSwitch> stats_;
   /**
    * The object to sync the interfaces to the system. This pointer could

--- a/fboss/agent/mnpu/SplitSwAgentInitializer.cpp
+++ b/fboss/agent/mnpu/SplitSwAgentInitializer.cpp
@@ -55,7 +55,15 @@ SplitSwAgentInitializer::getThrifthandlers() {
   return handlers;
 }
 
-void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
+void SplitSwAgentInitializer::handleExitSignal(
+    bool gracefulExit,
+    bool skipWarmBootStateSave) {
+  if (exitSignalReceived_.exchange(true)) {
+    XLOG(WARNING)
+        << "[Exit] Exit signal received while shutdown is already in progress, ignoring";
+    return;
+  }
+  exitStatus_ = gracefulExit ? 0 : 1;
   if (!sw_->isInitialized()) {
     XLOG(WARNING)
         << "[Exit] Signal received before initializing sw switch, waiting for initialization to finish.";
@@ -80,7 +88,7 @@ void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
   initializer_->stopFunctionScheduler();
   multiSwitchThriftHandler_->cancelEventSyncers();
   steady_clock::time_point switchGracefulExitBegin = steady_clock::now();
-  sw_->gracefulExit();
+  sw_->gracefulExit(skipWarmBootStateSave);
   steady_clock::time_point switchGracefulExitEnd = steady_clock::now();
   XLOG(DBG2) << "[Exit] Switch Graceful Exit time "
              << duration_cast<duration<float>>(
@@ -105,12 +113,6 @@ void SplitSwAgentInitializer::handleExitSignal(bool gracefulExit) {
 #endif
 #endif
   initializer_.reset();
-  this->waitForServerStopped();
-  if (gracefulExit) {
-    exit(0);
-  } else {
-    exit(1);
-  }
 }
 
 void SplitSwAgentInitializer::stopAgent(bool setupWarmboot, bool gracefulExit) {
@@ -130,6 +132,6 @@ void SplitSwAgentInitializer::exitForColdBoot() {
 }
 
 void SplitSwAgentInitializer::exitForWarmBoot(bool gracefulExit) {
-  handleExitSignal(gracefulExit);
+  handleExitSignal(gracefulExit, false /* skipWarmBootStateSave */);
 }
 } // namespace facebook::fboss

--- a/fboss/agent/mnpu/SplitSwAgentInitializer.h
+++ b/fboss/agent/mnpu/SplitSwAgentInitializer.h
@@ -5,7 +5,8 @@
 #include "fboss/agent/AgentDirectoryUtil.h"
 #include "fboss/agent/SwAgentInitializer.h"
 
-#include <folly/io/async/EventBase.h>
+#include <atomic>
+#include <vector>
 
 namespace facebook::fboss {
 
@@ -30,7 +31,7 @@ class SplitSwAgentInitializer : public SwAgentInitializer {
   std::vector<std::shared_ptr<apache::thrift::AsyncProcessorFactory>>
   getThrifthandlers() override;
 
-  void handleExitSignal(bool gracefulExit) override;
+  void handleExitSignal(bool gracefulExit, bool skipWarmBootStateSave) override;
 
   void stopAgent(bool setupWarmboot, bool gracefulExit) override;
 
@@ -39,6 +40,7 @@ class SplitSwAgentInitializer : public SwAgentInitializer {
   void exitForWarmBoot(bool gracefulExit);
   AgentDirectoryUtil agentDirectoryUtil_;
   MultiSwitchThriftHandler* multiSwitchThriftHandler_{nullptr};
+  std::atomic<bool> exitSignalReceived_{false};
 };
 
 } // namespace facebook::fboss

--- a/fboss/agent/single/MonolithicAgentInitializer.cpp
+++ b/fboss/agent/single/MonolithicAgentInitializer.cpp
@@ -110,7 +110,9 @@ void MonolithicAgentInitializer::createSwitch(
       sw_.get(), hwAgent_.get());
 }
 
-void MonolithicAgentInitializer::handleExitSignal(bool gracefulExit) {
+void MonolithicAgentInitializer::handleExitSignal(
+    bool gracefulExit,
+    bool skipWarmBootStateSave) {
   restart_time::mark(RestartEvent::SIGNAL_RECEIVED);
   XLOG(DBG2) << "[Exit] Signal received ";
   steady_clock::time_point begin = steady_clock::now();
@@ -132,7 +134,7 @@ void MonolithicAgentInitializer::handleExitSignal(bool gracefulExit) {
   steady_clock::time_point servicesStopped = steady_clock::now();
   XLOG(DBG2) << "[Exit] Services stop time "
              << duration_cast<duration<float>>(servicesStopped - begin).count();
-  sw_->gracefulExit();
+  sw_->gracefulExit(skipWarmBootStateSave);
   steady_clock::time_point switchGracefulExit = steady_clock::now();
   XLOG(DBG2)
       << "[Exit] Switch Graceful Exit time "

--- a/fboss/agent/single/MonolithicAgentInitializer.h
+++ b/fboss/agent/single/MonolithicAgentInitializer.h
@@ -69,7 +69,7 @@ class MonolithicAgentInitializer : public SwAgentInitializer {
    */
   virtual void setCmdLineFlagOverrides() const {}
 
-  void handleExitSignal(bool gracefulExit) override;
+  void handleExitSignal(bool gracefulExit, bool skipWarmBootStateSave) override;
 
   /*
    * MonoithicAgentInitializer overrides stopServices to stop the HwAgent first,

--- a/fboss/agent/test/AgentEnsemble.cpp
+++ b/fboss/agent/test/AgentEnsemble.cpp
@@ -3,6 +3,7 @@
 #include "fboss/agent/test/AgentEnsemble.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <map>
 #include <vector>
 
@@ -421,6 +422,12 @@ void AgentEnsemble::gracefulExit() {
   bool gracefulExit = !::testing::Test::HasFailure();
   initializer->stopAgent(
       true /* setupWarmboot */, gracefulExit /* gracefulExit */);
+  // handleExitSignal() now returns and lets serve() unwind on asyncInitThread_;
+  // join it then exit here to skip gtest TearDown() (which would tear down
+  // state the next warm boot depends on).
+  joinAsyncInitThread();
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  exit(gracefulExit ? 0 : 1);
 }
 
 void AgentEnsemble::applyNewState(

--- a/fboss/agent/test/SwSwitchTest.cpp
+++ b/fboss/agent/test/SwSwitchTest.cpp
@@ -10,7 +10,9 @@
 
 #include <gtest/gtest.h>
 
+#include "fboss/agent/AgentDirectoryUtil.h"
 #include "fboss/agent/ArpHandler.h"
+#include "fboss/agent/FbossEventBase.h"
 #include "fboss/agent/FbossHwUpdateError.h"
 #include "fboss/agent/MultiSwitchFb303Stats.h"
 #include "fboss/agent/NeighborUpdater.h"
@@ -26,12 +28,15 @@
 #include "fboss/agent/test/CounterCache.h"
 #include "fboss/agent/test/HwTestHandle.h"
 #include "fboss/agent/test/TestUtils.h"
+#include "fboss/lib/CommonFileUtils.h"
 
 #include <folly/IPAddressV4.h>
 #include <folly/IPAddressV6.h>
 #include <folly/MacAddress.h>
 
-#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
 
 using namespace facebook::fboss;
 using folly::IPAddressV4;
@@ -336,6 +341,38 @@ TEST_F(SwSwitchTest, gracefulExit) {
   sw->gracefulExit();
 }
 
+TEST_F(SwSwitchTest, gracefulExitSavesWarmBootState) {
+  auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
+    return bringAllPortsUp(state);
+  };
+  sw->updateStateBlocking("Bring Ports Up", bringPortsUpUpdateFn);
+
+  const auto* dirUtil = sw->getDirUtil();
+  auto canWarmBootFile = dirUtil->getSwSwitchCanWarmBootFile();
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+
+  // Persists warm-boot state and sets the can_warm_boot marker.
+  sw->gracefulExit();
+
+  EXPECT_TRUE(checkFileExists(canWarmBootFile));
+}
+
+TEST_F(SwSwitchTest, gracefulExitSkipWarmBootStateSave) {
+  auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
+    return bringAllPortsUp(state);
+  };
+  sw->updateStateBlocking("Bring Ports Up", bringPortsUpUpdateFn);
+
+  const auto* dirUtil = sw->getDirUtil();
+  auto canWarmBootFile = dirUtil->getSwSwitchCanWarmBootFile();
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+
+  // Cold shutdown: no warm-boot state persisted, so no can_warm_boot marker.
+  sw->gracefulExit(true /* skipWarmBootStateSave */);
+
+  EXPECT_FALSE(checkFileExists(canWarmBootFile));
+}
+
 TEST_F(SwSwitchTest, overlappingUpdatesWithExit) {
   auto bringPortsUpUpdateFn = [](const std::shared_ptr<SwitchState>& state) {
     return bringAllPortsUp(state);
@@ -549,4 +586,37 @@ TEST_F(SwSwitchTest, FillFsdbStatsNullShelManager) {
   // Should not crash - shelManager_ is null on NPU switches
   // and the code must guard against that.
   EXPECT_NO_THROW(sw->fillFsdbStats());
+}
+
+TEST_F(SwSwitchTest, RequestGracefulShutdownUnregisteredIsNoOp) {
+  // No handler registered: must not crash.
+  EXPECT_NO_THROW(sw->requestGracefulShutdown());
+}
+
+TEST_F(SwSwitchTest, RequestGracefulShutdownRunsHandlerExactlyOnce) {
+  FbossEventBase evb("RequestGracefulShutdownTestEvb");
+  std::thread evbThread([&evb]() { evb.loopForever(); });
+  evb.waitUntilRunning();
+
+  std::atomic<int> callCount{0};
+  sw->registerGracefulShutdownHandler(
+      &evb, [&callCount]() { callCount.fetch_add(1); });
+
+  // Concurrent fires must collapse to a single handler invocation.
+  constexpr int kThreads = 8;
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([this]() { sw->requestGracefulShutdown(); });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Flush the event base so the enqueued handler has run.
+  evb.runInFbossEventBaseThreadAndWait([]() {});
+  evb.terminateLoopSoon();
+  evbThread.join();
+
+  EXPECT_EQ(callCount.load(), 1);
 }

--- a/fboss/agent/test/SwitchHandlerTest.cpp
+++ b/fboss/agent/test/SwitchHandlerTest.cpp
@@ -8,10 +8,11 @@
  *
  */
 
+#include <fb303/ServiceData.h>
 #include <gtest/gtest.h>
 
+#include "fboss/agent/FbossEventBase.h"
 #include "fboss/agent/MultiHwSwitchHandler.h"
-#include "fboss/agent/MultiSwitchThriftHandler.h"
 #include "fboss/agent/SwSwitch.h"
 #include "fboss/agent/SwitchStats.h"
 #include "fboss/agent/mnpu/MultiSwitchHwSwitchHandler.h"
@@ -20,7 +21,7 @@
 #include "fboss/agent/test/TestUtils.h"
 #include "fboss/lib/CommonUtils.h"
 
-#include <algorithm>
+#include <atomic>
 
 using facebook::fboss::HwSwitchMatcher;
 using facebook::fboss::SwitchID;
@@ -57,6 +58,13 @@ class SwSwitchHandlerTest : public ::testing::Test {
   void TearDown() override {
     sw_->getHwSwitchHandler()->stop();
     sw_.reset();
+    // stop the shutdown evb only after sw_ is gone: sw_ holds a pointer to
+    // it (and a handler capturing this fixture) once
+    // registerShutdownCounterHandler() has run
+    if (shutdownEvbThread_.joinable()) {
+      shutdownEvb_.terminateLoopSoon();
+      shutdownEvbThread_.join();
+    }
   }
 
  protected:
@@ -108,9 +116,28 @@ class SwSwitchHandlerTest : public ::testing::Test {
     return sw_->getHwSwitchHandler();
   }
 
+  // Register a graceful shutdown handler that only counts invocations, on a
+  // fixture-owned event base (sw_ keeps pointers to both, so they must
+  // outlive it - see TearDown()).
+  void registerShutdownCounterHandler() {
+    shutdownEvbThread_ = std::thread([this]() { shutdownEvb_.loopForever(); });
+    shutdownEvb_.waitUntilRunning();
+    sw_->registerGracefulShutdownHandler(
+        &shutdownEvb_, [this]() { shutdownCount_.fetch_add(1); });
+  }
+
+  // Flush the shutdown evb and return how many times the handler ran.
+  int shutdownHandlerRunCount() {
+    shutdownEvb_.runInFbossEventBaseThreadAndWait([]() {});
+    return shutdownCount_.load();
+  }
+
   std::unique_ptr<SwSwitch> sw_;
   folly::test::TemporaryDirectory tmpDir_;
   std::unique_ptr<AgentDirectoryUtil> agentDirUtil_;
+  FbossEventBase shutdownEvb_{"GracefulShutdownTestEvb"};
+  std::thread shutdownEvbThread_;
+  std::atomic<int> shutdownCount_{0};
 };
 
 TEST_F(SwSwitchHandlerTest, GetOperDelta) {
@@ -961,4 +988,71 @@ TEST_F(SwSwitchHandlerTest, verifyRollback) {
   stateUpdateThread.join();
   clientRequestThread1.join();
   clientRequestThread2.join();
+}
+
+/*
+ * hw_agent restarts right after sw_agent starts. All HwSwitch connections
+ * drop, which creates cold boot markers and schedules a
+ * graceful shutdown, but the update thread can fail a pending (non
+ * HW-failure-protected) update before the EXITING run state is set. That
+ * must be treated like the exiting case and not crash the agent.
+ */
+TEST_F(
+    SwSwitchHandlerTest,
+    updateFailureWithNoActiveHwConnectionsDoesNotCrash) {
+  getHwSwitchHandler()->connected(SwitchID(1));
+  getHwSwitchHandler()->connected(SwitchID(2));
+  sw_->init(HwWriteBehavior::WRITE, SwitchFlags::DEFAULT);
+  sw_->initialConfigApplied(std::chrono::steady_clock::now());
+
+  // Register a graceful shutdown handler (the split-agent initializer always
+  // does) so we can verify the connection-loss path actually requests one.
+  // The handler only counts invocations - it does not stop the SwSwitch - so
+  // isExiting() deterministically stays false, which is the race window this
+  // test exercises.
+  registerShutdownCounterHandler();
+
+  // read fb303 directly: CounterCache::checkDelta is a no-op in OSS builds
+  constexpr auto kDropCounter = "hwswitch_disconnected_update_drop";
+  auto dropsBefore = facebook::fb303::fbData->getCounters()[kDropCounter];
+
+  // Drop all HwSwitch connections. This empties the connection status table
+  // (what handlePendingUpdates consults) and requests the graceful shutdown.
+  getHwSwitchHandler()->disconnected(SwitchID(1));
+  getHwSwitchHandler()->disconnected(SwitchID(2));
+  ASSERT_FALSE(sw_->isExiting());
+
+  // The update itself gets cancelled because no oper delta client ever
+  // attached (operDeltaSyncState_ is still DISCONNECTED) - independent of
+  // the connected()/disconnected() calls above, which only drive the
+  // connection status table. Net effect: applied state != desired state
+  // while isExiting() is false. Without connection-loss handling this hits
+  // "Failed to apply update to HW and the update is not marked for HW
+  // failure protection" and aborts.
+  sw_->updateStateBlocking(
+      "update with no active hw connections",
+      [](const std::shared_ptr<SwitchState>& state) {
+        auto newState = state->clone();
+        auto aclEntry = make_shared<AclEntry>(1, std::string("acl1"));
+        // an ACL entry needs at least one qualifier to pass
+        // StateUpdateValidator, else the update is rejected before
+        // reaching the HwSwitch handler
+        aclEntry->setDscp(0x24);
+        auto acls = newState->getAcls()->modify(&newState);
+        acls->addNode(aclEntry, scope());
+        return newState;
+      });
+  waitForStateUpdates(sw_.get());
+
+  // Nothing was applied: the cancelled update must not land in the
+  // published (applied) state.
+  EXPECT_EQ(sw_->getState()->getAcls()->getNodeIf("acl1"), nullptr);
+
+  // The drop is accounted, so it is alertable.
+  EXPECT_EQ(
+      facebook::fb303::fbData->getCounters()[kDropCounter], dropsBefore + 1);
+
+  // The graceful shutdown was requested exactly once (by the disconnect;
+  // the update-drop path's defensive request collapses into it).
+  EXPECT_EQ(shutdownHandlerRunCount(), 1);
 }


### PR DESCRIPTION
> **Stacked on #1492.** The first three commits belong to #1492 ("Fix agent
> EventBase double-drive abort on graceful exit") and are carried here only so this
> change compiles and tests standalone — it depends on the
> `SwSwitch::requestGracefulShutdown()` API and the
> `HwSwitchConnectionStatusTable::disconnected()` change that PR introduces. Please
> review only the last commit; I will rebase to drop the duplicates once #1492 merges.

## Summary

`fboss_sw_agent` crashes with SIGABRT when the hw agent is restarted ~1–2s
after the sw agent starts — i.e. while a fresh sw agent (coldboot) is still
applying its initial pending updates. Under config load this reproduces
every time. The same fatal also fingerprints on mid-test hw agent restarts.

Crashing stack: `SwSwitch::handlePendingUpdates` →
`LOG(FATAL) "Failed to apply update to HW and the update is not marked for HW
failure protection"`.

## Root cause

A shutdown/update race in split-agent (multi_switch) mode:

1. The hw agent restart kills the oper delta stream; the in-flight update
   either times out waiting for its ack or hits the DISCONNECTED sync state,
   and `MultiSwitchHwSwitchHandler::stateChanged` returns
   `HWSWITCH_STATE_UPDATE_CANCELLED` (nothing applied).
2. `HwSwitchConnectionStatusTable::disconnected()` sees the last connection
   drop, creates cold boot markers, and calls `requestGracefulShutdown()` —
   but that only *schedules* teardown on another event base; the EXITING run
   state is set later, inside `stop()`.
3. Back on the update thread, applied != desired. The only escape hatches are
   `isExiting()` (still false — the race) and `hwFailureProtected()` (false
   for initial config/route updates), so it falls into the FATAL.

The CANCELLED status — "connection lost, shutdown imminent", deliberately
distinct from FAILED — is dropped in `MultiHwSwitchHandler::stateChanged`,
so `SwSwitch` can't tell a connection loss from a real programming failure.

## Fix

Treat "all HwSwitch connections lost" the same as "already exiting" at the
FATAL site:

- `HwSwitchConnectionStatusTable::hasActiveConnections()` — new accessor.
- `MultiHwSwitchHandler::hasActiveHwSwitchConnections()` — always true in
  monolithic mode (mirrors `isHwSwitchConnected`), else consults the table.
- `SwSwitch::handlePendingUpdates`: if the update failed and no HwSwitch
  connections remain, log an error, increment a new
  `hwswitch_disconnected_update_drop` counter so the drop is alertable
  (the sole evidence was otherwise one ERR line per dropped update), request
  the graceful shutdown, and fall through like the `isExiting()` branch so
  blocking callers complete.

The `requestGracefulShutdown()` here is belt-and-braces: every path that
empties the connection table already requests one (and `call_once` collapses
the requests), but the drop path must not depend on that invariant — dropping
updates with no pending teardown would leave a zombie agent acking updates
that never touched hardware. A comment at the call site records this so it
doesn't read as dead code.

The connection-table check is a proxy for the dropped CANCELLED status. It is
correct because both cancellation paths erase the table entry before
`stateChanged` returns to the update thread: the stream-disconnect path via
`notifyHwSwitchDisconnected`, and the ack-timeout path via the
`disconnected()` call inside `MultiSwitchHwSwitchHandler::waitForOperSyncAck`.
A TODO at the site documents the exact alternative — propagating the aggregate
update status out of `MultiHwSwitchHandler::stateChanged` — which would not
depend on that ordering and would also cover partial cancellation in
multi-HwSwitch topologies (one of several HwSwitches cancelled), a pre-existing
gap not addressed here.

Behavior is unchanged for genuine HW programming failures with a live
connection (still FATAL), HW-failure-protected updates (still throw
`FbossHwUpdateError` to the caller), and monolithic mode.

## Test Plan

New unit test `SwSwitchHandlerTest.updateFailureWithNoActiveHwConnectionsDoesNotCrash`
in `fboss/agent/test/SwitchHandlerTest.cpp` covers the dropped update, the
counter bump, and the graceful-shutdown request. This change also adds a
`switch_handler_test` cmake target so `SwitchHandlerTest.cpp` is built and run
by the OSS cmake build, which it was not before.

Verified with the cmake build on this exact tree: builds clean, and the unit
test suite passes 1947/1947 including the new test.

The agent-coldboot system test that previously crashed reliably passes with
this change.
