### PR TITLE
[Nexthop][fboss2-dev] Add loopback interface creation and addressing to config interface

### DIFF
--- a/cmake/CliFboss2TestConfig.cmake
+++ b/cmake/CliFboss2TestConfig.cmake
@@ -15,6 +15,7 @@ add_executable(fboss2_cmd_config_test
   fboss/cli/fboss2/test/config/CmdConfigHostnameTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigHistoryTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceIpv6NdpTest.cpp
+  fboss/cli/fboss2/test/config/CmdConfigInterfaceLoopbackTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceSflowSampleDestTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceSwitchportAccessVlanTest.cpp
   fboss/cli/fboss2/test/config/CmdConfigInterfaceSwitchportTrunkAllowedVlanTest.cpp

--- a/cmake/CliFboss2TestIntegrationTest.cmake
+++ b/cmake/CliFboss2TestIntegrationTest.cmake
@@ -26,6 +26,7 @@ add_executable(fboss2_integration_test
   fboss/cli/fboss2/test/integration_test/ConfigInterfaceProfileTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigL2LearningModeTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigLoadBalancingTest.cpp
+  fboss/cli/fboss2/test/integration_test/ConfigLoopbackInterfaceTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigMacTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigPfcTest.cpp
   fboss/cli/fboss2/test/integration_test/ConfigPortQueueConfigTest.cpp

--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.cpp
@@ -10,6 +10,7 @@
 
 #include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h"
 
+#include "fboss/agent/types.h"
 #include "fboss/cli/fboss2/CmdHandler.cpp"
 
 #include <fmt/format.h>
@@ -28,13 +29,17 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/gen-cpp2/switch_config_types.h"
 #include "fboss/agent/platforms/common/PlatformMapping.h"
 #include "fboss/cli/fboss2/commands/config/QueueConfigUtils.h"
+#include "fboss/cli/fboss2/commands/config/interface/InterfaceAttrArgsBase.h"
 #include "fboss/cli/fboss2/commands/config/interface/InterfaceIpUtils.h"
 #include "fboss/cli/fboss2/commands/config/interface/ProfileValidation.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
+#include "fboss/cli/fboss2/gen-cpp2/cli_metadata_types.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 #include "fboss/cli/fboss2/utils/HostInfo.h"
@@ -104,15 +109,42 @@ InterfacesConfig::InterfacesConfig(const std::vector<std::string>& v)
           kValidConfigAttrs) {
   auto portNames = parseTokens(v);
 
-  // A `profile` attribute can CREATE an absent-but-valid INTERFACE_PORT, so its
-  // names are allowed to be missing from the running config at resolution time
-  // (they are created later in queryClient). Without it, every name must
-  // already resolve.
-  const bool allowMissing = findProfileValue(getAttributes()).has_value();
+  // Two kinds of absent-but-creatable names may be missing from the running
+  // config at resolution time: a `profile` attribute can CREATE an
+  // absent-but-valid INTERFACE_PORT, and a loopback token (loopback<N>) names
+  // a virtual interface this command creates on first use. Both are created
+  // later in queryClient. Without either, every name must already resolve.
+  const bool hasProfile = findProfileValue(getAttributes()).has_value();
+  const bool allowMissing =
+      hasProfile ||
+      std::any_of(portNames.begin(), portNames.end(), [](const auto& name) {
+        return utils::parseLoopbackIndex(name).has_value();
+      });
 
   // Now resolve the port names to InterfaceList. Unless allowMissing is set,
   // this throws if any port is not found.
   interfaces_ = utils::InterfaceList(std::move(portNames), allowMissing);
+
+  // When only a loopback token justified allowMissing, every unresolved name
+  // must itself be a loopback token; anything else is reported now, the same
+  // way InterfaceList would have.
+  if (!hasProfile) {
+    std::vector<std::string> notFound;
+    for (const utils::Intf& intf : interfaces_) {
+      if (!intf.isValid() &&
+          !utils::parseLoopbackIndex(intf.name()).has_value()) {
+        notFound.push_back(intf.name());
+      }
+    }
+    if (!notFound.empty()) {
+      throw std::invalid_argument(
+          "Port(s) or interface(s) not found in configuration: " +
+          folly::join(", ", notFound) +
+          ". Only loopback interfaces (loopback0-" +
+          folly::to<std::string>(utils::kMaxLoopbackIndex) +
+          ") can be created by this command without a profile.");
+    }
+  }
 }
 
 namespace {
@@ -260,6 +292,89 @@ std::string applyProfile(
       interfaces,
       value,
       actionLevel);
+}
+
+// Creates the virtual loopback interface for `index`, plus its backing VLAN
+// when absent, following the bootstrap-config convention (see
+// utils::kLoopbackIntfIdBase): intfID == vlanID == base + index, VLAN named
+// fbossLoopback<index>, isVirtual = true. The agent requires every VLAN-type
+// interface to reference an existing VLAN and be that VLAN's only interface,
+// so a same-numbered VLAN that is already in use as a data VLAN is refused.
+// Returns the created interface's name.
+std::string createLoopbackInterface(
+    cfg::SwitchConfig& swConfig,
+    int32_t index) {
+  const int32_t id = utils::kLoopbackIntfIdBase + index;
+  const std::string name = fmt::format("loopback{}", index);
+
+  // A same-id interface exists but did not resolve as this loopback (a
+  // resolvable one never reaches creation), so it is some non-loopback
+  // interface occupying the conventional slot.
+  for (const auto& existing : *swConfig.interfaces()) {
+    if (*existing.intfID() == id) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Cannot create {}: interface ID {} is already in use by a "
+              "non-loopback interface",
+              name,
+              id));
+    }
+    if (*existing.type() == cfg::InterfaceType::VLAN &&
+        *existing.vlanID() == id) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Cannot create {}: VLAN {} already has interface {}",
+              name,
+              id,
+              *existing.intfID()));
+    }
+  }
+  for (const auto& vlanPort : *swConfig.vlanPorts()) {
+    if (*vlanPort.vlanID() == id) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Cannot create {}: VLAN {} is already in use as a data VLAN "
+              "with member ports",
+              name,
+              id));
+    }
+  }
+
+  if (VlanManager::findVlan(swConfig, VlanID(id)) == nullptr) {
+    cfg::Vlan vlan;
+    vlan.id() = id;
+    vlan.name() = utils::loopbackVlanName(index);
+    vlan.routable() = true;
+    swConfig.vlans()->push_back(vlan);
+  }
+
+  cfg::Interface intf;
+  intf.intfID() = id;
+  intf.vlanID() = id;
+  intf.routerID() = 0;
+  intf.name() = name;
+  intf.isVirtual() = true;
+  swConfig.interfaces()->push_back(intf);
+  return name;
+}
+
+// Creates every requested-but-absent loopback interface (the only interface
+// kind `config interface` can create without a `profile` attribute). Names
+// that are neither resolvable nor loopback tokens were rejected by the
+// InterfacesConfig constructor (no profile) or belong to the profile flow.
+std::vector<std::string> createMissingLoopbackInterfaces(
+    const utils::InterfaceList& interfaces) {
+  std::vector<std::string> created;
+  auto& swConfig = *ConfigSession::getInstance().getAgentConfig().sw();
+  for (const utils::Intf& intf : interfaces) {
+    if (intf.isValid()) {
+      continue;
+    }
+    if (auto index = utils::parseLoopbackIndex(intf.name())) {
+      created.push_back(createLoopbackInterface(swConfig, *index));
+    }
+  }
+  return created;
 }
 
 // Configures a port as a routed (L3) port.
