### PR TITLE
Added fw_util support for P2 icecube800banw

### DIFF
--- a/fboss/platform/configs/icecube800banw/fw_util.json
+++ b/fboss/platform/configs/icecube800banw/fw_util.json
@@ -1,5 +1,24 @@
 {
   "fwConfigs": {
+    "cpu_cpld": {
+      "upgrade": [
+        {
+          "commandType": "jam",
+          "jamArgs": {
+            "jamExtraArgs": [
+              "-aprogram",
+              "-fmarconi_cpu_cpld",
+              "-v"
+            ]
+          }
+        }
+      ],
+      "version": {
+        "versionType": "sysfs",
+        "path": "/run/devmap/inforoms/CPU_FPGA_INFO_ROM/fw_ver"
+      },
+      "priority": 2
+    },
     "smb_fpga": {
       "upgrade": [
         {

--- a/fboss/platform/firmware_onboarding/configs/icecube800banw/BUCK
+++ b/fboss/platform/firmware_onboarding/configs/icecube800banw/BUCK
@@ -1,0 +1,11 @@
+load("@fbcode_macros//build_defs:export_files.bzl", "export_file")
+
+oncall("fboss_platform")
+
+export_file(
+    name = "spec",
+    src = "spec.json",
+    visibility = [
+        "//fboss/platform/firmware_onboarding/...",
+    ],
+)

--- a/fboss/platform/firmware_onboarding/configs/icecube800banw/spec.json
+++ b/fboss/platform/firmware_onboarding/configs/icecube800banw/spec.json
@@ -1,0 +1,35 @@
+{
+  "spec_version": "1.0",
+
+  "platform": {
+    "name": "icecube800banw",
+    "silicon": [
+      { "name": "TH6" }
+    ]
+  },
+
+  "components": [
+    {
+      "name": "smb_fpga",
+      "platform_identifier": "icecube800banw",
+      "location": "Switch Main Board",
+      "display_location": "smb",
+      "field_replaceable": false,
+      "firmware": {
+        "priority": 1,
+        "shared_with_platforms": []
+      }
+    },
+    {
+      "name": "cpu_cpld",
+      "platform_identifier": "icecube800banw",
+      "location": "System Control Module",
+      "display_location": "scm",
+      "field_replaceable": true,
+      "firmware": {
+        "priority": 2,
+        "shared_with_platforms": []
+      }
+    }
+  ]
+}

--- a/fboss/platform/firmware_onboarding/validator/BUCK
+++ b/fboss/platform/firmware_onboarding/validator/BUCK
@@ -55,6 +55,7 @@ python_unittest(
     network_access = network_access_utils.none(),
     resources = {
         "//fboss/platform/firmware_onboarding/configs/icecube800bc:spec": "tests/icecube800bc.json",
+        "//fboss/platform/firmware_onboarding/configs/icecube800banw:spec": "tests/icecube800banw.json",
     },
     deps = [":preflight"],
 )

--- a/fboss/platform/firmware_onboarding/validator/tests/test_canonical_examples.py
+++ b/fboss/platform/firmware_onboarding/validator/tests/test_canonical_examples.py
@@ -29,10 +29,7 @@ from fboss.platform.firmware_onboarding.validator.preflight import (
     run_preflight,
 )
 
-
-_CANONICAL_PLATFORMS: list[str] = [
-    "icecube800bc",
-]
+_CANONICAL_PLATFORMS: list[str] = ["icecube800bc", "icecube800banw"]
 
 
 class CanonicalExamplesTest(unittest.TestCase):
@@ -73,7 +70,5 @@ class CanonicalExamplesTest(unittest.TestCase):
                     # stays in sync if new tiers (e.g. `[depcheck]`) are added.
                     hard = [e for e in errors if _is_hard_failure(e)]
                     self.assertEqual(
-                        hard,
-                        [],
-                        f"{platform}/spec.json failed preflight: {errors}",
+                        hard, [], f"{platform}/spec.json failed preflight: {errors}"
                     )


### PR DESCRIPTION
# Summary
- Added CPU CPLD programming support to fw_util config file. The upgrade operation happens through JTAG and is supported only in the P2 variant
- Added the firmware_onboarding config for icecube800banw platform
- This change is dependent on the BSP version 0.7.27
# Test Plan
- Tested the change by downgrading and upgrading the firmware targets through fw_util