### PR TITLE
[Cisco][sFlow] Fix sFlow sample packet binding and CLI verification

### DIFF
--- a/fboss/agent/hw/sai/hw_test/HwTestMirrorUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestMirrorUtils.cpp
@@ -248,6 +248,26 @@ static void verifyPortMirrorDestinationImpl(
     }
   }
 
+  if ((flags & MIRROR_PORT_SFLOW) && mirror_dest_id.has_value()) {
+    auto samplePacketHandle = flags & MIRROR_PORT_INGRESS
+        ? portHandle->ingressSamplePacket
+        : portHandle->egressSamplePacket;
+    ASSERT_NE(samplePacketHandle, nullptr);
+    if (flags & MIRROR_PORT_INGRESS) {
+      auto samplePacketAdapterKey =
+          SaiApiTable::getInstance()->portApi().getAttribute(
+              portHandle->port->adapterKey(),
+              SaiPortTraits::Attributes::IngressSamplePacketEnable{});
+      EXPECT_EQ(samplePacketAdapterKey, samplePacketHandle->adapterKey());
+    } else {
+      auto samplePacketAdapterKey =
+          SaiApiTable::getInstance()->portApi().getAttribute(
+              portHandle->port->adapterKey(),
+              SaiPortTraits::Attributes::EgressSamplePacketEnable{});
+      EXPECT_EQ(samplePacketAdapterKey, samplePacketHandle->adapterKey());
+    }
+  }
+
   if (mirror_dest_id.has_value()) {
     EXPECT_NE(mirrorSaiOidList.size(), 0);
     EXPECT_EQ(mirrorSaiOidList[0], mirror_dest_id.value());

--- a/fboss/agent/hw/sai/hw_test/HwTestMirrorUtilsThriftHandler.cpp
+++ b/fboss/agent/hw/sai/hw_test/HwTestMirrorUtilsThriftHandler.cpp
@@ -409,6 +409,33 @@ static bool verifyPortMirrorDestinationImpl(
           SaiPortTraits::Attributes::EgressMirrorSession>(portHandle);
     }
   }
+  if ((flags & MIRROR_PORT_SFLOW) && mirrorDestID.has_value()) {
+    auto samplePacketHandle = flags & MIRROR_PORT_INGRESS
+        ? portHandle->ingressSamplePacket
+        : portHandle->egressSamplePacket;
+    if (!samplePacketHandle) {
+      XLOG(ERR) << "Sample packet handle is missing for port " << port;
+      return false;
+    }
+    sai_object_id_t samplePacketAdapterKey;
+    if (flags & MIRROR_PORT_INGRESS) {
+      samplePacketAdapterKey =
+          SaiApiTable::getInstance()->portApi().getAttribute(
+              portHandle->port->adapterKey(),
+              SaiPortTraits::Attributes::IngressSamplePacketEnable{});
+    } else {
+      samplePacketAdapterKey =
+          SaiApiTable::getInstance()->portApi().getAttribute(
+              portHandle->port->adapterKey(),
+              SaiPortTraits::Attributes::EgressSamplePacketEnable{});
+    }
+    if (samplePacketAdapterKey != samplePacketHandle->adapterKey()) {
+      XLOG(ERR) << "Sample packet mismatch for port " << port << ": expected "
+                << samplePacketHandle->adapterKey() << ", got "
+                << samplePacketAdapterKey;
+      return false;
+    }
+  }
   if (mirrorDestID.has_value()) {
     if (mirrorSaiOidList.size() == 0) {
       XLOG(ERR) << "mirrorSaiOidList.size() == 0"

--- a/fboss/agent/hw/sai/switch/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiPortManager.cpp
@@ -3672,6 +3672,44 @@ void SaiPortManager::programSamplingMirror(
         SaiPortTraits::Attributes::EgressSampleMirrorSession{mirrorOidList});
   }
 
+  // Setting the sampled-mirror session may change the sample-packet binding.
+  // Reconcile the hardware value with the handle retained by FBOSS. Use
+  // PortApi directly because SaiObject caches the expected OID and would skip
+  // the repair write.
+  auto samplePacketHandle = direction == MirrorDirection::INGRESS
+      ? portHandle->ingressSamplePacket
+      : portHandle->egressSamplePacket;
+
+  if (samplePacketHandle) {
+    auto& portApi = SaiApiTable::getInstance()->portApi();
+    auto portSaiId = portHandle->port->adapterKey();
+    auto expectedSamplePacketId = samplePacketHandle->adapterKey();
+    auto reconcileSamplePacketBinding = [&](auto samplePacketEnable) {
+      using SamplePacketEnable = decltype(samplePacketEnable);
+      auto actualSamplePacketId =
+          portApi.getAttribute(portSaiId, samplePacketEnable);
+      if (actualSamplePacketId == expectedSamplePacketId) {
+        return;
+      }
+      XLOG(WARNING) << "Restoring "
+                    << (direction == MirrorDirection::INGRESS ? "ingress"
+                                                              : "egress")
+                    << " sample packet on port " << portId << ": expected "
+                    << expectedSamplePacketId << ", got "
+                    << actualSamplePacketId;
+      portApi.setAttribute(
+          portSaiId, SamplePacketEnable{expectedSamplePacketId});
+    };
+
+    if (direction == MirrorDirection::INGRESS) {
+      reconcileSamplePacketBinding(
+          SaiPortTraits::Attributes::IngressSamplePacketEnable{});
+    } else {
+      reconcileSamplePacketBinding(
+          SaiPortTraits::Attributes::EgressSamplePacketEnable{});
+    }
+  }
+
   XLOG(DBG) << "Programming sampling mirror on port: " << std::hex
             << portHandle->port->adapterKey()
             << " action: " << (action == MirrorAction::START ? "start" : "stop")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`


```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```


# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
- Yuba and G202X Tajo SAI may clear the sample packet binding when a sampled mirror session is updated.
- This can leave sFlow incorrectly programmed even though the mirror session remains present.
- Existing HW and CLI verification did not validate the sample packet binding.

## Solution:
- Rebind the ingress or egress sample packet through the SAI Port API after updating a sampled mirror session on Yuba and G202X.
- Bypass the cached SAI object state so the sample packet attribute is written back to hardware.
- Extend HW test and Thrift CLI verification to confirm that the configured sample packet OID matches the expected sample packet handle.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->
- Passed fboss-forwarding-stack build.
- Verified sFlow mirror is active through the CLI.
- Verified the sample packet binding remains programmed after the mirror session update.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

```
[root@localhost ~]# fboss2 show hw-object PORT uncached |   grep -E 'SystemPortId: 11([,)]|$)' |   grep -oE '(Ingress|Egress)SamplePacketEnable: [0-9]+|SystemPortId: [0-9]+'
IngressSamplePacketEnable: 540431955284459521
EgressSamplePacketEnable: 0
SystemPortId: 11
```