@@ -610,22 +725,47 @@ CmdConfigInterfaceTraits::RetType CmdConfigInterface::queryClient(
     throw std::invalid_argument("No interface name provided");
   }
 
-  if (!interfaceConfig.hasAttributes()) {
-    throw std::runtime_error(
-        fmt::format(
-            "Incomplete command. Either provide attributes ({}) "
-            "or use a subcommand (switchport)",
-            kValidConfigAttrs));
-  }
-
   std::vector<std::string> results;
   bool changed = false;
+
+  // Requested loopback interfaces that do not exist yet are created up front,
+  // so the attribute loop below (ip-address, mtu, ...) can target them like
+  // any other interface.
+  const std::vector<std::string> createdLoopbacks =
+      createMissingLoopbackInterfaces(interfaces);
+  if (!createdLoopbacks.empty()) {
+    changed = true;
+    ConfigSession::getInstance().rebuildPortMap();
+    results.push_back(
+        fmt::format(
+            "created loopback interface(s): {}",
+            folly::join(", ", createdLoopbacks)));
+  }
+
+  if (!interfaceConfig.hasAttributes()) {
+    // A bare `config interface loopback<N>` is a complete command: it creates
+    // the interface. For everything else attributes are required.
+    if (createdLoopbacks.empty()) {
+      throw std::runtime_error(
+          fmt::format(
+              "Incomplete command. Either provide attributes ({}) "
+              "or use a subcommand (switchport)",
+              kValidConfigAttrs));
+    }
+    ConfigSession::getInstance().saveConfig(
+        cli::ServiceType::AGENT, cli::ConfigActionLevel::HITLESS);
+    return fmt::format(
+        "Successfully configured interface(s) {}: {}",
+        folly::join(", ", interfaces.getNames()),
+        folly::join(", ", results));
+  }
 
   // The `profile` attribute mutates the port set (adjusts/removes existing
   // ports and creates absent ones), so it must be applied first, over the
   // ORIGINAL interfaces (which still carry pending Intfs with getPort()==
   // nullptr). Re-resolve afterwards so the remaining attributes see valid
   // pointers for freshly-created ports and no stale pointers to removed ones.
+  // Loopback creation above re-resolves for the same reason.
   const std::optional<std::string> profileValue = findProfileValue(attributes);
 
   utils::InterfaceList resolved(std::vector<std::string>{});
@@ -640,10 +780,13 @@ CmdConfigInterfaceTraits::RetType CmdConfigInterface::queryClient(
         applyProfile(hostInfo, interfaces, *profileValue, &actionLevel));
     changed = true;
     ConfigSession::getInstance().rebuildPortMap();
+  }
+  const bool reresolve = profileValue.has_value() || !createdLoopbacks.empty();
+  if (reresolve) {
     resolved = utils::InterfaceList(interfaces.getNames());
   }
   const utils::InterfaceList& effectiveInterfaces =
-      profileValue.has_value() ? resolved : interfaces;
+      reresolve ? resolved : interfaces;
 
   for (const auto& [attr, value] : attributes) {
     if (attr == "profile") {

--- a/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
+++ b/fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h
@@ -47,7 +47,9 @@ struct CmdConfigInterfaceTraits : public WriteCommandTraits {
         "interface_config",
         args,
         "<port-list> [<attr> <value> ...] where <attr> is one "
-        "of: description, mtu, ip-address, ipv6-address, ...");
+        "of: description, mtu, ip-address, ipv6-address, ... "
+        "A loopback name (loopback0, loopback1, ...) creates the virtual "
+        "loopback interface on first use.");
   }
   using ObjectArgType = InterfacesConfig;
   using RetType = std::string;

--- a/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.cpp
+++ b/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.cpp
@@ -23,7 +23,9 @@
 #include <vector>
 
 #include "fboss/agent/gen-cpp2/switch_config_types.h"
+#include "fboss/agent/types.h"
 #include "fboss/cli/fboss2/commands/config/interface/InterfaceIpUtils.h"
+#include "fboss/cli/fboss2/commands/config/vlan/VlanManager.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/utils/InterfaceList.h"
 #include "fboss/lib/config/AgentConfigUtils.h"
