### PR TITLE
[Celestica] Leh800bcls: Fix SRv6 decapsulation QoS mapping and Multi-NPU packet routing

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentSrv6DecapTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentSrv6DecapTests.cpp
@@ -513,7 +513,7 @@ TYPED_TEST(AgentSrv6DecapTest, verifySrv6DecapEcnMarking) {
             std::optional<uint8_t>(64),
             0,
             std::vector<uint8_t>(7000, 0xff));
-        this->getSw()->sendPacketSwitchedAsync(std::move(txPacket));
+        this->sendPacketSwitchedAsync(std::move(txPacket));
       }
     };
 
@@ -535,7 +535,16 @@ TYPED_TEST(AgentSrv6DecapTest, verifySrv6DecapEcnMarking) {
 // classification at ingress. In UNIFORM mode, outer DSCP is also copied
 // to the inner (forwarded) packet.
 TYPED_TEST(AgentSrv6DecapTest, VerifyDscpQueueMapping) {
-  auto setup = [this]() { this->setupHelper(); };
+  auto setup = [this]() {
+    this->setupHelper();
+    // Exclude kV6RouteDstIp from trap ACLs for this test case because
+    // the Trap COPY action overrides packet QoS TC in the hardware pipeline.
+    auto config = this->getAgentEnsemble()->getCurrentConfig();
+    auto aclName = folly::to<std::string>("trap-", this->kV6RouteDstIp.str());
+    utility::delAcl(&config, aclName);
+    utility::delCPUMatcher(&config, aclName);
+    this->applyNewConfig(config);
+  };
 
   auto verify = [this]() {
     auto ecmpHelper = this->makeEcmpHelper();
@@ -565,7 +574,7 @@ TYPED_TEST(AgentSrv6DecapTest, VerifyDscpQueueMapping) {
       if (frontPanel) {
         this->getSw()->sendPacketOutOfPortAsync(std::move(txPacket), port);
       } else {
-        this->getSw()->sendPacketSwitchedAsync(std::move(txPacket));
+        this->sendPacketSwitchedAsync(std::move(txPacket));
       }
     };
 

--- a/fboss/agent/test/utils/AclTestUtils.cpp
+++ b/fboss/agent/test/utils/AclTestUtils.cpp
@@ -396,6 +396,25 @@ void delMatcher(cfg::SwitchConfig* config, const std::string& matcherName) {
   }
 }
 
+void delCPUMatcher(cfg::SwitchConfig* config, const std::string& matcherName) {
+  if (auto cpuTrafficPolicy = config->cpuTrafficPolicy()) {
+    if (auto trafficPolicy = cpuTrafficPolicy->trafficPolicy()) {
+      auto& matchActions = *trafficPolicy->matchToAction();
+      matchActions.erase(
+          std::remove_if(
+              matchActions.begin(),
+              matchActions.end(),
+              [&](cfg::MatchToAction const& matchAction) {
+                if (*matchAction.matcher() == matcherName) {
+                  return true;
+                }
+                return false;
+              }),
+          matchActions.end());
+    }
+  }
+}
+
 void addAclMirrorAction(
     cfg::SwitchConfig* cfg,
     const std::string& matcher,

--- a/fboss/agent/test/utils/AclTestUtils.h
+++ b/fboss/agent/test/utils/AclTestUtils.h
@@ -150,6 +150,7 @@ void addMatcher(
     const std::string& matcherName,
     const cfg::MatchAction& matchAction);
 void delMatcher(cfg::SwitchConfig* config, const std::string& matcherName);
+void delCPUMatcher(cfg::SwitchConfig* config, const std::string& matcherName);
 
 void addAclMirrorAction(
     cfg::SwitchConfig* cfg,


### PR DESCRIPTION
**Pre-submission checklist**
- [ ✓ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ✓ ] `pre-commit run`
```
[INFO] Stashing unstaged files to /work/home/gangtao/.cache/pre-commit/patch1788758710-2761128.
clang-format.............................................................Passed
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed
[INFO] Restored changes from /work/home/gangtao/.cache/pre-commit/patch1788758710-2761128.

```
# Summary
During Multi-NPU Split-Agent hardware testing on the `leh800bcls` platform, the SRv6 decapsulation QoS queue mapping test case (`AgentSrv6DecapTest/0.VerifyDscpQueueMapping` and `AgentSrv6DecapTest/1.VerifyDscpQueueMapping`) was failing on both NPU0 and NPU1. 

Specifically, all CPU-switched and front-panel injected IPv6-in-IPv6 decapsulated traffic was routed to the correct egress port but erroneously fell back to the minimum priority queue (Queue 0, Silver Queue) instead of matching the configured Olympic QoS map. This resulted in assertion timeouts during queue packet verification.
```
/var/FBOSS/fboss/fboss/agent/test/utils/QosTestUtils.cpp:242: Failure
Expected: (queuePacketsAfter) >= (queuePacketsBefore + delta), actual: 0 vs 9
```
# Root Cause
1. Ingress Pipeline Trap ACL Override Conflict 
    All decapsulated traffic (64 packets representing all Olympic DSCPs) ended up in Queue 0.
    In `AgentSrv6DecapTests.cpp`, a global Trap ACL is registered during `initialConfig` to match the inner destination IP `kV6RouteDstIp` (`2800:2::1/128`) with the action `COPY` to CPU, enabling packet snooping for other payload validation test cases. 
    In the TH6 hardware pipeline, when decapsulated traffic matches this active Trap ACL, the Ingress Field Processor (IFP)'s `COPY` to CPU action is assigned absolute priority. This action forcefully overrides and clears the internal priority (Traffic Class, TC) of the matching packets (resetting `TC = 0`) at the egress stage, completely bypassing the decapsulation RIF's ingress QoS DSCP trust mapping.
2. Low-Level SwSwitch Multi-NPU Packet Routing Bug
    `VerifyDscpQueueMapping`  timed out with 0 packets received when executed on NPU1 (Switch 1).
    Both test cases directly called the low-level `this->getSw()->sendPacketSwitchedAsync(...)` API. Because no target `SwitchID` was provided, the multi-ASIC fallback handler silently routed all CPU-injected packets to Switch 0 (NPU0). Therefore, the egress queue counters on NPU1's ports never incremented when testing NPU1.

# Solution
The QoS mapping test (`VerifyDscpQueueMapping`) only validates the egress port stats and does not require packet snooping. In `VerifyDscpQueueMapping::setup()`, we leverage the official FBOSS utility helpers `utility::delAcl` and `utility::delMatcher` to dynamically remove the specific Trap ACL (`"trap-2800:2::1"`) before applying the configuration. Since other snoop-based tests (such as `VerifySrv6DecapV6`) run their own setup cycle, the global Trap ACL remains intact for them. 

Replaced all low-level `getSw()->sendPacketSwitchedAsync` calls with `this->sendPacketSwitchedAsync` inside VerifyDscpQueueMapping. This helper automatically attaches the correct `SwitchID` under test, ensuring packets are physical-routed to the correct NPU.

# Test Plan
Rebuild the split-agent hardware tests binary and execute the suite on both NPU0 and NPU1 to verify that the queue counters increment perfectly and all assertions pass under both cold-boot and warm-boot states.
- NPU0
```
Running all tests took 0:01:46.618866 between 2026-09-07 09:54:54.476611 and 2026-09-07 09:56:41.095477
[ PASSED ] cold_boot.AgentSrv6DecapTest/0.VerifyDscpQueueMapping (17106 ms)
[ PASSED ] warm_boot.AgentSrv6DecapTest/0.VerifyDscpQueueMapping (10786 ms)
[ PASSED ] cold_boot.AgentSrv6DecapTest/1.VerifyDscpQueueMapping (17559 ms)
[ PASSED ] warm_boot.AgentSrv6DecapTest/1.VerifyDscpQueueMapping (10782 ms)
Summary:
   PASSED : 4
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0

Test output stored at: hwtest_results_2026_Sep_07-09_56_41_AM.csv

```
- NPU1
```
Running all tests took 0:01:47.990290 between 2026-09-07 09:57:16.896441 and 2026-09-07 09:59:04.886731
[ PASSED ] cold_boot.AgentSrv6DecapTest/0.VerifyDscpQueueMapping (17587 ms)
[ PASSED ] warm_boot.AgentSrv6DecapTest/0.VerifyDscpQueueMapping (10850 ms)
[ PASSED ] cold_boot.AgentSrv6DecapTest/1.VerifyDscpQueueMapping (18289 ms)
[ PASSED ] warm_boot.AgentSrv6DecapTest/1.VerifyDscpQueueMapping (10856 ms)
Summary:
   PASSED : 4
   FAILED : 0
   SKIPPED : 0
   TIMEOUT : 0

Test output stored at: hwtest_results_2026_Sep_07-09_59_04_AM.csv

```