### PR TITLE
[Accton][wedge800cact] Remove unused G202X TEMP_5~8 SMB_CPLD sensors

### DIFF
--- a/fboss/configs/platforms/accton/wedge800cact/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/accton/wedge800cact/platform_stack/sensor_service.json
@@ -1522,46 +1522,6 @@
           "compute": "@/1000"
         },
         {
-          "name": "SMB_U72_G202X_TEMP_5",
-          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp5_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 105
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "SMB_U72_G202X_TEMP_6",
-          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp6_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 105
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "SMB_U72_G202X_TEMP_7",
-          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp7_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 105
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "SMB_U72_G202X_TEMP_8",
-          "sysfsPath": "/run/devmap/sensors/SMB_CPLD/temp8_input",
-          "type": 3,
-          "thresholds": {
-            "upperCriticalVal": 125,
-            "maxAlarmVal": 105
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "SMB_U16_G202X_C_VDDC_VOUT",
           "sysfsPath": "/run/devmap/sensors/SMB_VRM1/in2_input",
           "type": 1,
@@ -1825,11 +1785,7 @@
         "SMB_U72_G202X_TEMP_1",
         "SMB_U72_G202X_TEMP_2",
         "SMB_U72_G202X_TEMP_3",
-        "SMB_U72_G202X_TEMP_4",
-        "SMB_U72_G202X_TEMP_5",
-        "SMB_U72_G202X_TEMP_6",
-        "SMB_U72_G202X_TEMP_7",
-        "SMB_U72_G202X_TEMP_8"
+        "SMB_U72_G202X_TEMP_4"
       ]
     }
   ]


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

## Summary:
Remove the four SMB CPLD temperature sensors `SMB_U72_G202X_TEMP_5` through `SMB_U72_G202X_TEMP_8` from the wedge800cact `sensor_service.json`.

### Motivation:
The SMB reads the MAC-surrounding temperatures from the SMB CPLD (tmp432), exposed as `temp<N>_input` under `/run/devmap/sensors/SMB_CPLD/`.

- The previous MAC, G200X, exposed 8 tmp432 temperature channels (`temp1_input` to `temp8_input`), 
  so the config carried `SMB_U72_G202X_TEMP_1` to `SMB_U72_G202X_TEMP_8`.
- The new MAC, G202X, is introduced starting from DVT and only requires 4 of these channels (`temp1_input` to `temp4_input`).

On G202X, `temp5_input`~`temp8_input` are not connected to any real device and simply read back **0** (this does not produce a read error). These constant 0 readings are meaningless and misleading in sensor data, so channels 5-8 are removed to keep the config aligned with the G202X hardware.

### Changes:
- `wedge800cact` Netlake-2 `sensor_service.json`:
  - Remove the sensor definitions for `SMB_U72_G202X_TEMP_5`, `SMB_U72_G202X_TEMP_6`, `SMB_U72_G202X_TEMP_7`, and `SMB_U72_G202X_TEMP_8` (mapped to `SMB_CPLD/temp5_input`-`temp8_input`).
  - Remove the same four names from the ASIC `temperatureSensorNames` list so only `SMB_U72_G202X_TEMP_1` - `SMB_U72_G202X_TEMP_4` remain.

## Test plan:
- Validated `sensor_service.json` is still valid JSON after the removal.
- Confirmed only `SMB_U72_G202X_TEMP_1`~`_4` remain, both in the sensor definitions and in the ASIC `temperatureSensorNames` list.
- On hardware, sensor_service reads the four remaining SMB CPLD temperatures normally.
  Before the change, `temp5_input`~`temp8_input` read a constant 0 (no read error) and only added noise to the sensor data; they are gone after the removal.
[w800c_g202x_sensor_service_log.txt](https://github.com/user-attachments/files/31827580/w800c_g202x_sensor_service_log.txt)
