### PR TITLE
[Celestica] Tahansb800bc: configs: SW OTP config

### DIFF
--- a/fboss/configs/platforms/celestica/tahansb800bc/platform_stack/fan_service.json
+++ b/fboss/configs/platforms/celestica/tahansb800bc/platform_stack/fan_service.json
@@ -16,12 +16,27 @@
     "pwmUpdateInterval": 5
   },
   "shutdownCondition": {
-    "numOvertempSensorForShutdown": 1,
+    "numOvertempSensorForShutdown": 2,
     "conditions": [
       {
         "sensorName": "SMB_U2_TH6_TEMP",
-        "overtempThreshold": 120,
-        "slidingWindowSize": 10
+        "overtempThreshold": 102,
+        "slidingWindowSize": 2
+      },
+      {
+        "sensorName": "SMB_U29_LEFT_TMP432_1_TEMP2",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
+      },
+      {
+        "sensorName": "SMB_U29_LEFT_TMP432_1_TEMP3",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
+      },
+      {
+        "sensorName": "SMB_U30_RIGHT_TMP432_2_TEMP2",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
       }
     ]
   },

--- a/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/fan_service.json
+++ b/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/fan_service.json
@@ -6,6 +6,7 @@
   "pwmTransitionValue": 50,
   "pwmLowerThreshold": 30,
   "pwmUpperThreshold": 100,
+  "shutdownCmd": "echo 0 > /run/devmap/cplds/SMB_CPLD/th6_pwr_en",
   "watchdog": {
     "sysfsPath": "/run/devmap/watchdogs/FAN_WATCHDOG",
     "value": 0
@@ -13,6 +14,31 @@
   "controlInterval": {
     "sensorReadInterval": 5,
     "pwmUpdateInterval": 5
+  },
+  "shutdownCondition": {
+    "numOvertempSensorForShutdown": 2,
+    "conditions": [
+      {
+        "sensorName": "SMB_U2_TH6_TEMP",
+        "overtempThreshold": 102,
+        "slidingWindowSize": 2
+      },
+      {
+        "sensorName": "SMB_U29_LEFT_TMP432_1_TEMP2",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
+      },
+      {
+        "sensorName": "SMB_U29_LEFT_TMP432_1_TEMP3",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
+      },
+      {
+        "sensorName": "SMB_U30_RIGHT_TMP432_2_TEMP2",
+        "overtempThreshold": 88,
+        "slidingWindowSize": 1
+      }
+    ]
   },
   "sensors": [
     {

--- a/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/platform_manager.json
@@ -943,6 +943,7 @@
     "/run/devmap/sensors/SMB_ADC2_SENSOR": "/SMB_SLOT@0/[SMB_ADC2_SENSOR]",
     "/run/devmap/sensors/SMB_INLET_TH6_TSENSOR": "/SMB_SLOT@0/[SMB_INLET_TH6_TSENSOR]",
     "/run/devmap/sensors/SMB_VDDCORE": "/SMB_SLOT@0/[SMB_VDDCORE]",
+    "/run/devmap/sensors/SMB_CPLD": "/SMB_SLOT@0/[SMB_CPLD]",
     "/run/devmap/gpiochips/MCB_GPIO_CHIP_1": "/[MCB_GPIO_CHIP_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_1_DEVICE_1": "/[MCB_SPI_MASTER_1_DEVICE_1]",
     "/run/devmap/flashes/MCB_SPI_MASTER_2_DEVICE_1": "/[MCB_SPI_MASTER_2_DEVICE_1]",

--- a/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/tahansb800bcm/platform_stack/sensor_service.json
@@ -3110,6 +3110,16 @@
             "lowerCriticalVal": 0
           },
           "compute": "@/1000.0"
+        },
+        {
+          "name": "SMB_U2_TH6_TEMP",
+          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp1_input",
+          "type": 3,
+          "thresholds": {
+            "maxAlarmVal": 100,
+            "upperCriticalVal": 103
+          },
+          "compute": "@/1000.0"
         }
       ],
       "versionedSensors": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
<img width="485" height="148" alt="image" src="https://github.com/user-attachments/assets/f0783290-aa7f-493a-ba00-9cbe88e0eb66" />

# Summary

Meta reported a TH6 PCIe link issue, which, after debugging, was found to be caused by an SW OTP. It appears that during the TH6 SDK/agent initialization process, the TH6_TEMP sensor reads an abnormal, untrustworthy temperature jump. This anomalous reading value should not be used to trigger OTP. Introduce auxiliary ASIC temperature sensors (TMP432 sensors) to assist in the OTP evaluation. During the TH6 SDK/agent initialization process, the TMP432 sensors values are trustworthy.

# Test Plan

Continuously execute the agent initialization stress test while simultaneously running platform_manager, sensor_service, and fan_service.
CLS SVT team has been running the stress test continuously for a week, and the OTP issue has not been reproduced.
