### PR TITLE
[Nexthop][m4062nhp][minipack3] Change l2LearningMode to SOFTWARE in agent.conf default config

### DIFF
--- a/fboss/oss/scripts/run_configs/default_configs/minipack3/agent.conf
+++ b/fboss/oss/scripts/run_configs/default_configs/minipack3/agent.conf
@@ -8775,7 +8775,7 @@
 
     },
     "switchSettings": {
-      "l2LearningMode": 0,
+      "l2LearningMode": 1,
       "qcmEnable": false,
       "ptpTcEnable": false,
       "l2AgeTimerSeconds": 300,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

As per https://github.com/facebook/fboss/blob/b6c29b90b7ab2b2e6690935bb40861eac6e42a38/fboss/agent/hw/sai/switch/SaiSwitch.cpp#L1002-L1006, we should only be using SW learning mode in production. Change l2LearningMode from default HARDWARE to default SOFTWARE in agent.conf.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

None.