### PR TITLE
[Nexthop][wedge800bnhp] Avoid creating TH5 port serdes with zeroed TX FIR / empty Preemphasis

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
@@ -1211,12 +1211,23 @@ void SaiPortManager::programSerdes(
       std::get<std::optional<SaiPortSerdesTraits::Attributes::TxFirPost3>>(
           serdesAttributes) = std::nullopt;
     }
-    // set main txfir only first to avoid programming errors, see CS00012393198
-    auto attributes = serdesAttributes;
     auto newTxFirMain =
         std::get<std::optional<SaiPortSerdesTraits::Attributes::TxFirMain>>(
             serdesAttributes);
-    if (newTxFirMain.has_value()) {
+    if (swPort->getZeroPreemphasis() && newTxFirMain.has_value()) {
+      // Broadcom rejects *creating* a port serdes object with TxFirMain set to
+      // 0. When zero preemphasis is requested (e.g. HW loopback tests) and the
+      // serdes is being created from scratch (such as during a VCO change that
+      // recreates the port), create it with only preemphasis set and leave the
+      // TX FIR taps unprogrammed. The setObject() below then programs the
+      // zeroed taps as an update, which the SDK does allow. This only matters
+      // when the profile actually has TX FIR taps; copper profiles have no
+      // TxFirMain and fall through to the path below.
+      createSerdesWithZeroPreemphasis(portHandle, swPort->getPinConfigs());
+    } else if (newTxFirMain.has_value()) {
+      // set main txfir only first to avoid programming errors, see
+      // CS00012393198
+      auto attributes = serdesAttributes;
       auto numLanes = newTxFirMain.value().value().size();
       SaiPortSerdesTraits::Attributes::TxFirPre1::ValueType txPre1;
       txPre1.resize(numLanes, 0);
@@ -1784,11 +1795,16 @@ void SaiPortManager::createSerdesWithZeroPreemphasis(
   }
 
 #if !defined(CHENAB_SAI_SDK)
-  SaiPortSerdesTraits::Attributes::Preemphasis::ValueType preemphasis;
-  preemphasis.resize(numExpectedTxLanes, 0);
-  std::get<std::optional<
-      std::decay_t<decltype(SaiPortSerdesTraits::Attributes::Preemphasis{})>>>(
-      attributes) = preemphasis;
+  // Only program Preemphasis when the profile actually has TX lanes. Setting an
+  // empty Preemphasis vector (e.g. for copper profiles with no tx pin configs)
+  // is rejected by the SDK with INVALID ATTRIBUTE MAX.
+  if (numExpectedTxLanes > 0) {
+    SaiPortSerdesTraits::Attributes::Preemphasis::ValueType preemphasis;
+    preemphasis.resize(numExpectedTxLanes, 0);
+    std::get<std::optional<std::decay_t<
+        decltype(SaiPortSerdesTraits::Attributes::Preemphasis{})>>>(
+        attributes) = preemphasis;
+  }
 #endif
   SaiPortSerdesTraits::AdapterHostKey serdesKey{portSaiId};
   auto& store = saiStore_->get<SaiPortSerdesTraits>();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary
On Tomahawk5, recreating a port serdes under zeroPreemphasis=true (set by LinkStateToggler in HW loopback tests) crashes during a VCO change that forces a port recreate:
- For optical profiles, avoid creating the serdes object with zeroed TxFirMain values. Create it without the TX FIR taps, then program the zeroed taps in a follow-up update accepted by the SDK.
- Preserve the existing copper-profile path and avoid programming an empty Preemphasis attribute when no TX lanes are present.

# Test Plan
wedge800bnhp:
```
Running all tests took 0:00:46.291503 between 2026-06-15 22:35:01.767058 and 2026-06-15 22:35:48.058561
[ PASSED ] cold_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/1 (10631 ms)
[ PASSED ] warm_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/1 (9513 ms)
[ PASSED ] cold_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/3 (10583 ms)
[ PASSED ] warm_boot.AgentPortBandwidthTest/AgentPortBandwidthParamTest.VerifyPortRateTraffic/3 (9488 ms)
Summary:
   PASSED : 4
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
