### PR TITLE
[Cisco] Stabilize Cisco ECN and watermark tests

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
@@ -5,8 +5,11 @@
 #include <functional>
 #include <map>
 #include <optional>
+#include <thread>
 #include <utility>
 #include <vector>
+
+#include <folly/ScopeGuard.h>
 
 #include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/HwSwitchMatcher.h"
@@ -24,21 +27,29 @@
 #include "fboss/agent/test/TestEnsembleIf.h"
 #include "fboss/agent/test/TestUtils.h"
 #include "fboss/agent/test/agent_hw_tests/AgentTestAddressConstants.h"
+#include "fboss/agent/test/utils/AclTestUtils.h"
 #include "fboss/agent/test/utils/AqmTestUtils.h"
 #include "fboss/agent/test/utils/ConfigUtils.h"
 #include "fboss/agent/test/utils/CoppTestUtils.h"
 #include "fboss/agent/test/utils/NetworkAITestUtils.h"
 #include "fboss/agent/test/utils/OlympicTestUtils.h"
 #include "fboss/agent/test/utils/PortStatsTestUtils.h"
+#include "fboss/agent/test/utils/PortTestUtils.h"
 #include "fboss/agent/test/utils/QosTestUtils.h"
 #include "fboss/agent/types.h"
 #include "fboss/lib/CommonUtils.h"
 
