### PR TITLE
[Nexthop] Use FbossError instead of SIGABRT for invalid min capacity percentage in aggregatePort configs

### DIFF
--- a/fboss/agent/ApplyThriftConfig.cpp
+++ b/fboss/agent/ApplyThriftConfig.cpp
@@ -3689,13 +3689,21 @@ uint8_t ThriftConfigApplier::computeMinimumLinkCount(
   switch (minCapacity.getType()) {
     case cfg::MinimumCapacity::Type::linkCount:
       // Thrift's byte type is an int8_t
-      CHECK_GE(minCapacity.get_linkCount(), 1);
+      if (minCapacity.get_linkCount() < 1) {
+        throw FbossError(
+            "Minimum capacity linkCount must be >= 1, got ",
+            minCapacity.get_linkCount());
+      }
 
       minLinkCount = minCapacity.get_linkCount();
       break;
     case cfg::MinimumCapacity::Type::linkPercentage:
-      CHECK_GT(minCapacity.get_linkPercentage(), 0);
-      CHECK_LE(minCapacity.get_linkPercentage(), 1);
+      if (minCapacity.get_linkPercentage() <= 0 ||
+          minCapacity.get_linkPercentage() > 1) {
+        throw FbossError(
+            "Minimum capacity linkPercentage must be in (0, 1], got ",
+            minCapacity.get_linkPercentage());
+      }
 
       minLinkCount =
           std::ceil(minCapacity.get_linkPercentage() * memberPortsSize);

--- a/fboss/agent/state/tests/AggregatePortTests.cpp
+++ b/fboss/agent/state/tests/AggregatePortTests.cpp
@@ -9,7 +9,8 @@
  */
 
 #include "fboss/agent/ApplyThriftConfig.h"
-#include "fboss/agent/hw/mock/MockPlatform.h"
+#include "fboss/agent/FbossError.h"
+#include "fboss/agent/hw/mock/MockPlatform.h" // NOLINT(misc-include-cleaner)
 #include "fboss/agent/state/AggregatePort.h"
 #include "fboss/agent/state/AggregatePortMap.h"
 #include "fboss/agent/state/DeltaFunctions.h"
@@ -1252,4 +1253,26 @@ TEST(AggregatePort, configTimeCapacityWithForwardingPorts) {
   EXPECT_EQ(finalAggPort->getConfiguredCapacityMbps(), 20000);
   EXPECT_EQ(finalAggPort->getActiveCapacityMbps(), 20000);
   EXPECT_EQ(finalAggPort->getStatus(), state::AggregatePortStatus::UP);
+}
+
+TEST(AggregatePort, invalidMinimumCapacityLinkPercentageThrows) {
+  auto platform = createMockPlatform();
+  auto [startState, config] = makeTwoPortAggPortConfig();
+  // linkPercentage is a fraction in (0, 1]; 50 is out of range.
+  config.aggregatePorts()[0].minimumCapacity()->set_linkPercentage(50);
+
+  // NOLINTNEXTLINE(modernize-type-traits): gtest EXPECT_THROW internals
+  EXPECT_THROW(
+      publishAndApplyConfig(startState, &config, platform.get()), FbossError);
+}
+
+TEST(AggregatePort, invalidMinimumCapacityLinkCountThrows) {
+  auto platform = createMockPlatform();
+  auto [startState, config] = makeTwoPortAggPortConfig();
+  // linkCount must be >= 1.
+  config.aggregatePorts()[0].minimumCapacity()->set_linkCount(0);
+
+  // NOLINTNEXTLINE(modernize-type-traits): gtest EXPECT_THROW internals
+  EXPECT_THROW(
+      publishAndApplyConfig(startState, &config, platform.get()), FbossError);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

Previously, an invalid `minimumCapacity` in an aggregate port config would trip a raw `CHECK` in `computeMinimumLinkCount`, aborting the agent with `SIGABRT`:

  `F20260908 17:41:52.271183 18014 ApplyThriftConfig.cpp:3611] Check failed: minCapacity.get_linkPercentage() <= 1 (50 vs. 1)`

This PR replaces those `CHECK`s with `FbossError` throws so invalid config is rejected with a clear, actionable message instead of crashing.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

**Unit  tests**

Added `AggregatePort.invalidMinimumCapacityLinkPercentageThrows` and `AggregatePort.invalidMinimumCapacityLinkCountThrows` in `AggregatePortTests.cpp`, asserting `publishAndApplyConfig` throws `FbossError` for out-of-range `linkPercentage` (50) and `linkCount` (0).

**On-device verification**

  1. Boot path — clear `FATAL` message instead of raw `CHECK`

  Running the fixed `fboss_sw_agent` against a config with `minimumCapacity.linkPercentage = 50`:

  `F0908 18:12:48.950331 24000 SwAgentInitializer.cpp:116] switch initialization failed: facebook::fboss::FbossError: Minimum capacity linkPercentage must be in (0, 1], got 50`

  2. Runtime reload path — config rejected, agent stays alive

  With the agent booted on a valid config, restoring the invalid `linkPercentage: 50` on disk and running `fboss2-dev config reload hitless`:

```
  CLI output (exit 1):
  localhost: Thrift call failed: 'facebook::fboss::FbossError: Minimum capacity linkPercentage must be in (0, 1], got 50'
```

  Agent log:
```
  V0908 18:17:34.977625 24260 ThriftHandler.cpp:2755] reloadConfig thrift request received from ::1 (unknown)
  V0908 18:17:34.978168 24193 SwSwitch.cpp:1993] preparing state update reload config initiated by thrift call; # Pending updates 0
  V0908 18:17:34.979446 24260 ThriftHandler.cpp:2755] reloadConfig thrift request failed in 1ms
  E20260908 18:17:34.979475 24210 service_tcc.h:152] Service handler threw an uncaught exception in method reloadConfig: facebook::fboss::FbossError: Minimum capacity linkPercentage must be in (0, 1], got 50.
```

  Agent survived the rejection — same PID before and after, service still active:
  
  ```
  PID before reload: 24161
  PID after reload:  24161
  fboss_sw_agent.service: active
  ```