### PR TITLE
[Nexthop][fboss2-dev] Contain per-suite config changes in run_test.py

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/fboss2_integration_test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/fboss2_integration_test_runner.py
@@ -7,6 +7,12 @@ import time
 from argparse import ArgumentParser
 
 from fboss_test_runner.runners.test_runner import TestRunner
+from fboss_test_runner.services.config_baseline import (
+    AGENT_COLDBOOT_TIMEOUT_SEC,
+    ConfigBaseline,
+    find_fboss2_cli,
+    wait_agent_responsive,
+)
 from fboss_test_runner.services.fboss_agent_utils import (
     cleanup_hw_agent_service,
     cleanup_sw_agent_service,
@@ -42,6 +48,12 @@ class Fboss2IntegrationTestRunner(TestRunner):
     device has production multi-switch services running or needs service setup from scratch.
     Cold boots both agents once to establish a clean state, then reuses the running
     agents between tests and only cold boots again when an agent is no longer up.
+
+    Config containment: before each gtest suite the /etc/coop git HEAD is
+    recorded, and after the suite the config is rolled back to it (see
+    services/config_baseline.py). One suite committing a config the hardware
+    rejects can crash-loop the agents; without the rollback every later suite
+    fails on the leftover config.
     """
 
     _AGENT_CONFIG_PATH = "/etc/coop/agent.conf"
@@ -69,6 +81,12 @@ class Fboss2IntegrationTestRunner(TestRunner):
         # that we health-gate per-test cold boots (or skip them entirely with
         # --skip-coldboot).
         self._initial_coldboot_done: bool = False
+        # /etc/coop git sha recorded at suite start; None when capture failed.
+        self._suite_baseline: str | None = None
+        self._config_baseline: ConfigBaseline | None = None
+        # systemd NRestarts per agent unit at suite start; a higher value at
+        # suite end means systemd auto-restarted a crashed agent.
+        self._suite_start_restarts: dict[str, int] = {}
 
     def add_subcommand_arguments(self, sub_parser: ArgumentParser) -> None:
         """Add CLI test-specific command line arguments"""
@@ -113,7 +131,7 @@ class Fboss2IntegrationTestRunner(TestRunner):
     def _get_warmboot_check_file(self) -> str:
         return ""
 
-    def _get_test_run_args(self, conf_file: str) -> list[str]:
+    def _get_test_run_args(self, conf_file: str) -> list[str]:  # noqa: ARG002
         return []
 
     def _setup_run(self, conf_file: str) -> None:
@@ -136,8 +154,7 @@ class Fboss2IntegrationTestRunner(TestRunner):
                 "Snapshotting agent config."
             )
             subprocess.run(
-                ["cp", self._AGENT_CONFIG_PATH, self._CONFIG_SNAPSHOT_PATH],
-                check=True,
+                ["cp", self._AGENT_CONFIG_PATH, self._CONFIG_SNAPSHOT_PATH], check=True
             )
         else:
             print("No running agents detected — setting up agent services.")
@@ -160,7 +177,7 @@ class Fboss2IntegrationTestRunner(TestRunner):
                 sw_agent_service_name=SW_AGENT_SERVICE_PROD,
             )
 
-    def _setup_coldboot_test(self, sai_replayer_log_path: str | None = None) -> None:
+    def _setup_coldboot_test(self, sai_replayer_log_path: str | None = None) -> None:  # noqa: ARG002
         # The first cold boot always runs: it loads the test config and
         # establishes a clean state (in prod multi-switch the running agents
         # still hold the old config until rebooted).
@@ -189,6 +206,88 @@ class Fboss2IntegrationTestRunner(TestRunner):
             sw_agent_service_name=SW_AGENT_SERVICE_PROD,
         )
         self._initial_coldboot_done = True
+
+    def _on_suite_start(self, suite: str) -> None:  # noqa: ARG002
+        self._suite_start_restarts = self._unit_restart_counts()
+        self._suite_baseline = self._get_config_baseline().capture()
+
+    def _on_suite_end(self, suite: str) -> None:
+        if not self._get_config_baseline().restore(self._suite_baseline):
+            print(
+                f"########## Failed to restore the config baseline after {suite}; "
+                "subsequent suites may fail spuriously"
+            )
+        self._suite_baseline = None
+
+    def _get_config_baseline(self) -> ConfigBaseline:
+        if self._config_baseline is None:
+            self._config_baseline = ConfigBaseline(
+                units_healthy=self._agents_healthy_for_suite,
+                agent_responsive=self._agent_responsive,
+                cold_boot_agents=self._cold_boot_agents,
+                fboss2_cli=find_fboss2_cli(),
+            )
+        return self._config_baseline
+
+    def _agent_responsive(self) -> bool:
+        # Generous timeout: this is also the wait after a cold boot.
+        return wait_agent_responsive(
+            find_fboss2_cli(), timeout_sec=AGENT_COLDBOOT_TIMEOUT_SEC
+        )
+
+    def _agents_healthy_for_suite(self) -> bool:
+        """Agents are healthy enough to trust a soft (CLI) rollback.
+
+        `systemctl is-active` alone is a snapshot, and the production units
+        run Restart=always with no start limit: a crash-looping agent never
+        reaches "failed", it reads "activating" for RestartSec and "active"
+        for the few seconds it lives each cycle. So on top of the liveness
+        check, require that systemd did not auto-restart any agent unit
+        since the suite started. NRestarts counts only Restart=-triggered
+        restarts, so the warmboot/coldboot restarts the CLI itself performs
+        on commit do not register (they reset the counter, which is why a
+        lower value is not treated as a crash). A crash during the suite
+        means the device is not in a state worth preserving; the caller cold
+        boots it from the baseline.
+        """
+        if not self._agents_ready():
+            return False
+        crashed = [
+            f"{unit} (NRestarts {self._suite_start_restarts.get(unit)} -> {after})"
+            for unit, after in self._unit_restart_counts().items()
+            if after > self._suite_start_restarts.get(unit, after)
+        ]
+        if crashed:
+            print(
+                "########## Agent unit auto-restarted during this suite: "
+                + ", ".join(crashed)
+            )
+            return False
+        return True
+
+    def _unit_restart_counts(self) -> dict[str, int]:
+        """systemd's NRestarts for each agent unit. Units that cannot be
+        queried are omitted (and so never count as crashed)."""
+        counts: dict[str, int] = {}
+        for unit in self._agent_services():
+            try:
+                result = subprocess.run(
+                    ["systemctl", "show", "-p", "NRestarts", "--value", unit],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                counts[unit] = int(result.stdout.strip())
+            except (OSError, ValueError) as e:
+                print(f"Warning: failed to read NRestarts for {unit}: {e}")
+        return counts
+
+    def _cold_boot_agents(self) -> None:
+        cold_boot_agents(
+            self._switch_indexes,
+            hw_agent_service_name=HW_AGENT_SERVICE_PROD,
+            sw_agent_service_name=SW_AGENT_SERVICE_PROD,
+        )
 
     def _agent_services(self) -> list[str]:
         """systemd unit names for the sw_agent and every hw_agent."""
@@ -251,8 +350,7 @@ class Fboss2IntegrationTestRunner(TestRunner):
         if self._is_prod_multi_switch:
             print("Restoring original agent config and restarting agents.")
             subprocess.run(
-                ["cp", self._CONFIG_SNAPSHOT_PATH, self._AGENT_CONFIG_PATH],
-                check=False,
+                ["cp", self._CONFIG_SNAPSHOT_PATH, self._AGENT_CONFIG_PATH], check=False
             )
             try:
                 cold_boot_agents(

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/test_runner.py
@@ -161,6 +161,15 @@ class TestRunner(abc.ABC):
     def _setup_warmboot_test(self, sai_replayer_log_path: str | None = None) -> None:  # noqa: B027
         pass
 
+    def _on_suite_start(self, suite: str) -> None:  # noqa: B027
+        """Called before the first test of each gtest suite (the `Suite` in
+        `Suite.Case`). The test list is sorted, so a suite's cases are
+        contiguous and this fires once per suite per run."""
+
+    def _on_suite_end(self, suite: str) -> None:  # noqa: B027
+        """Called after the last test of each gtest suite, including the final
+        suite (before _end_run). Runs even when the loop is aborted mid-suite."""
+
     def _end_run(self) -> None:  # noqa: B027
         pass
 
@@ -656,7 +665,7 @@ class TestRunner(abc.ABC):
         elif simulator in DNX_SIMULATOR_ASICS:
             self.env_var.update(DNX_SIMULATOR_ENV)
 
-    def _run_tests(
+    def _run_tests(  # noqa: PLR0912, PLR0915
         self, tests_to_run: list[str], conf_file: str, args: Namespace
     ) -> list[GtestResult]:
         sai_replayer_logging = getattr(args, "sai_replayer_logging", None)
@@ -689,10 +698,19 @@ class TestRunner(abc.ABC):
             return []
 
         all_results: list[GtestResult] = []
+        # The gtest suite whose tests are currently running; None outside a
+        # suite. Drives the _on_suite_start/_on_suite_end hooks.
+        current_suite: str | None = None
         try:
             self._setup_run(conf_file)
             num_tests = len(tests_to_run)
             for idx, test_to_run in enumerate(tests_to_run):
+                suite = test_to_run.split(".", 1)[0]
+                if suite != current_suite:
+                    if current_suite is not None:
+                        self._on_suite_end(current_suite)
+                    current_suite = suite
+                    self._on_suite_start(suite)
                 test_prefix = self.COLDBOOT_PREFIX
                 sai_replayer_log_path = self._get_sai_replayer_log_path(
                     test_prefix, test_to_run, sai_replayer_logging
@@ -771,6 +789,8 @@ class TestRunner(abc.ABC):
                     if any(r.status != GtestStatus.OK for r in run_outcome.results):
                         break
         finally:
+            if current_suite is not None:
+                self._on_suite_end(current_suite)
             self._end_run()
         return all_results
 
@@ -811,9 +831,7 @@ class TestRunner(abc.ABC):
         tests_to_run = self._get_tests_to_run()
         tests_to_run = self._filter_tests(tests_to_run)
         # Sort the tests to run to match internal test infra behavior
-        tests_to_run = sorted(tests_to_run)
-
-        return tests_to_run
+        return sorted(tests_to_run)
 
     def list_tests(self, args: Namespace) -> int:
         try:
@@ -834,14 +852,11 @@ class TestRunner(abc.ABC):
             conf_file = self._backup_and_modify_config(original_conf_file)
         except _TestBinaryNotFoundError as error:
             return TestExecutionResult(
-                exit_code=os.EX_TEMPFAIL,
-                setup_failure=str(error),
+                exit_code=os.EX_TEMPFAIL, setup_failure=str(error)
             )
         except Exception as error:
             return TestExecutionResult(
-                exit_code=os.EX_TEMPFAIL,
-                setup_failure=str(error),
-                error=error,
+                exit_code=os.EX_TEMPFAIL, setup_failure=str(error), error=error
             )
 
         # Test execution failures are not setup failures. Let them propagate so

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/services/config_baseline.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/services/config_baseline.py
@@ -1,0 +1,329 @@
+# @noautodeps
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+"""Suite-level containment of config changes made by fboss2 integration tests.
+
+One test suite committing a config the device cannot apply used to poison
+every suite that ran after it: the hw_agent crash-loops on the bad config,
+every later `config session commit` kills the sw_agent, and innocent tests
+fail. The fboss2 CLI keeps the live config in a git repo (/etc/coop), so the
+harness records the repo HEAD before a suite starts and rolls back to it after
+the suite ends -- healing the agents if the suite left them dead.
+
+Per-test isolation is intentionally not provided here; tests that need it
+snapshot/restore in their own SetUp/TearDown.
+"""
+
+import os
+import shutil
+import subprocess
+import time
+from collections.abc import Callable
+
+# The fboss2 CLI's git repo and the files it tracks there. Mirrors
+# ConfigSession (fboss/cli/fboss2/session/ConfigSession.{h,cpp}): each config
+# domain is a git-tracked file under the repo plus a stable daemon-facing
+# symlink at the repo root pointing at it.
+COOP_DIR = "/etc/coop"
+# (git-relative tracked file, daemon-facing symlink at the repo root)
+CONFIG_DOMAINS: tuple[tuple[str, str], ...] = (
+    ("cli/agent.conf", "agent.conf"),
+    ("bgpcpp/bgpcpp.conf", "bgpcpp.conf"),
+)
+METADATA_FILE = "cli/cli_metadata.json"
+TRACKED_FILES: tuple[str, ...] = (*(f for f, _ in CONFIG_DOMAINS), METADATA_FILE)
+GIT_AUTHOR = ("fboss_test_runner", "fboss-cli@localhost")
+
+# Same defaults the CLI's own tests use for waiting on an agent to come back
+# after a restart; a cold boot on some ASICs takes 90s+.
+AGENT_READY_TIMEOUT_SEC = 120
+AGENT_COLDBOOT_TIMEOUT_SEC = 300
+AGENT_POLL_INTERVAL_SEC = 10
+
+
+class ConfigBaseline:
+    """Capture the /etc/coop git baseline for a suite and restore it after.
+
+    Collaborators are injected so the runner (and the unit tests) decide how
+    "is the agent healthy" and "cold boot the agents" are answered:
+
+    - ``units_healthy()``: every agent systemd unit is active. This is what
+      catches a crash-looping hw_agent while the sw_agent still answers thrift
+      -- the thrift probe alone would report healthy and we would try a soft
+      rollback that cannot reach hardware.
+    - ``agent_responsive()``: the sw_agent serves thrift (switch CONFIGURED).
+    - ``cold_boot_agents()``: cold boot the agents from the on-disk config.
+    - ``fboss2_cli``: the fboss2 CLI binary used for the soft rollback path.
+    """
+
+    def __init__(
+        self,
+        units_healthy: Callable[[], bool],
+        agent_responsive: Callable[[], bool],
+        cold_boot_agents: Callable[[], None],
+        fboss2_cli: str | None = None,
+        repo_dir: str = COOP_DIR,
+    ) -> None:
+        self._units_healthy = units_healthy
+        self._agent_responsive = agent_responsive
+        self._cold_boot_agents = cold_boot_agents
+        self._fboss2_cli = fboss2_cli or find_fboss2_cli()
+        self._repo = repo_dir
+
+    # ---- git plumbing --------------------------------------------------
+
+    def _git(self, *args: str, check: bool = False) -> subprocess.CompletedProcess:
+        # safe.directory: the harness runs as root while /etc/coop is owned by
+        # the `coop` user; without it every git command refuses to run (the
+        # CLI's Git class passes the same override).
+        return subprocess.run(
+            [
+                "git",
+                "-c",
+                f"safe.directory={self._repo}",
+                "-C",
+                self._repo,
+                "-c",
+                f"user.name={GIT_AUTHOR[0]}",
+                "-c",
+                f"user.email={GIT_AUTHOR[1]}",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    def _tracked_present(self) -> list[str]:
+        return [f for f in TRACKED_FILES if os.path.exists(self._path(f))]
+
+    def _path(self, rel: str) -> str:
+        return os.path.join(self._repo, rel)
+
+    def head(self) -> str | None:
+        result = self._git("rev-parse", "HEAD")
+        return result.stdout.strip() if result.returncode == 0 else None
+
+    def _is_repo(self) -> bool:
+        return self._git("rev-parse", "--git-dir").returncode == 0
+
+    def _worktree_dirty(self) -> bool:
+        """True when a tracked config file on disk differs from HEAD (e.g. the
+        harness or an operator copied a config through the agent.conf symlink
+        without committing). Exact comparison is right here: the CLI commits
+        exactly the bytes it writes, so a clean tree means HEAD is what the
+        daemons read."""
+        result = self._git(
+            "status", "--porcelain", "--untracked-files=no", "--", *TRACKED_FILES
+        )
+        return bool(result.stdout.strip())
+
+    def _drifted(self, baseline: str) -> bool:
+        """The config moved away from the baseline: a commit landed since, or
+        the tracked files were edited behind git's back. Content is not
+        compared textually -- a baseline captured from a raw config file and
+        the CLI's re-serialization of the same config differ in layout while
+        meaning the same thing, and only the CLI can compare them
+        semantically (which its `config rollback` does)."""
+        return self.head() != baseline or self._worktree_dirty()
+
+    def _files_at_revision(self, revision: str) -> list[str]:
+        result = self._git("ls-tree", "--name-only", revision, "--", *TRACKED_FILES)
+        return [line for line in result.stdout.splitlines() if line]
+
+    def _commit(self, message: str) -> bool:
+        present = self._tracked_present()
+        if not present:
+            return False
+        self._git("add", "--", *present)
+        head = self.head()
+        if head is not None:
+            # Stage removals of tracked files that no longer exist on disk.
+            for gone in set(self._files_at_revision(head)) - set(present):
+                self._git("rm", "-q", "--cached", "--", gone)
+        result = self._git("commit", "-q", "-m", message)
+        if result.returncode != 0:
+            print(f"Warning: git commit failed: {result.stderr.strip()}")
+            return False
+        return True
+
+    def _initialize_repo(self) -> None:
+        """Mirror ConfigSession::initializeGit(): create the repo and seed the
+        tracked files from the live daemon configs, then make the initial
+        commit. A device the CLI has never committed on has plain files at the
+        symlink locations; those are the seeds."""
+        os.makedirs(self._path("cli"), exist_ok=True)
+        for tracked, live in CONFIG_DOMAINS:
+            tracked_path = self._path(tracked)
+            live_path = self._path(live)
+            if os.path.exists(tracked_path):
+                continue
+            if os.path.isfile(live_path) and not os.path.islink(live_path):
+                os.makedirs(os.path.dirname(tracked_path), exist_ok=True)
+                shutil.copyfile(live_path, tracked_path)
+            elif tracked == CONFIG_DOMAINS[0][0]:
+                # The agent config always exists in the repo, even if empty.
+                with open(tracked_path, "w") as f:
+                    f.write("{}")
+        if not os.path.exists(self._path(METADATA_FILE)):
+            with open(self._path(METADATA_FILE), "w") as f:
+                f.write("{}")
+        if not self._is_repo():
+            self._git("init", "-q", check=True)
+            self._git("symbolic-ref", "HEAD", "refs/heads/main")
+        if self.head() is None:
+            self._commit("Initial commit")
+
+    # ---- public API ----------------------------------------------------
+
+    def capture(self) -> str | None:
+        """Record the current config as the baseline and return its sha.
+
+        Initializes the git repo if the CLI has never done so, and first
+        commits any uncommitted drift in the tracked files (this harness and
+        operators copy configs through the agent.conf symlink without
+        committing), so the baseline is what the agents actually run. Returns
+        None when no baseline could be taken; restore() is then a no-op.
+        """
+        try:
+            if not self._is_repo() or self.head() is None:
+                self._initialize_repo()
+            head = self.head()
+            if head is None:
+                print("Warning: could not establish a config baseline commit")
+                return None
+            if self._worktree_dirty():
+                print("Committing uncommitted config drift as the suite baseline")
+                self._commit("fboss_test_runner: suite baseline snapshot")
+                head = self.head()
+            print(f"Suite config baseline: {head[:8]}")
+            return head
+        except Exception as e:
+            print(f"Warning: failed to capture config baseline: {e}")
+            return None
+
+    def restore(self, baseline: str | None) -> bool:
+        """Restore the config to ``baseline`` and make sure the agents run it.
+
+        Fast path when the config is unchanged and the agents are healthy.
+        Soft path (`fboss2-dev config rollback <sha>`, applied by the CLI at
+        the recorded action level) when the config drifted but the agents can
+        serve thrift. Hard path (check out the tracked files at the baseline,
+        commit, cold boot) when any agent unit is dead or the soft path failed.
+        Returns False if the agents could not be brought back.
+        """
+        if not baseline:
+            print("No config baseline captured; skipping suite restore")
+            return True
+
+        try:
+            drifted = self._drifted(baseline)
+        except Exception as e:
+            print(f"Warning: failed to compare config against baseline: {e}")
+            drifted = True
+
+        healthy = self._units_healthy() and self._agent_responsive()
+        if not drifted:
+            if healthy:
+                return True
+            print(
+                "########## Config matches baseline but agents are unhealthy; "
+                "cold booting"
+            )
+            return self._restore_hard(baseline)
+
+        print(
+            f"########## Test suite left the config off its baseline "
+            f"{baseline[:8]}; restoring"
+        )
+        if healthy and self._restore_soft(baseline):
+            return True
+        return self._restore_hard(baseline)
+
+    def _restore_soft(self, baseline: str) -> bool:
+        result = subprocess.run(
+            [self._fboss2_cli, "config", "rollback", baseline],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(
+                f"config rollback to baseline failed ({result.stderr.strip()}); "
+                "falling back to hard restore"
+            )
+            return False
+        if not self._agent_responsive():
+            print("Agent not responsive after rollback; falling back to hard restore")
+            return False
+        return True
+
+    def _restore_hard(self, baseline: str) -> bool:
+        print(
+            f"########## Hard-restoring config baseline {baseline[:8]} "
+            "(check out tracked files + cold boot agents)"
+        )
+        try:
+            at_baseline = set(self._files_at_revision(baseline))
+            if at_baseline:
+                self._git("checkout", baseline, "--", *sorted(at_baseline), check=True)
+            for tracked in TRACKED_FILES:
+                # Absent at the baseline (e.g. a BGP config a suite introduced):
+                # remove it, as the CLI's own rollback would.
+                if tracked not in at_baseline and os.path.exists(self._path(tracked)):
+                    os.remove(self._path(tracked))
+            for tracked, live in CONFIG_DOMAINS:
+                tracked_path = self._path(tracked)
+                live_path = self._path(live)
+                if not os.path.exists(tracked_path):
+                    if os.path.islink(live_path):
+                        os.remove(live_path)
+                    continue
+                # The daemons read through a stable symlink; a device the CLI
+                # has never committed on still has a plain file there.
+                if not os.path.islink(live_path) or os.readlink(live_path) != tracked:
+                    if os.path.lexists(live_path):
+                        os.remove(live_path)
+                    os.symlink(tracked, live_path)
+            self._commit(f"fboss_test_runner: restore baseline {baseline[:8]}")
+        except Exception as e:
+            print(f"Warning: hard restore of config baseline failed: {e}")
+            return False
+
+        # A crash-looping unit may sit in "failed" with its start limit
+        # exhausted; clear that so the restart is allowed to run.
+        subprocess.run(["systemctl", "reset-failed"], check=False)
+        try:
+            self._cold_boot_agents()
+        except Exception as e:
+            print(f"Warning: cold boot after baseline restore failed: {e}")
+        return self._agent_responsive()
+
+
+def find_fboss2_cli() -> str:
+    return shutil.which("fboss2-dev") or "/opt/fboss/bin/fboss2-dev"
+
+
+def wait_agent_responsive(
+    fboss2_cli: str,
+    timeout_sec: int = AGENT_READY_TIMEOUT_SEC,
+    poll_interval_sec: int = AGENT_POLL_INTERVAL_SEC,
+) -> bool:
+    """Poll a cheap thrift-backed CLI command until the sw_agent answers.
+
+    Poll-first, so a responsive agent returns on the first iteration with no
+    sleep. Two expected failure modes while an agent restarts -- "Connection
+    refused" (not yet listening) and "switch is still initializing" (HW init in
+    progress) -- both clear once the warmboot/coldboot finishes.
+    """
+    deadline = time.monotonic() + timeout_sec
+    while True:
+        result = subprocess.run(
+            [fboss2_cli, "show", "product"], capture_output=True, text=True, check=False
+        )
+        if result.returncode == 0:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        print(f"Agent not ready yet, retrying in {poll_interval_sec}s...")
+        time.sleep(poll_interval_sec)

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_config_baseline.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_config_baseline.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# @noautodeps
+# Copyright Meta Platforms, Inc. and affiliates.
+
+"""Unit tests for services/config_baseline.py.
+
+Git operations run for real against a temporary repo standing in for
+/etc/coop; only the fboss2 CLI and systemctl invocations are intercepted.
+"""
+
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import tempfile
+
+from fboss_test_runner.services import config_baseline
+from fboss_test_runner.services.config_baseline import ConfigBaseline
+
+FAKE_CLI = "/nonexistent/fboss2-dev"
+_REAL_RUN = subprocess.run
+
+
+def _read(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+class _Harness:
+    """A temp /etc/coop plus recorders for the CLI / systemctl calls."""
+
+    def __init__(self, tmp: str, seed_agent_conf: str | None = '{"sw": 1}') -> None:
+        self.repo = tmp
+        if seed_agent_conf is not None:
+            with open(os.path.join(tmp, "agent.conf"), "w") as f:
+                f.write(seed_agent_conf)
+        self.units_healthy = MagicMock(return_value=True)
+        self.agent_responsive = MagicMock(return_value=True)
+        self.cold_boot = MagicMock()
+        self.cli_calls: list[list[str]] = []
+        self.systemctl_calls: list[list[str]] = []
+        self.cli_rc = 0
+        # What the fake `config rollback` does to the repo when invoked.
+        self.cli_side_effect = None
+        self.baseline = ConfigBaseline(
+            units_healthy=self.units_healthy,
+            agent_responsive=self.agent_responsive,
+            cold_boot_agents=self.cold_boot,
+            fboss2_cli=FAKE_CLI,
+            repo_dir=tmp,
+        )
+
+    def fake_run(self, cmd, *args, **kwargs):
+        if cmd[0] == FAKE_CLI:
+            self.cli_calls.append(cmd)
+            if self.cli_side_effect:
+                self.cli_side_effect()
+            return subprocess.CompletedProcess(cmd, self.cli_rc, "", "boom")
+        if cmd[0] == "systemctl":
+            self.systemctl_calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        return _REAL_RUN(cmd, *args, **kwargs)
+
+    def git(self, *args: str) -> str:
+        return _REAL_RUN(
+            ["git", "-C", self.repo, *args], capture_output=True, text=True, check=True
+        ).stdout.strip()
+
+    def write_tracked_agent_conf(self, content: str, commit: bool = True) -> None:
+        """Simulate a test's `config session commit`: write cli/agent.conf,
+        point the agent.conf symlink at it, and commit."""
+        path = os.path.join(self.repo, "cli", "agent.conf")
+        with open(path, "w") as f:
+            f.write(content)
+        live = os.path.join(self.repo, "agent.conf")
+        if os.path.lexists(live):
+            os.remove(live)
+        os.symlink("cli/agent.conf", live)
+        if commit:
+            self.git("add", "cli/agent.conf")
+            self.git(
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-q",
+                "-m",
+                "test commit",
+            )
+
+
+class TestCapture(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.h = _Harness(self.tmpdir.name)
+        self.run_patch = patch.object(
+            config_baseline.subprocess, "run", side_effect=self.h.fake_run
+        )
+        self.run_patch.start()
+
+    def tearDown(self):
+        self.run_patch.stop()
+        self.tmpdir.cleanup()
+
+    def test_initializes_repo_from_plain_config(self):
+        sha = self.h.baseline.capture()
+        self.assertIsNotNone(sha)
+        self.assertEqual(self.h.git("rev-parse", "HEAD"), sha)
+        # Seeded from the plain /etc/coop/agent.conf, like ConfigSession does.
+        self.assertEqual(self.h.git("show", "HEAD:cli/agent.conf"), '{"sw": 1}')
+        self.assertEqual(self.h.git("show", "HEAD:cli/cli_metadata.json"), "{}")
+        # The live plain file is left alone until the CLI converts it.
+        self.assertFalse(os.path.islink(os.path.join(self.h.repo, "agent.conf")))
+
+    def test_reuses_existing_repo_head(self):
+        first = self.h.baseline.capture()
+        second = self.h.baseline.capture()
+        self.assertEqual(first, second)
+
+    def test_commits_uncommitted_drift(self):
+        first = self.h.baseline.capture()
+        # e.g. the runner cp'd a config through the symlink without committing
+        self.h.write_tracked_agent_conf('{"sw": 2}', commit=False)
+        second = self.h.baseline.capture()
+        self.assertNotEqual(first, second)
+        self.assertEqual(self.h.git("show", "HEAD:cli/agent.conf"), '{"sw": 2}')
+        self.assertIn("suite baseline snapshot", self.h.git("log", "-1", "--format=%s"))
+
+    def test_returns_none_when_git_unavailable(self):
+        with patch.object(
+            config_baseline.subprocess, "run", side_effect=OSError("no git")
+        ):
+            self.assertIsNone(self.h.baseline.capture())
+
+
+class TestRestore(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.h = _Harness(self.tmpdir.name)
+        self.run_patch = patch.object(
+            config_baseline.subprocess, "run", side_effect=self.h.fake_run
+        )
+        self.run_patch.start()
+        self.sha = self.h.baseline.capture()
+
+    def tearDown(self):
+        self.run_patch.stop()
+        self.tmpdir.cleanup()
+
+    def test_noop_without_baseline(self):
+        self.assertTrue(self.h.baseline.restore(None))
+        self.h.units_healthy.assert_not_called()
+        self.h.cold_boot.assert_not_called()
+
+    def test_fast_path_when_unchanged_and_healthy(self):
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertEqual(self.h.cli_calls, [])
+        self.h.cold_boot.assert_not_called()
+        self.assertEqual(self.h.git("rev-parse", "HEAD"), self.sha)
+
+    def test_soft_rollback_when_drifted_and_healthy(self):
+        self.h.write_tracked_agent_conf('{"sw": "poison"}')
+        # The CLI's rollback re-serializes the config; its output need not be
+        # byte-identical to the baseline blob, so success is judged by the
+        # rollback's exit code and the agent answering, not by content.
+        self.h.cli_side_effect = lambda: self.h.write_tracked_agent_conf(
+            '{\n  "sw": 1\n}'
+        )
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertEqual(self.h.cli_calls, [[FAKE_CLI, "config", "rollback", self.sha]])
+        self.h.cold_boot.assert_not_called()
+
+    def test_uncommitted_edit_counts_as_drift(self):
+        # Written behind git's back (harness cp through the symlink), HEAD
+        # unchanged: still drifted, still rolled back.
+        self.h.write_tracked_agent_conf('{"sw": "edited"}', commit=False)
+        self.h.cli_side_effect = lambda: self.h.write_tracked_agent_conf(
+            '{"sw": 1}', commit=False
+        )
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertEqual(len(self.h.cli_calls), 1)
+
+    def test_hard_restore_when_units_unhealthy(self):
+        self.h.write_tracked_agent_conf('{"sw": "poison"}')
+        # sw_agent answers thrift but the hw_agent unit is failed: the thrift
+        # probe alone would say healthy; the unit probe must win.
+        self.h.units_healthy.return_value = False
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertEqual(self.h.cli_calls, [])  # no soft rollback attempted
+        self.assertEqual(
+            _read(os.path.join(self.h.repo, "cli", "agent.conf")), '{"sw": 1}'
+        )
+        self.assertIn("restore baseline", self.h.git("log", "-1", "--format=%s"))
+        self.assertEqual(self.h.systemctl_calls, [["systemctl", "reset-failed"]])
+        self.h.cold_boot.assert_called_once()
+        # thrift probe short-circuited by the unit probe, then used post-coldboot
+        self.h.agent_responsive.assert_called_once()
+
+    def test_hard_restore_repairs_daemon_symlink(self):
+        self.h.write_tracked_agent_conf('{"sw": "poison"}')
+        live = os.path.join(self.h.repo, "agent.conf")
+        os.remove(live)
+        with open(live, "w") as f:
+            f.write("stale plain file")
+        self.h.units_healthy.return_value = False
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertTrue(os.path.islink(live))
+        self.assertEqual(os.readlink(live), "cli/agent.conf")
+        self.assertEqual(_read(live), '{"sw": 1}')
+
+    def test_soft_rollback_failure_falls_back_to_hard(self):
+        self.h.write_tracked_agent_conf('{"sw": "poison"}')
+        self.h.cli_rc = 1
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.assertEqual(len(self.h.cli_calls), 1)
+        self.h.cold_boot.assert_called_once()
+        self.assertEqual(
+            _read(os.path.join(self.h.repo, "cli", "agent.conf")), '{"sw": 1}'
+        )
+
+    def test_unchanged_config_but_dead_agents_cold_boots(self):
+        self.h.units_healthy.return_value = False
+        self.assertTrue(self.h.baseline.restore(self.sha))
+        self.h.cold_boot.assert_called_once()
+        self.assertEqual(self.h.cli_calls, [])
+
+    def test_reports_failure_when_agents_never_return(self):
+        self.h.units_healthy.return_value = False
+        self.h.agent_responsive.return_value = False
+        self.assertFalse(self.h.baseline.restore(self.sha))
+
+
+class TestWaitAgentResponsive(unittest.TestCase):
+    @patch("fboss_test_runner.services.config_baseline.time.sleep")
+    @patch("fboss_test_runner.services.config_baseline.subprocess.run")
+    def test_returns_immediately_when_ready(self, mock_run, mock_sleep):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+        self.assertTrue(config_baseline.wait_agent_responsive(FAKE_CLI, timeout_sec=30))
+        mock_sleep.assert_not_called()
+        self.assertEqual(mock_run.call_args[0][0], [FAKE_CLI, "show", "product"])
+
+    @patch("fboss_test_runner.services.config_baseline.time.sleep")
+    @patch("fboss_test_runner.services.config_baseline.time.monotonic")
+    @patch("fboss_test_runner.services.config_baseline.subprocess.run")
+    def test_polls_then_gives_up(self, mock_run, mock_monotonic, mock_sleep):
+        mock_run.return_value = subprocess.CompletedProcess([], 1, "", "refused")
+        mock_monotonic.side_effect = [0, 5, 15, 25, 40]
+        self.assertFalse(
+            config_baseline.wait_agent_responsive(
+                FAKE_CLI, timeout_sec=30, poll_interval_sec=10
+            )
+        )
+        self.assertGreaterEqual(mock_sleep.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_fboss2_integration_test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_fboss2_integration_test_runner.py
@@ -379,8 +379,7 @@ class TestEndRun(unittest.TestCase):
             sw_agent_service_name="fboss_sw_agent",
         )
         mock_run.assert_any_call(
-            ["rm", "-f", "/tmp/agent.conf.fboss2_test_snapshot"],
-            check=False,
+            ["rm", "-f", "/tmp/agent.conf.fboss2_test_snapshot"], check=False
         )
 
     @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
@@ -430,11 +429,12 @@ class TestSetupRunHook(unittest.TestCase):
         runner._setup_run = tracked_setup_run
         runner._setup_coldboot_test = tracked_setup_coldboot
         runner._test_framework = MagicMock()
+        # Stub the baseline out: the suite hooks would otherwise run real git
+        # commands against the live /etc/coop on a machine that has one.
+        runner._config_baseline = MagicMock()
 
         mock_args = _make_mock_args(
-            sai_replayer_logging=None,
-            simulator=None,
-            coldboot_only=True,
+            sai_replayer_logging=None, simulator=None, coldboot_only=True
         )
 
         with (
@@ -448,9 +448,7 @@ class TestSetupRunHook(unittest.TestCase):
             ),
         ):
             runner._run_tests(
-                tests_to_run=["TestA"],
-                conf_file="/etc/coop/agent.conf",
-                args=mock_args,
+                tests_to_run=["TestA"], conf_file="/etc/coop/agent.conf", args=mock_args
             )
 
         self.assertEqual(call_order[0], "_setup_run")
@@ -486,3 +484,134 @@ class TestKnownBadAndUnsupportedTestsFiles(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSuiteHooks(unittest.TestCase):
+    """The base loop fires _on_suite_start/_on_suite_end at gtest suite
+    boundaries and the fboss2 runner maps them onto config baseline
+    capture/restore."""
+
+    @patch("os.path.exists", return_value=True)
+    @patch(
+        "fboss_test_runner.runners.fboss2_integration_test_runner.cold_boot_agents",
+        return_value=None,
+    )
+    @patch(
+        "fboss_test_runner.runners.fboss2_integration_test_runner.is_agent_running",
+        return_value=[True, True],
+    )
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_hooks_fire_once_per_suite_in_order(
+        self, mock_run, mock_is_running, mock_cold_boot, mock_exists
+    ):
+        runner = Fboss2IntegrationTestRunner()
+        runner._test_framework = MagicMock()
+        events = []
+        baseline = MagicMock()
+        baseline.capture.side_effect = lambda: (events.append("capture"), "sha")[1]
+        baseline.restore.side_effect = lambda sha: (
+            events.append(f"restore:{sha}"),
+            True,
+        )[1]
+        runner._config_baseline = baseline
+
+        mock_args = _make_mock_args()
+        with (
+            patch.object(runner, "args", mock_args),
+            patch.object(runner, "_setup_coldboot_test"),
+            patch.object(
+                runner,
+                "_run_test",
+                side_effect=lambda *a, **_k: (
+                    events.append(f"run:{a[2]}"),
+                    RunOutcome(console_output="[       OK ] t", results=[]),
+                )[1],
+            ),
+        ):
+            runner._run_tests(
+                tests_to_run=["SuiteA.one", "SuiteA.two", "SuiteB.one"],
+                conf_file="/etc/coop/agent.conf",
+                args=mock_args,
+            )
+
+        self.assertEqual(
+            events,
+            [
+                "capture",
+                "run:SuiteA.one",
+                "run:SuiteA.two",
+                "restore:sha",
+                "capture",
+                "run:SuiteB.one",
+                "restore:sha",
+            ],
+        )
+
+    def test_restore_failure_is_reported_not_raised(self):
+        runner = Fboss2IntegrationTestRunner()
+        baseline = MagicMock()
+        baseline.restore.return_value = False
+        runner._config_baseline = baseline
+        runner._suite_baseline = "sha"
+        runner._on_suite_end("SuiteA")  # must not raise
+        baseline.restore.assert_called_once_with("sha")
+        self.assertIsNone(runner._suite_baseline)
+
+
+class TestAgentsHealthyForSuite(unittest.TestCase):
+    """The soft-rollback health gate must not trust a snapshot `is-active`:
+    a unit crash-looping under Restart=always reads "active" between crashes.
+    systemd's NRestarts (auto-restarts only) is compared before/after."""
+
+    def _runner(self, start_counts):
+        runner = Fboss2IntegrationTestRunner()
+        runner._switch_indexes = [0]
+        runner._suite_start_restarts = start_counts
+        return runner
+
+    @staticmethod
+    def _show(values):
+        """subprocess.run side effect: NRestarts per unit, in query order."""
+        it = iter(values)
+        return lambda *_a, **_k: MagicMock(stdout=f"{next(it)}\n")
+
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_auto_restart_marks_unhealthy(self, mock_run):
+        runner = self._runner({"fboss_sw_agent": 0, "fboss_hw_agent@0": 0})
+        mock_run.side_effect = self._show([0, 1])  # hw_agent crashed once
+        with patch.object(runner, "_agents_ready", return_value=True):
+            self.assertFalse(runner._agents_healthy_for_suite())
+        self.assertEqual(
+            mock_run.call_args[0][0],
+            ["systemctl", "show", "-p", "NRestarts", "--value", "fboss_hw_agent@0"],
+        )
+
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_unchanged_counts_and_active_units_is_healthy(self, mock_run):
+        runner = self._runner({"fboss_sw_agent": 2, "fboss_hw_agent@0": 0})
+        mock_run.side_effect = self._show([2, 0])
+        with patch.object(runner, "_agents_ready", return_value=True):
+            self.assertTrue(runner._agents_healthy_for_suite())
+
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_counter_reset_by_manual_restart_is_not_a_crash(self, mock_run):
+        # A CLI warmboot/coldboot commit does `systemctl restart`, which
+        # resets NRestarts to 0; that is not a crash.
+        runner = self._runner({"fboss_sw_agent": 3, "fboss_hw_agent@0": 3})
+        mock_run.side_effect = self._show([0, 0])
+        with patch.object(runner, "_agents_ready", return_value=True):
+            self.assertTrue(runner._agents_healthy_for_suite())
+
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_dead_unit_short_circuits(self, mock_run):
+        runner = self._runner({})
+        with patch.object(runner, "_agents_ready", return_value=False):
+            self.assertFalse(runner._agents_healthy_for_suite())
+        mock_run.assert_not_called()
+
+    @patch("fboss_test_runner.runners.fboss2_integration_test_runner.subprocess.run")
+    def test_unreadable_counter_does_not_block(self, mock_run):
+        runner = self._runner({"fboss_sw_agent": 0, "fboss_hw_agent@0": 0})
+        mock_run.return_value = MagicMock(stdout="")  # int("") -> ValueError
+        with patch.object(runner, "_agents_ready", return_value=True):
+            self.assertTrue(runner._agents_healthy_for_suite())


