### PR TITLE
[Nexthop] Fix getting SDK state dump in CLI

### DIFF
--- a/cmake/CliFboss2Test.cmake
+++ b/cmake/CliFboss2Test.cmake
@@ -93,6 +93,7 @@ add_executable(fboss2_cmd_test
   fboss/cli/fboss2/test/CmdShowRouteDetailsTest.cpp
   fboss/cli/fboss2/test/CmdShowRouteSummaryTest.cpp
   fboss/cli/fboss2/test/CmdShowRouteTest.cpp
+  fboss/cli/fboss2/test/CmdShowSdkDumpTest.cpp
   fboss/cli/fboss2/test/CmdShowSystemPortTest.cpp
   fboss/cli/fboss2/test/CmdShowTeFlowTest.cpp
   fboss/cli/fboss2/test/CmdShowTransceiverEepromTest.cpp

--- a/cmake/QsfpService.cmake
+++ b/cmake/QsfpService.cmake
@@ -379,6 +379,7 @@ add_library(qsfp_handler
 
 target_link_libraries(qsfp_handler
   Folly::folly
+  common_file_utils
   transceiver_manager
   port_manager
   log_thrift_call

--- a/cmake/QsfpServiceTests.cmake
+++ b/cmake/QsfpServiceTests.cmake
@@ -100,3 +100,17 @@ target_link_libraries(cpo_transceiver_manager_test
 gtest_discover_tests(cpo_transceiver_manager_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_executable(sdk_dump_path_test
+  fboss/util/oss/TestMain.cpp
+  fboss/qsfp_service/test/SdkDumpPathTest.cpp
+)
+
+target_link_libraries(sdk_dump_path_test
+  ${GTEST}
+  ${LIBGMOCK_LIBRARIES}
+  fboss_error
+  Folly::folly
+)
+
+gtest_discover_tests(sdk_dump_path_test)

--- a/fboss/agent/HwSwitch.cpp
+++ b/fboss/agent/HwSwitch.cpp
@@ -149,11 +149,16 @@ bool isSame(
 namespace facebook::fboss {
 
 std::string HwSwitch::getDebugDump() const {
-  /* dump sdk state in directory /var/facebook/fboss/fboss_sdk_dump.xxxx */
+  /*
+   * Dump sdk state into a scratch directory
+   * /var/facebook/fboss/fboss_sdk_dump.xxxx, read it back and return it. The
+   * directory is deleted on scope exit so we don't leak one directory per
+   * invocation (the dump content is returned to the caller).
+   */
   folly::test::TemporaryDirectory tmpDir(
       "fboss_sdk_dump",
       getPlatform()->getDirectoryUtil()->getPersistentStateDir(),
-      folly::test::TemporaryDirectory::Scope::PERMANENT);
+      folly::test::TemporaryDirectory::Scope::DELETE_ON_DESTRUCTION);
   auto fname = tmpDir.path().string() + "/hw_debug_dump";
   dumpDebugState(fname);
   XLOG(DBG0) << "Dumped debug state to " << fname;

--- a/fboss/agent/test/ThriftTest.cpp
+++ b/fboss/agent/test/ThriftTest.cpp
@@ -41,6 +41,8 @@
 #include <gtest/gtest.h>
 #include <map>
 
+#include <filesystem>
+
 DECLARE_bool(enable_nexthop_id_manager);
 DECLARE_bool(resolve_nexthops_from_id);
 DECLARE_int32(hwswitch_query_timeout);
@@ -446,9 +448,20 @@ TYPED_TEST(ThriftTestAllSwitchTypes, listHwObjects) {
 TYPED_TEST(ThriftTestAllSwitchTypes, getHwDebugDump) {
   ThriftHandler handler(this->sw_);
   std::string out;
-  EXPECT_HW_CALL(this->sw_, dumpDebugState(testing::_)).Times(1);
+  std::string capturedPath;
+  EXPECT_HW_CALL(this->sw_, dumpDebugState(testing::_))
+      .WillOnce(testing::Invoke([&](const std::string& path) {
+        capturedPath = path;
+      }));
   // Mock getHwDebugDump doesn't write any thing so expect FbossError
   EXPECT_THROW(handler.getHwDebugDump(out), FbossError);
+  // The scratch dump directory must not leak even when the dump fails:
+  // getDebugDump() returns the dump via memory, so the on-disk
+  // fboss_sdk_dump.* directory is removed on scope exit.
+  ASSERT_FALSE(capturedPath.empty());
+  EXPECT_FALSE(
+      std::filesystem::exists(
+          std::filesystem::path(capturedPath).parent_path()));
 }
 
 TYPED_TEST(ThriftTestAllSwitchTypes, getL2Table) {

--- a/fboss/cli/fboss2/BUCK
+++ b/fboss/cli/fboss2/BUCK
@@ -981,6 +981,7 @@ cpp_library(
         "//fboss/platform/fan_service/if:fan_service-cpp2-types",
         "//fboss/platform/rackmon/if:rackmonsvc-cpp2-services",
         "//fboss/platform/sensor_service/if:sensor_service-cpp2-services",
+        "//fboss/qsfp_service:sdk_dump_path",
         "//fboss/qsfp_service:transceiver-delay-constants",
         "//fboss/qsfp_service/if:qsfp-cpp2-services",
         "//fboss/qsfp_service/if:transceiver-cpp2-types",

--- a/fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.cpp
+++ b/fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.cpp
@@ -11,34 +11,29 @@
 #include "fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.h"
 #include "fboss/cli/fboss2/CmdHandler.cpp"
 
-#include <boost/algorithm/string.hpp>
 #include <folly/FileUtil.h>
-#include <folly/testing/TestUtil.h>
-#include <fstream>
+#include <folly/json/json.h>
 #include "fboss/cli/fboss2/utils/CmdClientUtils.h"
+#include "fboss/qsfp_service/SdkDumpPath.h"
 
 namespace facebook::fboss {
 
 CmdShowQsfpSdkDump::RetType CmdShowQsfpSdkDump::queryClient(
     const HostInfo& hostInfo) {
-  auto client =
-      utils::createClient<facebook::fboss::QsfpServiceAsyncClient>(hostInfo);
+  auto client = utils::createQsfpClient(hostInfo);
 
-  if (!tempSdkFile.get()) {
-    // Creating exception safe unique file which will get removed on exiting
-    // scope for unique pointer
-    tempSdkFile = std::make_unique<folly::test::TemporaryFile>(
-        folly::StringPiece() /* namePrefix */,
-        folly::fs::path() /* dir */,
-        folly::test::TemporaryFile::Scope::UNLINK_ON_DESTRUCTION /* scope */);
-  }
+  // qsfp_service confines the SDK dump to its own directory (kSdkDumpDir) and
+  // rejects absolute/traversing paths, using only the basename of the request.
+  // Send a plain basename and read the result back from the confined location.
+  std::string fileName = "fboss2_sdk_dump";
+  sdkDumpPath = std::string(kSdkDumpDir) + fileName;
 
-  bool rc = client->sync_getSdkState(tempSdkFile->path().string());
+  bool rc = client->sync_getSdkState(fileName);
   return rc;
 }
 
-void CmdShowQsfpSdkDump::printOutput(const RetType& rc, std::ostream& out) {
-  std::ifstream sdkDumpStream;
+void CmdShowQsfpSdkDump::printOutput(const RetType& rc, std::ostream& out)
+    const {
   std::string outputLine;
 
   if (!rc) {
@@ -47,13 +42,11 @@ void CmdShowQsfpSdkDump::printOutput(const RetType& rc, std::ostream& out) {
   }
   out << "Printing SDK state:" << std::endl;
 
-  // Read the temp file with SDK dump
-  if (!folly::readFile(tempSdkFile->path().string().c_str(), outputLine)) {
-    out << "Reading temp file " << tempSdkFile->path().string() << " failed"
-        << std::endl;
+  // Read the SDK dump from the service-owned dump directory.
+  if (!folly::readFile(sdkDumpPath.c_str(), outputLine)) {
+    out << "Reading dump file " << sdkDumpPath << " failed" << std::endl;
     return;
   }
-  // Print temp file
   out << outputLine << std::endl;
 }
 
@@ -66,12 +59,43 @@ CmdShowAgentSdkDump::RetType CmdShowAgentSdkDump::queryClient(
   return debugDump;
 }
 
-void CmdShowAgentSdkDump::printOutput(const RetType& rc, std::ostream& out) {
-  std::ifstream sdkDumpStream;
-  std::string outputLine;
-
+void CmdShowAgentSdkDump::printOutput(const RetType& rc, std::ostream& out)
+    const {
   out << "Printing Agent SDK state:" << std::endl;
   out << rc;
+
+  // getHwDebugDump can succeed but return no SDK state (e.g. Broadcom SAI may
+  // produce an empty dump), which would otherwise be silently printed as
+  // nothing. Surface the empty case so the user knows no data was captured.
+  if (rc.empty()) {
+    out << std::endl << "Warning: no SDK state was captured." << std::endl;
+    return;
+  }
+
+  // In multi-switch mode the payload is a JSON object keyed by switch id whose
+  // values are the per-switch dumps; warn for any switch with an empty dump.
+  try {
+    auto parsed = folly::parseJson(rc);
+    if (parsed.isObject()) {
+      bool allEmpty = true;
+      for (const auto& [switchId, dump] : parsed.items()) {
+        if (dump.isString() && dump.asString().empty()) {
+          out << std::endl
+              << "Warning: no SDK state was captured for switch "
+              << switchId.asString() << "." << std::endl;
+        } else {
+          allEmpty = false;
+        }
+      }
+      if (allEmpty && !parsed.empty()) {
+        out << "Warning: no SDK state was captured for any switch."
+            << std::endl;
+      }
+    }
+  } catch (const std::exception&) {
+    // Monolithic mode returns a raw (non-JSON) dump; the emptiness check above
+    // already covers it.
+  }
 }
 
 // Explicit template instantiation

--- a/fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.h
+++ b/fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.h
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include <folly/testing/TestUtil.h>
 #include "fboss/cli/fboss2/CmdHandler.h"
 
 namespace facebook::fboss {
@@ -27,10 +26,12 @@ class CmdShowQsfpSdkDump
     : public CmdHandler<CmdShowQsfpSdkDump, CmdShowQsfpSdkDumpTraits> {
  public:
   using RetType = CmdShowQsfpSdkDumpTraits::RetType;
-  std::unique_ptr<folly::test::TemporaryFile> tempSdkFile;
+  // Path under the service-owned dump directory (kSdkDumpDir) that
+  // qsfp_service writes the SDK state to and that printOutput reads back.
+  std::string sdkDumpPath;
 
   RetType queryClient(const HostInfo& hostInfo);
-  void printOutput(const RetType& rc, std::ostream& out = std::cout);
+  void printOutput(const RetType& rc, std::ostream& out = std::cout) const;
 };
 
 struct CmdShowAgentSdkDumpTraits : public ReadCommandTraits,
@@ -45,10 +46,9 @@ class CmdShowAgentSdkDump
     : public CmdHandler<CmdShowAgentSdkDump, CmdShowAgentSdkDumpTraits> {
  public:
   using RetType = CmdShowAgentSdkDumpTraits::RetType;
-  std::unique_ptr<folly::test::TemporaryFile> tempSdkFile;
 
   RetType queryClient(const HostInfo& hostInfo);
-  void printOutput(const RetType& rc, std::ostream& out = std::cout);
+  void printOutput(const RetType& rc, std::ostream& out = std::cout) const;
 };
 
 } // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/BUCK
+++ b/fboss/cli/fboss2/test/BUCK
@@ -199,6 +199,7 @@ cpp_unittest(
         "CmdShowRouteDetailsTest.cpp",
         "CmdShowRouteSummaryTest.cpp",
         "CmdShowRouteTest.cpp",
+        "CmdShowSdkDumpTest.cpp",
         "CmdShowSystemPortTest.cpp",
         "CmdShowTeFlowTest.cpp",
         "CmdShowTechSupportTest.cpp",

--- a/fboss/cli/fboss2/test/CmdShowSdkDumpTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowSdkDumpTest.cpp
@@ -1,0 +1,66 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+#include "fboss/cli/fboss2/commands/show/sdk/dump/CmdShowSdkDump.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+// getHwDebugDump can succeed but return no SDK state (e.g. Broadcom SAI may
+// produce an empty dump). These tests verify CmdShowAgentSdkDump::printOutput
+// surfaces the empty case to the user instead of silently printing nothing
+
+TEST(CmdShowAgentSdkDumpTest, emptyPayloadWarns) {
+  CmdShowAgentSdkDump cmd;
+  std::stringstream ss;
+  cmd.printOutput(std::string(""), ss);
+  auto out = ss.str();
+  EXPECT_THAT(out, HasSubstr("Printing Agent SDK state:"));
+  EXPECT_THAT(out, HasSubstr("Warning: no SDK state was captured."));
+  EXPECT_THAT(out, Not(HasSubstr("for switch")));
+}
+
+TEST(CmdShowAgentSdkDumpTest, multiSwitchAllEmptyWarns) {
+  CmdShowAgentSdkDump cmd;
+  std::stringstream ss;
+  cmd.printOutput(std::string(R"({"0": ""})"), ss);
+  auto out = ss.str();
+  EXPECT_THAT(out, HasSubstr("no SDK state was captured for switch 0."));
+  EXPECT_THAT(out, HasSubstr("no SDK state was captured for any switch."));
+}
+
+TEST(CmdShowAgentSdkDumpTest, multiSwitchMixedWarnsOnlyEmpty) {
+  CmdShowAgentSdkDump cmd;
+  std::stringstream ss;
+  cmd.printOutput(std::string(R"({"0": "somedata", "1": ""})"), ss);
+  auto out = ss.str();
+  EXPECT_THAT(out, HasSubstr("no SDK state was captured for switch 1."));
+  EXPECT_THAT(out, Not(HasSubstr("for switch 0.")));
+  EXPECT_THAT(out, Not(HasSubstr("for any switch.")));
+}
+
+TEST(CmdShowAgentSdkDumpTest, nonEmptyPayloadNoWarning) {
+  CmdShowAgentSdkDump cmd;
+  std::stringstream ss;
+  cmd.printOutput(std::string(R"({"0": "real dump"})"), ss);
+  auto out = ss.str();
+  EXPECT_THAT(out, HasSubstr("real dump"));
+  EXPECT_THAT(out, Not(HasSubstr("Warning:")));
+}
+
+TEST(CmdShowAgentSdkDumpTest, monolithicNonJsonNoWarning) {
+  CmdShowAgentSdkDump cmd;
+  std::stringstream ss;
+  cmd.printOutput(std::string("raw non-json dump text"), ss);
+  auto out = ss.str();
+  EXPECT_THAT(out, HasSubstr("raw non-json dump text"));
+  EXPECT_THAT(out, Not(HasSubstr("Warning:")));
+}
+
+} // namespace facebook::fboss

--- a/fboss/qsfp_service/BUCK
+++ b/fboss/qsfp_service/BUCK
@@ -56,6 +56,7 @@ cpp_library(
         "//fboss/agent:fboss-error",
         "//fboss/fsdb/client:fsdb_pub_sub",
         "//fboss/fsdb/common:flags",
+        "//fboss/lib:common_file_utils",
         "//fboss/lib:log_thrift_call",
         "//folly/logging:logging",
     ],

--- a/fboss/qsfp_service/QsfpServiceHandler.cpp
+++ b/fboss/qsfp_service/QsfpServiceHandler.cpp
@@ -2,8 +2,8 @@
 
 #include "fboss/qsfp_service/QsfpServiceHandler.h"
 #include "fboss/agent/FbossError.h"
-#include "fboss/fsdb/client/FsdbPubSubManager.h"
 #include "fboss/fsdb/common/Flags.h"
+#include "fboss/lib/CommonFileUtils.h"
 #include "fboss/lib/phy/gen-cpp2/phy_types.h"
 #include "fboss/lib/phy/gen-cpp2/prbs_types.h"
 #include "fboss/qsfp_service/SdkDumpPath.h"
@@ -527,6 +527,9 @@ bool QsfpServiceHandler::getSdkState(std::unique_ptr<std::string> fileName) {
   // empty/absolute/parent-traversing inputs and reduces the request to a
   // basename so a caller cannot overwrite arbitrary root-owned files.
   auto safePath = sanitizeSdkDumpPath(*fileName);
+  // Ensure the service-owned dump directory exists before the SDK tries to
+  // write into it; sanitizeSdkDumpPath confines safePath to kSdkDumpDir.
+  createDir(kSdkDumpDir);
   if (FLAGS_port_manager_mode) {
     return portManager_->getSdkState(safePath);
   } else {

--- a/fboss/qsfp_service/test/BUCK
+++ b/fboss/qsfp_service/test/BUCK
@@ -76,7 +76,7 @@ cpp_unittest(
 cpp_unittest(
     name = "sdk_dump_path_test",
     srcs = [
-        "facebook/SdkDumpPathTest.cpp",
+        "SdkDumpPathTest.cpp",
     ],
     # Pure in-process string sanitizer test; no network access needed.
     network_access = network_access_utils.none(),

--- a/fboss/qsfp_service/test/SdkDumpPathTest.cpp
+++ b/fboss/qsfp_service/test/SdkDumpPathTest.cpp
@@ -1,0 +1,70 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "fboss/qsfp_service/SdkDumpPath.h"
+
+#include <gtest/gtest.h>
+
+#include "fboss/agent/FbossError.h"
+
+namespace facebook::fboss {
+
+// Empty input is rejected.
+TEST(SdkDumpPathTest, RejectsEmpty) {
+  EXPECT_THROW(sanitizeSdkDumpPath(""), FbossError);
+}
+
+// Absolute paths are rejected outright so a caller cannot direct the SDK write
+// outside the service-owned dump directory.
+TEST(SdkDumpPathTest, RejectsAbsolute) {
+  EXPECT_THROW(sanitizeSdkDumpPath("/etc/cron.d/x"), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath("/etc/ld.so.preload"), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath("/root/.ssh/authorized_keys"), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath("/"), FbossError);
+}
+
+// A basename that reduces to "." or ".." is rejected.
+TEST(SdkDumpPathTest, RejectsDotBasename) {
+  EXPECT_THROW(sanitizeSdkDumpPath("."), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath(".."), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath("foo/."), FbossError);
+  EXPECT_THROW(sanitizeSdkDumpPath("foo/.."), FbossError);
+}
+
+// A trailing slash leaves an empty basename, which is rejected.
+TEST(SdkDumpPathTest, RejectsTrailingSlash) {
+  EXPECT_THROW(sanitizeSdkDumpPath("foo/"), FbossError);
+}
+
+// A plain valid filename is confined to kSdkDumpDir.
+TEST(SdkDumpPathTest, ConfinesValidName) {
+  EXPECT_EQ(
+      sanitizeSdkDumpPath("dump.txt"), std::string(kSdkDumpDir) + "dump.txt");
+}
+
+// A sub-path is reduced to its basename and confined to kSdkDumpDir.
+TEST(SdkDumpPathTest, ConfinesSubPathToBasename) {
+  EXPECT_EQ(
+      sanitizeSdkDumpPath("a/b/c/dump.txt"),
+      std::string(kSdkDumpDir) + "dump.txt");
+}
+
+// A relative path containing ".." components cannot escape kSdkDumpDir because
+// only the basename is used.
+TEST(SdkDumpPathTest, ParentTraversalStaysConfined) {
+  EXPECT_EQ(
+      sanitizeSdkDumpPath("../../etc/passwd"),
+      std::string(kSdkDumpDir) + "passwd");
+  EXPECT_EQ(
+      sanitizeSdkDumpPath("a/../../b/dump.txt"),
+      std::string(kSdkDumpDir) + "dump.txt");
+}
+
+// Legitimate names that merely contain ".." as a substring are not falsely
+// rejected.
+TEST(SdkDumpPathTest, AllowsDotDotSubstring) {
+  EXPECT_EQ(sanitizeSdkDumpPath("..bar"), std::string(kSdkDumpDir) + "..bar");
+  EXPECT_EQ(
+      sanitizeSdkDumpPath("foo/..bar"), std::string(kSdkDumpDir) + "..bar");
+}
+
+} // namespace facebook::fboss

--- a/fboss/util/BUCK
+++ b/fboss/util/BUCK
@@ -201,6 +201,7 @@ cpp_library(
     ],
     deps = [
         "//fboss/agent/hw:hardware_stats-cpp2-types",
+        "//fboss/qsfp_service:sdk_dump_path",
         "//folly:file_util",
         "//thrift/lib/cpp2/protocol:protocol",
     ],

--- a/fboss/util/CredoMacsecUtil.cpp
+++ b/fboss/util/CredoMacsecUtil.cpp
@@ -3,6 +3,7 @@
 #include <folly/FileUtil.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 #include "fboss/agent/hw/gen-cpp2/hardware_stats_types.h"
+#include "fboss/qsfp_service/SdkDumpPath.h"
 
 using namespace facebook::fboss;
 using namespace facebook::fboss::mka;
@@ -668,10 +669,18 @@ void CredoMacsecUtil::getSdkState(QsfpServiceAsyncClient* fbMacsecHandler) {
     return;
   }
 
-  bool rc = fbMacsecHandler->sync_getSdkState(FLAGS_filename);
+  // qsfp_service confines the SDK dump to a service-owned directory and uses
+  // only the basename of the request, rejecting absolute/traversing paths.
+  auto slashPos = FLAGS_filename.find_last_of('/');
+  auto basename = slashPos == std::string::npos
+      ? FLAGS_filename
+      : FLAGS_filename.substr(slashPos + 1);
+
+  bool rc = fbMacsecHandler->sync_getSdkState(basename);
   printf(
-      "SAI state dump to file %s was %s",
-      FLAGS_filename.c_str(),
+      "SAI state dump to file %s%s was %s",
+      kSdkDumpDir,
+      basename.c_str(),
       rc ? "Successful" : "Failed");
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

`fboss2 show sdk dump` was broken by `qsfp_service` SDK-dump path-traversal guard added in `Differential Revision: D109336251`: the CLI sent an absolute temp-file path which the guard rejected with `getSdkState: absolute fileName is not allowed.` This PR fixes the CLI to work with the guard, ensures the service-owned dump directory exists, stops the agent from leaking a scratch directory per debug-dump, and surfaces empty agent SDK dumps to the user.

**Changes**

- CLI
    - `show sdk dump` now sends a plain basename instead of absolute temp path, and reads the result back from the service-owned dir. This clears the `absolute fileName is not allowed` error.
    - `show sdk agent` now warns when the returned SDK state is empty instead of silently printing nothing.
- `qsfp_service`: `getSdkState` now calls `createDir(kSdkDumpDir)` so the confined dump directory exists before SDK writes into it.
- Agent: `getDebugDump()` now uses `folly::test::TemporaryDirectory::Scope::DELETE_ON_DESTRUCTION`, so the `fboss_sdk_dump.<token>` scratch dir is removed after the dump is read back - previously one dir leaked per invocation.
- `CredoMacsecUtil.cpp`: updated the `getSdkState` caller to send a basename.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

- New `SdkDumpPathTest` (path sanitizer) and `CmdShowSdkDumpTest` (empty-dump warnings)
- `Thrift.getHwDebugDump` extended to assert the scratch dir does not leak.

The unit tests failed without the fixes, passed with the fixes.

**DUT verification**

1. Path fix

Before 

```

# fboss2 show sdk dump
Thrift call failed: 'getSdkState: absolute fileName is not allowed: /tmp/2082-1b3a-8434-3a4a'

E0903 19:21:04 CmdHandler.cpp:324] localhost - Error in command execution: Thrift call failed:
  'getSdkState: absolute fileName is not allowed: /tmp/2082-1b3a-8434-3a4a'
localhost: Thrift call failed: 'getSdkState: absolute fileName is not allowed: /tmp/2082-...'
```

After

```

# fboss2 show sdk dump
Getting SDK state failed
```

Note that residual `Getting SDK state failed` is because of no xphy present on the box. The path error is gone and it can be verified from qsfp side.

```
  # qsfp_service.log — request now passes the path guard
  I0903 19:21:04.889  getSdkState thrift request ... failed in 0ms     # without fix (guard throws)
  I0903 19:59:29.228  getSdkState thrift request ... succeeded in 0ms   # with fix(guard passes)
  # confined dir created by the fixed server's createDir()
  $ ls -ld /var/facebook/fboss/sdk_dump/
  drwxr-xr-x. root root  /var/facebook/fboss/sdk_dump/     # did not exist before the call
```

2. Scratch-dir leak fix

  BEFORE (unpatched `fboss_hw_agent-sai_impl`):
  ```
  leaked /var/facebook/fboss/fboss_sdk_dump.* count BEFORE: 3
  # run `show sdk agent` x2
  leaked ... count AFTER: 5        # +1 leaked dir per call
  ```
  
  AFTER (patched `fboss_hw_agent-sai_impl`):
  ```
  leaked /var/facebook/fboss/fboss_sdk_dump.* count BEFORE: 0
  # run `show sdk agent` x5
  leaked ... count AFTER: 0        # no leak
  ```
  
3. Empty output fix

```
  fboss2 show sdk agent

  BEFORE (unpatched):
  Printing Agent SDK state:
  {
    "0": ""
  }

  AFTER (patched):
  Printing Agent SDK state:
  {
    "0": ""
  }
  Warning: no SDK state was captured for switch 0.
  Warning: no SDK state was captured for any switch.
``` 
