### PR TITLE
[Nexthop] Clear egress queue stats for all port queues, not just the configured…

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiPortManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiPortManager.cpp
@@ -3216,7 +3216,17 @@ void SaiPortManager::clearStats(PortID port) {
           }),
       statsToClear.end());
   portHandle->port->clearStats(statsToClear);
-  managerTable_->queueManager().clearStats(portHandle->configuredQueues);
+  // Clear all queues, not just configuredQueues. Where the port level out
+  // discard counter is derived from the per queue drop counters, a queue left
+  // out keeps outDiscards_ non-zero. configuredQueues covers only the port
+  // queue config, which is unicast only on XGS, so the multicast queues would
+  // never be cleared.
+  std::vector<SaiQueueHandle*> allQueues;
+  allQueues.reserve(portHandle->queues.size());
+  for (const auto& [_, queue] : portHandle->queues) {
+    allQueues.push_back(queue.get());
+  }
+  managerTable_->queueManager().clearStats(allQueues);
 
   // Reset accumulated inDiscards counter in portStats_.
   // inDiscards_ is a software-accumulated counter (+=) that is not


### PR DESCRIPTION
… ones

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

**Root cause**

`clear interface counters` reported success but left per-interface `Output Discards` unchanged, while `Input Discards` on the same port cleared correctly.

`SaiPortManager::clearStats` clears the port level counters and then the egress queue drop counters, but it only walked `portHandle->configuredQueues`. That list is built from the `SwtichState` port queue config, and `BroadcomXgsAsic::getQueueStreamTypes(INTERFACE_PORT)` returns `{UNICAST}` - so the multicast queues, which exist in HW and are present in SAI's `QOS_QUEUE_LIST` (and therefore in `portHandle->queues`), were never in it.

On XGS the port level `SAI_PORT_STAT_IF_OUT_DISCARDS` is derived from the sum of the per queue drop counters across every queue, so any queue left out of the clear pins `HwPortStats::outDiscards_` at a non-zero value indefinitely. Drops parked on multicast queue - flooded BUM traffic, e.g. a port that is the sole member of its VLAN - therefore survived the clear. 

`Input Discards` was unaffected before `inDiscards_` is accumulated in software and explicitly zeroed in `clearStats`, which masks the same behavior on the ingress size.

**Fix**

Iterate `portHandle->queues` instead.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->


**Before fix**

```
  # fboss2 show interface errors
   Interface Name  Input Errors  Input Discards  Output Errors  Output Discards
  ------------------------------------------------------------------------------------
   eth1/18/1       0             1               0              24096

  # fboss2 clear interface counters
  Counters cleared.

  # sleep 15   (allow a counter refresh interval)
  # fboss2 show interface errors
   Interface Name  Input Errors  Input Discards  Output Errors  Output Discards
  ------------------------------------------------------------------------------------
   eth1/18/1       0             0               0              24096
```

**After fix**

```
  # fboss2 show interface errors
   Interface Name  Input Errors  Input Discards  Output Errors  Output Discards
  ------------------------------------------------------------------------------------
   eth1/18/1       0             0               0              48621

  # fboss2 clear interface counters
  Counters cleared.

  # sleep 15   (allow a counter refresh interval)
  # fboss2 show interface errors
   Interface Name  Input Errors  Input Discards  Output Errors  Output Discards
  ------------------------------------------------------------------------------------
   eth1/18/1       0             0               0              0
```