### PR TITLE
[Nexthop][wedge800cact] Update platform_manager lanesPerPort for eth1/33/2 from 4 to 2

### DIFF
--- a/fboss/configs/platforms/accton/wedge800cact/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/accton/wedge800cact/platform_stack/platform_manager.json
@@ -436,7 +436,7 @@
               "numPorts": 1,
               "ledPerPort": 2,
               "startPort": 33,
-              "lanesPerPort": 4
+              "lanesPerPort": 2
             }
           ],
           "infoRomConfigs": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

## Issue
`eth1/33/2` (aka Port 33 LED 2, aka LED 98) on Wedge800CACT never lit up during any LED-status-driven path. Only `LedServiceTest.visualForceAllLeds`, which force-writes every declared LED directly, could touch it.

## Root cause
`lanesPerPort` in `platform_manager.json` declares the *whole cage's* lane count, not a single breakout sub-port's. Port 33 on Wedge800CACT is a 2-lane cage split into two single/dual-lane breakout sub-ports (`eth1/33/1` on lanes 0-1, `eth1/33/2` on lane 1), but `lanesPerPort` was set to `4`. With `lanesPerLed = lanesPerPort / ledPerPort = 4 / 2 = 2`, lanes {1,2} both bucket into LED 97 and lanes {3,4} bucket into LED 98. Lanes 3/4 don't physically exist on this 2-lane cage, so LED 98 was structurally unreachable by any real lane. `eth1/33/2`'s real lane (lane 2) fell into the first bucket and got silently routed to LED 97 instead, alongside `eth1/33/1`.

## Fix
Update `lanesPerPort` from `4` to `2`, matching the cage's actual lane count. This gives a clean 1:1 lane->LED map (`lane1->LED97`, `lane2->LED98`), so `eth1/33/2` now drives LED 98 independently.

# Test Plan

Without this fix, LED 98 is not driven on Wedge800CACT during any LED test (except for `visualForceAllLeds`), despite all tests reporting as passing. This was confirmed visually and by inspecting the test logs. With the fix, the LED is driven during each test; again, this was confirmed visually and also by inspecting the test logs.

Furthermore, this change does not cause any regression with the actual pass/fail status of the LED tests (which, as stated before, were already all passing):

```
[----------] 5 tests from LedServiceTest (1165 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test suite ran. (1165 ms total)
[  PASSED  ] 5 tests.
```