### PR TITLE
[Accton][wedge800cact] Update COM-E PmUnit name and versionedSensors keys

### DIFF
--- a/fboss/configs/platforms/accton/wedge800cact/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/accton/wedge800cact/platform_stack/platform_manager.json
@@ -50,14 +50,14 @@
         "address": "0x56",
         "kernelDeviceName": "24c128"
       },
-      "pmUnitName": "NETLAKE"
+      "pmUnitName": "NETLAKE20"
     }
   },
   "i2cAdaptersFromCpu": [
     "CPU_BUS@0"
   ],
   "versionedPmUnitConfigs": {
-    "NETLAKE": [
+    "NETLAKE20": [
       {
         "pmUnitConfig": {
           "pluggedInSlotType": "COMESE_SLOT",
@@ -910,7 +910,7 @@
       "outgoingSlotConfigs": {},
       "pciDeviceConfigs": []
     },
-    "NETLAKE": {
+    "NETLAKE20": {
       "pluggedInSlotType": "COMESE_SLOT",
       "i2cDeviceConfigs": [
         {

--- a/fboss/configs/platforms/accton/wedge800cact/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/accton/wedge800cact/platform_stack/sensor_service.json
@@ -527,7 +527,7 @@
     },
     {
       "slotPath": "/SCM_SLOT@0/COMESE_SLOT@0",
-      "pmUnitName": "NETLAKE",
+      "pmUnitName": "NETLAKE20",
       "sensors": [
         {
           "name": "COME_PU1_PVDDCR_VOUT",
@@ -738,9 +738,9 @@
               "compute": "@/1000"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 1
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 1
         },
         {
           "sensors": [
@@ -805,9 +805,9 @@
               "compute": "@/1000"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 2,
-          "productSubVersion": 2
+          "productionState": 1,
+          "productionSubState": 2,
+          "respinVariantIndicator": 2
         },
         {
           "sensors": [
@@ -872,9 +872,9 @@
               "compute": "@/1000"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 3,
-          "productSubVersion": 1
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 1
         },
         {
           "sensors": [
@@ -939,9 +939,9 @@
               "compute": "@/1000"
             }
           ],
-          "productProductionState": 1,
-          "productVersion": 3,
-          "productSubVersion": 2
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 2
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

## Summary:
Two related fixes for the wedge800cact Netlake-2 COM-E config:

1. **PmUnit name mismatch**: The Netlake-2 COM-E module reports `NETLAKE20` as its Product Name in the IDPROM, but the config defined the PmUnit as `NETLAKE`. This caused Platform Manager to emit a WARNING on every run and fall back to the config name. Renamed the PmUnit from `NETLAKE` to `NETLAKE20` so the config matches the IDPROM and the warning is gone.

2. **Stale versionedSensors keys**: The original PR used the old field names for the `versionedSensors` entries. The schema was later updated but that PR was never refreshed, so the checked-in config still carries the outdated keys. Updated them to the current field names.

## Changes:
- `wedge800cact` Netlake-2 configs:
  - `platform_manager.json`: rename PmUnit `NETLAKE` -> `NETLAKE20` (`pmUnitName` field and the `versionedPmUnitConfigs` / `pmUnitConfigs` keys).
  - `sensor_service.json`:
    - rename `pmUnitName` under `/SCM_SLOT@0/COMESE_SLOT@0` from `NETLAKE` to `NETLAKE20`.
    - update the `versionedSensors` entry keys from the old `productProductionState` / `productVersion` / `productSubVersion` to the current `productionState` / `productionSubState` / `respinVariantIndicator`.

## Test plan:
- Platform Manager runs to completion with no WARNING. 
  PlatformExplorer now logs: 
  ``` Found PmUnit name `NETLAKE20` in IDPROM ... at /SCM_SLOT@0/COMESE_SLOT@0 Going with PmUnit name `NETLAKE20` defined in config for /SCM_SLOT@0/COMESE_SLOT@0 At SlotPath /SCM_SLOT@0/COMESE_SLOT@0, updating to PmUnit with name: NETLAKE20 ```

- sensor_service correctly resolves the `/SCM_SLOT@0/COMESE_SLOT@0` PmUnit through Platform Manager,
  matches the right `versionedSensors` entry by the updated keys, and reads the expected sensor data.

  With the old (stale) keys, SensorService could not match the version and fell back to `v0.0.0`: 
  SensorServiceImpl.cpp:231 Processing NETLAKE20 PMUnit (v1.3.1). 
  Using VersionedPmSensor v0.0.0 (productName: UNSET): 19 sensors 
[w800c_come_platform_manager_log.txt](https://github.com/user-attachments/files/31823616/w800c_come_platform_manager_log.txt)

  After updating the keys, SensorService picks up the correct version: 
  SensorServiceImpl.cpp:231 Processing NETLAKE20 PMUnit (v1.3.1). 
  Using VersionedPmSensor v1.3.1 (productName: UNSET): 19 sensors 
[w800c_come_sensor_service_log.txt](https://github.com/user-attachments/files/31823618/w800c_come_sensor_service_log.txt)