@@ -55,6 +57,65 @@ const std::unordered_set<std::string> kKnownDeleteAttributes = [] {
 const std::string kValidDeleteAttrs = fmt::format(
     "loopback-mode, lookup-class, queue-config, {}, ip-address, ipv6-address",
     folly::join(", ", lldpAttrNames()));
+
+// A whole-interface delete of a loopback token (`delete interface
+// loopback<N>`) removes the virtual interface together with its backing VLAN
+// (the same-numbered VLAN `config interface loopback<N>` creates). The agent
+// requires every VLAN-type interface to reference an existing VLAN, and
+// rejects a VLAN left without an interface while it still has enabled member
+// ports, so the pair goes as a unit — through VlanManager::deleteVlan, which
+// cascades the interface and refuses when a port still names the VLAN as its
+// ingress VLAN. A VLAN with member ports is a data VLAN, not a loopback's,
+// and is refused rather than cascaded.
+//
+// Validates without mutating; returns the backing VLAN id to delete, or
+// nullopt when the interface has no backing VLAN in the config.
+std::optional<VlanID> checkLoopbackDeletable(
+    const cfg::SwitchConfig& swConfig,
+    const utils::Intf& intf) {
+  const cfg::Interface* iface = intf.getInterface();
+  if (!iface || !*iface->isVirtual() ||
+      *iface->type() != cfg::InterfaceType::VLAN) {
+    throw std::invalid_argument(
+        fmt::format("{} is not a loopback interface", intf.name()));
+  }
+  const auto vlanId = VlanID(*iface->vlanID());
+  if (VlanManager::findVlan(swConfig, vlanId) == nullptr) {
+    return std::nullopt;
+  }
+  // Mirror deleteVlan's refusals up front so a mixed port + loopback delete
+  // cannot fail after the ports are already gone.
+  if (*swConfig.defaultVlan() == *iface->vlanID()) {
+    throw std::invalid_argument(
+        fmt::format(
+            "Cannot delete {}: its VLAN {} is the global default VLAN",
+            intf.name(),
+            *iface->vlanID()));
+  }
+  for (const auto& port : *swConfig.ports()) {
+    if (*port.ingressVlan() == *iface->vlanID()) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Cannot delete {}: its VLAN {} is the ingress VLAN for port {}",
+              intf.name(),
+              *iface->vlanID(),
+              port.name().has_value() ? *port.name()
+                                      : std::to_string(*port.logicalID())));
+    }
+  }
+  for (const auto& vlanPort : *swConfig.vlanPorts()) {
+    if (*vlanPort.vlanID() == *iface->vlanID()) {
+      throw std::invalid_argument(
+          fmt::format(
+              "Cannot delete {}: its VLAN {} has member ports, so it is a "
+              "data VLAN. Delete it with 'delete vlan {}' instead",
+              intf.name(),
+              *iface->vlanID(),
+              *iface->vlanID()));
+    }
+  }
+  return vlanId;
+}
 
 } // namespace
 
@@ -103,31 +164,61 @@ CmdDeleteInterfaceTraits::RetType CmdDeleteInterface::queryClient(
     throw std::invalid_argument("No interface name provided");
   }
 
