### PR TITLE
[Nexthop] Fix SIGABRT in h/w agent on unsupported packet RX reason

### DIFF
--- a/fboss/agent/hw/sai/switch/SaiHostifManager.cpp
+++ b/fboss/agent/hw/sai/switch/SaiHostifManager.cpp
@@ -74,7 +74,7 @@ SaiHostifManager::~SaiHostifManager() {
   store.release();
 }
 
-std::pair<sai_int32_t, sai_packet_action_t>
+std::optional<std::pair<sai_int32_t, sai_packet_action_t>>
 SaiHostifManager::packetReasonToHostifTrap(
     cfg::PacketRxReason reason,
     const SaiPlatform* platform) {
@@ -175,19 +175,23 @@ SaiHostifManager::packetReasonToHostifTrap(
     case cfg::PacketRxReason::UNMATCHED:
       break;
   }
-  throw FbossError("invalid packet reason: ", reason);
+  XLOG(WARN) << "Unsupported packet rx reason for this platform: "
+             << apache::thrift::util::enumName(reason);
+  return std::nullopt;
 }
 
-SaiHostifTrapTraits::CreateAttributes
+std::optional<SaiHostifTrapTraits::CreateAttributes>
 SaiHostifManager::makeHostifTrapAttributes(
     cfg::PacketRxReason trapId,
     HostifTrapGroupSaiId trapGroupId,
     uint16_t priority,
     const SaiPlatform* platform) {
-  sai_int32_t hostifTrapId;
-  sai_packet_action_t hostifPacketAction;
-  std::tie(hostifTrapId, hostifPacketAction) =
+  std::optional<std::pair<sai_int32_t, sai_packet_action_t>> hostifTrap =
       packetReasonToHostifTrap(trapId, platform);
+  if (!hostifTrap.has_value()) {
+    return std::nullopt;
+  }
+  auto [hostifTrapId, hostifPacketAction] = *hostifTrap;
   SaiHostifTrapTraits::Attributes::PacketAction packetAction{
       hostifPacketAction};
   SaiHostifTrapTraits::Attributes::TrapType trapType{hostifTrapId};
@@ -271,7 +275,7 @@ std::shared_ptr<SaiHostifTrapCounter> SaiHostifManager::createHostifTrapCounter(
 #endif
 }
 
-HostifTrapSaiId SaiHostifManager::addHostifTrap(
+std::optional<HostifTrapSaiId> SaiHostifManager::addHostifTrap(
     cfg::PacketRxReason trapId,
     uint32_t queueId,
     uint16_t priority) {
@@ -287,12 +291,18 @@ HostifTrapSaiId SaiHostifManager::addHostifTrap(
         apache::thrift::util::enumName(trapId));
   }
   auto hostifTrapGroup = ensureHostifTrapGroup(queueId);
-  auto attributes = makeHostifTrapAttributes(
-      trapId, hostifTrapGroup->adapterKey(), priority, platform_);
+  std::optional<SaiHostifTrapTraits::CreateAttributes> attributes =
+      makeHostifTrapAttributes(
+          trapId, hostifTrapGroup->adapterKey(), priority, platform_);
+  if (!attributes.has_value()) {
+    XLOG(ERR) << "Skipping programming of unsupported packet rx reason: "
+              << apache::thrift::util::enumName(trapId);
+    return std::nullopt;
+  }
   SaiHostifTrapTraits::AdapterHostKey k =
-      GET_ATTR(HostifTrap, TrapType, attributes);
+      GET_ATTR(HostifTrap, TrapType, *attributes);
   auto& store = saiStore_->get<SaiHostifTrapTraits>();
-  auto hostifTrap = store.setObject(k, attributes);
+  auto hostifTrap = store.setObject(k, *attributes);
   auto handle = std::make_unique<SaiHostifTrapHandle>();
   handle->trap = hostifTrap;
   handle->trapGroup = hostifTrapGroup;
@@ -308,9 +318,11 @@ HostifTrapSaiId SaiHostifManager::addHostifTrap(
 void SaiHostifManager::removeHostifTrap(cfg::PacketRxReason trapId) {
   auto handleItr = handles_.find(trapId);
   if (handleItr == handles_.end()) {
-    throw FbossError(
-        "Attempted to remove non-existent trap for rx reason: ",
-        apache::thrift::util::enumName(trapId));
+    // The trap may never have been programmed if the rx reason is unsupported
+    // on this platform, in which case there is nothing to remove.
+    XLOG(WARN) << "Attempted to remove non-existent trap for rx reason: "
+               << apache::thrift::util::enumName(trapId);
+    return;
   }
   concurrentIndices_->hostifTrapIds.erase(
       handleItr->second->trap->adapterKey());
@@ -321,19 +333,28 @@ void SaiHostifManager::changeHostifTrap(
     cfg::PacketRxReason trapId,
     uint32_t queueId,
     uint16_t priority) {
+  // An unsupported reason was never programmed by addHostifTrap(), so it has
+  // no entry in handles_. Bail out on it before the lookup below, which treats
+  // a missing handle as a programming error.
+  auto hostifTrapGroup = ensureHostifTrapGroup(queueId);
+  std::optional<SaiHostifTrapTraits::CreateAttributes> attributes =
+      makeHostifTrapAttributes(
+          trapId, hostifTrapGroup->adapterKey(), priority, platform_);
+  if (!attributes.has_value()) {
+    XLOG(ERR) << "Skipping change of unsupported packet rx reason: "
+              << apache::thrift::util::enumName(trapId);
+    return;
+  }
   auto handleItr = handles_.find(trapId);
   if (handleItr == handles_.end()) {
     throw FbossError(
         "Attempted to change non-existent trap for rx reason: ",
         apache::thrift::util::enumName(trapId));
   }
-  auto hostifTrapGroup = ensureHostifTrapGroup(queueId);
-  auto attributes = makeHostifTrapAttributes(
-      trapId, hostifTrapGroup->adapterKey(), priority, platform_);
   SaiHostifTrapTraits::AdapterHostKey k =
-      GET_ATTR(HostifTrap, TrapType, attributes);
+      GET_ATTR(HostifTrap, TrapType, *attributes);
   auto& store = saiStore_->get<SaiHostifTrapTraits>();
-  auto hostifTrap = store.setObject(k, attributes);
+  auto hostifTrap = store.setObject(k, *attributes);
 
   handleItr->second->trap = hostifTrap;
   handleItr->second->trapGroup = hostifTrapGroup;

--- a/fboss/agent/hw/sai/switch/SaiHostifManager.h
+++ b/fboss/agent/hw/sai/switch/SaiHostifManager.h
@@ -72,7 +72,7 @@ class SaiHostifManager {
   SaiHostifManager& operator=(const SaiHostifManager&) = delete;
   SaiHostifManager(SaiHostifManager&&) = delete;
   SaiHostifManager& operator=(SaiHostifManager&&) = delete;
-  HostifTrapSaiId addHostifTrap(
+  std::optional<HostifTrapSaiId> addHostifTrap(
       cfg::PacketRxReason trapId,
       uint32_t queueId,
       uint16_t priority);
@@ -81,10 +81,12 @@ class SaiHostifManager {
       cfg::PacketRxReason trapId,
       uint32_t queueId,
       uint16_t priority);
-  static std::pair<sai_int32_t, sai_packet_action_t> packetReasonToHostifTrap(
+  static std::optional<std::pair<sai_int32_t, sai_packet_action_t>>
+  packetReasonToHostifTrap(
       cfg::PacketRxReason reason,
       const SaiPlatform* platform);
-  static SaiHostifTrapTraits::CreateAttributes makeHostifTrapAttributes(
+  static std::optional<SaiHostifTrapTraits::CreateAttributes>
+  makeHostifTrapAttributes(
       cfg::PacketRxReason trapId,
       HostifTrapGroupSaiId trapGroupId,
       uint16_t priority,

--- a/fboss/agent/hw/sai/switch/tests/HostifManagerTest.cpp
+++ b/fboss/agent/hw/sai/switch/tests/HostifManagerTest.cpp
@@ -26,18 +26,41 @@ class HostifManagerTest : public ManagerTestBase {};
 TEST_F(HostifManagerTest, createHostifTrap) {
   uint32_t queueId = 4;
   auto trapType = cfg::PacketRxReason::ARP;
-  HostifTrapSaiId trapId =
+  std::optional<HostifTrapSaiId> trapIdOpt =
       saiManagerTable->hostifManager().addHostifTrap(trapType, queueId, 1);
+  ASSERT_TRUE(trapIdOpt.has_value());
+  HostifTrapSaiId trapId = *trapIdOpt;
   auto trapTypeExpected = saiApiTable->hostifApi().getAttribute(
       trapId, SaiHostifTrapTraits::Attributes::TrapType{});
   auto trapPacketActionExpected = saiApiTable->hostifApi().getAttribute(
       trapId, SaiHostifTrapTraits::Attributes::PacketAction{});
-  sai_int32_t hostifTrapId;
-  sai_packet_action_t hostifPacketAction;
-  std::tie(hostifTrapId, hostifPacketAction) =
+  std::optional<std::pair<sai_int32_t, sai_packet_action_t>> hostifTrap =
       SaiHostifManager::packetReasonToHostifTrap(trapType, saiPlatform.get());
+  ASSERT_TRUE(hostifTrap.has_value());
+  auto [hostifTrapId, hostifPacketAction] = *hostifTrap;
   EXPECT_EQ(hostifTrapId, trapTypeExpected);
   EXPECT_EQ(hostifPacketAction, trapPacketActionExpected);
+}
+
+TEST_F(HostifManagerTest, unsupportedHostifTrapSkipped) {
+  // An rx reason that is not mappable on this platform should be skipped
+  // gracefully rather than throwing, so that a control-plane delta carrying
+  // it does not crash the agent.
+  uint32_t queueId = 4;
+  auto trapType = cfg::PacketRxReason::L3_SLOW_PATH;
+  auto& hostifManager = saiManagerTable->hostifManager();
+  EXPECT_FALSE(
+      SaiHostifManager::packetReasonToHostifTrap(trapType, saiPlatform.get())
+          .has_value());
+  // add/change/remove for an unsupported reason must not throw, and must not
+  // leave any trap state behind.
+  std::optional<HostifTrapSaiId> trapId;
+  EXPECT_NO_THROW(trapId = hostifManager.addHostifTrap(trapType, queueId, 1));
+  EXPECT_FALSE(trapId.has_value());
+  EXPECT_NO_THROW(hostifManager.changeHostifTrap(trapType, queueId, 2));
+  EXPECT_EQ(hostifManager.getHostifTrapHandle(trapType), nullptr);
+  EXPECT_NO_THROW(hostifManager.removeHostifTrap(trapType));
+  EXPECT_EQ(hostifManager.getHostifTrapHandle(trapType), nullptr);
 }
 
 TEST_F(HostifManagerTest, sharedHostifTrapGroup) {
@@ -45,8 +68,14 @@ TEST_F(HostifManagerTest, sharedHostifTrapGroup) {
   auto trapType1 = cfg::PacketRxReason::ARP;
   auto trapType2 = cfg::PacketRxReason::DHCP;
   auto& hostifManager = saiManagerTable->hostifManager();
-  HostifTrapSaiId trapId1 = hostifManager.addHostifTrap(trapType1, queueId, 1);
-  HostifTrapSaiId trapId2 = hostifManager.addHostifTrap(trapType2, queueId, 2);
+  std::optional<HostifTrapSaiId> trapId1Opt =
+      hostifManager.addHostifTrap(trapType1, queueId, 1);
+  ASSERT_TRUE(trapId1Opt.has_value());
+  HostifTrapSaiId trapId1 = *trapId1Opt;
+  std::optional<HostifTrapSaiId> trapId2Opt =
+      hostifManager.addHostifTrap(trapType2, queueId, 2);
+  ASSERT_TRUE(trapId2Opt.has_value());
+  HostifTrapSaiId trapId2 = *trapId2Opt;
   auto trapGroup1 = saiApiTable->hostifApi().getAttribute(
       trapId1, SaiHostifTrapTraits::Attributes::TrapGroup{});
   auto trapGroup2 = saiApiTable->hostifApi().getAttribute(
@@ -64,8 +93,14 @@ TEST_F(HostifManagerTest, removeHostifTrap) {
   auto trapType1 = cfg::PacketRxReason::ARP;
   auto trapType2 = cfg::PacketRxReason::DHCP;
   // create two traps using the same queue
-  HostifTrapSaiId trapId1 = hostifManager.addHostifTrap(trapType1, queueId, 1);
-  HostifTrapSaiId trapId2 = hostifManager.addHostifTrap(trapType2, queueId, 2);
+  std::optional<HostifTrapSaiId> trapId1Opt =
+      hostifManager.addHostifTrap(trapType1, queueId, 1);
+  ASSERT_TRUE(trapId1Opt.has_value());
+  HostifTrapSaiId trapId1 = *trapId1Opt;
+  std::optional<HostifTrapSaiId> trapId2Opt =
+      hostifManager.addHostifTrap(trapType2, queueId, 2);
+  ASSERT_TRUE(trapId2Opt.has_value());
+  HostifTrapSaiId trapId2 = *trapId2Opt;
   auto trapGroup1 = saiApiTable->hostifApi().getAttribute(
       trapId1, SaiHostifTrapTraits::Attributes::TrapGroup{});
   // remove one of them
@@ -96,7 +131,10 @@ TEST_F(HostifManagerTest, sharedHostifUserDefinedTrapGroup) {
   auto trapType = cfg::PacketRxReason::ARP;
   auto& hostifManager = saiManagerTable->hostifManager();
   // create a normal trap and user defined trap using the same queue
-  HostifTrapSaiId trapId1 = hostifManager.addHostifTrap(trapType, queueId, 1);
+  std::optional<HostifTrapSaiId> trapId1Opt =
+      hostifManager.addHostifTrap(trapType, queueId, 1);
+  ASSERT_TRUE(trapId1Opt.has_value());
+  HostifTrapSaiId trapId1 = *trapId1Opt;
   std::shared_ptr<SaiHostifUserDefinedTrapHandle> userDefinedTrap =
       saiManagerTable->hostifManager().ensureHostifUserDefinedTrap(queueId);
   HostifUserDefinedTrapSaiId trapId2 = userDefinedTrap->trap->adapterKey();
@@ -124,7 +162,10 @@ TEST_F(HostifManagerTest, removeHostifUserDefinedTrap) {
   auto trapType = cfg::PacketRxReason::ARP;
   auto& hostifManager = saiManagerTable->hostifManager();
   // create a normal trap and user defined trap using the same queue
-  HostifTrapSaiId trapId1 = hostifManager.addHostifTrap(trapType, queueId, 1);
+  std::optional<HostifTrapSaiId> trapId1Opt =
+      hostifManager.addHostifTrap(trapType, queueId, 1);
+  ASSERT_TRUE(trapId1Opt.has_value());
+  HostifTrapSaiId trapId1 = *trapId1Opt;
   std::shared_ptr<SaiHostifUserDefinedTrapHandle> userDefinedTrap =
       saiManagerTable->hostifManager().ensureHostifUserDefinedTrap(queueId);
   HostifUserDefinedTrapSaiId trapId2 = userDefinedTrap->trap->adapterKey();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

`SaiHostifManager::packetReasonToHostifTrap()` threw an `FbossError` for any packet RX reason it could not map to a SAI hostif trap on the current ASIC/SDK build (e.g. `L3_SLOW_PATH`, `MPLS_UNKNOWN_LABEL`). When such a reason arrives in control plane delta, the exception escapes the oper-delta thread in `SaiSwitch::stateChangedImplLocked`, aborting the h/w agent with `SIGABRT`.

The software agent's config validation layer (`isValidRxReasonToQueue`) cannot fully gate these reasons, because some are gated by compile-time SAI SDK macros (`SAI_API_VERSION`, `BRCM_SAI_SDK_DNX_GTE_11_0`, etc.) that are visible only in the SAI layer, not in the platform-agnostic agent code.

**Fix**

Make the SAI hostif trap mapping non-fatal, matching the established skip-with-diagnostic pattern already used throughout the SAI managers (and already used for `UNMATCHED` in this same function):

- `packetReasonToHostifTrap()` and `makeHostifTrapAttributes()` now return `std::optional`.
- An unsupported/unmappable RX reason logs `XLOG(ERR)` and returns `std::nullopt` instead of throwing.
- Callers skip programming the trap when no attributes are produced, so the agent stays up.

# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->

Before the fix: `HostifManagerTest.unsupportedHostifTrapSkipped` fails
After the fix: `HostifManagerTest.unsupportedHostifTrapSkipped` passes.