### PR TITLE
[Nexthop] Resolve RX packet's L3 interface from its VLAN, not its port

### DIFF
--- a/fboss/agent/DHCPv4Handler.cpp
+++ b/fboss/agent/DHCPv4Handler.cpp
@@ -22,6 +22,7 @@
 #include "fboss/agent/SwitchIdScopeResolver.h"
 #include "fboss/agent/SwitchStats.h"
 #include "fboss/agent/TxPacket.h"
+#include "fboss/agent/Utils.h"
 #include "fboss/agent/packet/DHCPv4Packet.h"
 #include "fboss/agent/packet/EthHdr.h"
 #include "fboss/agent/packet/Ethertype.h"
@@ -304,8 +305,7 @@ void DHCPv4Handler::processRequest(
 
   auto switchIp = state->getDhcpV4RelaySrc();
   if (switchIp.isZero()) {
-    auto interfaceIDOpt = sw->getState()->getInterfaceIDForPortIf(
-        PortDescriptor(pkt->getSrcPort()));
+    auto interfaceIDOpt = getInterfaceIDForPkt(*pkt, sw->getState());
     if (!interfaceIDOpt) {
       sw->stats()->dhcpV4DropPkt();
       XLOG(ERR) << "No interface for port " << pkt->getSrcPort()

--- a/fboss/agent/DHCPv6Handler.cpp
+++ b/fboss/agent/DHCPv6Handler.cpp
@@ -246,8 +246,7 @@ void DHCPv6Handler::processDHCPv6Packet(
 
   auto switchIp = state->getDhcpV6RelaySrc();
   if (switchIp.isZero()) {
-    auto intfIDOpt = sw->getState()->getInterfaceIDForPortIf(
-        PortDescriptor(pkt->getSrcPort()));
+    auto intfIDOpt = getInterfaceIDForPkt(*pkt, sw->getState());
     if (!intfIDOpt) {
       sw->stats()->dhcpV6DropPkt();
       XLOG(ERR) << "No interface for port " << pkt->getSrcPort()

--- a/fboss/agent/IPv4Handler.cpp
+++ b/fboss/agent/IPv4Handler.cpp
@@ -311,7 +311,7 @@ void IPv4Handler::handlePacket(
       return;
     }
     // Forward multicast packet directly to corresponding host interface
-    auto intfIDOpt = state->getInterfaceIDForPortIf(PortDescriptor(port));
+    auto intfIDOpt = getInterfaceIDForPkt(*pkt, state);
     if (intfIDOpt) {
       intf = state->getInterfaces()->getNodeIf(intfIDOpt.value());
     }

--- a/fboss/agent/IPv6Handler.cpp
+++ b/fboss/agent/IPv6Handler.cpp
@@ -297,7 +297,7 @@ void IPv6Handler::handlePacket(
     // Forward multicast packet directly to corresponding host interface
     // and let Linux handle it. In software we consume ICMPv6 Multicast
     // packets for function of NDP protocol, rest all are forwarded to host.
-    auto intfIDOpt = state->getInterfaceIDForPortIf(PortDescriptor(port));
+    auto intfIDOpt = getInterfaceIDForPkt(*pkt, state);
     if (intfIDOpt) {
       intf = state->getInterfaces()->getNodeIf(intfIDOpt.value());
     }
@@ -314,7 +314,7 @@ void IPv6Handler::handlePacket(
     } else {
       // Forward link-local packet directly to corresponding host interface
       // provided desAddr is assigned to that interface.
-      auto intfIDOpt = state->getInterfaceIDForPortIf(PortDescriptor(port));
+      auto intfIDOpt = getInterfaceIDForPkt(*pkt, state);
       if (intfIDOpt) {
         intf = state->getInterfaces()->getNodeIf(intfIDOpt.value());
       }
@@ -464,8 +464,7 @@ void IPv6Handler::handleRouterSolicitation(
 
   cursor.skip(4); // 4 reserved bytes
 
-  auto intfIDOpt = sw_->getState()->getInterfaceIDForPortIf(
-      PortDescriptor(pkt->getSrcPort()));
+  auto intfIDOpt = getInterfaceIDForPkt(*pkt, sw_->getState());
   auto intf = intfIDOpt
       ? sw_->getState()->getInterfaces()->getNodeIf(intfIDOpt.value())
       : nullptr;
@@ -963,19 +962,25 @@ void IPv6Handler::sendUnicastNeighborSolicitation(
 
   auto state = sw->getState();
 
-  InterfaceID intfID;
+  std::optional<InterfaceID> intfIDOpt;
   switch (portDescriptor.type()) {
     case PortDescriptor::PortType::PHYSICAL:
-      intfID = sw->getState()->getInterfaceIDForPort(portDescriptor);
-      break;
     case PortDescriptor::PortType::AGGREGATE:
-      intfID = sw->getState()->getInterfaceIDForPort(portDescriptor);
+      intfIDOpt = sw->getState()->getInterfaceIDForPortIf(portDescriptor);
       break;
     case PortDescriptor::PortType::SYSTEM_PORT:
       auto physPortID = getPortID(portDescriptor.sysPortID(), sw->getState());
       portToSend = PortDescriptor(physPortID);
-      intfID = sw->getState()->getInterfaceIDForPort(portToSend);
+      intfIDOpt = sw->getState()->getInterfaceIDForPortIf(portToSend);
   }
+  if (!intfIDOpt) {
+    // E.g. a trunk port belonging to several interfaces: the port alone
+    // cannot identify the interface to solicit from.
+    XLOG(DBG2) << "unicast neighbor solicitation not sent for " << targetIP
+               << ": no unique interface for " << portDescriptor.str();
+    return;
+  }
+  InterfaceID intfID = intfIDOpt.value();
 
   if (!Interface::isIpAttached(targetIP, intfID, state)) {
     auto intf = state->getInterfaces()->getNodeIf(intfID);

--- a/fboss/agent/NdpCache.cpp
+++ b/fboss/agent/NdpCache.cpp
@@ -134,10 +134,15 @@ inline void NdpCache::checkReachability(
   InterfaceID intfID;
   std::shared_ptr<Interface> srcIntf;
   switch (port.type()) {
-    case PortDescriptor::PortType::PHYSICAL:
-      intfID = getSw()->getState()->getInterfaceIDForPort(port);
+    case PortDescriptor::PortType::PHYSICAL: {
+      // A trunk port may belong to several interfaces, making port-based
+      // resolution ambiguous; the entries in this cache belong to this
+      // cache's own interface, so use that when the port alone cannot tell.
+      auto intfIDOpt = state->getInterfaceIDForPortIf(port);
+      intfID = intfIDOpt.value_or(getIntfID());
       srcIntf = state->getInterfaces()->getNodeIf(intfID);
       break;
+    }
     case PortDescriptor::PortType::AGGREGATE: {
       auto aggregatePort =
           getSw()->getState()->getAggregatePorts()->getNodeIf(port.aggPortID());

--- a/fboss/agent/SwSwitch.cpp
+++ b/fboss/agent/SwSwitch.cpp
@@ -2384,7 +2384,7 @@ void SwSwitch::handlePacket(std::unique_ptr<RxPacket> pkt) {
     }
   }
 
-  auto intfIdOpt = state->getInterfaceIDForPortIf(getPortFromPkt(pkt.get()));
+  auto intfIdOpt = getInterfaceIDForPkt(*pkt, state);
   if (!intfIdOpt) {
     XLOG_EVERY_N(ERR, 10000)
         << "No interface for port " << pkt->getSrcPort() << ", dropping pkt";

--- a/fboss/agent/Utils.cpp
+++ b/fboss/agent/Utils.cpp
@@ -15,6 +15,7 @@
 #include "fboss/agent/AsicUtils.h"
 #include "fboss/agent/FbossError.h"
 #include "fboss/agent/FsdbHelper.h"
+#include "fboss/agent/RxPacket.h"
 #include "fboss/agent/SysError.h"
 #include "fboss/agent/hw/HwSwitchFb303Stats.h"
 #include "fboss/agent/state/ArpEntry.h"
@@ -1296,6 +1297,23 @@ InterfaceID getInterfaceIDForPort(
   }
 
   throw FbossError("Interface not found for port ", portID);
+}
+
+std::optional<InterfaceID> getInterfaceIDForPkt(
+    const RxPacket& pkt,
+    const std::shared_ptr<SwitchState>& state) {
+  if (auto vlanID = pkt.getSrcVlanIf()) {
+    if (auto vlan = state->getVlans()->getNodeIf(*vlanID)) {
+      auto intfID = vlan->getInterfaceID();
+      if (state->getInterfaces()->getNodeIf(intfID)) {
+        return intfID;
+      }
+    }
+  }
+  auto port = pkt.isFromAggregatePort()
+      ? PortDescriptor(AggregatePortID(pkt.getSrcAggregatePort()))
+      : PortDescriptor(pkt.getSrcPort());
+  return state->getInterfaceIDForPortIf(port);
 }
 
 bool isPortDrained(

--- a/fboss/agent/Utils.h
+++ b/fboss/agent/Utils.h
@@ -51,6 +51,8 @@ struct dynamic;
 
 namespace facebook::fboss {
 
+class RxPacket;
+
 namespace cfg {
 class SwitchConfig;
 }
@@ -313,6 +315,19 @@ std::vector<PortID> getPortsForInterface(
 
 InterfaceID getInterfaceIDForPort(
     PortID port,
+    const std::shared_ptr<SwitchState>& state);
+
+/*
+ * Resolve the L3 interface a received packet ingressed on. Prefers the
+ * packet's ingress VLAN (resolved by the hardware, VLAN <-> interface is
+ * always 1:1) over the ingress port, since a trunk port may belong to
+ * multiple VLANs and thus multiple interfaces. Falls back to port-based
+ * resolution when the packet carries no VLAN (e.g. VOQ/fabric switches).
+ * Returns std::nullopt when no interface can be determined; such packets
+ * should be dropped rather than crash the agent.
+ */
+std::optional<InterfaceID> getInterfaceIDForPkt(
+    const RxPacket& pkt,
     const std::shared_ptr<SwitchState>& state);
 
 /*

--- a/fboss/agent/hw/sai/switch/SaiSwitch.cpp
+++ b/fboss/agent/hw/sai/switch/SaiSwitch.cpp
@@ -4078,7 +4078,7 @@ void SaiSwitch::packetRxCallbackPort(
   std::optional<VlanID> swVlanId = processVlanUntaggedPackets()
       ? std::nullopt
       : std::make_optional(VlanID(0));
-  auto swVlanIdStr = [swVlanId]() {
+  auto swVlanIdStr = [&swVlanId]() {
     return swVlanId.has_value()
         ? folly::to<std::string>(static_cast<int>(swVlanId.value()))
         : "None";
@@ -4137,14 +4137,34 @@ void SaiSwitch::packetRxCallbackPort(
       return;
     } else {
       swPortId = portItr->second.portID;
-      const auto vlanItr =
-          concurrentIndices_->vlanIds.find(PortDescriptorSaiId(portSaiId));
-      if (vlanItr == concurrentIndices_->vlanIds.cend()) {
-        XLOG(ERR) << "RX packet had port in no known vlan: 0x" << std::hex
-                  << portSaiId;
-        return;
+      // Prefer the 802.1Q tag stamped on the punted copy by the hardware:
+      // on a trunk port the packet's VLAN cannot be inferred from the port
+      // alone. Untagged, priority-tagged, QinQ and runt punts (and ASICs
+      // that strip the tag) fall back to the port's ingress VLAN.
+      std::optional<VlanID> tagVlanId;
+      try {
+        folly::io::Cursor cursor(rxPacket->buf());
+        EthHdr ethHdr{cursor};
+        const auto& vlanTags = ethHdr.getVlanTags();
+        if (vlanTags.size() == 1 && vlanTags[0].vid() != 0) {
+          tagVlanId = VlanID(vlanTags[0].vid());
+        }
+      } catch (const std::exception& ex) {
+        XLOG(DBG3) << "Failed to parse ethernet header of RX packet: "
+                   << ex.what();
       }
-      swVlanId = vlanItr->second;
+      if (tagVlanId.has_value()) {
+        swVlanId = tagVlanId;
+      } else {
+        const auto vlanItr =
+            concurrentIndices_->vlanIds.find(PortDescriptorSaiId(portSaiId));
+        if (vlanItr == concurrentIndices_->vlanIds.cend()) {
+          XLOG(ERR) << "RX packet had port in no known vlan: 0x" << std::hex
+                    << portSaiId;
+          return;
+        }
+        swVlanId = vlanItr->second;
+      }
     }
   } else {
     // VOQ / FABRIC switch: no vlan needed

--- a/fboss/agent/state/SwitchState.cpp
+++ b/fboss/agent/state/SwitchState.cpp
@@ -1006,9 +1006,19 @@ std::optional<InterfaceID> SwitchState::getInterfaceIDForPortIf(
         return std::nullopt;
       }
       // On VOQ/Fabric switches, port and interface have 1:1 relation.
-      // For non VOQ/Fabric switches, in practice, a port is always part of a
-      // single VLAN (and thus single interface).
-      return physicalPort->getInterfaceID();
+      // For non VOQ/Fabric switches, a port is typically part of a single
+      // VLAN (and thus single interface), but a trunk port may belong to
+      // several. Resolution by port is then ambiguous: return nullopt
+      // rather than abort, callers with a packet in hand should resolve via
+      // getInterfaceIDForPkt() which prefers the packet's ingress VLAN.
+      const auto& intfIDs = physicalPort->getInterfaceIDs();
+      if (intfIDs.size() != 1) {
+        XLOG(ERR) << "Cannot resolve single interface for port "
+                  << physicalPort->getName() << " which belongs to "
+                  << intfIDs.size() << " interfaces";
+        return std::nullopt;
+      }
+      return InterfaceID(intfIDs.at(0));
     }
     case PortDescriptor::PortType::AGGREGATE: {
       auto aggregatePort = getAggregatePorts()->getNodeIf(port.aggPortID());


### PR DESCRIPTION
## Summary

A trunk port belongs to several VLANs and thus several L3 interfaces, so resolving the ingress interface from the port alone is ambiguous: `Port::getInterfaceID()` CHECK-fails, aborting the sw agent, on the first CPU-punted frame received on such a port. VLAN <-> interface stays 1:1 even under trunking, and the hardware already resolves the ingress VLAN, so resolve from the packet instead:

- **New `getInterfaceIDForPkt()`** (`fboss/agent/Utils.{h,cpp}`): prefer the packet's source VLAN -> `Vlan::getInterfaceID()`; fall back to port-based resolution when the packet carries no VLAN (VOQ/fabric switches) or the VLAN isn't in the switch state.
- **Converted the RX-path resolution sites** to it: `SwSwitch::handlePacket`, IPv4/IPv6 handlers, DHCPv4/v6 handlers.
- **`SwitchState::getInterfaceIDForPortIf()`** now returns `nullopt` (with an error log) instead of aborting when a port has more than one interface; unresolvable packets are dropped and counted, matching the existing no-interface path.
- **HW agent** (`SaiSwitch::packetRxCallbackPort`) stamps the punt's VLAN from its 802.1Q tag when present (the ASIC inserts the resolved ingress VLAN on the punt copy) instead of the static port->PVID map; untagged, priority-tagged, QinQ and unparseable punts fall back to the PVID. Also fixes the RX debug log printing the VLAN captured before resolution.
- **Probe paths** that only know a port degrade gracefully: NDP reachability probes fall back to the cache's own interface; unicast neighbor solicitation is skipped with a debug log when the port is ambiguous.

## Test plan

Tested on a Minipack3 (TH5) with 800G optical ports, connected to a peer switch plus self-loopback cabled port pairs.

Baseline (unpatched): adding 2 VLANs to an up port via `fboss2 config interface <port> switchport trunk allowed vlan add <v1>,<v2>` + commit aborts the sw agent within 37-89s from ambient control-plane traffic alone (`Check failed: intfs.size() == 1 (3 vs. 1)`), re-crashing on the next punted frame after every restart. Confirmed triggers (via hw agent RX hex dumps): ordinary IPv6 NS / ARP / LLDP.

With this change, on a trunk port with native + 2 tagged VLANs (3 interfaces):

- Untagged broadcast ARP injected from the peer switch (previously an instant abort): punted, resolved to the native VLAN's interface, handled, FDB learned.
- 802.1Q-tagged ARP from the peer switch: hw agent derives the VLAN from the frame's tag (`Rx packet on port: 52 vlan: 2010`) and the sw agent resolves the tagged VLAN's interface — correct trunk attribution end-to-end.
- RX injections via thrift `sendPkt`: trunk VLAN -> that VLAN's interface; native VLAN -> native interface; VLAN not in switch state -> gracefully dropped through the new nullopt path (previously the abort site).
- Stress: a broadcast storm on a loopback-cabled trunk pair pushed ~1.4M punts through the new resolution path (~800k/~575k attributed to the two tagged VLANs, ~11k untagged to native) with zero CHECK failures and zero crashes.
- Full `ConfigInterfaceSwitchportTrunkAllowedVlanTest` integration suite on the device: 8/8 pass (previously `RemoveVlansOneByOne` failed with the agent abort), with the peer link up so ambient punts arrived on the trunk port throughout.
- 10+ config commits/warmboots across add/remove sequences with trunk state present; agents stayed healthy.

## Review notes

Pre-publication review findings, for reviewer attention:

- Fixed before posting: `EthHdr` parsing of the punt buffer is wrapped in try/catch (falls back to the PVID) so a runt/truncated punt cannot throw out of the SAI RX callback.
- Known behavior, unchanged trust model: the 802.1Q VID from the punt is taken verbatim by the hw agent (same as the existing CPU-port punt path). The sw agent consumer (`getInterfaceIDForPkt`) validates it against the switch state and falls back / drops for unknown VLANs.

## Known issue observed during testing (why this PR is a draft)

This change makes the control plane correct and crash-free, but while validating it we found that the **forwarding plane does not classify tagged ingress into the tagged VLAN** on the switch we tested (Minipack3 / TH5). With a trunk port carrying native VLAN A + tagged VLANs B and C, ARP requests injected from the peer switch behave as follows:

| Frame | Punt attribution / interface resolution (this PR) | Hardware MAC learning |
|---|---|---|
| tagged VID B | VLAN B (correct) | learned in **VLAN A** (wrong) |
| tagged VID C | VLAN C (correct) | learned in **VLAN A** (wrong) |
| untagged | VLAN A (correct) | VLAN A (correct) |

The agent programs a SAI VLAN member per (VLAN, port) with `SAI_VLAN_TAGGING_MODE_TAGGED` (`SaiVlanManager::createVlanMember`), and the punt copy retains the original 802.1Q tag (which this PR's attribution relies on), yet the pipeline assigns every ingress frame to the port's PVID — so MACs learn in the wrong VLAN and tagged traffic is presumably bridged in the native VLAN as well. In other words, the crash fixed here was only the first blocker for trunk ports; per-VLAN L2 behavior needs additional (likely port ingress-classification) programming that FBOSS does not do today.

We're keeping this PR as a draft until there's agreement on whether trunk-port support is a direction worth pursuing in FBOSS. Feedback welcome — including pointers if the hardware behavior above is expected with the current SAI programming and there's a known missing attribute.
