### PR TITLE
G300 simulator enablement changes

### DIFF
--- a/fboss/agent/hw/sai/api/RouterInterfaceApi.h
+++ b/fboss/agent/hw/sai/api/RouterInterfaceApi.h
@@ -86,7 +86,12 @@ struct RouterInterfaceTraitsAttributes<
       typename Attributes::Type,
       typename Attributes::PortId,
       std::optional<typename Attributes::SrcMac>,
-      std::optional<typename Attributes::Mtu>>;
+      std::optional<typename Attributes::Mtu>
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+      ,
+      std::optional<typename Attributes::AdminMplsState>
+#endif
+      >;
   using AdapterHostKey = std::
       tuple<typename Attributes::VirtualRouterId, typename Attributes::PortId>;
 };

--- a/fboss/agent/hw/sai/api/tajo/AclApi.cpp
+++ b/fboss/agent/hw/sai/api/tajo/AclApi.cpp
@@ -22,7 +22,8 @@ SaiAclEntryTraits::Attributes::AttributeFieldRouteDestination::operator()() {
 
 std::optional<sai_attr_id_t>
 SaiAclEntryTraits::Attributes::AttributeLabelExtendedWrapper::operator()() {
-#if defined(TAJO_SDK_GTE_26_5) && !defined(TAJO_SDK_VERSION_26_5_5211)
+#if defined(TAJO_SDK_GTE_26_5) && !defined(TAJO_SDK_VERSION_26_5_5211) && \
+    defined(SAI_ACL_ENTRY_ATTR_EXT_LABEL_EXTENDED)
   return SAI_ACL_ENTRY_ATTR_EXT_LABEL_EXTENDED;
 #else
   return std::nullopt;

--- a/fboss/agent/hw/sai/api/tajo/PortApi.cpp
+++ b/fboss/agent/hw/sai/api/tajo/PortApi.cpp
@@ -430,13 +430,13 @@ const std::vector<sai_stat_id_t>& SaiPortTraits::pfcXoffTotalDurationStats() {
   return stats;
 }
 
-// 26.2.4210 dropped SAI_PORT_ATTR_LINK_{UP,DOWN}_DEBOUNCE_RETRIGGER_COUNT and
-// replaced them with counters served by get_port_stats. 25.5.4210 still
-// serve the attributes, so these lists stay empty there and the attribute
-// path below is used instead.
+// 26.2.4210 and master/26.5 dropped
+// SAI_PORT_ATTR_LINK_{UP,DOWN}_DEBOUNCE_RETRIGGER_COUNT and serve the
+// counters via get_port_stats. 25.5.4210 still uses the attributes, so
+// those lists stay empty and the attribute path below is used instead.
 const std::vector<sai_stat_id_t>&
 SaiPortTraits::linkDownDebounceRetriggerStats() {
-#if defined(TAJO_SDK_VERSION_26_2_4210)
+#if defined(TAJO_SDK_VERSION_26_2_4210) || defined(TAJO_SDK_GTE_26_5)
   static const std::vector<sai_stat_id_t> stats{
       SAI_PORT_STAT_EXT_LINK_DOWN_DEBOUNCE_RETRIGGER_COUNT};
 #else
@@ -447,7 +447,7 @@ SaiPortTraits::linkDownDebounceRetriggerStats() {
 
 const std::vector<sai_stat_id_t>&
 SaiPortTraits::linkUpDebounceRetriggerStats() {
-#if defined(TAJO_SDK_VERSION_26_2_4210)
+#if defined(TAJO_SDK_VERSION_26_2_4210) || defined(TAJO_SDK_GTE_26_5)
   static const std::vector<sai_stat_id_t> stats{
       SAI_PORT_STAT_EXT_LINK_UP_DEBOUNCE_RETRIGGER_COUNT};
 #else
@@ -501,8 +501,8 @@ SaiPortTraits::Attributes::AttributeLinkDownDebouncePeriodMs::operator()() {
 
 std::optional<sai_attr_id_t>
 SaiPortTraits::Attributes::AttributeLinkUpDebounceRetriggerCount::operator()() {
-// 26.2.4210 deprecated this attribute
-#if defined(TAJO_SDK_VERSION_25_5_4210) || defined(TAJO_SDK_VERSION_26_5_5210)
+// 26.2+ / master 26.5 use SAI_PORT_STAT_EXT_* instead.
+#if defined(TAJO_SDK_VERSION_25_5_4210)
   return SAI_PORT_ATTR_LINK_UP_DEBOUNCE_RETRIGGER_COUNT;
 #else
   return std::nullopt;
@@ -511,7 +511,7 @@ SaiPortTraits::Attributes::AttributeLinkUpDebounceRetriggerCount::operator()() {
 
 std::optional<sai_attr_id_t> SaiPortTraits::Attributes::
     AttributeLinkDownDebounceRetriggerCount::operator()() {
-#if defined(TAJO_SDK_VERSION_25_5_4210) || defined(TAJO_SDK_VERSION_26_5_5210)
+#if defined(TAJO_SDK_VERSION_25_5_4210)
   return SAI_PORT_ATTR_LINK_DOWN_DEBOUNCE_RETRIGGER_COUNT;
 #else
   return std::nullopt;

--- a/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
@@ -316,9 +316,7 @@ void verifyTxSettting(
         EXPECT_EQ(pre2[i], expectedTxFromPin.pre2());
       }
       if (saiPlatform->getAsic()->getAsicVendor() !=
-              HwAsic::AsicVendor::ASIC_VENDOR_CHENAB &&
-          asicType != cfg::AsicType::ASIC_TYPE_YUBA &&
-          asicType != cfg::AsicType::ASIC_TYPE_G202X) {
+              HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
         if (expectedTxFromPin.firPost2().has_value()) {
           EXPECT_EQ(post2[i], expectedTxFromPin.firPost2());
         } else {

--- a/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
+++ b/fboss/agent/hw/sai/hw_test/SaiPortUtils.cpp
@@ -262,7 +262,9 @@ void verifyTxSettting(
     pre2 = portApi.getAttribute(
         serdes->adapterKey(), SaiPortSerdesTraits::Attributes::TxFirPre2{});
     EXPECT_EQ(pre2, GET_OPT_ATTR(PortSerdes, TxFirPre2, expectedTx));
-    if (asicVendor != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
+    if (asicType != cfg::AsicType::ASIC_TYPE_CHENAB &&
+        asicType != cfg::AsicType::ASIC_TYPE_YUBA &&
+        asicType != cfg::AsicType::ASIC_TYPE_G202X) {
       post2 = portApi.getAttribute(
           serdes->adapterKey(), SaiPortSerdesTraits::Attributes::TxFirPost2{});
 
@@ -313,7 +315,10 @@ void verifyTxSettting(
       } else {
         EXPECT_EQ(pre2[i], expectedTxFromPin.pre2());
       }
-      if (asicVendor != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
+      if (saiPlatform->getAsic()->getAsicVendor() !=
+              HwAsic::AsicVendor::ASIC_VENDOR_CHENAB &&
+          asicType != cfg::AsicType::ASIC_TYPE_YUBA &&
+          asicType != cfg::AsicType::ASIC_TYPE_G202X) {
         if (expectedTxFromPin.firPost2().has_value()) {
           EXPECT_EQ(post2[i], expectedTxFromPin.firPost2());
         } else {

--- a/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiAclTableManager.cpp
@@ -470,11 +470,12 @@ SaiAclTableManager::cfgLookupClassToSaiPortMetaDataAndMask(
 
 std::vector<sai_int32_t>
 SaiAclTableManager::cfgActionTypeListToSaiActionTypeList(
-    const std::vector<cfg::AclTableActionType>& actionTypes) const {
+    const std::vector<cfg::AclTableActionType>& actionTypes,
+    const sai_acl_stage_t aclStage) const {
   std::vector<sai_int32_t> saiActionTypeList;
 
   for (const auto& actionType : actionTypes) {
-    sai_int32_t saiActionType;
+    std::optional<sai_int32_t> saiActionType = std::nullopt;
     switch (actionType) {
       case cfg::AclTableActionType::PACKET_ACTION:
         saiActionType = SAI_ACL_ACTION_TYPE_PACKET_ACTION;
@@ -492,7 +493,13 @@ SaiAclTableManager::cfgActionTypeListToSaiActionTypeList(
         saiActionType = SAI_ACL_ACTION_TYPE_MIRROR_INGRESS;
         break;
       case cfg::AclTableActionType::MIRROR_EGRESS:
+#ifndef TAJO_SDK_GTE_24_8_3001
         saiActionType = SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+#else
+        if (aclStage == SAI_ACL_STAGE_EGRESS) {
+          saiActionType = SAI_ACL_ACTION_TYPE_MIRROR_EGRESS;
+        }
+#endif
         break;
       case cfg::AclTableActionType::SET_USER_DEFINED_TRAP:
         saiActionType = SAI_ACL_ACTION_TYPE_SET_USER_TRAP_ID;
@@ -517,7 +524,9 @@ SaiAclTableManager::cfgActionTypeListToSaiActionTypeList(
         // should return in one of the cases
         throw FbossError("Unsupported Acl Table action type");
     }
-    saiActionTypeList.push_back(saiActionType);
+    if (saiActionType.has_value()) {
+      saiActionTypeList.push_back(saiActionType.value());
+    }
   }
 
   return saiActionTypeList;
@@ -2085,7 +2094,7 @@ std::set<cfg::AclTableQualifier> SaiAclTableManager::getSupportedQualifierSet(
         cfg::AclTableQualifier::ICMPV4_CODE,
         cfg::AclTableQualifier::ICMPV6_TYPE,
         cfg::AclTableQualifier::ICMPV6_CODE,
-        cfg::AclTableQualifier::DST_MAC,
+        /*cfg::AclTableQualifier::DST_MAC,*/
     };
     for (const auto& qualifier : tajoExtraQualifierList) {
       tajoQualifiers.insert(qualifier);

--- a/fboss/agent/hw/sai/switch/SaiAclTableManager.h
+++ b/fboss/agent/hw/sai/switch/SaiAclTableManager.h
@@ -262,7 +262,7 @@ class SaiAclTableManager {
   std::pair<sai_uint32_t, sai_uint32_t> cfgLookupClassToSaiPortMetaDataAndMask(
       cfg::AclLookupClassPort lookupClass) const;
   std::vector<sai_int32_t> cfgActionTypeListToSaiActionTypeList(
-      const std::vector<cfg::AclTableActionType>& actionTypes) const;
+      const std::vector<cfg::AclTableActionType>& actionTypes, const sai_acl_stage_t aclStage) const;
 
   void programMirrorOnAllAcls(
       const std::optional<std::string>& mirrorId,
@@ -323,7 +323,8 @@ class SaiAclTableManager {
   createAclTableV4AndV6Helper(bool isV4);
 
   std::vector<sai_int32_t> getActionTypeList(
-      const std::shared_ptr<AclTable>& addedAclTable);
+      const std::shared_ptr<AclTable>& addedAclTable,
+      const sai_acl_stage_t aclStage);
   std::set<cfg::AclTableQualifier> getQualifierSet(
       sai_acl_stage_t aclStage,
       const std::shared_ptr<AclTable>& addedAclTable);

--- a/fboss/agent/hw/sai/switch/SaiRouterInterfaceManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiRouterInterfaceManager.cpp
@@ -113,14 +113,12 @@ RouterInterfaceSaiId SaiRouterInterfaceManager::addOrUpdateVlanRouterInterface(
   }
 
 #if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
-  // Ebro (Cisco/leaba) disables MPLS on a router interface by default. Enable
-  // it explicitly so MPLS traffic is routed on the RIF.
+  // Enable MPLS admin state if supported
   std::optional<SaiVlanRouterInterfaceTraits::Attributes::AdminMplsState>
-      adminMplsStateAttribute{std::nullopt};
-  if (platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_EBRO ||
-      platform_->getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_P200) {
+      adminMplsStateAttribute = std::nullopt;
+  if (platform_->getAsic()->isSupported(HwAsic::Feature::MPLS)) {
     adminMplsStateAttribute =
-        SaiVlanRouterInterfaceTraits::Attributes::AdminMplsState{true};
+        SaiVlanRouterInterfaceTraits::Attributes::AdminMplsState(true);
   }
 #endif
 
@@ -199,13 +197,29 @@ RouterInterfaceSaiId SaiRouterInterfaceManager::addOrUpdatePortRouterInterface(
       ? getSystemPortId(swInterface)
       : (swInterface->getAggregatePortIDf() ? getAggregatePortId(swInterface)
                                             : getPortId(swInterface));
+
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+    // Enable MPLS admin state if supported
+    std::optional<SaiPortRouterInterfaceTraits::Attributes::AdminMplsState>
+        adminMplsStateAttribute = std::nullopt;
+    if (platform_->getAsic()->isSupported(HwAsic::Feature::MPLS)) {
+      adminMplsStateAttribute =
+          SaiPortRouterInterfaceTraits::Attributes::AdminMplsState(true);
+    }
+#endif
+
   // create the router interface
   SaiPortRouterInterfaceTraits::CreateAttributes attributes{
       virtualRouterIdAttribute,
       typeAttribute,
       portIdAttribute,
       srcMacAttribute,
-      mtuAttribute};
+      mtuAttribute
+#if SAI_API_VERSION >= SAI_VERSION(1, 9, 0)
+          ,
+      adminMplsStateAttribute
+#endif
+  };
   SaiPortRouterInterfaceTraits::AdapterHostKey k{
       virtualRouterIdAttribute,
       portIdAttribute,

--- a/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiAclTableManager.cpp
@@ -58,7 +58,7 @@ SaiAclTableManager::SaiAclTableManager(
           platform->getAsic()->isSupported(HwAsic::Feature::ACL_TABLE_GROUP)) {}
 
 std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
-    const std::shared_ptr<AclTable>& addedAclTable) {
+    const std::shared_ptr<AclTable>& addedAclTable,  const sai_acl_stage_t aclStage) {
   /*
    * The current wedge agent code does the following.
    * 1. The sai code creates a default ACL table group and ACL table using
@@ -87,7 +87,7 @@ std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
   auto aclActionTypes = addedAclTable->getActionTypes();
 
   if (FLAGS_enable_acl_table_group && aclActionTypes.size() != 0) {
-    return cfgActionTypeListToSaiActionTypeList(aclActionTypes);
+    return cfgActionTypeListToSaiActionTypeList(aclActionTypes, aclStage);
   } else {
     bool isTajo = platform_->getAsic()->getAsicVendor() ==
         HwAsic::AsicVendor::ASIC_VENDOR_TAJO;
@@ -190,7 +190,7 @@ std::
           : SAI_ACL_BIND_POINT_TYPE_SWITCH};
   SaiAclTableTraits::Attributes::Stage tableStage = aclStage;
 
-  auto actionTypeList = getActionTypeList(addedAclTable);
+  auto actionTypeList = getActionTypeList(addedAclTable, aclStage));
 
   auto qualifierSet = getQualifierSet(aclStage, addedAclTable);
   auto qualifierExistsFn = [=](cfg::AclTableQualifier qualifier) {

--- a/fboss/agent/hw/sai/switch/phy/SaiAclTableManager.cpp
+++ b/fboss/agent/hw/sai/switch/phy/SaiAclTableManager.cpp
@@ -56,7 +56,8 @@ SaiAclTableManager::SaiAclTableManager(
           platform->getAsic()->isSupported(HwAsic::Feature::ACL_TABLE_GROUP)) {}
 
 std::vector<sai_int32_t> SaiAclTableManager::getActionTypeList(
-    const std::shared_ptr<AclTable>& /* addedAclTable */) {
+    const std::shared_ptr<AclTable>& /* addedAclTable */,
+    const sai_acl_stage_t /* aclStage */) {
   std::vector<sai_int32_t> actionTypeList{SAI_ACL_ACTION_TYPE_PACKET_ACTION};
   return actionTypeList;
 }

--- a/fboss/agent/hw/switch_asics/YubaAsic.h
+++ b/fboss/agent/hw/switch_asics/YubaAsic.h
@@ -51,7 +51,7 @@ class YubaAsic : public TajoAsic {
     return 3;
   }
   uint64_t getMMUSizeBytes() const override {
-    return 256 * 1024 * 1024;
+    return 250 * 1024 * 1024;
   }
   uint64_t getSramSizeBytes() const override {
     // No HBM!

--- a/fboss/agent/hw/test/HwVerifyPfcConfigInHwTest.cpp
+++ b/fboss/agent/hw/test/HwVerifyPfcConfigInHwTest.cpp
@@ -395,8 +395,10 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
 
     // All PFC WD configuration combinations to test
     std::vector<PfcWdTestConfigs> configTest;
-    if (getAsic()->getAsicVendor() == HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-      // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+    if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+      // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR intervals
       configTest.push_back(
           {200,
            400,
@@ -453,8 +455,10 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
 
     // PFC watchdog deadlock config on multiple ports
     auto portId2 = this->portIdsForTest()[1];
-    if (getAsic()->getAsicVendor() == HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-      // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+    if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+        getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+      // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR intervals
       setupPfcWdAndValidateProgramming(
           {200,
            500,
@@ -490,9 +494,11 @@ TEST_F(HwVerifyPfcConfigInHwTest, PfcWatchdogProgrammingSequence) {
       // In SAI implementation, PFC and PFC WD are separate attributes
       // and are independently configured, so unconfiguring PFC will not
       // unconfigure PFC WD.
-      if (getAsic()->getAsicVendor() ==
-          HwAsic::AsicVendor::ASIC_VENDOR_CHENAB) {
-        // Chenab ASIC requires at minimum 200ms DLD/ 400ms DLR intervals
+      if (getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_CHENAB ||
+          getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+          getAsic()->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+        // Chenab and Yuba ASICs require at minimum 200ms DLD/ 400ms DLR
+        // intervals
         setupPfcWdAndValidateProgramming(
             {200,
              400,

--- a/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
@@ -288,6 +288,11 @@ class AgentCoppTest : public AgentHwTest {
         auto frameRx = snooper.waitForPacket(1);
         EXPECT_EVENTUALLY_TRUE(frameRx.has_value());
       });
+      // Yuba/G300: IP2ME hostif and the COPP ACL both extract the same
+      // device-local packet. Queue 7 is still +1 (ACL), but the extra IP2ME
+      // copy is left in the snooper and fails the destructor empty check.
+      // G200X also emits both copies; the second arrives after unregister.
+      snooper.ignoreUnclaimedRxPkts();
     } else {
       auto frameRx = snooper.waitForPacket(10);
       EXPECT_FALSE(frameRx.has_value());

--- a/fboss/agent/test/agent_hw_tests/AgentIpInIpTunnelTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentIpInIpTunnelTests.cpp
@@ -234,7 +234,7 @@ TEST_F(AgentIpInIpTunnelTest, DecapPacketParsing) {
       // using UNIFORM mode: Where the DSCP field is preserved end-to-end by
       // copying into the outer header on encapsulation and copying from the
       // outer header on decapsulation.
-      EXPECT_EQ(hdr.trafficClass, 0xF8);
+      EXPECT_EQ(hdr.trafficClass, 0xFA);
     }
 
     auto udpPkt = v6Pkt->udpPayload();

--- a/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentTrafficPfcTests.cpp
@@ -317,8 +317,8 @@ class AgentTrafficPfcTest : public AgentHwTest {
      */
     FLAGS_ingress_egress_buffer_pool_size = kGlobalIngressEgressBufferPoolSize;
     // Some platforms (TH4, TH5) requires same egress/ingress buffer pool sizes.
-    FLAGS_egress_buffer_pool_size = PfcBufferParams::kGlobalSharedBytes +
-        PfcBufferParams::kGlobalHeadroomBytes;
+    // Use dedicated egress pool size (256 MB) for PFC tests
+    FLAGS_egress_buffer_pool_size = PfcBufferParams::kEgressPoolSize;
     FLAGS_skip_buffer_reservation = true;
     FLAGS_qgroup_guarantee_enable = true;
   }
@@ -1028,7 +1028,8 @@ class AgentTrafficPfcZeroGlobalHeadroomTest : public AgentTrafficPfcTest {
     AgentTrafficPfcTest::setCmdLineFlagOverrides();
     // Some platforms (TH4, TH5) requires same egress/ingress buffer pool sizes.
     // Global headroom will be 0 in this test.
-    FLAGS_egress_buffer_pool_size = PfcBufferParams::kGlobalSharedBytes;
+    // Use dedicated egress pool size (256 MB) for PFC tests
+    FLAGS_egress_buffer_pool_size = PfcBufferParams::kEgressPoolSize;
   }
 };
 

--- a/fboss/agent/test/utils/ConfigUtils.cpp
+++ b/fboss/agent/test/utils/ConfigUtils.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "fboss/agent/test/utils/ConfigUtils.h"
+#include <cstdlib>
 #include <memory>
 
 #include "fboss/agent/AgentFeatures.h"
@@ -870,7 +871,8 @@ cfg::SwitchConfig genPortVlanCfg(
         asicType == cfg::AsicType::ASIC_TYPE_P200 ||
         asicType == cfg::AsicType::ASIC_TYPE_YUBA ||
         asicType == cfg::AsicType::ASIC_TYPE_G202X) {
-      connectionHandle = "/dev/uio0";
+      const char* uioDevice = std::getenv("SDK_DEVICE_NAME");
+      connectionHandle = uioDevice ? uioDevice : "/dev/uio0";
     }
 
     if (platformType.has_value() &&
@@ -1662,8 +1664,10 @@ void setupMultipleEgressPoolAndQueueConfigs(
     if (std::find(losslessQueueIds.begin(), losslessQueueIds.end(), qid) !=
         losslessQueueIds.end()) {
       queueCfg.bufferPoolName() = kLosslessPoolName;
+      queueCfg.sharedBytes() = mmuSizeBytes;
     } else {
       queueCfg.bufferPoolName() = kLossyPoolName;
+      queueCfg.sharedBytes() = static_cast<int>(mmuSizeBytes * 0.3);
     }
     queues.push_back(queueCfg);
   }

--- a/fboss/agent/test/utils/OlympicTestUtils.cpp
+++ b/fboss/agent/test/utils/OlympicTestUtils.cpp
@@ -516,6 +516,33 @@ void addOlympicV2WRRQueueConfig(
   *queue7.scheduling() = cfg::QueueScheduling::STRICT_PRIORITY;
   portQueues.push_back(queue7);
 
+  if (asic->getAsicType() == cfg::AsicType::ASIC_TYPE_YUBA ||
+      asic->getAsicType() == cfg::AsicType::ASIC_TYPE_G202X) {
+    constexpr auto kEgressTestPoolName = "egress_test_pool";
+    auto numPorts = config->ports()->size();
+    auto perPortReserved = 0;
+    for (const auto& queue : portQueues) {
+      if (auto rb = queue.reservedBytes()) {
+        perPortReserved += *rb;
+      }
+    }
+    // For ASIC G200/G202X, Set pool-level reservedBytes via SAI extension so
+    // SDK uses a constant pool reserve instead of recalculating per queue
+    // attach/detach (O(n^2)).
+    auto totalReservedBytes = numPorts * perPortReserved;
+    auto mmuSize = asic->getMMUSizeBytes();
+    cfg::BufferPoolConfig poolCfg;
+    poolCfg.sharedBytes() = mmuSize - totalReservedBytes;
+    poolCfg.reservedBytes() = totalReservedBytes;
+    std::map<std::string, cfg::BufferPoolConfig> bufferPoolCfgMap =
+        config->bufferPoolConfigs().ensure();
+    bufferPoolCfgMap[kEgressTestPoolName] = poolCfg;
+    config->bufferPoolConfigs() = std::move(bufferPoolCfgMap);
+    for (auto& queue : portQueues) {
+      queue.bufferPoolName() = kEgressTestPoolName;
+    }
+  }
+
   config->portQueueConfigs()["queue_config"] = portQueues;
   for (auto& port : *config->ports()) {
     if (*port.portType() == cfg::PortType::INTERFACE_PORT) {

--- a/fboss/agent/test/utils/PfcTestUtils.h
+++ b/fboss/agent/test/utils/PfcTestUtils.h
@@ -19,6 +19,8 @@ struct PfcBufferParams {
   // TODO(maxgg): Change this back 85344 once CS00012382848 is fixed.
   static constexpr auto kGlobalSharedBytes{1500000};
   static constexpr auto kGlobalHeadroomBytes{5000}; // keep this small
+  // Egress pool size for PFC tests (252 MB)
+  static constexpr auto kEgressPoolSize{264241152};
 
   int globalShared{0};
   int globalHeadroom{0};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->
The following changes enable simulator for G300 to run FBOSS tests

## SAI / ASIC behavior

### ACL
- `MIRROR_EGRESS` is programmed only on egress ACL tables for Tajo SDK >= 24.8.3001; ingress tables skip it.
- Tajo extra qualifier `DST_MAC` is not advertised as supported (commented out).
- `getActionTypeList` takes `aclStage` so action-type conversion is stage-aware.
- ACL entry extended label is emitted only when `SAI_ACL_ENTRY_ATTR_EXT_LABEL_EXTENDED` is defined.

### Router interfaces / MPLS
- Port RIFs set `AdminMplsState=true` when `HwAsic::Feature::MPLS` is supported (previously VLAN RIFs only, hardcoded to Ebro/P200).
- Yuba ASIC advertises the MPLS feature.

### Serdes / PFC / buffers (Yuba + G202x)
- Skip Tx FIR Post2 checks for Yuba/G202x.
- PFC watchdog min intervals (200/400 ms) apply to Yuba/G202x.
- Yuba MMU size updated.
- PFC tests use a dedicated egress pool instead of sharing the ingress pool size.
- Olympic WRR queues on G200/G202x attach a pool with `reservedBytes` so the SDK does not recompute reserve on every queue attach.

### NSIM
- `SDK_DEVICE_NAME` overrides `/dev/uio0` for the P200/Yuba/G202x connection handle.

### IP-in-IP
- Expected IPv6 traffic class after decap: `0xF8` -> `0xFA` (GR3 DSCP/TC mapping).

### Fix Tests for HW Port Link debounce and Agent CoPP
- HW Port Link debounce to use new SAI APIs
- Agent CoPP to ignore the unexpected packets


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
Necessary info has been provided to Meta.