### PR TITLE
[Nexthop] run_test.py: fail a test when a unit it left running crashes

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/crash_detection.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/crash_detection.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Detect a systemd unit crashing while a test binary runs.
+
+Every runner leaves some production units running while its test binary
+executes (sai_test keeps fsdb and the platform services up, sai_agent keeps
+qsfp_service up, the fboss2 CLI suite runs against the production agents
+themselves), and those units run with ``Restart=always``. A crash the test
+caused is therefore invisible to gtest: systemd brings the unit back, the
+binary's own readiness wait rides through it, and the test reports OK while
+a core sits on disk and the hardware may never have received the config.
+
+Two signals, both read after the binary exits, cover it:
+
+* :func:`find_unclean_unit_exits` -- PID 1's own journal records of a unit's
+  main process dying uncleanly inside the window.
+* :func:`list_core_dumps` -- taken before and after the binary runs; a path
+  in the second set but not the first is a core dumped inside the window.
+"""
+
+import json
+import os
+import re
+import signal
+import subprocess
+
+_CORE_DUMP_DIRS = ["/var/core", "/var/lib/systemd/coredump"]
+
+# The kernel truncates the process name embedded in a core file name
+# (systemd-coredump: core.<comm>.<uid>.<boot>.<pid>.<ts>[.zst]) to
+# TASK_COMM_LEN - 1 characters.
+_TASK_COMM_LEN = 15
+
+# systemd (PID 1) logs one line per main-process exit of every unit, e.g.
+#   "fboss_hw_agent@0.service: Main process exited, code=dumped, status=6/ABRT"
+# Parsing this line is preferable to `systemctl show -p NRestarts,Result`:
+# NRestarts only moves for Restart=-triggered restarts (so a manual restart
+# followed by a crash reads "unchanged"), and Result is reset to "success" the
+# moment the unit is started again, so by the time a check runs after the test
+# the crash has already been papered over. The journal keeps the record.
+_MAIN_PROCESS_EXIT_RE = re.compile(
+    r"^(?P<unit>\S+): Main process exited, code=(?P<code>\w+), "
+    r"status=(?P<status>\d+)/(?P<name>\S+)$"
+)
+_OOM_KILL_RE = re.compile(
+    r"^(?P<unit>\S+): A process of this unit has been killed by the OOM killer"
+)
+
+# Exits systemd's own `systemctl stop/restart` produces on a well-behaved unit:
+# a clean exit, or termination by the stop signal (SIGTERM; SIGINT/SIGHUP for
+# units that set KillSignal=) either as a signal death or as the 128+N status
+# a shell/python wrapper returns when it relays it.
+_GRACEFUL_SIGNALS = frozenset({"TERM", "INT", "HUP"})
+_GRACEFUL_EXIT_STATUSES = frozenset(
+    {0, 128 + signal.SIGTERM, 128 + signal.SIGINT, 128 + signal.SIGHUP}
+)
+
+
+def _classify_unit_exit(message: str) -> str | None:
+    """Return a human-readable reason if `message` (a PID 1 journal line)
+    records an unclean main-process exit of a unit, else None."""
+    m = _OOM_KILL_RE.match(message)
+    if m:
+        return f"{m['unit']} killed by the OOM killer"
+    m = _MAIN_PROCESS_EXIT_RE.match(message)
+    if not m:
+        return None
+    code, status, name = m["code"], int(m["status"]), m["name"]
+    if code == "exited" and status in _GRACEFUL_EXIT_STATUSES:
+        return None
+    if code == "killed" and name in _GRACEFUL_SIGNALS:
+        return None
+    what = {"dumped": "dumped core", "killed": "was killed", "exited": "exited"}.get(
+        code, code
+    )
+    return f"{m['unit']} main process {what} (status={status}/{name})"
+
+
+def find_unclean_unit_exits(start_time: float) -> list[str]:
+    """Return one reason per systemd unit whose main process died uncleanly
+    since `start_time` (crash, abort, OOM kill, non-zero exit), oldest first.
+
+    Reads PID 1's journal records for the window. Clean stops and restarts --
+    the ones the test infrastructure and the fboss2 CLI perform on purpose --
+    exit 0 or die by SIGTERM and are not reported, so bouncing a unit inside
+    the window is fine; only an exit systemd would count as a failure is.
+    Units the runner stopped beforehand are inactive and produce nothing.
+    Returns [] when journalctl is unavailable or fails (workstations,
+    containers).
+
+    The window is compared on the record's own microsecond timestamp, so a
+    stop the runner performed right before launching the binary (a cold boot
+    of the agents, say) is not charged to the test; `--since` only bounds how
+    much journal is read.
+    """
+    since_usec = int(start_time * 1_000_000)
+    try:
+        result = subprocess.run(
+            [
+                "journalctl",
+                "-q",
+                "--no-pager",
+                "-o",
+                "json",
+                f"--since=@{int(start_time)}",
+                "_PID=1",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return []
+    if result.returncode != 0:
+        return []
+    reasons: list[str] = []
+    for line in result.stdout.splitlines():
+        try:
+            record = json.loads(line)
+            message = record.get("MESSAGE")
+            stamp = int(record.get("__REALTIME_TIMESTAMP", since_usec))
+        except (ValueError, TypeError, AttributeError):
+            continue
+        if stamp < since_usec or not isinstance(message, str):
+            continue
+        reason = _classify_unit_exit(message)
+        if reason:
+            reasons.append(reason)
+    return reasons
+
+
+def list_core_dumps() -> set[str]:
+    """Return the paths of every core file currently on disk.
+
+    Callers take this before and after a test binary runs and report the
+    difference. Comparing sets rather than mtimes means one core is charged
+    to exactly one test, even when systemd-coredump finishes writing it a
+    moment after the check that should have seen it, or when the next test
+    starts within a second of the previous one. Unreadable directories and
+    entries are skipped.
+    """
+    found: set[str] = set()
+    for dir_path in _CORE_DUMP_DIRS:
+        if not os.path.isdir(dir_path):
+            continue
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            found.add(entry.path)
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+    return found
+
+
+def core_is_from(core_path: str, exe_name: str) -> bool:
+    """True if the core file at `core_path` was dumped by `exe_name`."""
+    name = os.path.basename(core_path)
+    return name.startswith(f"core.{exe_name[:_TASK_COMM_LEN]}.") or exe_name in name

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/platform_services_test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/platform_services_test_runner.py
@@ -58,11 +58,14 @@ class PlatformServicesTestRunner(TestRunner):
     def _get_warmboot_check_file(self) -> str:
         return ""
 
-    def _get_test_run_args(self, conf_file: str) -> list[str]:
+    def _get_test_run_args(self, conf_file: str) -> list[str]:  # noqa: ARG002
         return []
 
     def _run_tests(
-        self, tests_to_run: list[str], conf_file: str, args: Namespace
+        self,
+        tests_to_run: list[str],
+        conf_file: str,
+        args: Namespace,  # noqa: ARG002
     ) -> list[GtestResult]:
         test_binary_name = self._get_test_binary_name()
         all_results: list[GtestResult] = []
@@ -70,7 +73,7 @@ class PlatformServicesTestRunner(TestRunner):
         for idx, test_to_run in enumerate(tests_to_run):
             test_prefix = test_binary_name + "."
             print("########## Running test: " + test_to_run, flush=True)
-            run_outcome = self._run_test(
+            run_outcome = self._run_test_guarded(
                 conf_file,
                 test_prefix,
                 test_to_run,
@@ -87,21 +90,14 @@ class PlatformServicesTestRunner(TestRunner):
 
     @staticmethod
     def _args_for_test_type(args: Namespace, test_type: str) -> Namespace:
-        return Namespace(
-            **{
-                **vars(args),
-                "fruid_path": None,
-                "type": test_type,
-            }
-        )
+        return Namespace(**{**vars(args), "fruid_path": None, "type": test_type})
 
     def list_tests(self, args: Namespace) -> int:
         test_types = [args.type] if args.type else self.TEST_TYPE_CHOICES
         exit_code = 0
         for test_type in test_types:
             exit_code = max(
-                exit_code,
-                super().list_tests(self._args_for_test_type(args, test_type)),
+                exit_code, super().list_tests(self._args_for_test_type(args, test_type))
             )
         return exit_code
 

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/runners/test_runner.py
@@ -43,6 +43,11 @@ from fboss_test_runner.constants import (
     XGS_SIMULATOR_ASICS,
     XGS_SIMULATOR_ENV,
 )
+from fboss_test_runner.crash_detection import (
+    core_is_from,
+    find_unclean_unit_exits,
+    list_core_dumps,
+)
 from fboss_test_runner.reporters.console_reporter import ConsoleReporter
 from fboss_test_runner.reporters.csv_reporter import CsvReporter
 from fboss_test_runner.reporters.json_reporter import JsonReporter
@@ -605,6 +610,86 @@ class TestRunner(abc.ABC):
             )
             return RunOutcome(result.as_log_line(), [result])
 
+    def _run_test_guarded(
+        self,
+        conf_file: str,
+        test_prefix: str,
+        test_to_run: str,
+        setup_warmboot: bool,
+        sai_replayer_logging_path: str | None = None,
+    ) -> RunOutcome:
+        """_run_test, then fail the test if a unit it left running crashed.
+
+        Every runner leaves some production units running while its binary
+        executes: sai_test keeps fsdb and the platform services up, sai_agent
+        keeps qsfp_service up, the CLI suite runs against the production
+        agents themselves. Those units run with `Restart=always`, so a crash
+        caused by the test is invisible to gtest: systemd brings the unit
+        back, the binary's own readiness wait rides through it, and the test
+        reports OK while a core sits on disk and the hardware may never have
+        got the config. Two signals, both read after the binary exits:
+          * A unit's main process died uncleanly during the window, as
+            recorded by PID 1 in the journal. Clean exits and SIGTERM deaths
+            are ignored, so the stop/restart the CLI or a warm-boot phase
+            performs on purpose does not register, and a console logout
+            bouncing serial-getty (Restart=always, exit 0) does not either.
+            Units the runner stopped beforehand are inactive and produce
+            nothing.
+          * A core file appeared that was not there before the binary
+            started, from anything but the test binary itself (that one
+            already failed on its own). Deliberately not limited to agent
+            cores: any process dumping core on a production image while a
+            test runs makes that result untrustworthy.
+        """
+        cores_before = list_core_dumps()
+        start_time = time.time()
+        run_outcome = self._run_test(
+            conf_file,
+            test_prefix,
+            test_to_run,
+            setup_warmboot,
+            sai_replayer_logging_path,
+        )
+        reasons = find_unclean_unit_exits(start_time)
+        own_binary = os.path.basename(self._get_test_binary_name())
+        cores = sorted(
+            core
+            for core in list_core_dumps() - cores_before
+            if not core_is_from(core, own_binary)
+        )
+        if cores:
+            reasons.append(f"new core dump(s): {', '.join(cores)}")
+        if reasons:
+            self._apply_agent_crash(
+                run_outcome, test_prefix, test_to_run, "; ".join(reasons)
+            )
+        return run_outcome
+
+    def _apply_agent_crash(
+        self, run_outcome: RunOutcome, test_prefix: str, test_to_run: str, reason: str
+    ) -> None:
+        """Downgrade a test to FAILED because a unit crashed while it ran.
+
+        The gtest binary reported its own verdict (often OK: the CLI suite's
+        readiness wait rides through a crash + `RestartSec` retry), so the
+        in-memory results are rewritten. A SKIPPED test is downgraded too: a
+        crash in its window is a real failure regardless of what it did. The
+        binary's own output is kept -- it is the only transcript of the run
+        -- with the verdict appended.
+        """
+        banner = (
+            f"########## CRASH detected during {test_prefix}{test_to_run}: "
+            f"{reason} -- marking test FAILED"
+        )
+        print(banner, flush=True)
+        for result in run_outcome.results:
+            if result.status in (GtestStatus.OK, GtestStatus.SKIPPED):
+                result.status = GtestStatus.FAILED
+        run_outcome.console_output = "\n".join(
+            [run_outcome.console_output.rstrip("\n"), banner]
+            + [result.as_log_line() for result in run_outcome.results]
+        )
+
     def _string_in_file(self, file_path: str, string: str) -> bool | None:
         try:
             with open(file_path) as file:
@@ -720,7 +805,7 @@ class TestRunner(abc.ABC):
                 print("########## Running test: " + test_to_run, flush=True)
                 if simulator:
                     self._restart_bcmsim(simulator)
-                run_outcome = self._run_test(
+                run_outcome = self._run_test_guarded(
                     conf_file,
                     test_prefix,
                     test_to_run,
@@ -771,7 +856,7 @@ class TestRunner(abc.ABC):
                         f"({wb_iter + 1}/{num_wb_iterations}): {test_to_run}",
                         flush=True,
                     )
-                    run_outcome = self._run_test(
+                    run_outcome = self._run_test_guarded(
                         conf_file,
                         test_prefix,
                         test_to_run,

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_crash_detection.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_crash_detection.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+"""Unit tests for fboss_test_runner.crash_detection."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import fboss_test_runner.crash_detection as _mod
+from fboss_test_runner.crash_detection import (
+    core_is_from,
+    find_unclean_unit_exits,
+    list_core_dumps,
+)
+
+
+def _journal(*messages: str, stamp_usec: int = 5_000_000_000) -> str:
+    """journalctl -o json output: one record per line, PID 1 style."""
+    return "\n".join(
+        json.dumps(
+            {
+                "_PID": "1",
+                "UNIT": m.split(":", 1)[0],
+                "MESSAGE": m,
+                "__REALTIME_TIMESTAMP": str(stamp_usec),
+            }
+        )
+        for m in messages
+    )
+
+
+def _patched_journalctl(stdout: str, returncode: int = 0):
+    return patch.object(
+        _mod.subprocess,
+        "run",
+        return_value=MagicMock(stdout=stdout, returncode=returncode),
+    )
+
+
+def test_unclean_exits_reports_crashes_not_clean_stops():
+    """Cores, kills by anything but the stop signal, OOM kills and non-zero
+    exits are crashes. A clean exit, a SIGTERM death and the 128+15 status a
+    wrapper relays on SIGTERM are what `systemctl stop/restart` produces and
+    must not fail a test (the fboss2 CLI restarts the agents on every
+    commit; a console logout bounces serial-getty with exit 0)."""
+    out = _journal(
+        "fboss_hw_agent@0.service: Main process exited, code=dumped, status=6/ABRT",
+        "fboss_sw_agent.service: Main process exited, code=exited, status=0/SUCCESS",
+        "serial-getty@ttyS0.service: Main process exited, code=exited, status=0/SUCCESS",
+        "qsfp_service.service: Main process exited, code=killed, status=15/TERM",
+        "hostcfgd.service: Main process exited, code=exited, status=143/n/a",
+        "sensor_service.service: Main process exited, code=killed, status=11/SEGV",
+        "fan_service.service: Main process exited, code=exited, status=1/FAILURE",
+        "platform_manager.service: A process of this unit has been killed by the OOM killer.",
+        "fboss_hw_agent@0.service: Scheduled restart job, restart counter is at 1.",
+        "Started FBOSS hw agent.",
+    )
+    with _patched_journalctl(out) as run:
+        reasons = find_unclean_unit_exits(1_000.0)
+    assert reasons == [
+        "fboss_hw_agent@0.service main process dumped core (status=6/ABRT)",
+        "sensor_service.service main process was killed (status=11/SEGV)",
+        "fan_service.service main process exited (status=1/FAILURE)",
+        "platform_manager.service killed by the OOM killer",
+    ]
+    # one journalctl call, PID 1 only, reading from the second the test started
+    cmd = run.call_args[0][0]
+    assert cmd[0] == "journalctl"
+    assert "_PID=1" in cmd
+    assert "--since=@1000" in cmd
+
+
+def test_unclean_exits_uses_record_timestamp_not_since_granularity():
+    """`--since=@N` is whole-second; the record's own microsecond timestamp
+    decides. A cold boot the runner performed right before launching the
+    binary (same second, earlier microseconds) is not charged to the test."""
+    before = _journal(
+        "fboss_sw_agent.service: Main process exited, code=dumped, status=6/ABRT",
+        stamp_usec=1_000_400_000,
+    )
+    after = _journal(
+        "fboss_hw_agent@0.service: Main process exited, code=dumped, status=6/ABRT",
+        stamp_usec=1_000_900_000,
+    )
+    with _patched_journalctl(before + "\n" + after):
+        assert find_unclean_unit_exits(1_000.5) == [
+            "fboss_hw_agent@0.service main process dumped core (status=6/ABRT)"
+        ]
+
+
+def test_unclean_exits_ignores_unparseable_lines():
+    out = (
+        "not json\n"
+        + json.dumps({"MESSAGE": ["array", "not", "str"]})
+        + "\n"
+        + _journal("x.service: Main process exited, code=dumped, status=11/SEGV")
+    )
+    with _patched_journalctl(out):
+        assert find_unclean_unit_exits(0.0) == [
+            "x.service main process dumped core (status=11/SEGV)"
+        ]
+
+
+def test_unclean_exits_empty_when_journalctl_unavailable():
+    with _patched_journalctl("", returncode=1):
+        assert find_unclean_unit_exits(0.0) == []
+    with patch.object(_mod.subprocess, "run", side_effect=FileNotFoundError):
+        assert find_unclean_unit_exits(0.0) == []
+
+
+def test_list_core_dumps_lists_files_in_every_dir(tmp_path, monkeypatch):
+    a = tmp_path / "coredump"
+    b = tmp_path / "core"
+    a.mkdir()
+    b.mkdir()
+    (a / "sub").mkdir()  # directories are not cores
+    monkeypatch.setattr(
+        _mod, "_CORE_DUMP_DIRS", [str(a), str(b), str(tmp_path / "nope")]
+    )
+    (a / "core.fboss_hw_agent-.0.abc.100.1000.zst").write_bytes(b"x")
+    (b / "core.fboss_sw_agent.0.abc.300.3000").write_bytes(b"x")
+    assert list_core_dumps() == {
+        str(a / "core.fboss_hw_agent-.0.abc.100.1000.zst"),
+        str(b / "core.fboss_sw_agent.0.abc.300.3000"),
+    }
+
+
+def test_list_core_dumps_missing_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(_mod, "_CORE_DUMP_DIRS", [str(tmp_path / "does-not-exist")])
+    assert list_core_dumps() == set()
+
+
+def test_core_is_from_truncates_comm():
+    """The kernel truncates the comm in the core name to 15 characters."""
+    core = "/var/lib/systemd/coredump/core.sai_test-sai_im.0.x.5.6.zst"
+    assert core_is_from(core, "sai_test-sai_impl")
+    assert not core_is_from(core, "sai_agent_hw_test-sai_impl")
+    assert core_is_from("/var/core/core.fboss_sw_agent.0.x.1.2", "fboss_sw_agent")

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_test_runner.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_test_runner.py
@@ -482,3 +482,172 @@ class TestGetTestRunCmdSwitchId:
         with patch.object(runner, "args", new=mock_args):
             cmd = runner._get_test_run_cmd("dummy.conf", "HwFooTest.Bar", [])
             assert not any("switch_id_for_testing" in item for item in cmd)
