### PR TITLE
[Celestica] Leh800bcls: fixup HwInitAndExit*Benchmark tests crash issue

### DIFF
--- a/fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp
+++ b/fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp
@@ -176,7 +176,13 @@ void initAndExitBenchmarkHelper(
               ensemble.getSw()->getPlatformMapping(),
               asic,
               ensemble.masterLogicalPortIds(),
-              ensemble.getSw()->getPlatformSupportsAddRemovePort());
+              ensemble.getSw()->getPlatformSupportsAddRemovePort(),
+              utility::kDefaultLoopbackMap(),
+              true,
+              utility::kBaseVlanId,
+              true,
+              true,
+              ensemble.getSw()->getPlatformType());
         }
         /*
          * Based on the uplink/downlink speed, use the ConfigFactory to create


### PR DESCRIPTION
**Pre-submission checklist**
- [√] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [√] `pre-commit run`
[INFO] Stashing unstaged files to /root/.cache/pre-commit/patch1787907207-3603478.
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.............................(no files to check)Skipped
fix end of files.....................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts............................(no files to check)Skipped
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
[INFO] Restored changes from /root/.cache/pre-commit/patch1787907207-3603478.


# Summary
During benchmark testing on Broadcom Tomahawk6 (TH6) multi_switch platforms (e.g., Leh800bcls), the HwInitAndExit*Benchmark tests failed with following crash info
[stderr] E20260804 11:39:27.430743 1647755 ExceptionTracer.cpp:263] exception stack complete
[stderr] terminate called after throwing an instance of 'facebook::fboss::FbossError' [stderr] what(): HwAsic not found for SwitchID: 0
[stderr] *** Aborted at 1785857967 (Unix time, try 'date -d @1785857967') *** [stderr] *** Signal 6 (SIGABRT) (0x19248b) received by PID 1647755 (pthread TID 0x7f34707cf5c0) (linux TID 1647755) (maybe from PID 1647755, UID 0) (code: sent by tkill or tgkill), stack trace: *** [stderr] @ 00000000002ce450 _ZN5folly10symbolizer12_GLOBAL__N_113signalHandlerEiP9siginfo_tPv
[stderr]

# Root Cause
In initAndExitBenchmarkHelper(), when calling utility::oneL3IntfNPortConfig, the platformType parameter is missing. This results in the system generating an incorrect configuration.

# Solution
Modified initAndExitBenchmarkHelper() in /fboss/agent/hw/benchmarks/HwInitAndExitBenchmarkHelper.cpp to pass the ensemble.getSw()->getPlatformType() platformType parameter, ensuring the correct configuration is generated for multi-switch platforms.

# Test Plan
The benchmark test case HwInitAndExit*Benchmark passed on both NPU0 and NPU1.

NPU0
```
================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
HwInitAndExit40Gx10GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx10GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx25GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx50GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx100GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit400Gx400GBenchmark: OK [NO_THRESHOLD]
================================================================================
```
```
benchmark_binary_name,benchmark_test_name,benchmark_time_ps,test_status,cpu_time_usec,max_rss,cpu_rx_pps,cpu_tx_pps,threshold_status,threshold_details
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit40Gx10GBenchmark,39489509251000,OK,6798892,778252,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx10GBenchmark,39491698821000,OK,6839697,809488,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx25GBenchmark,39895852995000,OK,6857566,783160,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx50GBenchmark,39729223025000,OK,6907140,784444,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx100GBenchmark,39749439922000,OK,6729907,779128,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit400Gx400GBenchmark,39642966280000,OK,6736316,803104,,,NO_THRESHOLD,
```

NPU1
```
================================================================================
BENCHMARK RESULTS SUMMARY
================================================================================
HwInitAndExit40Gx10GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx10GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx25GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx50GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit100Gx100GBenchmark: OK [NO_THRESHOLD]
HwInitAndExit400Gx400GBenchmark: OK [NO_THRESHOLD]
================================================================================
```
```
benchmark_binary_name,benchmark_test_name,benchmark_time_ps,test_status,cpu_time_usec,max_rss,cpu_rx_pps,cpu_tx_pps,threshold_status,threshold_details
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit40Gx10GBenchmark,39189658731000,OK,6804175,783364,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx10GBenchmark,40060501759000,OK,7005425,778980,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx25GBenchmark,39321327884000,OK,6913890,783268,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx50GBenchmark,39182569920000,OK,6839850,800356,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit100Gx100GBenchmark,39397667032000,OK,6763438,779776,,,NO_THRESHOLD,
/opt/fboss/bin/sai_multi_switch_all_benchmarks-sai_impl,HwInitAndExit400Gx400GBenchmark,39319867079000,OK,6790632,810188,,,NO_THRESHOLD,
```

