### PR TITLE
[Nexthop][fboss2-dev] fboss2 CLI tests: use 1 MB buffers in ConfigPortQueueConfigTest

### DIFF
--- a/fboss/cli/fboss2/test/integration_test/ConfigPortQueueConfigTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigPortQueueConfigTest.cpp
@@ -112,19 +112,14 @@ TEST_F(ConfigPortQueueConfigTest, BuildAndAssignPolicy) {
   XLOG(INFO) << "Using test interface " << ifName;
 
   XLOG(INFO) << "[Step 1] Configuring buffer pool...";
-  configureBufferPool(/*sharedBytes=*/78773528, /*headroomBytes=*/4405376);
+  configureBufferPool(/*sharedBytes=*/1048576, /*headroomBytes=*/0);
 
   XLOG(INFO) << "[Step 2] Configuring queues...";
   configureQueue(
-      2, {"scheduling", "SP", "shared-bytes", "83618832", "weight", "10"});
+      2, {"scheduling", "SP", "shared-bytes", "1048576", "weight", "10"});
   configureQueue(
       6,
-      {"scheduling",
-       "SP",
-       "shared-bytes",
-       "83618832",
-       "scaling-factor",
-       "TWO"});
+      {"scheduling", "SP", "shared-bytes", "1048576", "scaling-factor", "TWO"});
   configureQueue(
       7,
       {"scheduling",
@@ -142,7 +137,7 @@ TEST_F(ConfigPortQueueConfigTest, BuildAndAssignPolicy) {
       {"scheduling",
        "SP",
        "shared-bytes",
-       "83618832",
+       "1048576",
        "active-queue-management",
        "congestion-behavior",
        "ECN",
@@ -174,8 +169,8 @@ TEST_F(ConfigPortQueueConfigTest, BuildAndAssignPolicy) {
   const auto& pools = sw["bufferPoolConfigs"];
   ASSERT_TRUE(pools.count(bufferPoolName_))
       << "buffer pool " << bufferPoolName_ << " missing";
-  EXPECT_EQ(pools[bufferPoolName_]["sharedBytes"].asInt(), 78773528);
-  EXPECT_EQ(pools[bufferPoolName_]["headroomBytes"].asInt(), 4405376);
+  EXPECT_EQ(pools[bufferPoolName_]["sharedBytes"].asInt(), 1048576);
+  EXPECT_EQ(pools[bufferPoolName_]["headroomBytes"].asInt(), 0);
 
   // Named queue config
   ASSERT_TRUE(sw.count("portQueueConfigs"));
@@ -189,7 +184,7 @@ TEST_F(ConfigPortQueueConfigTest, BuildAndAssignPolicy) {
     const auto* q = findQueue(queues, 2);
     ASSERT_NE(q, nullptr);
     EXPECT_EQ((*q)["scheduling"].asInt(), kSchedSp);
-    EXPECT_EQ((*q)["sharedBytes"].asInt(), 83618832);
+    EXPECT_EQ((*q)["sharedBytes"].asInt(), 1048576);
     EXPECT_EQ((*q)["weight"].asInt(), 10);
     EXPECT_EQ(
         (*q).getDefault("streamType", kStreamUnicast).asInt(), kStreamUnicast);


### PR DESCRIPTION
# Summary

`ConfigPortQueueConfigTest.BuildAndAssignPolicy` used whole-ITM TH5 figures (78 MB pool shared + 4 MB headroom, 83 MB queue shared) taken from a lossless PFC sample config. On a half-populated TH5 (Wedge800B: cores 0–15 + 48–63, ITM 0 only) FBOSS's default egress pool is already sized to a whole ITM (`Tomahawk5Asic::getNumCellsAvailable()`), so binding a second ITM-sized pool is rejected by the SDK (`INCORRECT_SHARED_LIMIT` → `SAI_STATUS_FAILURE`), the `SaiApiError` escapes the replay path and hw_agent aborts; the systemd retry replays a reverted state, so the config is silently dropped while the test stays green.

The sizes carry no intent for an egress queue pool, so the test now uses 1 MB pool shared / 0 headroom / 1 MB queue shared — plain number swaps — and fits on every platform. The agent-side question (sizing the default pool per platform) is separate and not addressed here.

# Test Plan

`fboss2_integration_test --gtest_filter='ConfigPortQueueConfigTest.*'` run as root against the live agents:

- **Wedge800B** (brcm-sai 13.3.0.0_odp, the platform the old sizes broke on): `BuildAndAssignPolicy` OK (11.4 s), `DeleteWholeQueueConfig` OK (22.7 s); every commit's agent restart came back active in ~2 s with no systemd retry. With the old 78 MB pool the same test took a constant ~76 s on this box because hw_agent aborted on replay and was restarted 30 s later.
- **2-ITM TH5 lab device**: OK (22 s / 44 s); `coredumpctl` empty before and after, no ABRT in the agent journals; a further `systemctl restart fboss_sw_agent` with the 1 MB config still in place was clean (`NRestarts=0`).
- Full fboss2 CLI integration suite in our CI on two more 2-ITM TH5 devices: both tests pass.

## Review Findings

Diff is limited to constant replacements in one test file; `fboss-review` was not available in this environment, so no automated review table is attached.
