### PR TITLE
[Accton][minipack3n] Fix HwInitAndExit400Gx400GBenchmark failure

### DIFF
--- a/fboss/agent/hw/test/ConfigFactory.cpp
+++ b/fboss/agent/hw/test/ConfigFactory.cpp
@@ -262,6 +262,12 @@ cfg::SwitchConfig createUplinkDownlinkConfig(
       if (utility::findCfgPortIf(config, portId) == config.ports()->end()) {
         continue;
       }
+      // Skip ports that do not have a profile for the target speed.
+      // e.g. management ports may only support 10G/25G.
+      if (!platformMapping->getProfileIDBySpeedIf(portId, uplinkPortSpeed)
+               .has_value()) {
+        continue;
+      }
       utility::updatePortSpeed(
           platformMapping,
           supportsAddRemovePort,


### PR DESCRIPTION
Skip ports without a profile for the target speed in createUplinkDownlinkConfig.

Solution:
	In the non-RSW branch of createUplinkDownlinkConfig(), before calling
	updatePortSpeed(), check the non-throwing getProfileIDBySpeedIf() and skip
	(continue) any port that has no profile for the target speed. This skips
	only the speed override. All master logical ports are still
	added by onePortPerInterfaceConfig() and remain in the config, so every
	port is programmed and timed as before -- only the crash is removed. Ports
	without a 400G profile keep their native speed.
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run --files fboss/agent/hw/test/ConfigFactory.cpp`

# Summary
	HwInitAndExit400Gx400GBenchmark aborts on Minipack3N. For non-RSW
	platforms, createUplinkDownlinkConfig() calls updatePortSpeed(port,
	FOURHUNDREDG) for every master logical port. Minipack3N has ports that do
	not support 400G (e.g. management ports), so getProfileIDBySpeed()
	throws an uncaught FbossError and crashes the benchmark with SIGABRT:

		what(): Platform port 257 has no profile for speed FOURHUNDREDG

	As a result, the benchmark fails, and no init/exit timing is produced.

# Test Plan

test command: /opt/fboss/bin/sai_all_benchmarks-sai_impl --json --bm_regex ^HwInitAndExit400Gx400GBenchmark$ --config ./share/hw_test_configs/minipack3n.agent.materialized_JSON --mgmt-if eth0 --flexports --fruid_filepath=/var/facebook/fboss/fruid.json --enable_sai_log WARN --logging WARN

test result:
{
  "HwInitAndExit400Gx400GBenchmark": 18351293345000
}
{
  "cpu_time_usec": 27976729,
  "max_rss": 2579064
}
