### PR TITLE
[Nexthop][m4062nhp][platform_manager] Read the root IDPROM from a BSP-published path

### DIFF
--- a/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/platform_manager.json
@@ -7,9 +7,7 @@
     "SCM_SLOT": {
       "numOutgoingI2cBuses": 10,
       "idpromConfig": {
-        "busName": "CPU_BUS@3",
-        "address": "0x50",
-        "kernelDeviceName": "24c64"
+        "sysfsPath": "/run/nexthop_bsp/eeproms/SCM_IDPROM"
       }
     },
     "SMB_SLOT": {
@@ -428,9 +426,7 @@
       ]
     }
   },
-  "i2cAdaptersFromCpu": [
-    "CPU_BUS@3"
-  ],
+  "i2cAdaptersFromCpu": [],
   "symbolicLinkToDevicePath": {
     "/run/devmap/eeproms/CHASSIS_EEPROM": "/[CHASSIS_EEPROM]",
     "/run/devmap/eeproms/SCM_EEPROM": "/[IDPROM]",

--- a/fboss/platform/platform_manager/ConfigValidator.cpp
+++ b/fboss/platform/platform_manager/ConfigValidator.cpp
@@ -112,7 +112,10 @@ bool ConfigValidator::isValidSlotTypeConfig(
     XLOG(ERR) << "SlotTypeConfig must have either IDPROM or PmUnit name";
     return false;
   }
-  if (slotTypeConfig.idpromConfig()) {
+  // With sysfsPath the BSP instantiates the IDPROM, so there is no address for
+  // platform_manager to use.
+  if (slotTypeConfig.idpromConfig() &&
+      !slotTypeConfig.idpromConfig()->sysfsPath()) {
     try {
       I2cAddr(*slotTypeConfig.idpromConfig()->address());
     } catch (std::invalid_argument& e) {
@@ -388,6 +391,28 @@ bool ConfigValidator::isValidI2cAdaptersFromCpu(
   if (hasVirtual && hasExact) {
     XLOG(ERR)
         << "i2cAdaptersFromCpu must not mix CPU_BUS@N virtual names with exact adapter names";
+    return false;
+  }
+  return true;
+}
+
+bool ConfigValidator::isValidIdpromSysfsPath(
+    const IdpromConfig& idpromConfig,
+    const std::string& slotName) {
+  if (!idpromConfig.sysfsPath()->starts_with("/")) {
+    XLOG(ERR) << fmt::format(
+        "IDPROM sysfsPath '{}' in SlotTypeConfig '{}' must be absolute",
+        *idpromConfig.sysfsPath(),
+        slotName);
+    return false;
+  }
+  // sysfsPath already makes the IDPROM's location revision independent, so
+  // pairing it with a bus is a sign the config means two different things.
+  if (!idpromConfig.busName()->empty()) {
+    XLOG(ERR) << fmt::format(
+        "IDPROM in SlotTypeConfig '{}' sets both sysfsPath and busName '{}'",
+        slotName,
+        *idpromConfig.busName());
     return false;
   }
   return true;
@@ -991,9 +1016,14 @@ bool ConfigValidator::isValid(const PlatformConfig& config) {
       return false;
     }
     // Validate IDPROM busName is directly connected (no MUX/FPGA in between)
-    if (slotTypeConfig.idpromConfig()) {
+    if (slotTypeConfig.idpromConfig() &&
+        slotTypeConfig.idpromConfig()->sysfsPath()) {
+      if (!isValidIdpromSysfsPath(*slotTypeConfig.idpromConfig(), slotName)) {
+        return false;
+      }
+    } else if (slotTypeConfig.idpromConfig()) {
       const auto& busName = *slotTypeConfig.idpromConfig()->busName();
-      int index;
+      int index = 0;
       bool isIncomingBus =
           re2::RE2::FullMatch(busName, kIncomingBusRegex, &index);
       bool isCpuBus = std::find(

--- a/fboss/platform/platform_manager/ConfigValidator.h
+++ b/fboss/platform/platform_manager/ConfigValidator.h
@@ -36,6 +36,9 @@ class ConfigValidator {
       const I2cAdapterBlockConfig& i2cAdapterBlockConfig);
   bool isValidI2cAdaptersFromCpu(
       const std::vector<std::string>& i2cAdaptersFromCpu);
+  bool isValidIdpromSysfsPath(
+      const IdpromConfig& idpromConfig,
+      const std::string& slotName);
   bool isValidPciDeviceConfig(const PciDeviceConfig& pciDeviceConfig);
   bool isValidI2cDeviceConfig(const I2cDeviceConfig& i2cDeviceConfig);
   bool isValidCpldSysfsAttrs(const std::vector<CpldSysfsAttr>& cpldSysfsAttrs);

--- a/fboss/platform/platform_manager/PlatformExplorer.cpp
+++ b/fboss/platform/platform_manager/PlatformExplorer.cpp
@@ -328,24 +328,32 @@ std::optional<std::string> PlatformExplorer::getPmUnitNameFromSlot(
   std::optional<int> respinVariantIndicatorInEeprom{std::nullopt};
   if (slotTypeConfig.idpromConfig()) {
     auto idpromConfig = *slotTypeConfig.idpromConfig();
-    auto eepromI2cBusNum =
-        dataStore_.getI2cBusNum(slotPath, *idpromConfig.busName());
     std::string eepromPath;
 
-    /*
-    Because of upstream kernel issues, we have to manually read the
-    SCM EEPROM for the Meru800BFA/BIA & Icecube800banw platforms. It is read
-    directly with ioctl and written to the /run/devmap file. See:
-    https://github.com/facebookexternal/fboss.bsp.arista/pull/31/files
-    */
     uint16_t eepromOffset = *idpromConfig.offset();
-    if ((platformConfig_.platformName().value() == "MERU800BFA" ||
+    if (idpromConfig.sysfsPath()) {
+      // The BSP instantiates this IDPROM and publishes a handle for it, so
+      // there is no bus to resolve and no device to create here. Record the
+      // path the same way createI2cDevice() would, so DevicePath-based
+      // consumers such as the /run/devmap symlinks still resolve.
+      dataStore_.updateSysfsPath(
+          Utils().createDevicePath(slotPath, "IDPROM"),
+          *idpromConfig.sysfsPath());
+      eepromPath = fmt::format("{}/eeprom", *idpromConfig.sysfsPath());
+    } else if (
+        (platformConfig_.platformName().value() == "MERU800BFA" ||
          platformConfig_.platformName().value() == "MERU800BIA" ||
          platformConfig_.platformName().value() == "ICECUBE800BANW" ||
          platformConfig_.platformName().value() == "BLACKWOLF800BANW" ||
          platformConfig_.platformName().value() == "SAINTPAUL") &&
         (!(idpromConfig.busName()->starts_with("INCOMING")) &&
          *idpromConfig.address() == "0x50")) {
+      /*
+      Because of upstream kernel issues, we have to manually read the
+      SCM EEPROM for the Meru800BFA/BIA & Icecube800banw platforms. It is read
+      directly with ioctl and written to the /run/devmap file. See:
+      https://github.com/facebookexternal/fboss.bsp.arista/pull/31/files
+      */
       // ICECUBE800BANW has SMB at root level, others have SCM
       std::string eepromName =
           (platformConfig_.platformName().value() == "ICECUBE800BANW")
@@ -374,6 +382,8 @@ std::optional<std::string> PlatformExplorer::getPmUnitNameFromSlot(
             ExplorationErrorType::IDPROM_READ, slotPath, "IDPROM", errMsg);
       }
     } else {
+      auto eepromI2cBusNum =
+          dataStore_.getI2cBusNum(slotPath, *idpromConfig.busName());
       createI2cDevice(
           Utils().createDevicePath(slotPath, "IDPROM"),
           *idpromConfig.kernelDeviceName(),

--- a/fboss/platform/platform_manager/platform_manager_config.thrift
+++ b/fboss/platform/platform_manager/platform_manager_config.thrift
@@ -324,11 +324,16 @@ struct EmbeddedSensorConfig {
 // `kernelDeviceName`: The device name used by kernel to identify the device
 //
 // `offset`: The offset at which Meta V5 IDPROM format resides.
+//
+// `sysfsPath`: Absolute path of the IDPROM's i2c device directory, used
+// when the BSP resolves the IDPROM instead of using the other fields via
+// platform_manager.
 struct IdpromConfig {
   1: string busName;
   2: string address;
   3: string kernelDeviceName;
   4: i16 offset;
+  5: optional string sysfsPath;
 }
 
 // Defines a generic IP block in the FPGA

--- a/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
+++ b/fboss/platform/platform_manager/tests/ConfigValidatorTest.cpp
@@ -501,6 +501,30 @@ TEST(ConfigValidatorTest, SlotTypeConfig) {
   slotTypeConfig = getValidSlotTypeConfig();
   slotTypeConfig.idpromConfig()->address() = "0xK4";
   EXPECT_FALSE(ConfigValidator().isValidSlotTypeConfig(slotTypeConfig));
+  // An address is not required when the BSP instantiates the IDPROM and
+  // platform_manager only reads it back from sysfsPath.
+  slotTypeConfig = getValidSlotTypeConfig();
+  slotTypeConfig.idpromConfig()->address() = "";
+  slotTypeConfig.idpromConfig()->busName() = "";
+  slotTypeConfig.idpromConfig()->sysfsPath() =
+      "/run/nexthop_bsp/eeproms/SCM_IDPROM";
+  EXPECT_TRUE(ConfigValidator().isValidSlotTypeConfig(slotTypeConfig));
+}
+
+TEST(ConfigValidatorTest, IdpromSysfsPath) {
+  auto idpromConfig = IdpromConfig();
+  idpromConfig.sysfsPath() = "/run/nexthop_bsp/eeproms/SCM_IDPROM";
+  EXPECT_TRUE(
+      ConfigValidator().isValidIdpromSysfsPath(idpromConfig, "SCM_SLOT"));
+
+  idpromConfig.sysfsPath() = "run/nexthop_bsp/eeproms/SCM_IDPROM";
+  EXPECT_FALSE(
+      ConfigValidator().isValidIdpromSysfsPath(idpromConfig, "SCM_SLOT"));
+
+  idpromConfig.sysfsPath() = "/run/nexthop_bsp/eeproms/SCM_IDPROM";
+  idpromConfig.busName() = "CPU_BUS@3";
+  EXPECT_FALSE(
+      ConfigValidator().isValidIdpromSysfsPath(idpromConfig, "SCM_SLOT"));
 }
 
 TEST(ConfigValidatorTest, SlotConfig) {


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Allow platform_manager to read an IDPROM from a BSP-published sysfs path when the BSP resolves the device location.

- Add optional sysfsPath support to IdpromConfig and preserve the existing devmap integration.
- Remove revision-dependent IDPROM bus selection from platform exploration.
- Validate sysfs-based IDPROM configurations and add coverage for the new configuration shape.


# Test Plan

- added unit test checks
- verified on hardware
