### PR TITLE
[Cisco] Enable unresolved-route class ID before Copp warmboot replay.

### DIFF
--- a/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
+++ b/fboss/agent/test/agent_hw_tests/AgentCoppTests.cpp
@@ -75,6 +75,7 @@ template <typename TestType>
 class AgentCoppTest : public AgentHwTest {
   void setCmdLineFlagOverrides() const override {
     FLAGS_sai_user_defined_trap = true;
+    FLAGS_classid_for_unresolved_routes = true;
     AgentHwTest::setCmdLineFlagOverrides();
   }
 
@@ -1309,10 +1310,6 @@ TYPED_TEST(AgentCoppTest, UnresolvedRouteNextHopToLowPriQueue) {
       RoutePrefix<folly::IPAddressV6>{
           folly::IPAddressV6{"2803:6080:d038:3065::1"}, 128}};
   auto setup = [=, this]() {
-    auto asic =
-        checkSameAndGetAsicForTesting(this->getAgentEnsemble()->getL3Asics());
-    FLAGS_classid_for_unresolved_routes =
-        (asic->getAsicVendor() != HwAsic::AsicVendor::ASIC_VENDOR_CHENAB);
     this->setup();
     utility::EcmpSetupAnyNPorts6 ecmp6(
         this->getProgrammedState(), this->getSw()->needL2EntryForNeighbor());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

<!-- Explain the motivation for making this change and any other context that you think would help reviewers of your code. What existing problem does the pull request solve? -->

`AgentCoppTest::UnresolvedRouteNextHopToLowPriQueue` was setting `FLAGS_classid_for_unresolved_routes` inside the per-test `setup()` lambda.

On warmboot, `setup()` is skipped. SAI route replay then programs unresolved CPU routes with Metadata 0, so traffic hits IP2ME (CPU queue 2) instead of the unresolved-route ACL (CPU queue 0) and the test fails.

Set `FLAGS_classid_for_unresolved_routes = true` in `setCmdLineFlagOverrides()` so the flag is present before agent init / SAI replay on both coldboot and warmboot. This also drops the Chenab vendor special-case that left the flag off in `setup()`. The flag is now always enabled for this test fixture.


# Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. How exactly did you verify that your PR solves the issue you wanted to solve? -->

[result] AgentCoppTest/0.UnresolvedRouteNextHopToLowPriQueue [coldboot]: PASSED (exit code 0)
[result] AgentCoppTest/0.UnresolvedRouteNextHopToLowPriQueue [warmboot]: PASSED (exit code 0)
[result] AgentCoppTest/1.UnresolvedRouteNextHopToLowPriQueue [coldboot]: PASSED (exit code 0)
[result] AgentCoppTest/1.UnresolvedRouteNextHopToLowPriQueue [warmboot]: PASSED (exit code 0)


<!-- If a relevant Github issue exists for this PR, please make sure you link that issue to this PR -->