+
+
+class TestAgentCrashDowngrade:
+    """A unit crash detected after a test must fail that test even though the
+    gtest binary itself reported OK (systemd Restart= resurrects a crashed
+    production agent inside the test's own readiness wait, so gtest never
+    sees it)."""
+
+    _MOD = "fboss_test_runner.runners.test_runner"
+
+    def _make_args(self, mock_args, **overrides):
+        # _run_tests probes these with os.path / getattr; a bare Mock breaks them.
+        mock_args.sai_replayer_logging = None
+        mock_args.simulator = None
+        for k, v in overrides.items():
+            setattr(mock_args, k, v)
+        return mock_args
+
+    def _make_conf(self, tmp_path):
+        conf = tmp_path / "test.conf"
+        conf.write_text("")
+        return str(conf)
+
+    def _ok_outcome(self):
+        return RunOutcome(
+            "[ OK ] cold_boot.HwT.t (1 ms)",
+            [GtestResult("cold_boot.HwT.t", GtestStatus.OK, 1)],
+        )
+
+    def _run(self, runner, mock_args, tmp_path, exits):
+        args = self._make_args(mock_args, coldboot_only=True)
+        conf = self._make_conf(tmp_path)
+        with (
+            patch.object(runner, "_run_test", return_value=self._ok_outcome()),
+            patch.object(runner, "_setup_coldboot_test"),
+            patch.object(runner, "_end_run"),
+            patch(f"{self._MOD}.find_unclean_unit_exits", return_value=exits) as e,
+            patch(f"{self._MOD}.list_core_dumps", return_value=set()) as c,
+        ):
+            all_results = runner._run_tests(["HwT.t"], conf, args)
+        # the journal is read once per test; cores are listed before and after
+        e.assert_called_once()
+        assert c.call_count == 2
+        return all_results
+
+    def test_crash_reason_downgrades_ok_to_failed(self, runner, mock_args, tmp_path):
+        all_results = self._run(
+            runner,
+            mock_args,
+            tmp_path,
+            exits=["fboss_hw_agent@0.service main process dumped core (status=6/ABRT)"],
+        )
+        assert [r.status for r in all_results] == [GtestStatus.FAILED]
+
+    def test_no_crash_leaves_result_untouched(self, runner, mock_args, tmp_path):
+        all_results = self._run(runner, mock_args, tmp_path, exits=[])
+        assert [r.status for r in all_results] == [GtestStatus.OK]
+
+
+class TestCrashDetection:
+    """What `_run_test_guarded` treats as a crash: any unit the test left
+    running (production agents for the CLI suite, qsfp_service and the
+    platform services for the SAI suites, ...) dying uncleanly inside the
+    test window, or any core dump from a process other than the test binary."""
+
+    _MOD = "fboss_test_runner.runners.test_runner"
+
+    _OLD_CORE = "/var/lib/systemd/coredump/core.fboss_sw_agent.0.x.9.9.zst"
+
+    def _reason(self, runner, exits, cores):
+        """Run one guarded test and return the crash reason handed to
+        _apply_agent_crash, or None if it was not called."""
+        outcome = RunOutcome("", [GtestResult("cold_boot.HwT.t", GtestStatus.OK, 1)])
+        listings = iter([{self._OLD_CORE}, {self._OLD_CORE, *cores}])
+        with (
+            patch(f"{self._MOD}.time.time", return_value=1.0),
+            patch.object(runner, "_run_test", return_value=outcome),
+            patch.object(runner, "_apply_agent_crash") as apply,
+            patch(f"{self._MOD}.find_unclean_unit_exits", return_value=exits) as e,
+            patch(
+                f"{self._MOD}.list_core_dumps", side_effect=lambda: next(listings)
+            ) as c,
+        ):
+            assert (
+                runner._run_test_guarded("c", "cold_boot.", "HwT.t", False) is outcome
+            )
+        # both probes look at the window that opened when the binary started
+        e.assert_called_once_with(1.0)
+        assert c.call_count == 2
+        if not apply.called:
+            return None
+        apply.assert_called_once()
+        assert apply.call_args[0][:3] == (outcome, "cold_boot.", "HwT.t")
+        return apply.call_args[0][3]
+
+    def test_unit_crash_is_reported(self, runner):
+        reason = self._reason(
+            runner,
+            ["qsfp_service.service main process dumped core (status=6/ABRT)"],
+            [],
+        )
+        assert reason == "qsfp_service.service main process dumped core (status=6/ABRT)"
+
+    def test_foreign_core_is_reported(self, runner):
+        cores = [
+            "/var/lib/systemd/coredump/core.fboss_hw_agent-.0.x.1.2.zst",
+            "/var/lib/systemd/coredump/core.qsfp_service.0.x.3.4.zst",
+        ]
+        assert self._reason(runner, [], cores) == "new core dump(s): " + ", ".join(
+            cores
+        )
+
+    def test_own_core_is_ignored(self, runner):
+        """The test binary dumping core already failed the test on its own;
+        naming its core as a unit crash would be noise."""
+        with patch.object(
+            runner,
+            "_get_test_binary_name",
+            return_value="/opt/fboss/bin/sai_test-sai_impl",
+        ):
+            assert (
+                self._reason(
+                    runner,
+                    [],
+                    ["/var/lib/systemd/coredump/core.sai_test-sai_im.0.x.5.6.zst"],
+                )
+                is None
+            )
+
+    def test_unit_crash_and_core_are_both_named(self, runner):
+        reason = self._reason(
+            runner,
+            ["fboss_hw_agent@0.service main process dumped core (status=11/SEGV)"],
+            ["/var/lib/systemd/coredump/core.fboss_hw_agent-.0.x.1.2.zst"],
+        )
+        assert reason == (
+            "fboss_hw_agent@0.service main process dumped core (status=11/SEGV); "
+            "new core dump(s): /var/lib/systemd/coredump/core.fboss_hw_agent-.0.x.1.2.zst"
+        )
+
+    def test_healthy_window_is_not_a_crash(self, runner):
+        assert self._reason(runner, [], []) is None
+
+    def test_apply_downgrades_ok_and_skipped_only(self, runner):
+        outcome = RunOutcome(
+            "gtest transcript line 1\ngtest transcript line 2\n",
+            [
+                GtestResult("cold_boot.HwT.ok", GtestStatus.OK, 1),
+                GtestResult("cold_boot.HwT.skipped", GtestStatus.SKIPPED, 1),
+                GtestResult("cold_boot.HwT.timeout", GtestStatus.TIMEOUT, 1),
+            ],
+        )
+        runner._apply_agent_crash(
+            outcome, "cold_boot.", "HwT.*", "x.service dumped core"
+        )
+        assert [r.status for r in outcome.results] == [
+            GtestStatus.FAILED,
+            GtestStatus.FAILED,
+            GtestStatus.TIMEOUT,
+        ]
+        # the binary's transcript is kept (it is the only copy), the verdict
+        # is appended after it
+        assert outcome.console_output.startswith(
+            "gtest transcript line 1\ngtest transcript line 2\n########## CRASH"
+        )
+        assert "x.service dumped core" in outcome.console_output
+        assert outcome.console_output.endswith(
+            "\n".join(r.as_log_line() for r in outcome.results)
+        )


