### PR TITLE
[Nexthop] Fix nan% issue in "show interface traffic" CLI output

### DIFF
--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
@@ -240,8 +240,10 @@ std::vector<double> CmdShowInterfaceTraffic::getTrafficTotals(
     totalBW += folly::copy(tc.portSpeed().value());
   }
 
-  inPctT = (inMbpsT / totalBW) * 100;
-  outPctT = (outMbpsT / totalBW) * 100;
+  if (totalBW > 0) {
+    inPctT = (inMbpsT / totalBW) * 100;
+    outPctT = (outMbpsT / totalBW) * 100;
+  }
 
   std::vector<double> rv{inMbpsT, inPctT, inKppsT, outMbpsT, outPctT, outKppsT};
   return rv;

--- a/fboss/cli/fboss2/test/CmdShowInterfaceTrafficTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowInterfaceTrafficTest.cpp
@@ -185,6 +185,23 @@ TEST_F(CmdShowInterfaceTrafficTestFixture, printOutput) {
   EXPECT_EQ(expectedOutput, output);
 }
 
+// A box with every front panel port down and no transceivers reports zero for
+// every rate counter, so isInterestingTraffic() filters out every row and the
+// Total is computed over an empty set. Totals must read 0.00%.
+TEST_F(CmdShowInterfaceTrafficTestFixture, printOutputNoInterestingTraffic) {
+  auto cmd = CmdShowInterfaceTraffic();
+  auto model = cmd.createModel(portInfo, {} /* intCounters */, queriedIfs);
+
+  EXPECT_TRUE(model.traffic_counters()->empty());
+
+  std::stringstream ss;
+  cmd.printOutput(model, ss);
+
+  const std::string output = ss.str();
+  EXPECT_NE(output.find("Total"), std::string::npos);
+  EXPECT_NE(output.find("0.00%"), std::string::npos);
+}
+
 // CLI reference wiki hooks: a human description and a non-empty sample model.
 // Property checks only (no golden text).
 TEST_F(CmdShowInterfaceTrafficTestFixture, wikiDocHooks) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

When no interfaces are up, we see nan% in CLI o/p instead of 0%. This PR fixes that by avoiding 0/0.

```
$ fboss2 show interface traffic
No interfaces with In/Out errors - all-clear!

 Interface Name  Peer  Intvl  InMbps  InPct  InKpps  OutMbps  OutPct  OutKpps
----------------------------------------------------------------------------------------
 Total           --    --     0.00    -nan%  0.00    0.00     -nan%   0.00
 ```


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Added a unit test.