### PR DESCRIPTION
# Summary

One fboss2 integration test suite committing a config the hardware rejects poisons every suite that runs after it: the hw_agent crash-loops on the bad config, every later `config session commit` kills the sw_agent, and innocent tests fail.

We root-caused a concrete instance on a Wedge800 (TH5): `ConfigPortQueueConfigTest` commits a second ingress buffer pool that the SDK rejects with `INCORRECT_SHARED_LIMIT`; the hw_agent then aborts on that config on warm boot, cold boot and delta apply alike, and every subsequent suite in the run failed, including `ConfigVlanDefaultTest.SetDefaultVlanTo300`, which has nothing to do with buffer pools. This has bitten us several times with different offending configs, so this PR fixes the *containment* problem rather than any single bad config.

The fboss2 CLI already keeps the live config in a git repo (`/etc/coop`), so the harness can record the repo HEAD before a suite starts and roll back to it after the suite ends, healing the agents if the suite left them dead. Per-test isolation is intentionally not attempted; suites that need it already snapshot/restore in their own `SetUp`/`TearDown`.

## Change

- **`runners/test_runner.py`**: the per-test loop derives the gtest suite from each `Suite.Case` and fires two new no-op hooks, `_on_suite_start(suite)` / `_on_suite_end(suite)`, at suite boundaries (the test list is sorted, so a suite's cases are contiguous). The end hook also fires for the final suite from the loop's `finally`, before `_end_run`. Runners that don't override the hooks are unaffected.
- **New `services/config_baseline.py`**, `ConfigBaseline`:
  - `capture()`: initialize the `/etc/coop` repo if the CLI never has (seeding `cli/agent.conf` from the live file, mirroring `ConfigSession::initializeGit()`), commit any uncommitted drift in the tracked files (the harness itself copies configs through the `agent.conf` symlink without committing), record HEAD.
  - `restore(sha)`: **fast path** when HEAD is still the baseline, the tree is clean and the agents are healthy; **soft path** `fboss2-dev config rollback <sha>` when the config drifted but the agents are healthy; **hard path** (check out the tracked files at the baseline, fix the daemon symlinks, commit, `systemctl reset-failed`, cold boot) when the agents are not healthy or the soft path fails.
  - Collaborators (unit health, thrift probe, cold boot, CLI path) are injected, so the runner wires in its existing `_agents_ready()` and `cold_boot_agents()`.
- **`runners/fboss2_integration_test_runner.py`**: implements the hooks. A restore failure is printed loudly, never raised: a cleanup failure should not become a test error.

### "Healthy" is more than `systemctl is-active`

The production units run `Restart=always`, `RestartSec=30`, `StartLimitIntervalSec=0`, so a crash-looping agent **never reaches `failed`**: it cycles `activating` (30s), `active`, crash. A snapshot `is-active` can therefore read `active` in the healthy-looking window and we would hand a rollback to an agent about to die again. The runner records each agent unit's `NRestarts` at suite start and treats a higher value at suite end as a crash. `NRestarts` counts only `Restart=`-triggered restarts, so the warmboot/coldboot restarts the CLI performs on commit do not register (they reset the counter, which is why a *lower* value is not treated as a crash). This is also what catches a crash-looping hw_agent while the sw_agent still serves thrift, exactly the wedge we diagnosed.

For the same reason, the pre-existing per-test "cold boot if a unit is `failed`" recovery in this runner cannot trigger on production images either.

### Drift is defined by git state, not content

A baseline captured from the raw image config and `config rollback`'s thrift re-serialization of the same config differ by thousands of lines of layout while meaning the same thing, so textual comparison is not trustworthy (it caused a false hard restore during testing). Drift means `HEAD != baseline` or tracked files dirty, which is exact since the CLI commits exactly what it writes; soft-path success means rollback exit 0 plus agent responsive. Only the CLI can compare these configs semantically, and its rollback already does.

### Device-only details worth calling out

- git runs as root on a repo owned by `coop`, so every command passes `-c safe.directory`, as the C++ `Git` class does.
- `git checkout <sha> -- <paths>` rejects the whole pathspec if any path is absent at that revision (e.g. `bgpcpp.conf` on a device with no BGP commits), so the hard path checks out only files present at the baseline and removes the rest.

Two pre-existing lint errors in the touched files (`ARG002`, `RET504`) are fixed in passing so pre-commit is clean on the diff.

# Test Plan

- New `unittests/test_config_baseline.py` drives `ConfigBaseline` against a real temporary git repo with only the CLI and `systemctl` intercepted: repo init from a plain file, drift commit, fast path, soft rollback (including re-serialized output), uncommitted-edit-as-drift, hard restore when units are unhealthy, symlink repair, soft-to-hard fallback, cold boot on dead-but-unchanged agents.
- `test_fboss2_integration_test_runner.py`: hooks fire once per suite in order (capture, run, restore); restore failure is reported not raised; the `NRestarts` gate (increase means unhealthy, unchanged means healthy, reset by a manual restart is not a crash, unreadable does not block).
- 323 harness unit tests pass.

## Verification on hardware

Verified end to end through `run_test.py fboss2_integration` on an NH-4010-F:

| Scenario | Result |
|---|---|
| Read-only suite (`ConfigSessionClearTest`) | fast path, no output, no agent action |
| Committing suite (`ConfigVlanDefaultTest`, `ConfigArpTest`) | one rollback-to-baseline commit at suite end |
| Raw image config copied over `agent.conf` + committing suite | drift committed as baseline, then soft rollback only (the case that used to false-escalate) |
| Suite commits, then `systemctl stop fboss_hw_agent@0` | unit dead, hard path: baseline checked out and committed, cold boot, agents back in 45s, config back on baseline |
| Suite commits, then `SIGKILL` hw_agent (`Restart=` brings it straight back, so `is-active` alone said healthy) | `NRestarts` 1 to 2 detected, hard path, agents back in ~60s, config back on baseline |
| 3-suite run (`ConfigArpTest`, `ConfigSessionClearTest`, `ConfigVlanDefaultTest`) | 10/10 passed, agents active at the end |
