### PR TITLE
[Nexthop][fboss2-dev] Derive traffic-counter CLI types from the thrift enum and restore the DUT on test failure

### DIFF
--- a/fboss/cli/fboss2/commands/config/traffic_counter/CmdConfigTrafficCounter.cpp
+++ b/fboss/cli/fboss2/commands/config/traffic_counter/CmdConfigTrafficCounter.cpp
@@ -14,6 +14,7 @@
 
 #include <fmt/format.h>
 #include <folly/String.h>
+#include <thrift/lib/cpp/util/EnumUtils.h>
 #include <algorithm>
 #include <iostream>
 #include "fboss/cli/fboss2/session/ConfigSession.h"
@@ -21,18 +22,20 @@
 namespace facebook::fboss {
 
 namespace {
-// Accepted spellings of cfg::CounterType, matched case insensitively.
-constexpr std::string_view kTypePackets = "packets";
-constexpr std::string_view kTypeBytes = "bytes";
-constexpr std::string_view kTypeList = "PACKETS,BYTES";
+// Every cfg::CounterType spelling the CLI accepts, matched case insensitively.
+std::string validTypeList() {
+  std::vector<std::string> names;
+  for (auto type : apache::thrift::TEnumTraits<cfg::CounterType>::values) {
+    names.push_back(apache::thrift::util::enumNameSafe(type));
+  }
+  return folly::join(",", names);
+}
 
 std::string typesToString(const std::vector<cfg::CounterType>& types) {
   std::vector<std::string> names;
   names.reserve(types.size());
   for (auto type : types) {
-    names.push_back(
-        type == cfg::CounterType::BYTES ? std::string("BYTES")
-                                        : std::string("PACKETS"));
+    names.push_back(apache::thrift::util::enumNameSafe(type));
   }
   return folly::join(",", names);
 }
@@ -43,7 +46,7 @@ TrafficCounterArg::TrafficCounterArg(std::vector<std::string> v) {
     throw std::invalid_argument(
         fmt::format(
             "Expected <name> <types>, where types is a comma separated list of {}",
-            kTypeList));
+            validTypeList()));
   }
 
   name_ = v[0];
@@ -54,30 +57,24 @@ TrafficCounterArg::TrafficCounterArg(std::vector<std::string> v) {
 
   std::vector<std::string> tokens;
   folly::split(',', v[1], tokens);
-  bool hasPackets = false;
-  bool hasBytes = false;
-  for (auto token : tokens) {
-    folly::toLowerAscii(token);
-    if (token == kTypePackets) {
-      hasPackets = true;
-    } else if (token == kTypeBytes) {
-      hasBytes = true;
-    } else {
+  for (auto& token : tokens) {
+    folly::toUpperAscii(token);
+    cfg::CounterType type{};
+    if (!apache::thrift::TEnumTraits<cfg::CounterType>::findValue(
+            token, &type)) {
       throw std::invalid_argument(
           fmt::format(
               "Invalid counter type '{}'. Expected a comma separated list of {}",
               token,
-              kTypeList));
+              validTypeList()));
+    }
+    if (std::find(types_.begin(), types_.end(), type) == types_.end()) {
+      types_.push_back(type);
     }
   }
-  // Store in a fixed order so the config, and the already-configured
-  // comparison below, do not depend on the order the types were typed in.
-  if (hasPackets) {
-    types_.push_back(cfg::CounterType::PACKETS);
-  }
-  if (hasBytes) {
-    types_.push_back(cfg::CounterType::BYTES);
-  }
+  // Store in enum order so the config, and the already-configured comparison
+  // below, do not depend on the order the types were typed in.
+  std::sort(types_.begin(), types_.end());
   data_.push_back(v[1]);
 }
 