### PR DESCRIPTION
## Summary

Every `run_test.py` runner leaves some production systemd units running while its test binary executes (`sai_test` keeps fsdb and the platform services up, `sai_agent`/`link` keep qsfp_service up, `bsp_tests` keeps both agents up while unloading kmods, the fboss2 CLI suite runs against the agents themselves), and all of those units run with `Restart=always` (`RestartSec=30`). A crash the test caused is therefore invisible to gtest: systemd brings the unit back, the binary's own readiness wait rides through it, and the test reports OK while a core sits on disk and the hardware may never have received the config. The motivating case was a CLI test whose commit crashed the hw_agent on every run and still passed 4/4 times, one hw_agent core each. gtest cannot see that, so the harness has to.

`TestRunner._run_test_guarded()` now wraps every `_run_test` call (cold- and warm-boot phases, and `PlatformServicesTestRunner`'s own loop) and, once the binary exits, looks for a crash inside the window. When it finds one, `_apply_agent_crash()` downgrades every OK/SKIPPED result of that test to FAILED (so the console/CSV/JSON summary counts it) and appends a banner naming the reason to the binary's transcript.

Two signals, both read after the binary exits, in the new `fboss_test_runner/crash_detection.py`:
- **A unit's main process died uncleanly inside the window**, taken from PID 1's own journal records (`journalctl -o json --since=@<start> _PID=1`, `find_unclean_unit_exits`): `code=dumped` (any signal), `code=killed` by anything but SIGTERM/SIGINT/SIGHUP, a non-zero exit status (other than the 128+N a wrapper relays for those signals), or an OOM kill. Clean stops and restarts — the `systemctl restart` the fboss2 CLI performs on commit, a warm-boot phase bouncing the test-owned OSS unit, a console logout bouncing `serial-getty` — exit 0 or die by SIGTERM and do not register. Units the runner masked are inactive and produce nothing, so no per-runner watch list is needed.
- **A core file that was not there before the binary started** in `/var/lib/systemd/coredump` or `/var/core` (`list_core_dumps` before and after, set difference), from any process except the test binary itself (that test already failed on its own). Comparing sets rather than mtimes charges one core to exactly one test, even when systemd-coredump finishes writing it after the check or the next test starts a second later.

Why the journal rather than `systemctl show`: `NRestarts` only moves for `Restart=`-triggered restarts (a manual restart followed by a crash reads "unchanged"), and `Result` is reset to `success` the moment the unit is started again — by the time the check runs after the binary exits, a crash 30 s earlier has already been papered over. The journal line keeps the exit code and signal, and its microsecond timestamp decides membership in the window, so a cold boot the runner performed right before launching the binary is not charged to the test. When `journalctl` is unavailable (workstation, container) that signal is simply empty; the core check still runs.

Known limitations: a crash that lands *between* tests (after one binary exits, before the next starts) is attributed to no test. Any unit on the box is watched, so a unit crash-looping for reasons unrelated to the test (a mis-configured platform daemon, say) fails every test in the run — that is a true statement about the device, but it is not attributed to a cause. An agent that aborts on every graceful stop would flag every committing CLI test. The production agents failing to come back after the post-run `enable_services` restart is outside every window and is a follow-up.

## Test Plan

- `python3 -m pytest fboss/oss/scripts/run_scripts/fboss_test_runner/unittests` → **338 passed** on top of current `main` (323 existing + 15 new: `crash_detection` ×7 — crash/clean-stop/OOM classification incl. `serial-getty` exit 0 and wrapper status 143, record-timestamp window, unparseable lines, journalctl missing, core listing, comm truncation; `_run_test_guarded` ×6 — unit crash, new core, pre-existing core ignored, own-binary core ignored, both, healthy window, downgrade rules keep the transcript; end-to-end through `_run_tests` ×2).
- ruff check + format clean.
- Journal record shape verified on a lab switch (read-only): a real `fboss_sw_agent` abort is logged by PID 1 as `fboss_sw_agent.service: Main process exited, code=dumped, status=6/ABRT` with `EXIT_CODE=dumped`, and `--since=@<epoch>` is accepted. `_classify_unit_exit` reports it.
- Python-only change to the on-device test harness; the cmake/getdeps build is not affected.
