### PR TITLE
[Celestica] montblancm: Add PVT configs and incorporate changes from PR #1381

### DIFF
--- a/fboss/configs/platforms/celestica/montblancm/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/celestica/montblancm/platform_stack/platform_manager.json
@@ -170,6 +170,224 @@
           ]
         },
         "productSubVersion": 1
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMA_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMB_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 3
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "xdpe15284",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "xdpe15284",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMA_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMB_TSENSOR"
+            }
+          ]
+        },
+        "pmUnitVersions": [
+          {
+            "productionState": 3,
+            "productionSubState": 1,
+            "respinVariantIndicator": 1
+          }
+        ]
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "mp29608",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMA_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMB_TSENSOR"
+            }
+          ]
+        },
+        "pmUnitVersions": [
+          {
+            "productionState": 3,
+            "productionSubState": 1,
+            "respinVariantIndicator": 2
+          }
+        ]
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "bp4f_raa228244",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMA_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMMB_TSENSOR"
+            }
+          ]
+        },
+        "pmUnitVersions": [
+          {
+            "productionState": 3,
+            "productionSubState": 1,
+            "respinVariantIndicator": 3
+          }
+        ]
       }
     ],
     "MINIPACK3M_3V3_L": [
@@ -629,9 +847,16 @@
         {
           "busName": "MCB_IOB_I2C_MASTER_14",
           "address": "0x33",
-          "kernelDeviceName": "mp3_fancpld",
+          "kernelDeviceName": "fbfancpld",
           "pmUnitScopedName": "MCB_FAN_CPLD",
-          "isWatchdog": true
+          "isWatchdog": true,
+          "fanCpldConfig": {
+            "numFans": 8,
+            "pwmMax": 40,
+            "speedMultiplier": 150,
+            "hasRearTach": true,
+            "hasLeds": true
+          }
         },
         {
           "busName": "MCB_IOB_I2C_MASTER_14",

--- a/fboss/configs/platforms/celestica/montblancm/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/celestica/montblancm/platform_stack/sensor_service.json
@@ -1029,6 +1029,583 @@
           "productionState": 1,
           "productionSubState": 3,
           "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_MISC_VIN",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+            "type": 1,
+            "thresholds": {
+              "lowerCriticalVal": 10.7,
+              "minAlarmVal": 10.82,
+              "maxAlarmVal": 13.22,
+              "upperCriticalVal": 13.35
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.75,
+              "upperCriticalVal": 1.82
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.36,
+              "upperCriticalVal": 1.46
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 131.84
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 30.9
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 164.8
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU1_RAA228244_PVDDCR_SOC_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 38.625
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDDCR_SOC_MISC_VIN",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+            "type": 1,
+            "thresholds": {
+              "lowerCriticalVal": 10.7,
+              "minAlarmVal": 10.82,
+              "maxAlarmVal": 13.22,
+              "upperCriticalVal": 13.35
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_VOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+            "type": 1,
+            "thresholds": {
+              "maxAlarmVal": 1.29,
+              "upperCriticalVal": 1.42
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_TEMP",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+            "type": 3,
+            "thresholds": {
+              "maxAlarmVal": 100
+            },
+            "compute": "@/1000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_POUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+            "type": 0,
+            "thresholds": {
+              "upperCriticalVal": 24.72
+            },
+            "compute": "@/1000000"
+          },
+          {
+            "name": "COME_PU37_RAA228244_PVDD_MISC_IOUT",
+            "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+            "type": 2,
+            "thresholds": {
+              "upperCriticalVal": 30.9
+            },
+            "compute": "@/1000"
+          }
+          ],
+          "productionState": 1,
+          "productionSubState": 3,
+          "respinVariantIndicator": 3
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_XDPE19283D_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_TEMP2",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_XDPE19283D_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_MP29608_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_MP29608_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.75,
+                "upperCriticalVal": 1.82
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.36,
+                "upperCriticalVal": 1.46
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_SOC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_RAA228244_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_RAA228244_PVDDCR_SOC_MISC_VIN",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in1_input",
+              "type": 1,
+              "thresholds": {
+                "lowerCriticalVal": 10.7,
+                "minAlarmVal": 10.82,
+                "maxAlarmVal": 13.22,
+                "upperCriticalVal": 13.35
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_RAA228244_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "maxAlarmVal": 1.29,
+                "upperCriticalVal": 1.42
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_RAA228244_PVDD_MISC_TEMP",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/temp1_input",
+              "type": 3,
+              "thresholds": {
+                "maxAlarmVal": 100
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_RAA228244_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_RAA228244_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 3
         }
       ]
     },
@@ -1967,20 +2544,20 @@
           "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/curr1_input",
           "type": 2,
           "thresholds": {
-            "upperCriticalVal": 15,
-            "maxAlarmVal": 10
+            "upperCriticalVal": 22,
+            "maxAlarmVal": 20
           },
-          "compute": "0.274*@/1000"
+          "compute": "0.402*@/1000"
         },
         {
           "name": "SCM_12V_COME_POWER",
           "sysfsPath": "/run/devmap/sensors/SCM_VOLTAGE_MONITOR2/power1_input",
           "type": 0,
           "thresholds": {
-            "upperCriticalVal": 200,
-            "maxAlarmVal": 180
+            "upperCriticalVal": 290,
+            "maxAlarmVal": 250
           },
-          "compute": "0.238*@/1000000"
+          "compute": "0.35*@/1000000"
         },
         {
           "name": "SCM_12V_HSC_PIN",
@@ -7070,5 +7647,29 @@
         "SMB_TH5_TEMP"
       ]
     }
