### PR TITLE
[Nexthop] Fix ARS spray test by checking deviation from fair share

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentLoadBalancerTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentLoadBalancerTests.cpp
@@ -211,6 +211,19 @@ class AgentLoadBalancerTestSpray
     return features;
   }
 
+  /*
+   * PER_PACKET_QUALITY splits evenly only when the members are in the same
+   * ASIC core, which no fixed ecmp width guarantees across platforms, so check
+   * each member's share of the total instead. PER_PACKET_RANDOM is uniform by
+   * construction and keeps the equal-share check. See MemberShareBounds.
+   */
+  std::optional<utility::MemberShareBounds> sprayShareBounds() const override {
+    if constexpr (loadAware) {
+      return utility::MemberShareBounds{};
+    }
+    return std::nullopt;
+  }
+
   std::unique_ptr<EcmpDataPlateUtils> getECMPHelper() override {
     if (!this->getEnsemble()) {
       // run during listing produciton features

--- a/fboss/agent/test/utils/EcmpDataPlaneTestUtil.cpp
+++ b/fboss/agent/test/utils/EcmpDataPlaneTestUtil.cpp
@@ -117,6 +117,19 @@ bool HwEcmpDataPlaneTestUtil<EcmpSetupHelperT>::isLoadBalanced(
   return rc;
 }
 
+template <typename EcmpSetupHelperT>
+bool HwEcmpDataPlaneTestUtil<EcmpSetupHelperT>::isTrafficSprayed(
+    const std::vector<PortDescriptor>& portDescs,
+    const MemberShareBounds& bounds) {
+  return utility::isTrafficSprayed<PortID, HwPortStats>(
+      portDescs,
+      [ensemble = ensemble_](
+          const std::vector<PortID>& portIds) -> std::map<PortID, HwPortStats> {
+        return ensemble->getLatestPortStats(portIds);
+      },
+      bounds);
+}
+
 template <typename AddrT>
 void HwEcmpDataPlaneTestUtil<AddrT>::programLoadBalancer(
     const cfg::LoadBalancer& lb) {
@@ -147,7 +160,8 @@ void HwEcmpDataPlaneTestUtil<AddrT>::pumpTrafficPortAndVerifyLoadBalanced(
     bool loopThroughFrontPanel,
     const std::vector<NextHopWeight>& weights,
     int deviation,
-    bool loadBalanceExpected) {
+    bool loadBalanceExpected,
+    const std::optional<MemberShareBounds>& sprayBounds) {
   auto helper = this->ecmpSetupHelper();
   const auto portDescs = helper->ecmpPortDescs(ecmpWidth);
   std::vector<PortID> ports;
@@ -188,7 +202,9 @@ void HwEcmpDataPlaneTestUtil<AddrT>::pumpTrafficPortAndVerifyLoadBalanced(
       },
       this->getNumPacketsToPump(),
       [=, this]() {
-        return this->isLoadBalanced(portDescs, weights, deviation);
+        return sprayBounds.has_value()
+            ? this->isTrafficSprayed(portDescs, *sprayBounds)
+            : this->isLoadBalanced(portDescs, weights, deviation);
       },
       loadBalanceExpected);
 }

--- a/fboss/agent/test/utils/EcmpDataPlaneTestUtil.h
+++ b/fboss/agent/test/utils/EcmpDataPlaneTestUtil.h
@@ -7,6 +7,7 @@
 #include "fboss/agent/types.h"
 
 #include "fboss/agent/test/EcmpSetupHelper.h"
+#include "fboss/agent/test/utils/LoadBalancerTestUtils.h"
 
 namespace facebook::fboss {
 class TestEnsembleIf;
@@ -46,6 +47,9 @@ class HwEcmpDataPlaneTestUtil {
       const std::vector<PortDescriptor>& portDescs,
       const std::vector<NextHopWeight>& weights,
       uint8_t deviation);
+  bool isTrafficSprayed(
+      const std::vector<PortDescriptor>& portDescs,
+      const MemberShareBounds& bounds);
 
   void programLoadBalancer(const cfg::LoadBalancer& lb);
 
@@ -57,12 +61,17 @@ class HwEcmpDataPlaneTestUtil {
     programLoadBalancer(lb);
   }
 
+  /*
+   * When sprayBounds is set, each member is checked against a share of the
+   * total rather than against every other member. See MemberShareBounds.
+   */
   void pumpTrafficPortAndVerifyLoadBalanced(
       unsigned int ecmpWidth,
       bool loopThroughFrontPanel,
       const std::vector<NextHopWeight>& weights,
       int deviation,
-      bool loadBalanceExpected);
+      bool loadBalanceExpected,
+      const std::optional<MemberShareBounds>& sprayBounds = std::nullopt);
 
  protected:
   static constexpr uint64_t kDefaultPacketCount{10000};

--- a/fboss/agent/test/utils/LoadBalancerTestRunner.h
+++ b/fboss/agent/test/utils/LoadBalancerTestRunner.h
@@ -186,6 +186,15 @@ class HwLoadBalancerTestRunner {
     return false;
   }
 
+  /*
+   * Fixtures whose spray distribution depends on the core the member ports sit
+   * in rather than on an equal split return bounds here, to be checked per
+   * member against the fair share. See MemberShareBounds.
+   */
+  virtual std::optional<utility::MemberShareBounds> sprayShareBounds() const {
+    return std::nullopt;
+  }
+
   bool isFeatureSupported(HwAsic::Feature feature) const {
     return getEnsemble()->getHwAsicTable()->isFeatureSupportedOnAnyAsic(
         feature);
@@ -219,7 +228,8 @@ class HwLoadBalancerTestRunner {
           loopThroughFrontPanel,
           weights,
           deviation,
-          loadBalanceExpected);
+          loadBalanceExpected,
+          sprayShareBounds());
     };
 
     runTestAcrossWarmBoots(setup, verify, []() {}, []() {});

--- a/fboss/agent/test/utils/LoadBalancerTestUtils.cpp
+++ b/fboss/agent/test/utils/LoadBalancerTestUtils.cpp
@@ -392,13 +392,74 @@ std::set<uint64_t> getSortedPortBytesIncrement(
   return portBytesIncrement;
 }
 
+template <typename PortStatsT>
+uint64_t getPortOutBytes(const PortStatsT& stats) {
+  if constexpr (std::is_same_v<PortStatsT, HwPortStats>) {
+    return *stats.outBytes_();
+  } else if constexpr (std::is_same_v<PortStatsT, HwSysPortStats>) {
+    return stats.queueOutBytes_()->at(getDefaultQueue()) +
+        stats.queueOutDiscardBytes_()->at(getDefaultQueue());
+  }
+  throw FbossError("Unsupported port stats type in getPortOutBytes");
+}
+
+/*
+ * Every member must carry between floorPct and ceilPct of the fair share
+ * (total / numMembers). See MemberShareBounds for why this is the right
+ * assertion for per-packet quality spray. Kept in integer arithmetic:
+ *   floorPct * total <= 100 * numMembers * memberBytes <= ceilPct * total
+ */
+template <typename PortIdT, typename PortStatsT>
+bool isTrafficSprayedImpl(
+    const std::map<PortIdT, PortStatsT>& portIdToStats,
+    const MemberShareBounds& bounds) {
+  const uint64_t numMembers = portIdToStats.size();
+  uint64_t total = 0;
+  for (const auto& [portId, stats] : portIdToStats) {
+    total += getPortOutBytes(stats);
+  }
+  if (!numMembers || !total) {
+    // No members, or no traffic at all, is a failure and not a vacuous pass.
+    XLOG(INFO) << "Traffic not sprayed, members: " << numMembers
+               << " total bytes: " << total;
+    return false;
+  }
+  bool sprayed = true;
+  for (const auto& [portId, stats] : portIdToStats) {
+    auto memberBytes = getPortOutBytes(stats);
+    auto scaled = 100 * numMembers * memberBytes;
+    if (scaled < uint64_t(bounds.floorPct) * total ||
+        scaled > uint64_t(bounds.ceilPct) * total) {
+      XLOG(INFO) << "Member " << fmt::format("{}", portId)
+                 << " outBytes: " << memberBytes << " is outside "
+                 << bounds.floorPct << "%-" << bounds.ceilPct
+                 << "% of the fair share " << (total / numMembers);
+      sprayed = false;
+    }
+  }
+  return sprayed;
+}
+
 template <typename PortIdT, typename PortStatsT>
 std::pair<uint64_t, uint64_t> getHighestAndLowestBytes(
     const std::map<PortIdT, PortStatsT>& portIdToStats) {
   auto portBytes = getSortedPortBytes(portIdToStats);
   auto lowest = portBytes.empty() ? 0 : *portBytes.begin();
   auto highest = portBytes.empty() ? 0 : *portBytes.rbegin();
-  XLOG(DBG0) << " Highest bytes: " << highest << " lowest bytes: " << lowest;
+  // Highest/lowest alone cannot tell "one member took all the traffic" from
+  // "one member took none", so log every member.
+  for (const auto& [portId, stats] : portIdToStats) {
+    XLOG(INFO) << "Member " << fmt::format("{}", portId)
+               << " outBytes: " << getPortOutBytes(stats);
+  }
+  XLOG(INFO) << "Members: " << portIdToStats.size()
+             << " highest bytes: " << highest << " lowest bytes: " << lowest
+             << " deviation: "
+             << (lowest ? fmt::format(
+                              "{:.2f}%",
+                              (static_cast<double>(highest - lowest) / lowest) *
+                                  100.0)
+                        : std::string("n/a, lowest is 0"));
   return std::make_pair(highest, lowest);
 }
 
@@ -1117,6 +1178,18 @@ template std::set<uint64_t> getSortedPortBytesIncrement(
 template std::set<uint64_t> getSortedPortBytesIncrement(
     const std::map<PortID, HwPortStats>& beforePortIdToStats,
     const std::map<PortID, HwPortStats>& afterPortIdToStats);
+
+template uint64_t getPortOutBytes(const HwPortStats& stats);
+
+template uint64_t getPortOutBytes(const HwSysPortStats& stats);
+
+template bool isTrafficSprayedImpl<PortID, HwPortStats>(
+    const std::map<PortID, HwPortStats>& portIdToStats,
+    const MemberShareBounds& bounds);
+
+template bool isTrafficSprayedImpl<SystemPortID, HwSysPortStats>(
+    const std::map<SystemPortID, HwSysPortStats>& portIdToStats,
+    const MemberShareBounds& bounds);
 
 template std::pair<uint64_t, uint64_t> getHighestAndLowestBytes(
     const std::map<SystemPortID, HwSysPortStats>& portIdToStats);

--- a/fboss/agent/test/utils/LoadBalancerTestUtils.h
+++ b/fboss/agent/test/utils/LoadBalancerTestUtils.h
@@ -167,6 +167,59 @@ bool isDeviationWithinThreshold(
     int maxDeviationPct,
     bool noTrafficOk = false);
 
+/*
+ * Bounds each ECMP member's egress traffic must fall within, expressed as a
+ * percentage of the fair share (total traffic / number of members).
+ *
+ * TH5 requires the ports in loopback mode to be in the same core to load
+ * balance packets correctly. facebook/fboss 1212ea9dfc lowered the spray ecmp
+ * width from 8 to 6 for this reason. That keeps the members within one core
+ * only where a platform's first 6 master logical ports share one - where they
+ * land on separate cores the split is uneven, deterministic and reproducible,
+ * so no fixed width works across platforms.
+ *
+ * So assert participation rather than an equal split: the floor catches a
+ * starved or dead member (and a group that never sprayed at all), the ceiling
+ * catches one member hogging traffic while the rest stay just above the floor.
+ */
+struct MemberShareBounds {
+  int floorPct{25};
+  int ceilPct{200};
+};
+
+template <typename PortStatsT>
+uint64_t getPortOutBytes(const PortStatsT& stats);
+
+template <typename PortIdT, typename PortStatsT>
+bool isTrafficSprayedImpl(
+    const std::map<PortIdT, PortStatsT>& portIdToStats,
+    const MemberShareBounds& bounds);
+
+template <typename PortIdT, typename PortStatsT>
+std::vector<PortIdT> ecmpPortIds(const std::vector<PortDescriptor>& ecmpPorts) {
+  return folly::gen::from(ecmpPorts) |
+      folly::gen::map([](const auto& portDesc) {
+           if constexpr (std::is_same_v<PortStatsT, HwPortStats>) {
+             return portDesc.phyPortID();
+           } else if constexpr (std::is_same_v<PortStatsT, HwSysPortStats>) {
+             return portDesc.sysPortID();
+           }
+           throw FbossError("Unsupported port stats type in ecmpPortIds");
+         }) |
+      folly::gen::as<std::vector<PortIdT>>();
+}
+
+template <typename PortIdT, typename PortStatsT>
+bool isTrafficSprayed(
+    const std::vector<PortDescriptor>& ecmpPorts,
+    const std::function<std::map<PortIdT, PortStatsT>(
+        const std::vector<PortIdT>&)>& getPortStatsFn,
+    const MemberShareBounds& bounds) {
+  auto portIdToStats =
+      getPortStatsFn(ecmpPortIds<PortIdT, PortStatsT>(ecmpPorts));
+  return isTrafficSprayedImpl(portIdToStats, bounds);
+}
+
 template <typename PortIdT, typename PortStatsT>
 bool isLoadBalancedImpl(
     const std::map<PortIdT, PortStatsT>& portIdToStats,
@@ -202,17 +255,8 @@ bool isLoadBalanced(
         const std::vector<PortIdT>&)>& getPortStatsFn,
     int maxDeviationPct,
     bool noTrafficOk = false) {
-  auto portIDs =
-      folly::gen::from(ecmpPorts) | folly::gen::map([](const auto& portDesc) {
-        if constexpr (std::is_same_v<PortStatsT, HwPortStats>) {
-          return portDesc.phyPortID();
-        } else if constexpr (std::is_same_v<PortStatsT, HwSysPortStats>) {
-          return portDesc.sysPortID();
-        }
-        throw FbossError("Unsupported port stats type in isLoadBalanced");
-      }) |
-      folly::gen::as<std::vector<PortIdT>>();
-  auto portIdToStats = getPortStatsFn(portIDs);
+  auto portIdToStats =
+      getPortStatsFn(ecmpPortIds<PortIdT, PortStatsT>(ecmpPorts));
   return isLoadBalancedImpl(
       portIdToStats, weights, maxDeviationPct, noTrafficOk);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

**Issue**:

 `AgentLoadBalancerTestV6ArsSpray.EcmpLoadBalanceFullHashCpuTraffic` fails intermittently on Wedge800BACT at                                                                                                   `[0/1619] LoadBalancerTestUtils.cpp: Value of: isLoadBalanced() Actual: false Expected: true.`
 
In one of the failures, this is what is seen:
 
 ```
I0826 20:48:39.506009  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(1) outBytes: 2616555
I0826 20:48:39.506014  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(3) outBytes: 2619700
I0826 20:48:39.506017  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(5) outBytes: 2605335
I0826 20:48:39.506018  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(13) outBytes: 2613580
I0826 20:48:39.506019  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(22) outBytes: 3247170
I0826 20:48:39.506021  4683 LoadBalancerTestUtils.cpp:416] NOS-13295: member PortID(24) outBytes: 3297660
I0826 20:48:39.506023  4683 LoadBalancerTestUtils.cpp:419] NOS-13295: members: 6 highest bytes: 3297660 lowest bytes: 2605335 deviation: 26.57%
```

Note that the deviation in this case is `26.57%` which is slightly above the strict test threshold assert of `25%`.

Four member ports are at ~0.92× the fair share, two at ~1.16×. All 200k packets egressed (17,000,000 bytes exactly), all six members active — spray works. The expected skew of this mode is ~25% against a 25% tolerance, so the test sits exactly on its own pass/fail boundary and flakes indefinitely.

On some platforms (e.g. TH5), we need ports to be on same core for load balancing spray to work roughly evenly. However, port/platform mapping is different across different platforms and it is not guaranteed that first six logical ports would end up sitting in same core. So the fix in https://github.com/facebook/fboss/commit/1212ea9dfc25b2d6a7fe9c591e7c691c9b07229f is loosely ended and works only for few platforms (e.g. minipack3).

**Fix**:

Instead of strictly asserting on equality of quality spray, we verify the participation. That is, every member must carry 25% to 200% of the fair share (`total / numMembers` ).

The floor catches a starved or dead member and a group that never sprayed; the ceiling catches one member hogging while the rest sit just above the floor.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Passes consistently.

```
Running all tests took 0:00:40.420734 between 2026-08-26 21:53:57.553296 and 2026-08-26 21:54:37.974030
[ PASSED ] cold_boot.AgentLoadBalancerTestV6ArsSpray.EcmpLoadBalanceFullHashCpuTraffic (9328 ms)
[ PASSED ] warm_boot.AgentLoadBalancerTestV6ArsSpray.EcmpLoadBalanceFullHashCpuTraffic (10293 ms)
Summary:
   PASSED : 2
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0
```