+namespace facebook::fboss {
 namespace {
 constexpr uint8_t kECT1{1}; // ECN capable transport(1), ECT(1)
 constexpr uint8_t kECT0{2}; // ECN capable transport(0), ECT(0)
 constexpr uint8_t kNotECT{0}; // Not ECN-Capable Transport, Not-ECT
 constexpr auto kDefaultTxPayloadBytes{7000};
+// SAI normalizes a configured maximum of 1 to true zero; 0 means unlimited.
+constexpr uint32_t kCiscoEcnClosedRatePps{1};
+constexpr uint32_t kCiscoEcnPrimeRatePps{12};
+constexpr auto kCiscoEcnPrimeDuration{std::chrono::milliseconds(500)};
+constexpr auto kCiscoEcnQueueConfigName{"ecn_prime_queue_config"};
 
 struct AqmTestStats {
   uint64_t wredDroppedPackets;
@@ -86,9 +97,19 @@ void verifyEcnMarkedPacketCount(
   EXPECT_GT(after.outPackets, before.outPackets + deltaEcnMarkedPackets);
 }
 
+bool requiresCiscoDequeueEcnPriming(const HwAsic* hwAsic) {
+  switch (hwAsic->getAsicType()) {
+    case cfg::AsicType::ASIC_TYPE_EBRO:
+    case cfg::AsicType::ASIC_TYPE_YUBA:
+    case cfg::AsicType::ASIC_TYPE_G202X:
+      return true;
+    default:
+      return false;
+  }
+}
+
 } // namespace
 
-namespace facebook::fboss {
 class AgentAqmTest : public AgentHwTest {
  public:
   cfg::SwitchConfig initialConfig(
@@ -197,6 +218,28 @@ class AgentAqmTest : public AgentHwTest {
       utility::addQueueShaperConfig(&config, queueId, minKbps, maxKbps);
       utility::addQueueBurstSizeConfig(
           &config, queueId, minBurstKb, maxBurstKb);
+    }
+  }
+
+  void queuePpsShaperSetup(
+      const std::vector<int>& queueIds,
+      cfg::SwitchConfig& config,
+      uint32_t maxPps) {
+    auto asic = checkSameAndGetAsicForTesting(getAgentEnsemble()->getL3Asics());
+    auto& queueConfig = asic->getSwitchType() == cfg::SwitchType::VOQ
+        ? *config.defaultVoqConfig()
+        : config.portQueueConfigs()[kCiscoEcnQueueConfigName];
+    for (auto queueId : queueIds) {
+      bool queueFound{false};
+      for (auto& queue : queueConfig) {
+        if (queue.id() == queueId) {
+          queue.portQueueRate() = cfg::PortQueueRate();
+          queue.portQueueRate()->pktsPerSec() = utility::getRange(0, maxPps);
+          queueFound = true;
+          break;
+        }
+      }
+      CHECK(queueFound) << "Queue " << queueId << " not found";
     }
   }
 
@@ -510,6 +553,9 @@ class AgentAqmTest : public AgentHwTest {
         ceilFn(roundedBufferThreshold, effectiveBytesPerPacket) +
         expectedMarkedOrDroppedPacketCount;
 
+    const bool needsCiscoEcnPriming =
+        isEct(ecnCodePoint) && requiresCiscoDequeueEcnPriming(asic);
+
     auto setup = [&]() {
       cfg::SwitchConfig config{getSw()->getConfig()};
       // Configure both WRED and ECN thresholds
@@ -565,11 +611,87 @@ class AgentAqmTest : public AgentHwTest {
       // Update the stats to initialize them before sending packets to build up
       // the queue.
       getAgentEnsemble()->getSw()->updateStats();
+      const PortID egressPort = masterLogicalInterfacePortIds()[0];
+
+      auto applyQueuePpsRate = [&](uint32_t maxPps) {
+        cfg::SwitchConfig config{getSw()->getConfig()};
+        queuePpsShaperSetup({kQueueId}, config, maxPps);
+        applyNewConfig(config);
+        waitForStateUpdates(getAgentEnsemble()->getSw());
+      };
+
+      if (needsCiscoEcnPriming) {
+        // Cold setup starts closed, but warm boot restores the last applied
+        // queue rate. Close it again before filling the queue.
+        applyQueuePpsRate(kCiscoEcnClosedRatePps);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+      }
+
       HwPortStats beforePortStats = utility::sendPacketsWithQueueBuildup(
           sendPackets,
           getAgentEnsemble(),
-          masterLogicalInterfacePortIds()[0],
-          numPacketsToSend);
+          egressPort,
+          numPacketsToSend,
+          !needsCiscoEcnPriming);
+
+      SCOPE_EXIT {
+        if (needsCiscoEcnPriming) {
+          utility::setCreditWatchdogAndPortTx(
+              getAgentEnsemble(), egressPort, true);
+        }
+      };
+
+      if (needsCiscoEcnPriming) {
+        // Cisco ASIC dequeue marking uses a cached deq_ctrl decision. Prime
+        // that cache with packet-mode dequeues while the queue is above the
+        // ECN threshold, close the shaper, and refill every packet that
+        // escaped before starting the measured drain.
+        getAgentEnsemble()->getSw()->updateStats();
+        auto primeStats = getLatestPortStats(egressPort);
+        uint64_t accountedOutPackets = utility::getPortOutPkts(primeStats);
+
+        applyQueuePpsRate(kCiscoEcnPrimeRatePps);
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, true);
+        std::this_thread::sleep_for(kCiscoEcnPrimeDuration);
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, false);
+        applyQueuePpsRate(kCiscoEcnClosedRatePps);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+        getAgentEnsemble()->getSw()->updateStats();
+
+        auto postPrimeStats = getLatestPortStats(egressPort);
+        uint64_t currentOutPackets = utility::getPortOutPkts(postPrimeStats);
+        CHECK_GE(currentOutPackets, accountedOutPackets);
+        uint64_t refillPackets = currentOutPackets - accountedOutPackets;
+        CHECK_GT(refillPackets, 0);
+        CHECK_LE(refillPackets, numPacketsToSend);
+        XLOG(DBG0) << "Cisco ECN priming dequeued " << refillPackets
+                   << " packets";
+        accountedOutPackets = currentOutPackets;
+
+        constexpr int kMaxRefillRounds{5};
+        for (int round = 0; round < kMaxRefillRounds && refillPackets > 0;
+             ++round) {
+          sendPackets(egressPort, static_cast<int>(refillPackets));
+          std::this_thread::sleep_for(std::chrono::milliseconds(300));
+          getAgentEnsemble()->getSw()->updateStats();
+          currentOutPackets =
+              utility::getPortOutPkts(getLatestPortStats(egressPort));
+          CHECK_GE(currentOutPackets, accountedOutPackets);
+          refillPackets = currentOutPackets - accountedOutPackets;
+          accountedOutPackets = currentOutPackets;
+          XLOG(DBG0) << "Cisco ECN refill round " << round
+                     << " leaked packets: " << refillPackets;
+        }
+        CHECK_EQ(refillPackets, 0);
+
+        getAgentEnsemble()->getSw()->updateStats();
+        beforePortStats = getLatestPortStats(egressPort);
+        applyQueuePpsRate(kCiscoEcnPrimeRatePps);
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, true);
+      }
 
       AqmTestStats before{};
       extractAqmTestStats(
@@ -631,6 +753,14 @@ class AgentAqmTest : public AgentHwTest {
       if (verifyPacketCountFn.has_value()) {
         (*verifyPacketCountFn)(
             after, before, expectedMarkedOrDroppedPacketCount);
+      }
+      if (needsCiscoEcnPriming) {
+        // Persist a closed queue for the warm-boot verification iteration.
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, false);
+        applyQueuePpsRate(kCiscoEcnClosedRatePps);
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, true);
       }
     };
 
@@ -738,18 +868,43 @@ class AgentAqmTest : public AgentHwTest {
      * spacing of packets egressing to have ECN accounting done
      * with minimal error. However, in prod devices, we should expect
      * to see this +/- error with ECN marking.
+     *
+     * Cisco ASICs use packet-mode shaping to release packets while congested,
+     * then close and refill the queue. This initializes the
+     * dequeue-side CGM cache before the measured drain.
      */
     auto shaperSetup = [&](cfg::SwitchConfig& config,
                            const std::vector<int>& queueIds,
                            const int txPacketLen) {
-      auto maxQueueShaperKbps = ceil(500000 * txPacketLen / 1000);
-      queueShaperAndBurstSetup(
-          queueIds,
-          config,
-          0,
-          maxQueueShaperKbps,
-          utility::kQueueConfigBurstSizeMinKb,
-          utility::kQueueConfigBurstSizeMaxKb);
+      auto asic =
+          checkSameAndGetAsicForTesting(getAgentEnsemble()->getL3Asics());
+      if (requiresCiscoDequeueEcnPriming(asic)) {
+        // Packet mode is required on Cisco ASICs. Very low bit-mode rates are
+        // rounded up high enough to drain the queue before it can be closed.
+        if (asic->getSwitchType() != cfg::SwitchType::VOQ) {
+          config.portQueueConfigs()[kCiscoEcnQueueConfigName] =
+              config.portQueueConfigs()["queue_config"];
+          auto egressPort =
+              utility::findCfgPort(config, masterLogicalInterfacePortIds()[0]);
+          CHECK(egressPort != config.ports()->end());
+          egressPort->portQueueConfigName() = kCiscoEcnQueueConfigName;
+        }
+        queuePpsShaperSetup(queueIds, config, kCiscoEcnClosedRatePps);
+        // Drop ingress on the egress port so MAC-loopback traffic cannot
+        // re-enter the queue after TX drain.
+        const PortID egressPort = masterLogicalInterfacePortIds()[0];
+        utility::addIngressPortDropAcl(
+            &config, egressPort, "verifyEcnThreshold-egress-rx-disable");
+      } else {
+        auto maxQueueShaperKbps = ceil(500000 * txPacketLen / 1000);
+        queueShaperAndBurstSetup(
+            queueIds,
+            config,
+            0,
+            maxQueueShaperKbps,
+            utility::kQueueConfigBurstSizeMinKb,
+            utility::kQueueConfigBurstSizeMaxKb);
+      }
     };
     validateAqmThresholds(
         kECT0,

--- a/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentAqmTests.cpp
@@ -100,6 +100,7 @@ void verifyEcnMarkedPacketCount(
 bool requiresCiscoDequeueEcnPriming(const HwAsic* hwAsic) {
   switch (hwAsic->getAsicType()) {
     case cfg::AsicType::ASIC_TYPE_EBRO:
+    case cfg::AsicType::ASIC_TYPE_P200:
     case cfg::AsicType::ASIC_TYPE_YUBA:
     case cfg::AsicType::ASIC_TYPE_G202X:
       return true;

--- a/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentWatermarkTests.cpp
@@ -10,15 +10,18 @@
 #include "fboss/agent/test/EcmpSetupHelper.h"
 #include "fboss/agent/test/TestUtils.h"
 #include "fboss/agent/test/agent_hw_tests/AgentTestAddressConstants.h"
+#include "fboss/agent/test/utils/AclTestUtils.h"
 #include "fboss/agent/test/utils/AqmTestUtils.h"
 #include "fboss/agent/test/utils/ConfigUtils.h"
 #include "fboss/agent/test/utils/CoppTestUtils.h"
 #include "fboss/agent/test/utils/OlympicTestUtils.h"
+#include "fboss/agent/test/utils/PortTestUtils.h"
 #include "fboss/agent/test/utils/QosTestUtils.h"
 #include "fboss/lib/CommonUtils.h"
 
 #include <fb303/ServiceData.h>
 #include <fmt/format.h>
+#include <folly/ScopeGuard.h>
 
 DECLARE_bool(disable_neighbor_updates);
 
@@ -515,7 +518,21 @@ TEST_F(AgentWatermarkTest, VerifyDeviceWatermarkHigherThanQueueWatermark) {
 }
 
 TEST_F(AgentWatermarkTest, VerifyQueueWatermarkAccuracy) {
-  auto setup = [this]() { _setup(false); };
+  auto setup = [this]() {
+    // A packet that egresses the congested port, loops back on the MAC and
+    // re-enters the same queue is counted as TXed while still occupying a
+    // buffer. sendPacketsWithQueueBuildup() then compensates for it and the
+    // queue peaks above kNumberOfPacketsToSend. Deny ingress on the egress
+    // port so each packet gets exactly one pass through the queue.
+    auto config = getAgentEnsemble()->getCurrentConfig();
+    const PortID kEgressPort = masterLogicalInterfacePortIds()[0];
+    utility::addIngressPortDropAcl(
+        &config, kEgressPort, "verifyQueueWatermarkAccuracy-egress-rx-disable");
+    applyNewConfig(config);
+    XLOG(DBG0) << "Disabled egress port ingress via ACL on port "
+               << kEgressPort;
+    _setup(false);
+  };
   auto verify = [this]() {
     for (const auto& switchId : switchIdsUnderTest()) {
       const auto asic = getSw()->getHwAsicTable()->getHwAsic(switchId);
@@ -547,19 +564,34 @@ TEST_F(AgentWatermarkTest, VerifyQueueWatermarkAccuracy) {
         // Send packets out on port1, so that it gets looped back, and
         // forwarded in the pipeline to egress port0 where the watermark
         // will be validated.
+        const PortID loopbackPort{
+            getAgentEnsemble()->masterLogicalInterfacePortIds(switchId)[1]};
+        const auto initialStats = getLatestPortStats(loopbackPort);
         sendUdpPkts(
             utility::kOlympicQueueToDscp().at(kQueueId).front(),
             folly::IPAddressV6(kTestDstIpV6),
             numPacketsToSend,
             kTxPacketPayloadLen,
-            getAgentEnsemble()->masterLogicalInterfacePortIds(switchId)[1]);
+            loopbackPort);
+        WITH_RETRIES({
+          const auto currentStats = getLatestPortStats(loopbackPort);
+          EXPECT_EVENTUALLY_GE(
+              currentStats.inUnicastPkts_().value(),
+              initialStats.inUnicastPkts_().value() + numPacketsToSend);
+        });
       };
 
+      const auto egressPort = masterLogicalInterfacePortIds()[0];
+      SCOPE_EXIT {
+        utility::setCreditWatchdogAndPortTx(
+            getAgentEnsemble(), egressPort, true);
+      };
       utility::sendPacketsWithQueueBuildup(
           sendPackets,
           getAgentEnsemble(),
-          masterLogicalInterfacePortIds()[0],
-          kNumberOfPacketsToSend);
+          egressPort,
+          kNumberOfPacketsToSend,
+          false /* enableTxAtEnd */);
 
       uint64_t expectedWatermarkBytes;
       uint64_t roundedWatermarkBytes;
@@ -589,8 +621,7 @@ TEST_F(AgentWatermarkTest, VerifyQueueWatermarkAccuracy) {
       std::map<int16_t, int64_t> queueWaterMarks;
       int64_t maxWatermarks = 0;
       WITH_RETRIES_N_TIMED(20, std::chrono::milliseconds(1000), {
-        queueWaterMarks =
-            getQueueWatermarks(masterLogicalInterfacePortIds()[0], isVoq);
+        queueWaterMarks = getQueueWatermarks(egressPort, isVoq);
         if (queueWaterMarks.at(kQueueId) > maxWatermarks) {
           maxWatermarks = queueWaterMarks.at(kQueueId);
         }

--- a/fboss/agent/test/utils/AclTestUtils.cpp
+++ b/fboss/agent/test/utils/AclTestUtils.cpp
@@ -150,6 +150,17 @@ cfg::AclEntry* addAclEntry(
   }
 }
 
+cfg::AclEntry* addIngressPortDropAcl(
+    cfg::SwitchConfig* cfg,
+    PortID ingressPort,
+    const std::string& aclName) {
+  cfg::AclEntry acl;
+  acl.name() = aclName;
+  acl.srcPort() = ingressPort;
+  acl.actionType() = cfg::AclActionType::DENY;
+  return addAclEntry(cfg, acl, kDefaultAclTable());
+}
+
 cfg::AclEntry* addAcl_DEPRECATED(
     cfg::SwitchConfig* cfg,
     const std::string& aclName,

--- a/fboss/agent/test/utils/AclTestUtils.h
+++ b/fboss/agent/test/utils/AclTestUtils.h
@@ -40,6 +40,11 @@ cfg::AclEntry* addAclEntry(
     const std::string& tableName,
     cfg::AclStage aclStage = cfg::AclStage::INGRESS);
 
+cfg::AclEntry* addIngressPortDropAcl(
+    cfg::SwitchConfig* cfg,
+    PortID ingressPort,
+    const std::string& aclName);
+
 cfg::AclEntry* addAcl_DEPRECATED(
     cfg::SwitchConfig* cfg,
     const std::string& aclName,

--- a/fboss/agent/test/utils/AqmTestUtils.cpp
+++ b/fboss/agent/test/utils/AqmTestUtils.cpp
@@ -214,7 +214,8 @@ HwPortStats sendPacketsWithQueueBuildup(
     std::function<void(PortID port, int numPacketsToSend)> sendPktsFn,
     TestEnsembleIf* ensemble,
     PortID port,
-    int numPackets) {
+    int numPackets,
+    bool enableTxAtEnd) {
   auto getOutPackets = [&](const HwPortStats& stats) -> int64_t {
     return *stats.outUnicastPkts_() + *stats.outMulticastPkts_() +
         *stats.outBroadcastPkts_();
@@ -295,8 +296,10 @@ HwPortStats sendPacketsWithQueueBuildup(
     sendPktsFn(port, numPackets - queuedPackets);
   }
 
-  // Enable TX to send traffic out
-  utility::setCreditWatchdogAndPortTx(ensemble, port, true);
+  if (enableTxAtEnd) {
+    // Enable TX to send traffic out
+    utility::setCreditWatchdogAndPortTx(ensemble, port, true);
+  }
 
   // Return the stats at the point when port stopped actual TX!
   return kStatsWithTxDisabled;

--- a/fboss/agent/test/utils/AqmTestUtils.h
+++ b/fboss/agent/test/utils/AqmTestUtils.h
@@ -57,7 +57,8 @@ HwPortStats sendPacketsWithQueueBuildup(
     std::function<void(PortID port, int numPacketsToSend)> sendPktsFn,
     TestEnsembleIf* ensemble,
     PortID port,
-    int numPackets);
+    int numPackets,
+    bool enableTxAtEnd = true);
 
 } // namespace utility
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Stabilize ECN threshold and queue watermark hardware tests on Cisco ASICs by making queue draining and packet accounting deterministic.

# Problem

Cisco ASICs cache the dequeue-side ECN decision. Without priming this cache, the ECN threshold test can observe inconsistent packet marking, especially across warm boots.

The queue watermark accuracy test can also overcount buffered traffic when packets transmitted through MAC loopback re-enter the congested egress queue. Those packets are counted as transmitted while still consuming queue buffers, inflating the measured watermark.

# Fix
- Detect Cisco ASICs requiring dequeue-side ECN priming: Ebro, Yuba, and G202X.
- Use packet-per-second queue shaping for controlled draining.
- Fill the queue above the ECN threshold, briefly drain it to prime the cached dequeue decision, close the queue, and refill packets released during priming.
- Preserve the required closed queue state for warm-boot verification.
- Add an ingress-port drop ACL on the egress port to prevent MAC-loopback traffic from re-entering the queue.
- Extend `sendPacketsWithQueueBuildup()` with an option to leave TX disabled so callers can control when draining starts.
- Restore TX and credit-watchdog state through scope guards.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

Manually ran the affected hardware tests and confirmed they passed:
- `AgentAqmEcnOnlyTest.verifyEcnThreshold`
- `AgentWatermarkTest.VerifyQueueWatermarkAccuracy`
- Cold-boot and warm-boot verification passed.


[result] AgentAqmEcnOnlyTest.verifyEcnThreshold [coldboot]: PASSED (exit code 0)
[result] [==========] Running 1 test from 1 test suite.

[result] AgentAqmEcnOnlyTest.verifyEcnThreshold [warmboot]: PASSED (exit code 0)
[result] [==========] Running 1 test from 1 test suite.

[result] AgentWatermarkTest.VerifyQueueWatermarkAccuracy [coldboot]: PASSED (exit code 0)
[result] [==========] Running 1 test from 1 test suite.

[result] AgentWatermarkTest.VerifyQueueWatermarkAccuracy [warmboot]: PASSED (exit code 0)
[result] [==========] Running 1 test from 1 test suite.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
