### PR TITLE
[Celestica] Leh800bcls: Fix SRv6 encapsulation tests by passing correct SwitchID for packet injection

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentSrv6EncapTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSrv6EncapTests.cpp
@@ -1214,7 +1214,7 @@ TYPED_TEST(AgentSrv6EncapTest, verifySrv6EncapEcnMarking) {
             tcField,
             64,
             std::vector<uint8_t>(7000, 0xff));
-        this->getSw()->sendPacketSwitchedAsync(std::move(txPacket));
+        this->sendPacketSwitchedAsync(std::move(txPacket));
       }
     };
 
@@ -1270,7 +1270,7 @@ TYPED_TEST(AgentSrv6EncapTest, VerifyDscpQueueMapping) {
       if (frontPanel) {
         this->getSw()->sendPacketOutOfPortAsync(std::move(txPacket), port);
       } else {
-        this->getSw()->sendPacketSwitchedAsync(std::move(txPacket));
+        this->sendPacketSwitchedAsync(std::move(txPacket));
       }
     };
 


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
```
# Summary
In Multi-NPU Split-Agent architectures (such as the leh800bcls platform), executing SRv6 encapsulation hardware tests on a secondary NPU (switch 1 / NPU1) was failing. Specifically, `AgentSrv6EncapTest/0.VerifyDscpQueueMapping` succeeded on NPU0 but timed out on NPU1 with egress queue packet counters remaining at zero during CPU-injected packet validation.
```
/var/FBOSS/fboss/fboss/agent/test/utils/QosTestUtils.cpp:242: Failure
Expected: (queuePacketsAfter) >= (queuePacketsBefore + delta), actual: 0 vs 22
```
# Root Cause
In the affected test cases, packets were injected into the data path by directly calling the low-level `this->getSw()->sendPacketSwitchedAsync(std::move(txPacket))`. Because no explicit target `SwitchID` was provided, the multi-ASIC fallback mechanism in `MultiHwSwitchHandler::sendPacketSwitchedAsync` silently routed all CPU-switched packets to `switch 0` (NPU0). As a result, when the test suite was evaluating NPU1, the packet counters on NPU1's egress ports never incremented, leading to assertion timeouts.

# Solution
Replaced the direct `this->getSw()->sendPacketSwitchedAsync(...)` calls with `this->sendPacketSwitchedAsync(...)` in both `VerifyDscpQueueMapping` and `verifySrv6EncapEcnMarking` test cases in `AgentSrv6EncapTests.cpp`. 
The `AgentHwTest::sendPacketSwitchedAsync` helper automatically resolves and attaches the correct `SwitchID` under test (via `getSwitchIdUnderTest`), ensuring that the injected packets are physical-routed to the correct NPU.

# Test Plan
1. Rebuild the hardware agent test binary.
2. Run the modified SRv6 encapsulation tests on both NPU0 and NPU1 to verify that the queue counters increment as expected and the assertions pass:
   - `AgentSrv6EncapTest/0.VerifyDscpQueueMapping`
   - `AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking`
   - `AgentSrv6EncapTest/1.VerifyDscpQueueMapping`
   - `AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking`
- NPU0
```
Running all tests took 0:05:15.215277 between 2026-09-05 15:19:42.391088 and 2026-09-05 15:24:57.606365
[ PASSED ] cold_boot.AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking (43278 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking (36009 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/0.VerifyDscpQueueMapping (17323 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/0.VerifyDscpQueueMapping (10845 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking (43384 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking (36033 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/1.VerifyDscpQueueMapping (18093 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/1.VerifyDscpQueueMapping (10850 ms)
Summary:
   PASSED : 8
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0

Test output stored at: hwtest_results_2026_Sep_05-03_24_57_PM.csv
```
- NPU1
```
Running all tests took 0:05:15.844570 between 2026-09-05 15:26:16.183331 and 2026-09-05 15:31:32.027901
[ PASSED ] cold_boot.AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking (43355 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/0.verifySrv6EncapEcnMarking (35892 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/0.VerifyDscpQueueMapping (18079 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/0.VerifyDscpQueueMapping (10809 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking (43279 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/1.verifySrv6EncapEcnMarking (36075 ms)
[ PASSED ] cold_boot.AgentSrv6EncapTest/1.VerifyDscpQueueMapping (18257 ms)
[ PASSED ] warm_boot.AgentSrv6EncapTest/1.VerifyDscpQueueMapping (10733 ms)
Summary:
   PASSED : 8
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0

Test output stored at: hwtest_results_2026_Sep_05-03_31_32_PM.csv

```