### PR TITLE
[Celestica] Leh800bcls: Fix SystemScaleMemoryBenchmark for Multi-NPU Split Agent setup

### DIFF
--- a/fboss/agent/test/utils/SystemScaleTestUtils.cpp
+++ b/fboss/agent/test/utils/SystemScaleTestUtils.cpp
@@ -314,7 +314,7 @@ void syncFib(
 void configureMaxRouteEntries(
     AgentEnsemble* ensemble,
     const RouteDistributionGenerator& routeGenerator) {
-  auto switchIds = ensemble->getHwAsicTable()->getSwitchIDs();
+  std::set<SwitchID> switchIds = {SwitchID(FLAGS_switch_id_for_testing)};
   CHECK_EQ(switchIds.size(), 1);
   auto asic = checkSameAndGetAsic(
       ensemble->getHwAsicTable()->getL3Asics(), FLAGS_switch_id_for_testing);
@@ -510,7 +510,12 @@ cfg::SwitchConfig getSystemScaleTestSwitchConfiguration(
       asic,
       ensemble.masterLogicalPortIds(),
       ensemble.getSw()->getPlatformSupportsAddRemovePort(),
-      asic->desiredLoopbackModes());
+      asic->desiredLoopbackModes(),
+      true, /* interfaceHasSubnet */
+      kBaseVlanId, /* baseVlanId */
+      true, /* optimizePortProfile */
+      true, /* setInterfaceMac */
+      ensemble.getSw()->getPlatformType());
 
   utility::setupDefaultAclTableGroups(config);
   // We don't want to set queue rate that limits the number of rx pkts
@@ -576,7 +581,10 @@ std::pair<uint64_t, uint64_t> startRxMeasure(AgentEnsemble* ensemble) {
   constexpr uint8_t kCpuQueue = 0;
   std::map<int, CpuPortStats> cpuStatsBefore;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsBefore);
-  auto statsBefore = cpuStatsBefore[0];
+  auto switchIndex =
+      ensemble->getSw()->getSwitchInfoTable().getSwitchIndexFromSwitchId(
+          SwitchID(FLAGS_switch_id_for_testing));
+  auto statsBefore = cpuStatsBefore.at(switchIndex);
   auto [pktsBefore, bytesBefore] = utility::getCpuQueueOutPacketsAndBytes(
       *statsBefore.portStats_(), kCpuQueue);
 
@@ -600,7 +608,9 @@ std::pair<uint64_t, uint64_t> startRxMeasure(AgentEnsemble* ensemble) {
         folly::IPAddressV6(kRxMeasureDstIp),
         47231,
         kBgpPort);
-    ensemble->getSw()->sendPacketSwitchedAsync(std::move(txPacket));
+    ensemble->getSw()->sendPacketSwitchedAsync(
+        std::move(txPacket),
+        LocalSwitchIDs{SwitchID(FLAGS_switch_id_for_testing)});
   }
   return std::make_pair(pktsBefore, bytesBefore);
 }
@@ -613,7 +623,10 @@ std::pair<uint64_t, uint64_t> stopRxMeasure(AgentEnsemble* ensemble) {
   constexpr uint8_t kCpuQueue = 0;
   std::map<int, CpuPortStats> cpuStatsAfter;
   ensemble->getSw()->getAllCpuPortStats(cpuStatsAfter);
-  auto statsAfter = cpuStatsAfter[0];
+  auto switchIndex =
+      ensemble->getSw()->getSwitchInfoTable().getSwitchIndexFromSwitchId(
+          SwitchID(FLAGS_switch_id_for_testing));
+  auto statsAfter = cpuStatsAfter.at(switchIndex);
   auto [pktsAfter, bytesAfter] = utility::getCpuQueueOutPacketsAndBytes(
       *statsAfter.portStats_(), kCpuQueue);
   return std::make_pair(pktsAfter, bytesAfter);


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
[INFO] Stashing unstaged files to /work/home/gangtao/.cache/pre-commit/patch1787818530-1565282.
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```
# Summary
In multi-NPU (or Split Agent) environments such as the dual-Tomahawk6 platforms (`ladakh800bcls` and `leh800bcls`), running system-scale performance benchmarks like `SystemScaleMemoryBenchmark` fails during the initialization or packet-measure phase. 
The sai_multi_switch_all_benchmarks-sai_impl process will report timeout, whereas fboss_hw_agent-sai_impl will report the following error:
```
fboss_hw_agent_oss0.log:Jul 27 11:10:18 localhost.localdomain fboss_hw_agent_oss@0[88291]: Error: counter_get() failed(Invalid unit).
```
# Root Cause
SystemScaleTestUtils.cpp was originally designed under a single-switch topology assumption, relying on global switch list fetchers and hardcoded index 0 for CPU ports and packet routing. Furthermore, getSystemScaleTestSwitchConfiguration omitted platformType, falling back to std::nullopt. Consequently, this generates an incorrect agent.conf, triggering low-level SDK failures such as counter_get() failed(Invalid unit).

# Solution
- Pass PlatformType Explicitly: Correctly pass ensemble.getSw()->getPlatformType() to oneL3IntfNPortConfig inside getSystemScaleTestSwitchConfiguration. This ensures the config generator constructs proper, platform-specific port profiles matching Tomahawk6 NPUs, resolving low-level SDK "Invalid unit" errors.

- Constrain Route Scale Check: Changed getSwitchIDs() inside configureMaxRouteEntries to {SwitchID(FLAGS_switch_id_for_testing)}. This guarantees the switch set size under test is always 1, safely preserving the single-switch checkpoint assertion across any multi-NPU topologies.

- Isolate CPU Stats Collection via Switch Index: Resolve the correct local switch index from the logical Switch ID using getSwitchIndexFromSwitchId(), and safely query the CPU stats map (cpuStatsBefore/cpuStatsAfter) using .at(switchIndex.

- Targeted Packet Routing: Route injected loopback packets specifically to the target ASIC by explicitly passing the SwitchID to the async sender: getSw()->sendPacketSwitchedAsync(std::move(txPacket), LocalSwitchIDs{SwitchID(FLAGS_switch_id_for_testing)}).

# Test Plan
SystemScaleMemoryBenchmark  passed on both NPU0 and NPU1
- NPU0 
```
[root@localhost log]# tail -n 20 BenchmarkTest_Npu0_SystemScaleMemoryBenchmark-20260803_075905/sai_multi_switch_all_benchmarks-sai_impl_SystemScaleMemoryBenchmark_20260802_064332.log 
================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
SystemScaleMemoryBenchmark: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x
[root@localhost log]#

```
- NPU1
```
================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
SystemScaleMemoryBenchmark: OK [NO_THRESHOLD]
================================================================================

Total: 1 benchmarks
OK: 1
Failed: 0
Timed Out: 0
Skipped (known bad, pre-filtered): 0
Threshold: 0 pass, 0 exceeded, 1 not configured
Cleaning up FBOSS HW Agent Service for index=0...
Cleaning up FBOSS HW Agent Service for index=1...
++ set +x
```