### PR TITLE
[Celestica] Leh800bcls: Upgrade BCM logDropReasons OSS stub to real decoder

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/bcm/oss/SaiSwitchManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/bcm/oss/SaiSwitchManager.cpp
@@ -4,8 +4,14 @@
 
 #include "fboss/agent/hw/HwSwitchFb303Stats.h"
 
+#include <folly/String.h>
+#include <folly/logging/xlog.h>
+
 extern "C" {
 #include <experimental/saiswitchextensions.h>
+#if defined(BRCM_SAI_SDK_XGS_GTE_15_0)
+#include <experimental/saidropextensions.h>
+#endif
 }
 
 namespace facebook::fboss {
@@ -17,11 +23,91 @@ void publishSwitchPipelineStats(HwSwitchPipelineStats& /*pipelineStats*/) {}
 void publishSwitchTemperatureStats(
     HwSwitchTemperatureStats& /*temperatureStats*/) {}
 
-// Decoding the raw reason codes needs the vendor tables, which are not open
-// sourced, so drop them rather than CHECK the lists are empty: on XGS >= 15.0
-// the caller really does populate them.
 void logDropReasons(
-    const std::vector<sai_int32_t>& /*ingressDropReasons*/,
-    const std::vector<sai_int32_t>& /*egressDropReasons*/) {}
+    const std::vector<sai_int32_t>& ingressDropReasons,
+    const std::vector<sai_int32_t>& egressDropReasons) {
+#if defined(BRCM_SAI_SDK_XGS_GTE_15_0)
+  std::vector<std::string> ingressNames;
+  for (auto reason : ingressDropReasons) {
+    switch (static_cast<sai_packet_drop_type_ingress_t>(reason)) {
+      case SAI_PACKET_DROP_TYPE_INGRESS_L3_DST_DISCARD:
+        ingressNames.push_back("L3_DST_DISCARD");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_L3_TTL_ERROR:
+        ingressNames.push_back("L3_TTL_ERROR");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_SRC_ROUTE_DROP:
+        ingressNames.push_back("SRC_ROUTE_DROP");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_RFILDR:
+        ingressNames.push_back("RFILDR");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_SRC_PORT_KNOCKOUT_DROP:
+        ingressNames.push_back("SRC_PORT_KNOCKOUT_DROP");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_RDISC:
+        ingressNames.push_back("RDISC");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_RIMDR:
+        ingressNames.push_back("RIMDR");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_RDROP:
+        ingressNames.push_back("RDROP");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_L2_DST_LOOKUP_MISS:
+        ingressNames.push_back("L2_DST_LOOKUP_MISS");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_L2_DST_DISCARD:
+        ingressNames.push_back("L2_DST_DISCARD");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_L3_DST_LOOKUP_MISS:
+        ingressNames.push_back("L3_DST_LOOKUP_MISS");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_L3_HDR_ERROR:
+        ingressNames.push_back("L3_HDR_ERROR");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_PROTOCOL_PKT_DROP:
+        ingressNames.push_back("PROTOCOL_PKT_DROP");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_MEMBERSHIP_CHECK_FAILED:
+        ingressNames.push_back("MEMBERSHIP_CHECK_FAILED");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_SPANNING_TREE_CHECK_FAILED:
+        ingressNames.push_back("SPANNING_TREE_CHECK_FAILED");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_URPF_CHECK_FAILED:
+        ingressNames.push_back("URPF_CHECK_FAILED");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_STORM_CONTROL_DROP:
+        ingressNames.push_back("STORM_CONTROL_DROP");
+        break;
+      case SAI_PACKET_DROP_TYPE_INGRESS_RUC:
+        // Exclude RUC as it is a non-drop reason
+        break;
+      default:
+        ingressNames.push_back(std::to_string(reason));
+        break;
+    }
+  }
+  if (!ingressNames.empty()) {
+    XLOG(INFO) << "DROP reasons ingress: " << folly::join(", ", ingressNames);
+  }
+
+  std::vector<std::string> egressNames;
+  for (auto reason : egressDropReasons) {
+    switch (static_cast<sai_packet_drop_type_egress_t>(reason)) {
+      case SAI_PACKET_DROP_TYPE_EGRESS_TL2_MTU:
+        egressNames.push_back("TL2_MTU");
+        break;
+      default:
+        egressNames.push_back(std::to_string(reason));
+        break;
+    }
+  }
+  if (!egressNames.empty()) {
+    XLOG(INFO) << "DROP reasons egress: " << folly::join(", ", egressNames);
+  }
+#endif
+}
 
 } // namespace facebook::fboss


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```
# Summary
Following commit `3e2ff0c591` which introduced a no-op OSS stub for `logDropReasons()` to resolve SAI 15.4 linker failures, Broadcom XGS platforms in the open-source branch still lack actual drop reason decoding and logging. As a result, tests in `AgentDropReasonTests.cpp` consistently fail with timeouts.
The test expects to observe the drop reason `L3_DST_DISCARD` but instead logs `ingress=[] egress=[]`
indefinitely, or fails due to unexpected companion generic drop reasons (e.g. `60`, `66`) being reported alongside it.
```
I0905 09:15:52.168330 493017 AgentDropReasonTests.cpp:137] Drop reason test [L3 DST discard] observed: ingress=[] egress=[]
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentDropReasonTests.cpp:181: Failure
Value of: reasons.ingress.contains(kL3DstDiscard)
  Actual: false
