### PR TITLE
[sai][tomahawk3] Do not create zero-preemphasis port serdes on TH3

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
@@ -1423,7 +1423,7 @@ void SaiPortManager::programSerdes(
   }
   if (platform_->getAsic()->getAsicType() ==
           cfg::AsicType::ASIC_TYPE_TOMAHAWK3 &&
-      swPort->getZeroPreemphasis()) {
+      swPort->getZeroPreemphasis() && supportsZeroPreemphasis) {
     createSerdesWithZeroPreemphasis(portHandle, swPort->getPinConfigs());
   }
   if (platform_->getAsic()->getAsicType() ==

--- a/fboss/agent/hw/switch_asics/Tomahawk3Asic.cpp
+++ b/fboss/agent/hw/switch_asics/Tomahawk3Asic.cpp
@@ -89,7 +89,6 @@ bool Tomahawk3Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::SAI_PORT_SERDES_PROGRAMMING:
     case HwAsic::Feature::PORT_WRED_COUNTER:
     case HwAsic::Feature::ACL_METADATA_QUALIFER:
-    case HwAsic::Feature::PORT_SERDES_ZERO_PREEMPHASIS:
     case HwAsic::Feature::SAI_PRBS:
     case HwAsic::Feature::SAI_ECMP_HASH_ALGORITHM:
     case HwAsic::Feature::ACL_BYTE_COUNTER:
@@ -106,6 +105,7 @@ bool Tomahawk3Asic::isSupported(Feature feature) const {
     case HwAsic::Feature::ECN_PROBABILISTIC_MARKING:
       return true;
     case HwAsic::Feature::QCM:
+    case HwAsic::Feature::PORT_SERDES_ZERO_PREEMPHASIS:
     case HwAsic::Feature::SMAC_EQUALS_DMAC_CHECK_ENABLED:
     case HwAsic::Feature::PORT_TTL_DECREMENT_DISABLE:
     case HwAsic::Feature::PORT_INTERFACE_TYPE:


### PR DESCRIPTION
## Summary

`Tomahawk3Asic::isSupported()` advertises `PORT_SERDES_ZERO_PREEMPHASIS` as
supported, but the Broadcom SAI SDK rejects creating a zero-preemphasis port
serdes on Tomahawk3 — `create_port_serdes` returns `SAI_STATUS_NOT_IMPLEMENTED`
for the resulting empty-preemphasis object.

`LinkStateToggler` sets `zeroPreemphasis=true` on every port, so any port
(re)create reaches `SaiPortManager::createSerdesWithZeroPreemphasis()`, which
builds an empty `Preemphasis` attribute. Under `AgentHwTest` the resulting
`SaiApiError` is fatal (`SwSwitch::applyUpdate`) and aborts the hw_agent. It
reproduces on:

- the 400G→100G VCO change in `AgentPortBandwidthParamTest.VerifyPortRateTraffic/1`, and
- the warm-boot serdes reconciliation path.

This matches the guidance already documented in `AgentPortProfileTests.cpp`.

## Fix

1. Mark `PORT_SERDES_ZERO_PREEMPHASIS` unsupported on Tomahawk3.
2. Gate the `createSerdesWithZeroPreemphasis()` call on `supportsZeroPreemphasis`.

`changeZeroPreemphasis()` already early-returns when `!supportsZeroPreemphasis`,
so (1) covers that path too.

## Test Plan

On a Tomahawk3 (BCM56980) system (FBOSS 6.11.1, SAI 14.3),
`AgentPortBandwidthParamTest.VerifyPortRateTraffic/1` now passes both cold and
warm boot:

```
[ PASSED ] cold_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/1 (12950 ms)
[ PASSED ] warm_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/1 (8280 ms)
   PASSED : 2   FAILED : 0
```

No `SAI_STATUS_NOT_IMPLEMENTED` / hw_agent abort on either the port-recreate or
the warm-boot reconciliation path.

