### PR TITLE
[Nexthop] Skip setting CREATE_ONLY next hop group attributes

### DIFF
--- a/fboss/agent/hw/sai/api/NextHopGroupApi.h
+++ b/fboss/agent/hw/sai/api/NextHopGroupApi.h
@@ -171,6 +171,18 @@ SAI_ATTRIBUTE_NAME(NextHopGroup, HierarchicalNextHop)
 SAI_ATTRIBUTE_NAME(NextHopGroup, ArsNextHopGroupMetaData)
 SAI_ATTRIBUTE_NAME(NextHopGroup, SplitHorizonEnable)
 
+#if SAI_API_VERSION >= SAI_VERSION(1, 16, 0)
+// HierarchicalNextHop and HashAlgorithm are CREATE_ONLY attributes, so
+// they should not be set after create.
+template <>
+struct IsCreateOnlyAttribute<SaiNextHopGroupTraits::Attributes::HashAlgorithm>
+    : public std::true_type {};
+template <>
+struct IsCreateOnlyAttribute<
+    SaiNextHopGroupTraits::Attributes::HierarchicalNextHop>
+    : public std::true_type {};
+#endif
+
 struct SaiNextHopGroupMemberTraits {
   static constexpr sai_object_type_t ObjectType =
       SAI_OBJECT_TYPE_NEXT_HOP_GROUP_MEMBER;

--- a/fboss/agent/hw/sai/api/Traits.h
+++ b/fboss/agent/hw/sai/api/Traits.h
@@ -453,6 +453,17 @@ template <typename AttrT>
 concept SaiAttributeType =
     IsSaiAttribute<std::remove_reference_t<AttrT>>::value;
 
+/*
+ * SAI attributes declared CREATE_ONLY may be passed at create but
+ * are not settable.
+ */
+template <typename AttrT>
+struct IsCreateOnlyAttribute : public std::false_type {};
+
+template <typename AttrT>
+struct IsCreateOnlyAttribute<std::optional<AttrT>>
+    : public IsCreateOnlyAttribute<AttrT> {};
+
 template <typename T>
 struct IsSaiEntryStruct : public std::false_type {};
 

--- a/fboss/agent/hw/sai/store/SaiObject.h
+++ b/fboss/agent/hw/sai/store/SaiObject.h
@@ -451,8 +451,17 @@ class SaiObject {
         oldAttr,
         newAttr);
     if (oldAttr != newAttr) {
-      if (!skipHwWrite) {
-        setAttributeInHardware(newAttr);
+      // CREATE_ONLY attributes cannot be set after create, so only update the
+      // store. This matters on warm boot when the adapter has no getter (e.g.
+      // brcm-sai for SAI_NEXT_HOP_GROUP_ATTR_HIERARCHICAL_NEXTHOP): reload
+      // stores nullopt and the first apply looks like a change. Every input
+      // that decides a create-only value must be part of the adapter host key,
+      // so a real value change yields a new object rather than a set on this
+      // one. Marking an attribute IsCreateOnlyAttribute asserts that property.
+      if constexpr (!IsCreateOnlyAttribute<std::decay_t<AttrT>>::value) {
+        if (!skipHwWrite) {
+          setAttributeInHardware(newAttr);
+        }
       }
       oldAttr = std::forward<AttrT>(newAttr);
     }

--- a/fboss/agent/hw/sai/store/tests/NextHopGroupStoreTest.cpp
+++ b/fboss/agent/hw/sai/store/tests/NextHopGroupStoreTest.cpp
@@ -249,6 +249,39 @@ TEST_F(NextHopGroupStoreTest, nextHopGroupCreateCtor) {
   auto obj = createObj<SaiNextHopGroupTraits>(k, c, 0);
 }
 
+#if SAI_API_VERSION >= SAI_VERSION(1, 16, 0)
+// HierarchicalNextHop is create-only and brcm-sai has no getter for it, so a
+// warm-boot reload stores nullopt. FakeSai does implement the getter, so the
+// nullopt state is set up directly here rather than via SaiStore::reload().
+// Applying a value on top of nullopt must not issue a set (FakeSai rejects
+// one), but the store must adopt the value.
+TEST_F(NextHopGroupStoreTest, createOnlyAttrNotReadBackSkipsHwWrite) {
+  auto& store = saiStore->get<SaiNextHopGroupTraits>();
+  SaiNextHopGroupTraits::AdapterHostKey k;
+  SaiNextHopGroupTraits::CreateAttributes created{
+      SAI_NEXT_HOP_GROUP_TYPE_ECMP, std::nullopt, std::nullopt, std::nullopt};
+  auto obj = store.setObject(k, created);
+  auto id = obj->adapterKey();
+  auto& nextHopGroupApi = saiApiTable->nextHopGroupApi();
+  auto hwBefore = nextHopGroupApi.getAttribute(
+      id, SaiNextHopGroupTraits::Attributes::HierarchicalNextHop{});
+
+  SaiNextHopGroupTraits::CreateAttributes desired{
+      SAI_NEXT_HOP_GROUP_TYPE_ECMP,
+      std::nullopt,
+      std::nullopt,
+      SaiNextHopGroupTraits::Attributes::HierarchicalNextHop{!hwBefore}};
+  EXPECT_NO_THROW(store.setObject(k, desired));
+  EXPECT_EQ(
+      GET_OPT_ATTR(NextHopGroup, HierarchicalNextHop, obj->attributes()),
+      !hwBefore);
+  EXPECT_EQ(
+      nextHopGroupApi.getAttribute(
+          id, SaiNextHopGroupTraits::Attributes::HierarchicalNextHop{}),
+      hwBefore);
+}
+#endif
+
 TEST_F(NextHopGroupStoreTest, nextHopGroupMemberCreateCtor) {
   auto nhgId = createNextHopGroup();
   SaiNextHopGroupMemberTraits::AdapterHostKey k{nhgId, 42};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

The HW agent SIGABRTs on warm boot in `AgentFlowletSprayTest.VerifyEcmpRandomSpray` and `AgentLoadBalancerTestV6EcmpSpray.EcmpLoadBalanceFullHashCpuTraffic` on Tomahawk6 platforms. `SAI_NEXT_HOP_GROUP_ATTR_HIERARCHICAL_NEXTHOP` is `CREATE_ONLY` in the SAI spec, and Broadcom 14.2 SAI doesn't implement a getter. On warm boot `SaiStore::reload()` falls back to the attribute's `StdNullOptDefault`,  and `SaiObject::checkAndSetAttribute` sees `nullopt != false` and issues a set on a create only attribute, which returns `NOT_SUPPORTED` and hw agent aborts.

This change adds an `IsCreateOnlyAttribute` trait, specialised for `HierarchicalNextHop`. `checkAndSetAttribute()` no longer writes create-only attributes to hardware; instead, the store adopts the desired value in its cache, preserving the value programmed during object creation.

`HashAlgorithm` is included on spec grounds: it is also `CREATE_ONLY`, but it does not trigger this issue because Broadcom SAI implements its getter.

# Test Plan

The tests now pass:
```
[ PASSED ] cold_boot.AgentFlowletSprayTest.VerifyEcmpRandomSpray (39999 ms)
[ PASSED ] warm_boot.AgentFlowletSprayTest.VerifyEcmpRandomSpray (37260 ms)
[ PASSED ] cold_boot.AgentLoadBalancerTestV6EcmpSpray.EcmpLoadBalanceFullHashCpuTraffic (21232 ms)
[ PASSED ] warm_boot.AgentLoadBalancerTestV6EcmpSpray.EcmpLoadBalanceFullHashCpuTraffic (19543 ms)
```