### PR TITLE
[Celestica] Icecubem: Config: Update COME 2.0 EEPROM version to v3.1.1 and cleanup legacy sensors

### DIFF
--- a/fboss/configs/platforms/celestica/icecubem/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/icecubem/platform_stack/sensor_service.json
@@ -2465,8 +2465,8 @@
               "compute": "@/1000.0"
             }
           ],
-          "productionState": 1,
-          "productionSubState": 2,
+          "productionState": 3,
+          "productionSubState": 1,
           "respinVariantIndicator": 1
         },
         {
@@ -2610,148 +2610,6 @@
           "productionState": 1,
           "productionSubState": 2,
           "respinVariantIndicator": 2
-        },
-        {
-          "sensors": [
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 131.84
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT2",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/power4_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 30.9
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in1_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 13.22,
-                "minAlarmVal": 10.82,
-                "upperCriticalVal": 13.35,
-                "lowerCriticalVal": 10.7
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in3_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 1.75,
-                "upperCriticalVal": 1.82
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT2",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/in4_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 1.36,
-                "upperCriticalVal": 1.46
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 100
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP2",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/temp2_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 100
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 164.8
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT2",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON1/curr4_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 38.625
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/power3_input",
-              "type": 0,
-              "thresholds": {
-                "upperCriticalVal": 24.72
-              },
-              "compute": "@/1000000.0"
-            },
-            {
-              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in1_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 13.22,
-                "minAlarmVal": 10.82,
-                "upperCriticalVal": 13.35,
-                "lowerCriticalVal": 10.7
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/in3_input",
-              "type": 1,
-              "thresholds": {
-                "maxAlarmVal": 1.29,
-                "upperCriticalVal": 1.42
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/temp1_input",
-              "type": 3,
-              "thresholds": {
-                "upperCriticalVal": 100
-              },
-              "compute": "@/1000.0"
-            },
-            {
-              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT1",
-              "sysfsPath": "/run/devmap/sensors/COME_HWMON2/curr3_input",
-              "type": 2,
-              "thresholds": {
-                "upperCriticalVal": 30.9
-              },
-              "compute": "@/1000.0"
-            }
-          ],
-          "productionState": 1,
-          "productionSubState": 3,
-          "respinVariantIndicator": 1
         },
         {
           "sensors": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

<img width="1062" height="370" alt="icecubem" src="https://github.com/user-attachments/assets/4425b3a8-096b-43f7-b4bc-a9f8576485ed" />

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

During the COME 2.0 (Icecubem) bring-up process with Infineon chips, the EEPROM hardware version has been updated to **3.1.1** (productionState: 3, productionSubState: 1, respinVariantIndicator: 1).

This PR updates the sensor configuration in `sensor_service.json` to properly support this hardware revision and cleans up deprecated sensor entries. Without this change, `sensor_service` would fail to recognize the Infineon-equipped COME 2.0 module or correctly map its telemetry rails.

Main changes include:
- **EEPROM Version Update**: Aligned COME 2.0 hardware version mapping to `3.1.1` (`productionState: 3`, `productionSubState: 1`, `respinVariantIndicator: 1`).
- **Legacy Cleanup**: Removed deprecated and redundant `XDPE19283D` sensor configuration blocks (`COME_PU1_XDPE19283D_*` and `COME_PU37_XDPE19283D_*`) associated with legacy v1.3.1 board configurations.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

1. **Syntax Validation**: Validated JSON syntax using `JSONLint`.
2. **Formatting**: Pretty-printed configurations using the `jq` command for readability.
3. **Build & Config Tests**: Compilation and configuration validation tests passed successfully.
4. **Service Verification**: Confirmed that the following services start and run without errors:
    - `platform_manager`
    - `sensor_service`/`sensor_service_client`/`sensor_service_sw_test`/`sensor_service_hw_test`

5. **Hardware Identification**: Verified that the COME 2.0 EEPROM version (**3.1.1**) is accurately identified during initial bring-up via FRU/EEPROM utilities.
6. **Telemetry Verification**: Confirmed Infineon power rail sensor readings (voltage, current, power, and temperature) are correctly captured and validated via `sensor_service_client`.

**Attachments:**
[icecubem_come20_infineon_test_logs.zip](https://github.com/user-attachments/files/31770103/icecubem_come20_infineon_test_logs.zip)

