### PR TITLE
Lower FSDB GHA build parallelism to 12 to fix OOM

### DIFF
--- a/.github/workflows/fsdb.yml
+++ b/.github/workflows/fsdb.yml
@@ -37,7 +37,7 @@ jobs:
           --env-var
           GITHUB_ACTIONS_BUILD
           --num-jobs
-          18
+          12
           --local
           &&
           sudo


### PR DESCRIPTION
Summary:
The `FSDB-Build` GitHub Actions job has been OOMing since 8/29.

The `fsdb_all_services` build compiles the thrift_cow explicit-instantiation TUs in `github/cmake/fsdb/FsdbOperInstantiations.cmake`, whose peak memory scales with the size of the agent thrift model rather than with the size of any diff. Two recent additions of container fields to the FSDB state tree pushed those TUs over the runner's memory budget at `--num-jobs 18`:

- D117445896 added `portAclTableGroupMaps` (`map<SwitchIdList, map<string, AclTableGroupFields>>`)
- D117822246 added `ecmpGroupSettings` (`map<EcmpGroupType, EcmpGroupSettings>`)

Each new `map<K, Struct>` in the state tree forces a fresh `ThriftMapNode` instantiation plus the full visitor set (`PathVisitor`, `ExtendedPathVisitor`, `DeltaVisitor`, `RecurseVisitor`, `PatchApplier`, `PatchBuilder`) across every instantiation TU, so a few added thrift lines cost far more memory than their diff size suggests. Both changes are correct and are not being reverted.

Drop `--num-jobs` from 18 to 12 on the 32-core runner to restore headroom. This is a mitigation, not a fix: the next container field added to `SwitchSettings` will re-cross the budget. Sharding the instantiation TUs further is the durable fix and is left as follow-up.

Differential Revision: D118149389