+  ],
+  "loggedSensorNames": [
+    "SMB_XP3P3_PG",
+    "SMB_XP3P3_SMB_PG",
+    "SMB_XP3P3_CLK_PG",
+    "SMB_XP3P3_L_OSFP_PG",
+    "SMB_XP3P3_R_OSFP_PG",
+    "SMB_XP1P8_CLK_PG",
+    "SMB_XP1P8_PG",
+    "SMB_XP1P2_PG",
+    "SMB_VR_ALERT_XP12R0V_SCM_STA",
+    "SMB_VR_ALERT_XP3R3V_LEFT_STA",
+    "SMB_VR_ALERT_XP3R3V_RIGHT_STA",
+    "SMB_VR_ALERT_TH5_TRVDD_0_STA",
+    "SMB_VR_ALERT_TH5_TRVDD_1_STA",
+    "SMB_VR_ALERT_TH5_VDD_CORE_STA",
+    "PDB_PSU_R_ALERT",
+    "PDB_PSU_L_ALERT",
+    "CPLD_PSU_L_PG",
+    "CPLD_PSU_R_PG",
+    "PSU_L_AC_OK",
+    "PSU_R_AC_OK",
+    "PDB_L_SENSOR_INT",
+    "PDB_R_SENSOR_INT"
   ]
 }


### PR DESCRIPTION
**Pre-submission checklist**
- [✓] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [✓] `pre-commit run`

<img width="766" height="216" alt="image" src="https://github.com/user-attachments/assets/36b1c068-08d7-472b-bf1a-a8a4c0d735d8" />

# Summary

1. Added support for Minipack3 Netlake2.0 PVT phase COME cards across three versions: 3.1.1, 3.1.2, and 3.1.3 by updating sensor_service.json and platform_manager.json.
2. Synchronized platform_manager.json and sensor_service.json common configurations with Montblanc(Minipack3 Netlake1.0).
3. Includes changes from PR[#1381](https://dev.azure.com/celestica-hps/facebook/_workitems/edit/1381/).
     1). Update TPS25990 thresholds and calculation coefficients for Netlake 2.0 COMe and new SCM board in sensor_service.json.
     2). Add support for Netlake 2.0 COMe V3 (Renesas solution) by updating sensor_service.json and platform_manager.json.

# Test Plan

run platform_manager
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/platform_manager -config_file ./configs/montblancm/platform_manager.json --enable_pkg_mgmnt=false –run_once=true --reload_kmods > platform_manager_log.txt 2>&1

run sensor_service
Execution Command:
1). LD_LIBRARY_PATH=./lib/ ./bin/platform_manager -enable_pkg_mgmnt=false -run_once=false --reload_kmods &
2). LD_LIBRARY_PATH=./lib/ ./bin/sensor_service -config_file ./configs/montblancm/sensor_service.json > sensor_service_log.txt 2>&1

run sensor_service_hw_test
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/sensor_service_hw_test -config_file ./configs/montblancm/sensor_service.json > sensor_service_hw_test_log.txt 2>&1

run sensor_service_client
Execution Command:
LD_LIBRARY_PATH=./lib/ ./bin/sensor_service_client > sensor_service_client_log.txt 2>&1

# Result: Platform identified successfully; all sensor tests PASSED.
1. The threshold has been updated.
<img width="1864" height="214" alt="image" src="https://github.com/user-attachments/assets/5bfb81c1-3315-4ebe-9fe3-d6bef12907ad" />

2. support version 3.1.1
<img width="1845" height="127" alt="image" src="https://github.com/user-attachments/assets/ee13b3e5-e37d-41df-a7d8-e93da881012f" />


3. support version 3.1.2
<img width="1831" height="100" alt="image" src="https://github.com/user-attachments/assets/977976ce-795d-486e-88e6-78cea6790cea" />


4. support version 3.1.3

<img width="1897" height="303" alt="image" src="https://github.com/user-attachments/assets/9f8c9a5f-1871-43e3-877a-cea24d8bd991" />


please see the detailed logs:
[version_3_1_1_log.zip](https://github.com/user-attachments/files/31902103/version_3_1_1_log.zip)
[version_3_1_2_log.zip](https://github.com/user-attachments/files/31902111/version_3_1_2_log.zip)
[version_3_1_3_log.zip](https://github.com/user-attachments/files/31902130/version_3_1_3_log.zip)