Expected: true

I0905 09:15:52.169175 493017 AgentDropTestBase.cpp:186] Drop test [L3 DST discard] port 1: inUnicastPkts=29 outUnicastPkts=29 inDiscardsRaw=29 inDiscards=0 inDstNullDiscards=29 outDiscards=0 inAclDiscards=0 outForwardingDiscards=0
I0905 09:15:52.169196 493017 AgentDropTestBase.cpp:186] Drop test [L3 DST discard] port 3: inUnicastPkts=0 outUnicastPkts=0 inDiscardsRaw=0 inDiscards=0 inDstNullDiscards=0 outDiscards=0 inAclDiscards=0 outForwardingDiscards=0
I0905 09:15:52.169201 493017 AgentDropReasonTests.cpp:184] Drop reason test [L3 DST discard] final: ingress=[] egress=[]
/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentDropReasonTests.cpp:155: Failure
Value of: reported.contains(expected)
  Actual: false
Expected: true
L3 DST discard: expected reason L3_DST_DISCARD not reported

/var/FBOSS/fboss/fboss/agent/test/agent_hw_tests/AgentDropTestBase.cpp:222: Failure
Value of: found
  Actual: false
Expected: true
L3 DST discard log: expected log containing 'DROP reasons ingress' not found
```

# Root Cause
- The current implementation of `logDropReasons` in `npu/bcm/oss/SaiSwitchManager.cpp` is an empty no-op stub since the proprietary implementation resides in Meta's closed-source `facebook/` directory. No actual logs containing `"DROP reasons ingress"` are emitted on public builds.

# Solution
- Upgraded the no-op stub in the BCM-OSS-specific file `fboss/agent/hw/sai/switch/npu/bcm/oss/SaiSwitchManager.cpp` into a real decoder. It utilizes the standard, public experimental SAI headers `<experimental/saidropextensions.h>` under the `BRCM_SAI_SDK_XGS_GTE_15_0` macro to decode and print named drop reasons. This fully avoids symbol conflicts with Meta's internal builds.
- Mapped specific experimental ingress drop types such as `SAI_PACKET_DROP_TYPE_INGRESS_RDISC` (59), `SAI_PACKET_DROP_TYPE_INGRESS_RUC` (60), `SAI_PACKET_DROP_TYPE_INGRESS_RIMDR` (65), and `SAI_PACKET_DROP_TYPE_INGRESS_RDROP` (66) to their string names.

# Test Plan
- Successfully built the target `fboss_hw_agent-sai_impl` and `multi_switch_agent_hw_test` using SAI 15.4.0.0_odp and 14.2.0.0_odp.
- Ran the case on both NPU0 and 1 in Leh800bcls and verified that `AgentDropReasonTest.ingressL3DstDiscardDrop` passes successfully.
  - NPU0
    ```text
    ########## Warmboot test results (1/1, iter 1/1): Note: Google Test filter = AgentDropReasonTest.ingressL3DstDiscardDrop
    [==========] Running 1 test from 1 test suite.
    [----------] Global test environment set-up.
    [----------] 1 test from AgentDropReasonTest
    [ RUN      ] AgentDropReasonTest.ingressL3DstDiscardDrop
    [       OK ] AgentDropReasonTest.ingressL3DstDiscardDrop (10813 ms)
    [----------] 1 test from AgentDropReasonTest (10813 ms total)

    [----------] Global test environment tear-down
    [==========] 1 test from 1 test suite ran. (10813 ms total)
    [   PASSED ] 1 test.

    Failed to stop fboss_hw_agent@0.service: Unit fboss_hw_agent@0.service not loaded.
    Failed to stop fboss_hw_agent_for_testing_0.service: Unit fboss_hw_agent_for_testing_0.service not loaded.
    Removed "/etc/systemd/system/multi-user.target.wants/fboss_hw_agent_oss@0.service".
    Removed "/etc/systemd/system/fboss_hw_agent_oss@0.service".
    Failed to stop fboss_hw_agent@1.service: Unit fboss_hw_agent@1.service not loaded.
    Failed to stop fboss_hw_agent_for_testing_1.service: Unit fboss_hw_agent_for_testing_1.service not loaded.
    Removed "/etc/systemd/system/multi-user.target.wants/fboss_hw_agent_oss@1.service".
    Removed "/etc/systemd/system/fboss_hw_agent_oss@1.service".
    Cleaning up FBOSS HW Agent Service for index=0...
    Cleaning up FBOSS HW Agent Service for index=1...
    Running all tests took 0:00:51.709249 between 2026-09-05 13:40:20.871990 and 2026-09-05 13:41:12.581239
    [ PASSED ] cold_boot.AgentDropReasonTest.ingressL3DstDiscardDrop (14678 ms)
    [ PASSED ] warm_boot.AgentDropReasonTest.ingressL3DstDiscardDrop (10813 ms)
    Summary:
       PASSED : 2
       FAILED : 0
       SKIPPED : 0
       TIMEOUT : 0

    Test output stored at: hwtest_results_2026_Sep_05-01_41_12_PM.csv
    ```
  - NPU1
    ```text
    ########## Warmboot test results (1/1, iter 1/1): Note: Google Test filter = AgentDropReasonTest.ingressL3DstDiscardDrop
    [==========] Running 1 test from 1 test suite.
    [----------] Global test environment set-up.
    [----------] 1 test from AgentDropReasonTest
    [ RUN      ] AgentDropReasonTest.ingressL3DstDiscardDrop
    [       OK ] AgentDropReasonTest.ingressL3DstDiscardDrop (9751 ms)
    [----------] 1 test from AgentDropReasonTest (9751 ms total)

    [----------] Global test environment tear-down
    [==========] 1 test from 1 test suite ran. (9751 ms total)
    [   PASSED ] 1 test.

    Failed to stop fboss_hw_agent@0.service: Unit fboss_hw_agent@0.service not loaded.
    Failed to stop fboss_hw_agent_for_testing_0.service: Unit fboss_hw_agent_for_testing_0.service not loaded.
    Removed "/etc/systemd/system/multi-user.target.wants/fboss_hw_agent_oss@0.service".
    Removed "/etc/systemd/system/fboss_hw_agent_oss@0.service".
    Failed to stop fboss_hw_agent@1.service: Unit fboss_hw_agent@1.service not loaded.
    Failed to stop fboss_hw_agent_for_testing_1.service: Unit fboss_hw_agent_for_testing_1.service not loaded.
    Removed "/etc/systemd/system/multi-user.target.wants/fboss_hw_agent_oss@1.service".
    Removed "/etc/systemd/system/fboss_hw_agent_oss@1.service".
    Cleaning up FBOSS HW Agent Service for index=0...
    Cleaning up FBOSS HW Agent Service for index=1...
    Running all tests took 0:00:48.917083 between 2026-09-05 13:42:45.095872 and 2026-09-05 13:43:34.012955
    [ PASSED ] cold_boot.AgentDropReasonTest.ingressL3DstDiscardDrop (13634 ms)
    [ PASSED ] warm_boot.AgentDropReasonTest.ingressL3DstDiscardDrop (9751 ms)
    Summary:
       PASSED : 2
       FAILED : 0
       SKIPPED : 0
       TIMEOUT : 0

    Test output stored at: hwtest_results_2026_Sep_05-01_43_34_PM.csv
    ```