-  // No attributes => delete the whole port(s) from the config.
+  // No attributes => delete the whole port(s) / loopback interface(s) from
+  // the config.
   if (attributes.empty()) {
     auto& swConfig = *ConfigSession::getInstance().getAgentConfig().sw();
     std::set<PortID> portsToDelete;
+    std::vector<int32_t> loopbackIntfIdsToDelete;
+    std::set<VlanID> loopbackVlansToDelete;
     std::vector<std::string> deletedNames;
     for (const utils::Intf& intf : interfaces) {
-      const cfg::Port* port = intf.getPort();
-      if (!port) {
-        continue;
+      if (const cfg::Port* port = intf.getPort()) {
+        portsToDelete.insert(PortID(*port->logicalID()));
+        deletedNames.push_back(intf.name());
+      } else if (utils::parseLoopbackIndex(intf.name()).has_value()) {
+        // Every loopback is checked before anything is removed, so a refused
+        // delete leaves the config untouched.
+        if (auto vlanId = checkLoopbackDeletable(swConfig, intf)) {
+          loopbackVlansToDelete.insert(*vlanId);
+        }
+        loopbackIntfIdsToDelete.push_back(*intf.getInterface()->intfID());
+        deletedNames.push_back(intf.name());
       }
-      portsToDelete.insert(PortID(*port->logicalID()));
-      deletedNames.push_back(intf.name());
     }
-    if (portsToDelete.empty()) {
+    if (portsToDelete.empty() && loopbackIntfIdsToDelete.empty()) {
       throw std::invalid_argument(
-          "No port found for the specified interface(s)");
+          "No port or loopback interface found for the specified "
+          "interface(s)");
     }
-    utility::removePortsFromConfig(
-        swConfig,
-        portsToDelete,
-        utility::PortRemovalMode::Erase,
-        /*pruneEmptyVlansAndInterfaces=*/true);
+    if (!portsToDelete.empty()) {
+      utility::removePortsFromConfig(
+          swConfig,
+          portsToDelete,
+          utility::PortRemovalMode::Erase,
+          /*pruneEmptyVlansAndInterfaces=*/true);
+    }
+    // deleteVlan cascades the interface bound to the VLAN; the erase below
+    // covers a loopback whose backing VLAN is absent from the config.
+    for (const auto& vlanId : loopbackVlansToDelete) {
+      VlanManager::deleteVlan(swConfig, vlanId);
+    }
+    auto& intfs = *swConfig.interfaces();
+    intfs.erase(
+        std::remove_if(
+            intfs.begin(),
+            intfs.end(),
+            [&](const cfg::Interface& iface) {
+              return std::find(
+                         loopbackIntfIdsToDelete.begin(),
+                         loopbackIntfIdsToDelete.end(),
+                         *iface.intfID()) != loopbackIntfIdsToDelete.end();
+            }),
+        intfs.end());
     // Removing a port is a HITLESS change: the agent's reloadConfig() applies
     // the port-set delta live, matching how 'config interface <port> profile'
-    // adds/removes ports. No agent warmboot is needed.
+    // adds/removes ports. Removing a loopback interface and its VLAN is the
+    // same config reload 'delete vlan' relies on. No agent warmboot is needed.
     ConfigSession::getInstance().saveConfig();
     return fmt::format(
         "Deleted interface(s): {}", folly::join(", ", deletedNames));

--- a/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h
+++ b/fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h
@@ -24,6 +24,9 @@ namespace facebook::fboss {
  *
  * Usage: delete interface <port-list> [<attr> [<value>] ...]
  *
+ * With no attribute, deletes the named ports; a loopback<N> token deletes the
+ * virtual loopback interface together with its backing VLAN.
+ *
  * Valueless attributes (reset to default):
  *   loopback-mode, lookup-class, lldp-expected-value, lldp-expected-chassis,
  *   lldp-expected-ttl, lldp-expected-port-desc, lldp-expected-system-name,

--- a/fboss/cli/fboss2/test/config/BUCK
+++ b/fboss/cli/fboss2/test/config/BUCK
@@ -17,6 +17,7 @@ cpp_unittest(
         "CmdConfigHostnameTest.cpp",
         "CmdConfigIcmpV4UnavailableSrcAddrTest.cpp",
         "CmdConfigInterfaceIpv6NdpTest.cpp",
+        "CmdConfigInterfaceLoopbackTest.cpp",
         "CmdConfigInterfaceSflowSampleDestTest.cpp",
         "CmdConfigInterfaceSwitchportAccessVlanTest.cpp",
         "CmdConfigInterfaceSwitchportTrunkAllowedVlanTest.cpp",

--- a/fboss/cli/fboss2/test/config/CmdConfigInterfaceLoopbackTest.cpp
+++ b/fboss/cli/fboss2/test/config/CmdConfigInterfaceLoopbackTest.cpp
@@ -1,0 +1,374 @@
+/*
+ *  Copyright (c) 2004-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "fboss/agent/gen-cpp2/switch_config_types.h"
+#include "fboss/cli/fboss2/commands/config/interface/CmdConfigInterface.h"
+#include "fboss/cli/fboss2/commands/delete/interface/CmdDeleteInterface.h"
+#include "fboss/cli/fboss2/session/ConfigSession.h"
+#include "fboss/cli/fboss2/test/config/CmdConfigTestBase.h"
+#include "fboss/cli/fboss2/utils/InterfaceList.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+// Seed mirrors the loopback layout real devices carry:
+//  - interface intfID 10 / VLAN 10 ("fbossLoopback0"): the bootstrap-config
+//    loopback0, virtual and UNNAMED (the bootstrap config emits it without a
+//    name), so resolution must fall back to the conventional intfID;
+//  - interface intfID 11 / VLAN 11: a Meta-style loopback carrying the
+//    interface name "fbossLoopback1" and production-shaped /32 + /128 host
+//    addresses;
+//  - VLAN 12 is an ordinary data VLAN with a member port, occupying
+//    loopback2's conventional VLAN id;
+//  - interface intfID 13 is a non-loopback SVI occupying loopback3's
+//    conventional interface id.
+class CmdConfigInterfaceLoopbackTestFixture : public CmdConfigTestBase {
+ public:
+  CmdConfigInterfaceLoopbackTestFixture()
+      : CmdConfigTestBase(
+            "fboss_intf_loopback_test_%%%%-%%%%-%%%%-%%%%",
+            R"({
+  "sw": {
+    "ports": [
+      {
+        "logicalID": 1,
+        "name": "eth1/1/1",
+        "state": 2,
+        "speed": 100000
+      }
+    ],
+    "vlans": [
+      {"name": "fbossLoopback0", "id": 10, "recordStats": true, "routable": true},
+      {"name": "fbossLoopback1", "id": 11, "recordStats": true, "routable": true},
+      {"name": "Vlan12", "id": 12, "recordStats": true, "routable": false},
+      {"name": "Vlan2001", "id": 2001, "recordStats": true, "routable": true},
+      {"name": "default", "id": 4094, "recordStats": true, "routable": false}
+    ],
+    "vlanPorts": [
+      {"vlanID": 12, "logicalPort": 1}
+    ],
+    "defaultVlan": 4094,
+    "interfaces": [
+      {
+        "intfID": 10,
+        "routerID": 0,
+        "vlanID": 10,
+        "mtu": 9412,
+        "isVirtual": true
+      },
+      {
+        "intfID": 11,
+        "routerID": 0,
+        "vlanID": 11,
+        "name": "fbossLoopback1",
+        "mtu": 9000,
+        "isVirtual": true,
+        "ipAddresses": ["10.254.113.0/32", "fc00:0:0:1::/128"]
+      },
+      {
+        "intfID": 13,
+        "routerID": 0,
+        "vlanID": 2001,
+        "name": "svi2001",
+        "mtu": 9000
+      }
+    ]
+  }
+})") {}
+
+ protected:
+  const std::string cmdPrefix_ = "config interface";
+
+  static const cfg::Interface* findIntf(int32_t intfId) {
+    const auto& intfs =
+        *ConfigSession::getInstance().getAgentConfig().sw()->interfaces();
+    for (const auto& intf : intfs) {
+      if (*intf.intfID() == intfId) {
+        return &intf;
+      }
+    }
+    return nullptr;
+  }
+
+  static const cfg::Vlan* findVlan(int32_t vlanId) {
+    const auto& vlans =
+        *ConfigSession::getInstance().getAgentConfig().sw()->vlans();
+    for (const auto& vlan : vlans) {
+      if (*vlan.id() == vlanId) {
+        return &vlan;
+      }
+    }
+    return nullptr;
+  }
+};
+
+// Loopback token parsing: shape, case, and index bounds
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, parseLoopbackIndex) {
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback0"), 0);
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback99"), 99);
+  EXPECT_EQ(utils::parseLoopbackIndex("Loopback1"), 1);
+  EXPECT_EQ(utils::parseLoopbackIndex("LOOPBACK2"), 2);
+
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback"), std::nullopt);
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback100"), std::nullopt);
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback-1"), std::nullopt);
+  EXPECT_EQ(utils::parseLoopbackIndex("loopback1x"), std::nullopt);
+  EXPECT_EQ(utils::parseLoopbackIndex("xloopback1"), std::nullopt);
+  EXPECT_EQ(utils::parseLoopbackIndex("eth1/1/1"), std::nullopt);
+}
+
+// The bootstrap config's loopback0 has no interface name; the token must
+// resolve through the conventional intfID and take the address.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, addAddressToUnnamedLoopback0) {
+  setupTestableConfigSession(
+      cmdPrefix_, "loopback0 ip-address 10.254.113.1/32");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback0", "ip-address", "10.254.113.1/32"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully configured"));
+  const auto* intf = findIntf(10);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_THAT(*intf->ipAddresses(), ElementsAre("10.254.113.1/32"));
+}
+
+// A Meta-style loopback named fbossLoopback1 resolves from the loopback1
+// token; adding a v6 host address keeps the existing addresses.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, addAddressToNamedLoopback1) {
+  setupTestableConfigSession(
+      cmdPrefix_, "loopback1 ipv6-address 2401:db00:e717:100::d:0/128");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config(
+      {"loopback1", "ipv6-address", "2401:db00:e717:100::d:0/128"});
+
+  cmd.queryClient(localhost(), config);
+
+  const auto* intf = findIntf(11);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_THAT(
+      *intf->ipAddresses(),
+      UnorderedElementsAre(
+          "10.254.113.0/32",
+          "fc00:0:0:1::/128",
+          "2401:db00:e717:100::d:0/128"));
+}
+
+// Re-applying an already-configured address is a clean no-op (no duplicate)
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, reapplyAddressIsIdempotent) {
+  setupTestableConfigSession(
+      cmdPrefix_, "loopback1 ip-address 10.254.113.0/32");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback1", "ip-address", "10.254.113.0/32"});
+
+  cmd.queryClient(localhost(), config);
+
+  const auto* intf = findIntf(11);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_THAT(
+      *intf->ipAddresses(),
+      UnorderedElementsAre("10.254.113.0/32", "fc00:0:0:1::/128"));
+}
+
+// A missing loopback is created on first use: virtual interface plus backing
+// VLAN at the conventional ids, and the requested address applied.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, createsMissingLoopback) {
+  setupTestableConfigSession(
+      cmdPrefix_,
+      "loopback5 ip-address 10.254.113.5/32 ipv6-address fc00:0:0:5::/128");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config(
+      {"loopback5",
+       "ip-address",
+       "10.254.113.5/32",
+       "ipv6-address",
+       "fc00:0:0:5::/128"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("created loopback interface(s): loopback5"));
+
+  const auto* intf = findIntf(15);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_EQ(*intf->vlanID(), 15);
+  EXPECT_TRUE(*intf->isVirtual());
+  EXPECT_EQ(intf->name().value_or(""), "loopback5");
+  EXPECT_EQ(*intf->routerID(), 0);
+  EXPECT_THAT(
+      *intf->ipAddresses(),
+      UnorderedElementsAre("10.254.113.5/32", "fc00:0:0:5::/128"));
+
+  const auto* vlan = findVlan(15);
+  ASSERT_NE(vlan, nullptr);
+  EXPECT_EQ(*vlan->name(), "fbossLoopback5");
+  EXPECT_TRUE(*vlan->routable());
+}
+
+// A bare `config interface loopback<N>` (no attributes) creates the interface
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, bareCreateLoopback) {
+  setupTestableConfigSession(cmdPrefix_, "loopback6");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback6"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("created loopback interface(s): loopback6"));
+  const auto* intf = findIntf(16);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_TRUE(*intf->isVirtual());
+  ASSERT_NE(findVlan(16), nullptr);
+}
+
+// A bare command on an EXISTING loopback still needs attributes
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, bareExistingLoopbackThrows) {
+  setupTestableConfigSession(cmdPrefix_, "loopback0");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback0"});
+
+  EXPECT_THROW(cmd.queryClient(localhost(), config), std::runtime_error);
+}
+
+// The conventional interface id is occupied by a non-loopback interface
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, intfIdCollisionThrows) {
+  setupTestableConfigSession(cmdPrefix_, "loopback3 ip-address 10.0.3.1/32");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback3", "ip-address", "10.0.3.1/32"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("already in use"));
+  }
+}
+
+// The conventional VLAN id is occupied by a data VLAN with member ports
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, dataVlanCollisionThrows) {
+  setupTestableConfigSession(cmdPrefix_, "loopback2 ip-address 10.0.2.1/32");
+  auto cmd = CmdConfigInterface();
+  InterfacesConfig config({"loopback2", "ip-address", "10.0.2.1/32"});
+
+  try {
+    cmd.queryClient(localhost(), config);
+    FAIL() << "expected std::invalid_argument";
+  } catch (const std::invalid_argument& e) {
+    EXPECT_THAT(e.what(), HasSubstr("data VLAN"));
+  }
+}
+
+// Tokens above the loopback index bound are ordinary unknown names
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, outOfRangeIndexNotFound) {
+  setupTestableConfigSession(cmdPrefix_, "loopback100 ip-address 10.0.0.1/32");
+  EXPECT_THROW(
+      InterfacesConfig({"loopback100", "ip-address", "10.0.0.1/32"}),
+      std::invalid_argument);
+}
+
+// A non-loopback unknown name mixed with a loopback token is still rejected
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, mixedUnknownNameStillThrows) {
+  setupTestableConfigSession(
+      cmdPrefix_, "loopback7 eth9/9/9 ip-address 10.0.0.1/32");
+  EXPECT_THROW(
+      InterfacesConfig({"loopback7", "eth9/9/9", "ip-address", "10.0.0.1/32"}),
+      std::invalid_argument);
+}
+
+// The shared resolution also serves `delete interface`: removing one address
+// from a loopback leaves the others in place.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deleteAddressFromLoopback) {
+  setupTestableConfigSession(
+      "delete interface", "loopback1 ip-address 10.254.113.0/32");
+  auto cmd = CmdDeleteInterface();
+  InterfaceDeleteConfig config({"loopback1", "ip-address", "10.254.113.0/32"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Successfully removed"));
+  const auto* intf = findIntf(11);
+  ASSERT_NE(intf, nullptr);
+  EXPECT_THAT(*intf->ipAddresses(), ElementsAre("fc00:0:0:1::/128"));
+}
+
+// `delete interface loopback<N>` removes the named loopback and its backing
+// VLAN as a unit.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deleteNamedLoopback) {
+  setupTestableConfigSession("delete interface", "loopback1");
+  auto cmd = CmdDeleteInterface();
+  InterfaceDeleteConfig config({"loopback1"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Deleted interface(s): loopback1"));
+  EXPECT_EQ(findIntf(11), nullptr);
+  EXPECT_EQ(findVlan(11), nullptr);
+  // Unrelated objects are untouched.
+  EXPECT_NE(findIntf(10), nullptr);
+  EXPECT_NE(findVlan(10), nullptr);
+  EXPECT_NE(findIntf(13), nullptr);
+}
+
+// The unnamed bootstrap loopback0 resolves by conventional intfID and deletes
+// the same way.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deleteUnnamedLoopback0) {
+  setupTestableConfigSession("delete interface", "loopback0");
+  auto cmd = CmdDeleteInterface();
+  InterfaceDeleteConfig config({"loopback0"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("Deleted interface(s): loopback0"));
+  EXPECT_EQ(findIntf(10), nullptr);
+  EXPECT_EQ(findVlan(10), nullptr);
+}
+
+// Ports and loopbacks can be deleted in one command.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deletePortAndLoopbackTogether) {
+  setupTestableConfigSession("delete interface", "eth1/1/1 loopback1");
+  auto cmd = CmdDeleteInterface();
+  InterfaceDeleteConfig config({"eth1/1/1", "loopback1"});
+
+  auto result = cmd.queryClient(localhost(), config);
+
+  EXPECT_THAT(result, HasSubstr("eth1/1/1"));
+  EXPECT_THAT(result, HasSubstr("loopback1"));
+  EXPECT_TRUE(
+      ConfigSession::getInstance().getAgentConfig().sw()->ports()->empty());
+  EXPECT_EQ(findIntf(11), nullptr);
+  EXPECT_EQ(findVlan(11), nullptr);
+}
+
+// A loopback that does not exist is an ordinary unknown interface.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deleteMissingLoopbackThrows) {
+  setupTestableConfigSession("delete interface", "loopback5");
+  EXPECT_THROW(InterfaceDeleteConfig({"loopback5"}), std::invalid_argument);
+  EXPECT_NE(findIntf(10), nullptr);
+}
+
+// Whole-loopback delete is a config reload (HITLESS), like 'delete vlan'.
+TEST_F(CmdConfigInterfaceLoopbackTestFixture, deleteLoopbackIsHitless) {
+  setupTestableConfigSession("delete interface", "loopback1");
+  auto cmd = CmdDeleteInterface();
+  InterfaceDeleteConfig config({"loopback1"});
+  cmd.queryClient(localhost(), config);
+  EXPECT_EQ(
+      ConfigSession::getInstance().getRequiredAction(cli::ServiceType::AGENT),
+      cli::ConfigActionLevel::HITLESS);
+}
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/integration_test/BUCK
+++ b/fboss/cli/fboss2/test/integration_test/BUCK
@@ -37,6 +37,7 @@ cpp_binary(
         "ConfigIpRouteTest.cpp",
         "ConfigL2LearningModeTest.cpp",
         "ConfigLoadBalancingTest.cpp",
+        "ConfigLoopbackInterfaceTest.cpp",
         "ConfigMacTest.cpp",
         "ConfigPfcTest.cpp",
         "ConfigPortQueueConfigTest.cpp",

--- a/fboss/cli/fboss2/test/integration_test/ConfigLoopbackInterfaceTest.cpp
+++ b/fboss/cli/fboss2/test/integration_test/ConfigLoopbackInterfaceTest.cpp
@@ -1,0 +1,177 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+/**
+ * End-to-end test for loopback interface addressing:
+ *   fboss2-dev config interface loopback<N> [ip-address <A.B.C.D/32>]
+ *                                           [ipv6-address <A:B::C/128>]
+ *   fboss2-dev delete interface loopback<N> ip-address/ipv6-address <addr>
+ *   fboss2-dev delete interface loopback<N>
+ *
+ * Loopbacks follow the bootstrap-config convention: the virtual interface at
+ * intfID == vlanID == 10 + N, backed by the same-numbered VLAN
+ * ("fbossLoopback<N>"). The bootstrap config ships loopback0 (usually
+ * unnamed); other indices are created by the CLI on first use.
+ */
+
+#include <folly/json/dynamic.h>
+#include <folly/logging/xlog.h>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include "fboss/cli/fboss2/test/integration_test/Fboss2IntegrationTest.h"
+
+using namespace facebook::fboss;
+
+namespace {
+// Test-owned host addresses, shaped like the production loopback addressing
+// (IPv4 /32 + IPv6 /128 host routes). Stable across runs so a re-run after a
+// crash converges instead of leaking new state.
+constexpr auto kV4Addr = "10.254.113.31/32";
+constexpr auto kV6Addr = "fc00:0:0:31::/128";
+// Index 9 (intfID/vlanID 19) is not shipped by any bootstrap config, so this
+// exercises CLI-side creation.
+constexpr auto kCreatedLoopback = "loopback9";
+constexpr int kCreatedIntfId = 19;
+
+const folly::dynamic* findInterfaceById(const folly::dynamic& sw, int intfId) {
+  if (!sw.count("interfaces")) {
+    return nullptr;
+  }
+  for (const auto& intf : sw["interfaces"]) {
+    if (intf.isObject() && intf.count("intfID") &&
+        intf["intfID"].asInt() == intfId) {
+      return &intf;
+    }
+  }
+  return nullptr;
+}
+
+bool hasAddress(const folly::dynamic& intf, const std::string& addr) {
+  if (!intf.count("ipAddresses")) {
+    return false;
+  }
+  for (const auto& a : intf["ipAddresses"]) {
+    if (a.asString() == addr) {
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
+class ConfigLoopbackInterfaceTest : public Fboss2IntegrationTest {};
+
+// Add v4 + v6 host addresses to the bootstrap loopback0, verify they land on
+// the virtual interface, then remove them again — restoring the DUT exactly.
+TEST_F(ConfigLoopbackInterfaceTest, AddressRoundTripOnLoopback0) {
+  XLOG(INFO) << "[Step 1] Adding addresses to loopback0...";
+  auto add = runCli(
+      {"config",
+       "interface",
+       "loopback0",
+       "ip-address",
+       kV4Addr,
+       "ipv6-address",
+       kV6Addr});
+  ASSERT_EQ(add.exitCode, 0) << add.stderr;
+  commitConfig();
+  waitForAgentReady();
+
+  XLOG(INFO) << "[Step 2] Verifying addresses in running config...";
+  {
+    auto config = getRunningConfig();
+    const auto& sw = config["sw"];
+    // The bootstrap loopback0 lives at the conventional intfID 10.
+    const auto* intf = findInterfaceById(sw, 10);
+    ASSERT_NE(intf, nullptr) << "no loopback0 interface (intfID 10)";
+    EXPECT_TRUE((*intf)["isVirtual"].asBool());
+    EXPECT_TRUE(hasAddress(*intf, kV4Addr)) << kV4Addr << " missing";
+    EXPECT_TRUE(hasAddress(*intf, kV6Addr)) << kV6Addr << " missing";
+  }
+
+  XLOG(INFO) << "[Step 3] Removing the addresses again...";
+  discardSession();
+  ASSERT_EQ(
+      runCli({"delete", "interface", "loopback0", "ip-address", kV4Addr})
+          .exitCode,
+      0);
+  ASSERT_EQ(
+      runCli({"delete", "interface", "loopback0", "ipv6-address", kV6Addr})
+          .exitCode,
+      0);
+  commitConfig();
+  waitForAgentReady();
+
+  XLOG(INFO) << "[Step 4] Verifying restore...";
+  {
+    auto config = getRunningConfig();
+    const auto* intf = findInterfaceById(config["sw"], 10);
+    ASSERT_NE(intf, nullptr);
+    EXPECT_FALSE(hasAddress(*intf, kV4Addr)) << kV4Addr << " not removed";
+    EXPECT_FALSE(hasAddress(*intf, kV6Addr)) << kV6Addr << " not removed";
+  }
+  XLOG(INFO) << "TEST PASSED";
+}
+
+// Create a loopback that no bootstrap config ships, address it, verify the
+// interface + backing VLAN shape, then delete the whole loopback and verify
+// both are gone — restoring the DUT exactly. A stable index is used so a
+// re-run after a crash converges (creation tolerates the interface already
+// existing from an aborted prior run).
+TEST_F(ConfigLoopbackInterfaceTest, CreateLoopbackWithAddresses) {
+  XLOG(INFO) << "[Step 1] Creating " << kCreatedLoopback << " with addresses";
+  auto create = runCli(
+      {"config",
+       "interface",
+       kCreatedLoopback,
+       "ip-address",
+       kV4Addr,
+       "ipv6-address",
+       kV6Addr});
+  ASSERT_EQ(create.exitCode, 0) << create.stderr;
+  commitConfig();
+  waitForAgentReady();
+
+  XLOG(INFO) << "[Step 2] Verifying interface and VLAN shape...";
+  {
+    auto config = getRunningConfig();
+    const auto& sw = config["sw"];
+    const auto* intf = findInterfaceById(sw, kCreatedIntfId);
+    ASSERT_NE(intf, nullptr)
+        << kCreatedLoopback << " (intfID " << kCreatedIntfId << ") missing";
+    EXPECT_TRUE((*intf)["isVirtual"].asBool());
+    EXPECT_EQ((*intf)["vlanID"].asInt(), kCreatedIntfId);
+    EXPECT_TRUE(hasAddress(*intf, kV4Addr));
+    EXPECT_TRUE(hasAddress(*intf, kV6Addr));
+
+    bool sawVlan = false;
+    for (const auto& vlan : sw["vlans"]) {
+      if (vlan["id"].asInt() == kCreatedIntfId) {
+        sawVlan = true;
+        EXPECT_TRUE(vlan["routable"].asBool());
+        break;
+      }
+    }
+    EXPECT_TRUE(sawVlan) << "backing VLAN " << kCreatedIntfId << " missing";
+  }
+
+  XLOG(INFO) << "[Step 3] Deleting " << kCreatedLoopback << "...";
+  discardSession();
+  auto del = runCli({"delete", "interface", kCreatedLoopback});
+  ASSERT_EQ(del.exitCode, 0) << del.stderr;
+  commitConfig();
+  waitForAgentReady();
+
+  XLOG(INFO) << "[Step 4] Verifying interface and VLAN are gone...";
+  {
+    auto config = getRunningConfig();
+    const auto& sw = config["sw"];
+    EXPECT_EQ(findInterfaceById(sw, kCreatedIntfId), nullptr)
+        << kCreatedLoopback << " still present";
+    for (const auto& vlan : sw["vlans"]) {
+      EXPECT_NE(vlan["id"].asInt(), kCreatedIntfId)
+          << "backing VLAN " << kCreatedIntfId << " still present";
+    }
+  }
+  XLOG(INFO) << "TEST PASSED";
+}

--- a/fboss/cli/fboss2/utils/InterfaceList.cpp
+++ b/fboss/cli/fboss2/utils/InterfaceList.cpp
@@ -9,17 +9,72 @@
  */
 
 #include "fboss/cli/fboss2/utils/InterfaceList.h"
+#include <fmt/format.h>
 #include <folly/Conv.h>
 #include <folly/String.h>
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 #include "fboss/agent/gen-cpp2/switch_config_types.h"
+#include "fboss/agent/types.h"
 #include "fboss/cli/fboss2/session/ConfigSession.h"
 #include "fboss/cli/fboss2/utils/PortMap.h"
 
 namespace facebook::fboss::utils {
+
+namespace {
+
+constexpr std::string_view kLoopbackPrefix = "loopback";
+
+// Resolves a loopback token against the conventional layout: an interface
+// named "fbossLoopback<N>" (Meta-style configs), else the virtual interface
+// at intfID kLoopbackIntfIdBase + N (bootstrap configs leave it unnamed).
+// The literal name "loopback<N>" is covered by the caller's ordinary
+// name lookup before this runs.
+cfg::Interface* findLoopbackInterface(const PortMap& portMap, int32_t index) {
+  if (cfg::Interface* named =
+          portMap.getInterfaceByName(loopbackVlanName(index))) {
+    return named;
+  }
+  cfg::Interface* byId =
+      portMap.getInterface(InterfaceID(kLoopbackIntfIdBase + index));
+  if (byId != nullptr && *byId->isVirtual()) {
+    return byId;
+  }
+  return nullptr;
+}
+
+} // namespace
+
+std::optional<int32_t> parseLoopbackIndex(const std::string& name) {
+  if (name.size() <= kLoopbackPrefix.size() ||
+      name.size() > kLoopbackPrefix.size() + 2) {
+    return std::nullopt;
+  }
+  for (size_t i = 0; i < kLoopbackPrefix.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(name[i])) !=
+        kLoopbackPrefix[i]) {
+      return std::nullopt;
+    }
+  }
+  const std::string digits = name.substr(kLoopbackPrefix.size());
+  auto parsed = folly::tryTo<int32_t>(digits);
+  if (!parsed.hasValue() || parsed.value() < 0 ||
+      parsed.value() > kMaxLoopbackIndex) {
+    return std::nullopt;
+  }
+  return parsed.value();
+}
+
+std::string loopbackVlanName(int32_t index) {
+  return fmt::format("fbossLoopback{}", index);
+}
 
 InterfaceList::InterfaceList(std::vector<std::string> names, bool allowMissing)
     : names_(std::move(names)) {
@@ -46,13 +101,19 @@ InterfaceList::InterfaceList(std::vector<std::string> names, bool allowMissing)
       }
     } else {
       // If not found as a port, try as an interface name, then as an
-      // interface ID.
+      // interface ID, then as a loopback token against the conventional
+      // loopback layout.
       cfg::Interface* interface = portMap.getInterfaceByName(name);
       if (!interface) {
         // A purely-numeric name may be an interface ID.
         auto parsedInterfaceId = folly::tryTo<int32_t>(name);
         if (parsedInterfaceId.hasValue() && *parsedInterfaceId >= 0) {
           interface = portMap.getInterface(InterfaceID(*parsedInterfaceId));
+        }
+      }
+      if (!interface) {
+        if (auto loopbackIndex = parseLoopbackIndex(name)) {
+          interface = findLoopbackInterface(portMap, *loopbackIndex);
         }
       }
       if (interface) {

--- a/fboss/cli/fboss2/utils/InterfaceList.h
+++ b/fboss/cli/fboss2/utils/InterfaceList.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -17,6 +18,26 @@
 #include "fboss/cli/fboss2/utils/CmdUtilsCommon.h"
 
 namespace facebook::fboss::utils {
+
+/*
+ * Loopback interfaces follow the deployment convention: loopback<N> is the
+ * virtual (isVirtual) interface with intfID == kLoopbackIntfIdBase + N, backed
+ * by the same-numbered VLAN (named fbossLoopback<N>). The bootstrap config
+ * ships loopback0 this way, typically without an interface name, so resolution
+ * by token falls back to the conventional intfID when no name matches.
+ */
+inline constexpr int32_t kLoopbackIntfIdBase = 10;
+inline constexpr int32_t kMaxLoopbackIndex = 99;
+
+// Parses a loopback interface token ("loopback<N>", case-insensitive) into
+// its index N. Returns nullopt for anything else, including an index above
+// kMaxLoopbackIndex -- such a token is treated as an ordinary (unknown)
+// interface name rather than a loopback.
+std::optional<int32_t> parseLoopbackIndex(const std::string& name);
+
+// The conventional name for loopback <index>'s backing VLAN (and the
+// interface name Meta-style configs carry), e.g. "fbossLoopback0".
+std::string loopbackVlanName(int32_t index);
 
 /*
  * Intf represents a unified interface/port object that can contain


### PR DESCRIPTION
# Summary

Adds loopback interface support to the existing `config interface` / `delete interface` families, reusing the `config interface <name> ip-address <A.B.C.D/N>` syntax. Loopbacks follow the deployment convention: `loopback<N>` is the virtual (`isVirtual=true`) interface at `intfID == vlanID == 10 + N`, backed by the same-numbered routable VLAN named `fbossLoopback<N>`.

- **Resolution** (shared by config and delete): a `loopback<N>` token now resolves in `InterfaceList` — by literal interface name, by the conventional `fbossLoopback<N>` name (Meta-style configs), or by the conventional intfID with `isVirtual` set (the bootstrap loopback0 ships unnamed).
- **Creation**: `config interface loopback<N> ...` creates the virtual interface plus its backing VLAN when absent, then applies the requested attributes; a bare `config interface loopback<N>` just creates it. Occupied conventional ids — a non-loopback interface at `intfID 10+N`, a same-numbered VLAN owned by another interface, or a data VLAN with member ports — are refused with specific errors, since the agent requires every VLAN-type interface to reference an existing VLAN and be its only interface.
- **Addressing**: `ip-address` / `ipv6-address` add and delete work on loopbacks through the existing attribute paths once the token resolves; multiple mixed v4/v6 host addresses per loopback are supported, and re-applying an address is a clean no-op.
- **Deletion**: a bare `delete interface loopback<N>` removes the virtual interface together with its backing VLAN (via `VlanManager::deleteVlan`, so the pair goes as a unit). Refused, with the config untouched, when the VLAN has member ports, is the default VLAN, or is a port's ingress VLAN — those are data VLANs and belong to `delete vlan`. Ports and loopbacks may be mixed in one command.
- Everything commits **HITLESS** (config reload, no agent restart), matching the rest of the `config interface` family.

# Test Plan

Unit tests (new `CmdConfigInterfaceLoopbackTest.cpp`, seed mirroring the deployed loopback layout plus a Meta-style named loopback with production-shaped /32 + /128 addresses):

```
$ cmd_config_test
[==========] 893 tests from 77 test suites ran.
[  PASSED  ] 893 tests.
```

Integration tests (new `ConfigLoopbackInterfaceTest`), run on a lab:

```
[ RUN      ] ConfigLoopbackInterfaceTest.AddressRoundTripOnLoopback0
[       OK ] ConfigLoopbackInterfaceTest.AddressRoundTripOnLoopback0 (248 ms)
[ RUN      ] ConfigLoopbackInterfaceTest.CreateLoopbackWithAddresses
[       OK ] ConfigLoopbackInterfaceTest.CreateLoopbackWithAddresses (174 ms)
[  PASSED  ] 2 tests.
```

Sample usage on the same device (bootstrap loopback0 is unnamed, intfID 10):

```
$ fboss2-dev config interface loopback0 ip-address 10.254.113.31/32 ipv6-address fc00:0:0:31::/128
Successfully configured interface(s) loopback0: ip-address=10.254.113.31/32, ipv6-address=fc00:0:0:31::/128
$ fboss2-dev config session diff
       {
         "intfID": 10,
-        "ipAddresses": [],
+        "ipAddresses": [
+          "10.254.113.31/32",
+          "fc00:0:0:31::/128"
+        ],
         "isStateSyncDisabled": false,
         "isVirtual": true,
$ fboss2-dev config session commit
Config session committed successfully as 17ea3d8 and config reloaded for fboss_sw_agent.
$ fboss2-dev show config running agent | jq '.sw.interfaces[] | select(.intfID==10 or .intfID==19) | {intfID, vlanID, isVirtual, name, ipAddresses}'
{
  "intfID": 10, "vlanID": 10, "isVirtual": true, "name": null,
  "ipAddresses": [ "10.254.113.31/32", "fc00:0:0:31::/128" ]
}
{
  "intfID": 19, "vlanID": 19, "isVirtual": true, "name": "loopback9",
  "ipAddresses": []
}
$ fboss2-dev delete interface loopback0 ip-address 10.254.113.31/32
Successfully removed IP address 10.254.113.31/32 from interface(s): loopback0
$ fboss2-dev delete interface loopback0 ipv6-address fc00:0:0:31::/128
Successfully removed IPv6 address fc00:0:0:31::/128 from interface(s): loopback0
$ fboss2-dev config session commit
Config session committed successfully as 42eadaf and config reloaded for fboss_sw_agent.
```

(`loopback9` above was created by the CLI via `config interface loopback9 ip-address ...` in the integration run — interface + backing VLAN created at the conventional ids, committed hitlessly; the test then removes it with `delete interface loopback9` and verifies both the interface and VLAN 19 are gone from the running config.)

## Review Findings

Pre-publication automated review (7 reviewer passes; no blocking correctness defects found on the tested paths). Known concerns listed for reviewer attention:

| File:Line | Severity | Issue |
|-----------|----------|-------|
| `CmdConfigInterface.cpp:343` | Medium | A pre-existing same-id VLAN with no ports/interface is adopted as the loopback's backing VLAN as-is (name/`routable` not fixed up to the `fbossLoopback<N>`/`routable=true` convention). |
| `CmdConfigInterface.cpp:317` | Low | Duplicate tokens for one index in a single command (`loopback5 Loopback5`) yield a misleading "already in use by a non-loopback interface" error; nothing is saved. |
| `CmdConfigInterface.cpp:731` | Low | Loopback creation mutates the in-memory session config before later attribute validation (e.g. bad `mtu`, `profile` on a loopback) can throw; on-disk config is untouched since `saveConfig` is skipped. |
| `CmdConfigInterface.cpp:750` | Low | Bare `config interface loopback<N>` on an already-existing loopback throws "Incomplete command" rather than being an idempotent no-op. |
| `InterfaceList.cpp:42` | Low | Name-based `fbossLoopback<N>` resolution does not check `isVirtual`, unlike the intfID fallback. |


