### PR TITLE
[Nexthop][fboss2-dev] Add recordConfigBaseline()/rollbackConfig() test fixture helpers

### DIFF
--- a/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.cpp
@@ -50,6 +50,7 @@
 #include "fboss/cli/fboss2/CmdLocalOptions.h"
 #include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/session/Git.h"
 #include "fboss/cli/fboss2/utils/CmdClientUtilsCommon.h"
 #include "fboss/cli/fboss2/utils/CmdInitUtils.h"
 #include "fboss/cli/fboss2/utils/HostInfo.h"
@@ -102,6 +103,51 @@ void Fboss2IntegrationTest::discardSession() const {
   // Reset the in-memory singleton so the next CLI command starts a fresh
   // session from the current system config, not stale in-process state.
   ConfigSession::resetInstance();
+}
+
+std::string Fboss2IntegrationTest::recordConfigBaseline() const {
+  discardSession();
+  // Constructing the session initializes the /etc/coop repo if the CLI never
+  // has, so HEAD exists even on a pristine box.
+  auto sha = ConfigSession::getInstance().getGit().getHead();
+  if (sha.empty()) {
+    throw std::runtime_error("No config commit to use as a baseline");
+  }
+  XLOG(INFO) << "Config baseline: " << Git::shortSha1(sha);
+  return sha;
+}
+
+void Fboss2IntegrationTest::rollbackConfig(
+    const std::string& baselineSha) const {
+  if (baselineSha.empty()) {
+    return;
+  }
+  discardSession();
+  if (ConfigSession::getInstance().getGit().getHead() == baselineSha) {
+    XLOG(INFO) << "Config still at baseline " << Git::shortSha1(baselineSha)
+               << "; nothing to roll back";
+    return;
+  }
+
+  XLOG(INFO) << "Rolling config back to " << Git::shortSha1(baselineSha);
+  auto result = runCli({"config", "rollback", baselineSha});
+  if (result.exitCode != 0) {
+    // Like commitConfig(): an agent restart applying the rollback can drop
+    // the thrift connection mid-call after the rollback commit was made.
+    if (!isAgentRestartSignature(result.stderr)) {
+      throw std::runtime_error(
+          fmt::format("Failed to roll back config: {}", result.stderr));
+    }
+    XLOG(INFO) << "Rollback dropped connection (likely agent restart); "
+                  "waiting for agent";
+  }
+  waitForAgentReady();
+  auto head = ConfigSession::getInstance().getGit().getHead();
+  if (head == baselineSha) {
+    throw std::runtime_error("Rollback did not create a new commit");
+  }
+  XLOG(INFO) << "Config rolled back to baseline as new commit "
+             << Git::shortSha1(head);
 }
 
 Fboss2IntegrationTest::Result Fboss2IntegrationTest::executeCliCommand(
@@ -444,21 +490,28 @@ void Fboss2IntegrationTest::commitConfig() const {
   // confirm the actual outcome via getRunningConfig() / waitForRunningConfig().
   // Treat the disconnect signatures as expected: log, wait for the agent to
   // come back, and return without failing the test here.
+  if (isAgentRestartSignature(result.stderr)) {
+    XLOG(INFO)
+        << "Commit dropped connection (likely agent restart). "
+           "Waiting for agent to come back; caller must verify via running config.";
+    waitForAgentReady();
+    return;
+  }
+  ASSERT_EQ(result.exitCode, 0) << "Failed to commit config: " << result.stderr;
+}
+
+bool Fboss2IntegrationTest::isAgentRestartSignature(const std::string& stderr) {
   static constexpr std::array<std::string_view, 3> kRestartSignatures = {
       "Channel got EOF",
       "Connection refused",
       "Socket not open",
   };
   for (auto sig : kRestartSignatures) {
-    if (result.stderr.find(sig) != std::string::npos) {
-      XLOG(INFO)
-          << "Commit dropped connection (likely agent restart): " << sig
-          << ". Waiting for agent to come back; caller must verify via running config.";
-      waitForAgentReady();
-      return;
+    if (stderr.find(sig) != std::string::npos) {
+      return true;
     }
   }
-  ASSERT_EQ(result.exitCode, 0) << "Failed to commit config: " << result.stderr;
+  return false;
 }
 
 void Fboss2IntegrationTest::waitForAgentReady(

--- a/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h
+++ b/fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h
@@ -238,6 +238,12 @@ class Fboss2IntegrationTest : public ::testing::Test {
   void commitConfig() const;
 
   /**
+   * True when a CLI command's stderr shows the thrift connection was dropped
+   * by an agent restart (the command itself was likely accepted).
+   */
+  static bool isAgentRestartSignature(const std::string& stderr);
+
+  /**
    * Get the MTU of a kernel interface using 'ip -json link'.
    * @param vlanId The VLAN ID (interface name will be fboss<vlanId>)
    * @return MTU value
@@ -383,6 +389,24 @@ class Fboss2IntegrationTest : public ::testing::Test {
    * This ensures each test starts with a fresh session based on current HEAD.
    */
   void discardSession() const;
+
+  /**
+   * Record the /etc/coop git HEAD as the config baseline for this test.
+   * Call in SetUp() and pass the result to rollbackConfig() in TearDown()
+   * so the DUT is left as found even when a test fails mid-way. Discards
+   * any pending session first so the baseline is the committed config.
+   */
+  std::string recordConfigBaseline() const;
+
+  /**
+   * Roll the config back to a recordConfigBaseline() revision via
+   * `config rollback <sha>` and wait for the agent. ConfigSession::rollback()
+   * re-applies each commit being undone at the action level it recorded
+   * (hitless / warmboot / coldboot), so the restore needs the same restart
+   * the test's own commits did -- no guessing here. A no-op when HEAD is
+   * still at the baseline.
+   */
+  void rollbackConfig(const std::string& baselineSha) const;
 
   /**
    * Wait until the FBOSS agent is responsive (ready to serve thrift requests).


### PR DESCRIPTION
# Summary

Integration tests that mutate the running config need to leave the DUT as they found it even when the test body fails part-way. Rather than giving `Fboss2IntegrationTest` its own snapshot/restore mechanism (serialize the session config, re-commit it with a hardcoded action level), this adds two thin helpers on top of the CLI's own `config rollback`:

- **`recordConfigBaseline()`** — discards any pending session and returns the `/etc/coop` git HEAD. Constructing the session initializes the repo on a pristine box, so a baseline always exists. Call in `SetUp()`.
- **`rollbackConfig(sha)`** — runs `config rollback <sha>` in-process and waits for the agent; a no-op when HEAD is still at the baseline; a failure to create the rollback commit is an error. Call in `TearDown()`.

Because `ConfigSession::rollback()` re-applies at the highest action level recorded by the commits being undone (#1447), the restore takes exactly the restart the test's own commits did — warmboot for a VLAN membership change, hitless for a CoPP action, coldboot if a commit recorded `AGENT_COLDBOOT`. The test never has to guess.

The dropped-connection tolerance already in `commitConfig()` (an agent restart can cut the thrift call after the commit landed) is factored into `isAgentRestartSignature()` so the rollback path shares it.

No test is switched over in this PR; the first user is the `switchport access vlan` test in the next PR of the stack.

# Test Plan

- Builds as part of `fboss2_integration_test`.
- Exercised on a lab device (NH-4010-F) via the stacked VLAN test: `SetUp` recorded HEAD, two `AGENT_WARMBOOT` commits, `TearDown` rolled back as a new commit whose metadata recorded `AGENT_WARMBOOT`; agents active afterwards; `git diff <baseline> HEAD -- cli/agent.conf` empty. A hitless-only suite using the same helpers rolled back with `HITLESS` in ~80 ms.

Based-on: "main"