@@ -98,7 +95,10 @@ CmdConfigTrafficCounterTraits::RetType CmdConfigTrafficCounter::queryClient(
       });
 
   if (it != counters.end()) {
-    if (*it->types() == newTypes) {
+    // The CLI stores types in enum order, but a hand-written config need not.
+    auto existingTypes = *it->types();
+    std::sort(existingTypes.begin(), existingTypes.end());
+    if (existingTypes == newTypes) {
       return fmt::format(
           "Traffic counter '{}' is already configured with type '{}'",
           name,

--- a/fboss/cli/fboss2/commands/config/traffic_counter/CmdConfigTrafficCounter.h
+++ b/fboss/cli/fboss2/commands/config/traffic_counter/CmdConfigTrafficCounter.h
@@ -43,6 +43,7 @@ struct CmdConfigTrafficCounterTraits : public WriteCommandTraits {
            "name_and_types",
            args,
            "Counter name followed by a comma separated list of counter types (PACKETS,BYTES)")
+        ->required()
         ->expected(2);
   }
   using ObjectArgType = TrafficCounterArg;

--- a/fboss/cli/fboss2/commands/delete/traffic_counter/CmdDeleteTrafficCounter.h
+++ b/fboss/cli/fboss2/commands/delete/traffic_counter/CmdDeleteTrafficCounter.h
@@ -33,8 +33,14 @@ class TrafficCounterNameArg : public utils::BaseObjectArgType<std::string> {
 
 struct CmdDeleteTrafficCounterTraits : public WriteCommandTraits {
   static void addCliArg(CLI::App& cmd, std::vector<std::string>& args) {
+    // required() + expected(1) keeps CLI11 from reclassifying the counter
+    // name as a subcommand when it happens to match one elsewhere in the tree.
     cmd.add_option(
-        "counter_name", args, "<name> - name of the traffic counter to delete");
+           "counter_name",
+           args,
+           "<name> - name of the traffic counter to delete")
+        ->required()
+        ->expected(1);
   }
   using ObjectArgType = TrafficCounterNameArg;
   using RetType = std::string;

--- a/fboss/cli/fboss2/test/config/CmdConfigTrafficCounterTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigTrafficCounterTest.cpp
@@ -30,7 +30,8 @@ class CmdConfigTrafficCounterTestFixture : public CmdConfigTestBase {
             R"({
   "sw": {
     "trafficCounters": [
-      {"name": "existing_counter", "types": [0]}
+      {"name": "existing_counter", "types": [0]},
+      {"name": "unordered_counter", "types": [1, 0]}
     ]
   }
 })") {}
@@ -130,9 +131,9 @@ TEST_F(CmdConfigTrafficCounterTestFixture, createNewCounterSingleType) {
 
   auto& counters =
       *ConfigSession::getInstance().getAgentConfig().sw()->trafficCounters();
-  ASSERT_EQ(counters.size(), 2);
-  EXPECT_EQ(*counters[1].name(), "new_counter");
-  EXPECT_EQ(*counters[1].types(), std::vector{cfg::CounterType::PACKETS});
+  ASSERT_EQ(counters.size(), 3);
+  EXPECT_EQ(*counters[2].name(), "new_counter");
+  EXPECT_EQ(*counters[2].types(), std::vector{cfg::CounterType::PACKETS});
 }
 
 TEST_F(CmdConfigTrafficCounterTestFixture, createNewCounterBothTypes) {
@@ -146,10 +147,10 @@ TEST_F(CmdConfigTrafficCounterTestFixture, createNewCounterBothTypes) {
 
   auto& counters =
       *ConfigSession::getInstance().getAgentConfig().sw()->trafficCounters();
-  ASSERT_EQ(counters.size(), 2);
-  EXPECT_EQ(*counters[1].name(), "stat_both");
+  ASSERT_EQ(counters.size(), 3);
+  EXPECT_EQ(*counters[2].name(), "stat_both");
   EXPECT_EQ(
-      *counters[1].types(),
+      *counters[2].types(),
       (std::vector{cfg::CounterType::PACKETS, cfg::CounterType::BYTES}));
 }
 
@@ -165,7 +166,7 @@ TEST_F(CmdConfigTrafficCounterTestFixture, updateExistingCounter) {
 
   auto& counters =
       *ConfigSession::getInstance().getAgentConfig().sw()->trafficCounters();
-  ASSERT_EQ(counters.size(), 1);
+  ASSERT_EQ(counters.size(), 2);
   EXPECT_EQ(*counters[0].name(), "existing_counter");
   EXPECT_EQ(*counters[0].types(), std::vector{cfg::CounterType::BYTES});
 }
@@ -182,7 +183,26 @@ TEST_F(CmdConfigTrafficCounterTestFixture, alreadyConfigured) {
 
   auto& counters =
       *ConfigSession::getInstance().getAgentConfig().sw()->trafficCounters();
-  ASSERT_EQ(counters.size(), 1);
+  ASSERT_EQ(counters.size(), 2);
+}
+
+TEST_F(CmdConfigTrafficCounterTestFixture, alreadyConfiguredUnorderedTypes) {
+  // Seed stores unordered_counter as [BYTES, PACKETS]; asking for the same
+  // set in any spelling order is a no-op, not an update.
+  setupTestableConfigSession(cmdPrefix_, "unordered_counter PACKETS,BYTES");
+  CmdConfigTrafficCounter cmd;
+  HostInfo hostInfo("testhost");
+  TrafficCounterArg arg({"unordered_counter", "PACKETS,BYTES"});
+
+  auto result = cmd.queryClient(hostInfo, arg);
+  EXPECT_THAT(result, HasSubstr("already"));
+
+  auto& counters =
+      *ConfigSession::getInstance().getAgentConfig().sw()->trafficCounters();
+  ASSERT_EQ(counters.size(), 2);
+  EXPECT_EQ(
+      *counters[1].types(),
+      (std::vector{cfg::CounterType::BYTES, cfg::CounterType::PACKETS}));
 }
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/ConfigTrafficCounterTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigTrafficCounterTest.cpp
@@ -20,14 +20,15 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include "fboss/agent/gen-cpp2/switch_config_types.h"
 #include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
 
 using namespace facebook::fboss;
 
 namespace {
-// CounterType enum values from switch_config.thrift
-constexpr int kPackets = 0;
-constexpr int kBytes = 1;
+// The running config serializes cfg::CounterType as its integer value.
+constexpr int kPackets = static_cast<int>(cfg::CounterType::PACKETS);
+constexpr int kBytes = static_cast<int>(cfg::CounterType::BYTES);
 // A name unlikely to collide with any production counter.
 const std::string kTestCounter = "fboss2-it-traffic-counter";
 } // namespace
@@ -63,13 +64,10 @@ class ConfigTrafficCounterTest : public Fboss2IntegrationTest {
     return sw.count("trafficCounters") ? sw["trafficCounters"].size() : 0;
   }
 
-  // An earlier run that died between create and delete would leave the test
-  // counter behind, and every later run would then exercise the update path
-  // instead of the create path. Reset the config rather than refuse to run.
+  // Removes the test counter from the running config if it is present.
   // Nothing else may reference kTestCounter - a traffic policy pointing at a
   // counter this deletes would make the next commit invalid.
-  void SetUp() override {
-    Fboss2IntegrationTest::SetUp();
+  void removeTestCounterIfPresent() {
     if (!getCounterTypes(kTestCounter).has_value()) {
       return;
     }
@@ -79,6 +77,20 @@ class ConfigTrafficCounterTest : public Fboss2IntegrationTest {
     commitConfig();
     ASSERT_FALSE(getCounterTypes(kTestCounter).has_value())
         << "cleanup delete left '" << kTestCounter << "' in the running config";
+  }
+
+  // An earlier run that died between create and delete would leave the test
+  // counter behind, and every later run would then exercise the update path
+  // instead of the create path. Reset the config rather than refuse to run.
+  void SetUp() override {
+    Fboss2IntegrationTest::SetUp();
+    removeTestCounterIfPresent();
+  }
+
+  // Restore the DUT even when the body failed between create and delete.
+  void TearDown() override {
+    removeTestCounterIfPresent();
+    Fboss2IntegrationTest::TearDown();
   }
 };
 


### PR DESCRIPTION
# Summary

Follow-up to #1521 (`config` / `delete traffic-counter`), applying the fixes from a post-merge review pass. No behaviour change for valid input; the CLI gets more robust and the test cleans up after itself.

- **Type parsing and printing are derived from the thrift enum.** `TrafficCounterArg` now resolves each comma separated token with `TEnumTraits<cfg::CounterType>::findValue` (case insensitive) and prints names with `enumNameSafe`, replacing the hand-rolled `packets`/`bytes` string constants and the `BYTES ? "BYTES" : "PACKETS"` ternary. A new `cfg::CounterType` value is accepted and printed correctly without touching the CLI, and the error message lists the valid values from the enum.
- **Order-insensitive "already configured" check.** The CLI stores types in enum order, but a hand-written config may list `[BYTES, PACKETS]`. `queryClient` now compares a sorted copy of the existing types, so re-applying the same set is a no-op instead of an unneeded hitless commit. Unit test `alreadyConfiguredUnorderedTypes` covers this with a seeded `[1, 0]` counter.
- **`required()` / `expected(N)` on the positionals**, matching every other single-positional `config`/`delete` command in the tree (e.g. `CmdDeleteQosPolicy.h`, `CmdConfigDhcpReplySourceOverride.h`); this keeps CLI11 from reclassifying the counter name as a subcommand.
- **Integration test `TearDown()`.** `ConfigTrafficCounterTest` previously relied on the *next* run's `SetUp()` to remove a leftover counter. The cleanup now lives in a helper called from both `SetUp()` and `TearDown()`, so a run that fails between create and delete restores the device immediately, as sibling tests (`ConfigVlanCreateTest`, `ConfigCoppCpuTrafficPolicyTest`) do.

# Test Plan

Unit (`cmd_config_test --gtest_filter='*TrafficCounter*'`):

```
[----------] 6 tests from CmdConfigTrafficCounterTestFixture
[       OK ] CmdConfigTrafficCounterTestFixture.argValidation
[       OK ] CmdConfigTrafficCounterTestFixture.createNewCounterSingleType
[       OK ] CmdConfigTrafficCounterTestFixture.createNewCounterBothTypes
[       OK ] CmdConfigTrafficCounterTestFixture.updateExistingCounter
[       OK ] CmdConfigTrafficCounterTestFixture.alreadyConfigured
[       OK ] CmdConfigTrafficCounterTestFixture.alreadyConfiguredUnorderedTypes
[----------] 7 tests from CmdDeleteTrafficCounterTestFixture
[       OK ] CmdDeleteTrafficCounterTestFixture.argValid
[       OK ] CmdDeleteTrafficCounterTestFixture.argWrongArity
[       OK ] CmdDeleteTrafficCounterTestFixture.argEmptyName
[       OK ] CmdDeleteTrafficCounterTestFixture.deleteUnreferencedCounter
[       OK ] CmdDeleteTrafficCounterTestFixture.deleteCpuPolicyReferencedCounterRefused
[       OK ] CmdDeleteTrafficCounterTestFixture.deleteDataPlanePolicyReferencedCounterRefused
[       OK ] CmdDeleteTrafficCounterTestFixture.deleteAbsentCounterRefused
[  PASSED  ] 13 tests.
```

Integration: `ConfigTrafficCounterTest.CreateThenDelete` is being re-run on a lab switch; result will be posted in a comment.

clang-tidy on the touched files reports nothing outside gtest's own `EXPECT_THROW` macro expansion.

## Review Findings

This PR *is* the outcome of an fboss-review pass over #1521 (reliability, engineering, code quality, silent-failure, testing reviewers); no findings above the confidence threshold remain on the resulting diff.
