### PR TITLE
[Nexthop][m4062nhp] Adjust DPM voltage rail information

### DIFF
--- a/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/nexthop/m4062nhp/platform_stack/sensor_service.json
@@ -186,14 +186,14 @@
           "compute": "@/1000.0"
         },
         {
-          "name": "DPM_POS1V15_SWT",
+          "name": "DPM_POS1V05_SWT",
           "sysfsPath": "/run/devmap/sensors/DPM/in15_input",
           "type": 1,
           "thresholds": {
-            "maxAlarmVal": 1.203,
-            "minAlarmVal": 1.087,
-            "upperCriticalVal": 1.261,
-            "lowerCriticalVal": 1.043
+            "maxAlarmVal": 1.149,
+            "minAlarmVal": 1.000,
+            "upperCriticalVal": 1.211,
+            "lowerCriticalVal": 0.950
           },
           "compute": "@/1000.0"
         },


### PR DESCRIPTION
**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Update the in15_input voltage rail with the most up-to-date information.

# Test Plan

Verified on hardware.
