### PR TITLE
[P200][Cisco]Fix P200 SerDes six-tap programming

### DIFF
--- a/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/npu/SaiPortManager.cpp
@@ -1759,7 +1759,9 @@ SaiPortManager::serdesAttributesFromSwPinConfigs(
       if (platform_->getAsic()->getAsicType() ==
               cfg::AsicType::ASIC_TYPE_YUBA ||
           platform_->getAsic()->getAsicType() ==
-              cfg::AsicType::ASIC_TYPE_G202X) {
+              cfg::AsicType::ASIC_TYPE_G202X ||
+          platform_->getAsic()->getAsicType() ==
+              cfg::AsicType::ASIC_TYPE_P200) {
         if (auto firPre1 = tx->firPre1()) {
           txPre1.push_back(zeroPreemphasis ? 0 : *firPre1);
         }


### PR DESCRIPTION
P200 uses FIR fields for the primary tap settings. Route P200 through the FIR configuration path and program post2/post3 when six-tap programming is enabled.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Route P200 through the FIR configuration path so its port-profile FIR settings are programmed as SAI PortSerdes TX FIR attributes.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

Added and ran a P200 800G port-profile test. It programs the P200 profile and verifies SAI PortSerdes TX FIR readback against the platform mapping through `verifyTxSettting()`, including `TX_FIR_PRE1`, `TX_FIR_PRE2`, `TX_FIR_PRE3`, `TX_FIR_MAIN`, and `TX_FIR_POST1`.

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
