### PR TITLE
[Accton][minipack3bam] Update COM-E PmUnit name to match IDPROM

### DIFF
--- a/fboss/configs/platforms/accton/minipack3bam/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/accton/minipack3bam/platform_stack/platform_manager.json
@@ -95,7 +95,7 @@
         "address": "0x56",
         "kernelDeviceName": "24c128"
       },
-      "pmUnitName": "NETLAKE"
+      "pmUnitName": "NETLAKE20"
     },
     "OPTICL_SLOT": {
       "numOutgoingI2cBuses": 1,
@@ -120,7 +120,7 @@
     "CPU_BUS@0"
   ],
   "versionedPmUnitConfigs": {
-    "NETLAKE": [
+    "NETLAKE20": [
       {
         "pmUnitConfig": {
           "pluggedInSlotType": "COMESE_SLOT",
@@ -1093,7 +1093,7 @@
     "FAN": {
       "pluggedInSlotType": "FAN_SLOT"
     },
-    "NETLAKE": {
+    "NETLAKE20": {
       "pluggedInSlotType": "COMESE_SLOT",
       "i2cDeviceConfigs": [
         {

--- a/fboss/configs/platforms/accton/minipack3bam/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/accton/minipack3bam/platform_stack/sensor_service.json
@@ -689,7 +689,7 @@
     },
     {
       "slotPath": "/SCM_SLOT@0/COMESE_SLOT@0",
-      "pmUnitName": "NETLAKE",
+      "pmUnitName": "NETLAKE20",
       "sensors": [
         {
           "name": "COME_PU1_PVDDCR_TEMP",


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

## Summary:
The Netlake-2 COM-E module reports `NETLAKE20` as its Product Name in the IDPROM, but the platform configs defined the PmUnit as `NETLAKE`. This mismatch caused Platform Manager to emit a WARNING on every run and fall back to the config name. This PR renames the PmUnit from `NETLAKE` to `NETLAKE20` in the `minipack3bam` Netlake-2 configs so the config matches the IDPROM and the warning is gone.

## Changes:
- `minipack3bam` Netlake-2 configs:
  - `platform_manager.json`: rename PmUnit `NETLAKE` -> `NETLAKE20` (`pmUnitName` field and the `versionedPmUnitConfigs` / `pmUnitConfigs` keys).
  - `sensor_service.json`: rename `pmUnitName` under `/SCM_SLOT@0/COMESE_SLOT@0` from `NETLAKE` to `NETLAKE20`.

## Test plan:
- Platform Manager runs to completion with no WARNING.
  PlatformExplorer now logs: 
 ``` Found PmUnit name `NETLAKE20` in IDPROM ... at /SCM_SLOT@0/COMESE_SLOT@0 Going with PmUnit name `NETLAKE20` defined in config for /SCM_SLOT@0/COMESE_SLOT@0 At SlotPath /SCM_SLOT@0/COMESE_SLOT@0, updating to PmUnit with name: NETLAKE20 ```  
[mp3bam_come_platform_manager_log.txt](https://github.com/user-attachments/files/31823233/mp3bam_come_platform_manager_log.txt)

- sensor_service correctly resolves the `/SCM_SLOT@0/COMESE_SLOT@0` PmUnit
  through Platform Manager and reads the expected sensor data.
[mp3bam_come_sensor_service_log.txt](https://github.com/user-attachments/files/31823235/mp3bam_come_sensor_service_log.txt)
