### PR TITLE
[Accton][wedge800bact] platform: Add NETLAKE2 PVT versioned support for v3.1.1/v3.1.2/v3.1.3

### DIFF
--- a/fboss/configs/platforms/accton/wedge800bact/platform_stack/platform_manager.json
+++ b/fboss/configs/platforms/accton/wedge800bact/platform_stack/platform_manager.json
@@ -107,6 +107,56 @@
           ]
         },
         "productSubVersion": 1
+      },
+      {
+        "pmUnitConfig": {
+          "pluggedInSlotType": "COMESE_SLOT",
+          "i2cDeviceConfigs": [
+            {
+              "busName": "INCOMING@0",
+              "address": "0x20",
+              "kernelDeviceName": "raa228228",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR1"
+            },
+            {
+              "busName": "INCOMING@0",
+              "address": "0x21",
+              "kernelDeviceName": "raa228228",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x40",
+              "kernelDeviceName": "ina230",
+              "pmUnitScopedName": "COME_VOLTAGE_MONITOR3"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4c",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR1"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x4a",
+              "kernelDeviceName": "tmp75",
+              "pmUnitScopedName": "COME_TSENSOR2"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x50",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM1_TSENSOR"
+            },
+            {
+              "busName": "INCOMING@1",
+              "address": "0x51",
+              "kernelDeviceName": "spd5118",
+              "pmUnitScopedName": "COME_DIMM2_TSENSOR"
+            }
+          ]
+        },
+        "productSubVersion": 3
       }
     ]
   },

--- a/fboss/configs/platforms/accton/wedge800bact/platform_stack/sensor_service.json
+++ b/fboss/configs/platforms/accton/wedge800bact/platform_stack/sensor_service.json
@@ -530,16 +530,6 @@
       "pmUnitName": "NETLAKE20",
       "sensors": [
         {
-          "name": "COME_PU1_PVDDCR_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.82,
-            "maxAlarmVal": 1.75
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU1_PVDDCR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp1_input",
           "type": 3,
@@ -552,16 +542,6 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_PU1_PVDDCR_SOC_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.46,
-            "maxAlarmVal": 1.36
-          },
-          "compute": "@/1000"
-        },
-        {
           "name": "COME_PU1_PVDDCR_SOC_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/temp2_input",
           "type": 3,
@@ -570,16 +550,6 @@
             "maxAlarmVal": 100,
             "minAlarmVal": 0,
             "lowerCriticalVal": -5
-          },
-          "compute": "@/1000"
-        },
-        {
-          "name": "COME_PU37_PVDD_MISC_VOUT",
-          "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
-          "type": 1,
-          "thresholds": {
-            "upperCriticalVal": 1.42,
-            "maxAlarmVal": 1.29
           },
           "compute": "@/1000"
         },
@@ -628,7 +598,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_U28_OUTLET_SENSOR_TEMP",
+          "name": "COME_U28_INLET_SENSOR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_TSENSOR1/temp1_input",
           "type": 3,
           "thresholds": {
@@ -640,7 +610,7 @@
           "compute": "@/1000"
         },
         {
-          "name": "COME_U29_INLET_SENSOR_TEMP",
+          "name": "COME_U29_OUTLET_SENSOR_TEMP",
           "sysfsPath": "/run/devmap/sensors/COME_TSENSOR2/temp1_input",
           "type": 3,
           "thresholds": {
@@ -656,9 +626,7 @@
           "sysfsPath": "/run/devmap/sensors/COME_DIMM1_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 80,
-            "maxAlarmVal": 79,
-            "minAlarmVal": 10
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         },
@@ -667,9 +635,7 @@
           "sysfsPath": "/run/devmap/sensors/COME_DIMM2_TSENSOR/temp1_input",
           "type": 3,
           "thresholds": {
-            "upperCriticalVal": 80,
-            "maxAlarmVal": 79,
-            "minAlarmVal": 10
+            "upperCriticalVal": 85
           },
           "compute": "@/1000"
         }
@@ -688,6 +654,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
               "type": 2,
@@ -708,6 +684,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -726,6 +712,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -755,6 +751,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -775,6 +781,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
               "type": 2,
@@ -793,6 +809,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -822,6 +848,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
               "type": 2,
@@ -842,6 +878,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -860,6 +906,16 @@
                 "maxAlarmVal": 22.25
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU37_PVDD_MISC_IOUT",
@@ -889,6 +945,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU1_PVDDCR_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
               "type": 2,
@@ -907,6 +973,16 @@
                 "maxAlarmVal": 27.81
               },
               "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
             },
             {
               "name": "COME_PU1_PVDDCR_SOC_IOUT",
@@ -929,6 +1005,16 @@
               "compute": "@/1000000"
             },
             {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
               "name": "COME_PU37_PVDD_MISC_IOUT",
               "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
               "type": 2,
@@ -942,6 +1028,297 @@
           "productionState": 1,
           "productionSubState": 3,
           "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power2_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr2_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 1
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in2_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 2
+        },
+        {
+          "sensors": [
+            {
+              "name": "COME_PU1_PVDDCR_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 131.84,
+                "maxAlarmVal": 118.66
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.82,
+                "maxAlarmVal": 1.75
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 164.8,
+                "maxAlarmVal": 148.32
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/power4_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/in4_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.46,
+                "maxAlarmVal": 1.36
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU1_PVDDCR_SOC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR1/curr4_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 38.625,
+                "maxAlarmVal": 34.76
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_POUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/power3_input",
+              "type": 0,
+              "thresholds": {
+                "upperCriticalVal": 24.72,
+                "maxAlarmVal": 22.25
+              },
+              "compute": "@/1000000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_VOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/in3_input",
+              "type": 1,
+              "thresholds": {
+                "upperCriticalVal": 1.42,
+                "maxAlarmVal": 1.29
+              },
+              "compute": "@/1000"
+            },
+            {
+              "name": "COME_PU37_PVDD_MISC_IOUT",
+              "sysfsPath": "/run/devmap/sensors/COME_VOLTAGE_MONITOR2/curr3_input",
+              "type": 2,
+              "thresholds": {
+                "upperCriticalVal": 30.9,
+                "maxAlarmVal": 27.81
+              },
+              "compute": "@/1000"
+            }
+          ],
+          "productionState": 3,
+          "productionSubState": 1,
+          "respinVariantIndicator": 3
         }
       ]
     },


### PR DESCRIPTION
**Pre-submission checklist**
- [ ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [ ] `pre-commit run`
clang-format.........................................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
shfmt................................................(no files to check)Skipped
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check json...............................................................Passed
check for merge conflicts................................................Passed
ruff check...........................................(no files to check)Skipped
ruff format..........................................(no files to check)Skipped
Prevent sai_impl in fboss manifest.......................................Passed

## Summary:
Add versioned configuration support for NETLAKE2 PVT on the wedge800bact platform. NETLAKE2 PVT boards use different voltage regulator (VR) sources depending on the hardware sub-version. This change introduces per-version configs in both `platform_manager` and `sensor_service` to ensure proper initialization and sensor monitoring across all variants.

### Changes:
#### platform_manager:
Added a new `VersionedPmUnitConfig` entry with `productSubVersion: 3` (Renesas) for the COMESE_SLOT PM unit.
- Registers `raa228228` VR devices (COME_VOLTAGE_MONITOR1/2), `ina230`, `tmp75` temperature sensors, and `spd5118` DIMM thermal sensors.
- Version-to-VR mapping: productSubVersion 1 (Infineon), 2 (MPS), 3 (Renesas)
#### sensor_service: 
Introduced `versionedSensors` entries (keyed by `respinVariantIndicator`) to distinguish sensor sysfsPath differences among NETLAKE2 VR variants:
- `respinVariantIndicator: 1` → v3.1.1 (Infineon) — uses `power2/in2/curr2` and `power3/in3/curr3` channels
- `respinVariantIndicator: 2` → v3.1.2 (MPS) — uses `power3/in2/curr3` and `power4/in3/curr4` channels
- `respinVariantIndicator: 3` → v3.1.3 (Renesas) — uses `power3/in3/curr3` and `power4/in4/curr4` channels Updated DIMM temperature sensor thresholds per vendor guidance:
- `COME_JCN1A_DIMM_CHA_TEMP` and `COME_JCN2A_DIMM_CHB_TEMP`:
  - `upperCriticalVal` changed from 80 to 85.
  - Removed `maxAlarmVal` and `minAlarmVal` — per vendor, lower critical/min/max thresholds are N/A because protection and warning SELs should be configured for the upper side of the temperature range only.

## Dependencies:
  Kernel config `CONFIG_SENSORS_ISL68137` must be enabled (provides `raa228228` hwmon driver for Renesas VR).

## Test Plan:
Hardware Verification — Verified on wedge800bact devices equipped with each NETLAKE20 variant:
1. COME EEPROM verification (`weutil -eeprom COME`) — Confirmed hardware identity for each DUT:
   - All boards report: Product Name `NETLAKE20`, Production State `PVT`, Production Sub-State `1`
   - `Re-Spin/Variant Indicator: 1` → v3.1.1 (Infineon)
   - `Re-Spin/Variant Indicator: 2` → v3.1.2 (MPS)
   - `Re-Spin/Variant Indicator: 3` → v3.1.3 (Renesas)
[w800b_weutil_come_come_3.1.1.txt](https://github.com/user-attachments/files/32047838/w800b_weutil_come_come_3.1.1.txt)
[w800b_weutil_come_come_3.1.2.txt](https://github.com/user-attachments/files/32047839/w800b_weutil_come_come_3.1.2.txt)
[w800b_weutil_come_come_3.1.3.txt](https://github.com/user-attachments/files/32047840/w800b_weutil_come_come_3.1.3.txt)
2. platform_manager started and initialized correctly on all versions.
[w800b_platform_manager_come_3.1.1.txt](https://github.com/user-attachments/files/32047822/w800b_platform_manager_come_3.1.1.txt)
[w800b_platform_manager_come_3.1.2.txt](https://github.com/user-attachments/files/32047823/w800b_platform_manager_come_3.1.2.txt)
[w800b_platform_manager_come_3.1.3.txt](https://github.com/user-attachments/files/32047824/w800b_platform_manager_come_3.1.3.txt)
3. platform_manager_hw_test — All test cases passed.
[w800b_platform_manager_hw_test_come_3.1.1.txt](https://github.com/user-attachments/files/32047825/w800b_platform_manager_hw_test_come_3.1.1.txt)
[w800b_platform_manager_hw_test_come_3.1.2.txt](https://github.com/user-attachments/files/32047827/w800b_platform_manager_hw_test_come_3.1.2.txt)
[w800b_platform_manager_hw_test_come_3.1.3.txt](https://github.com/user-attachments/files/32047828/w800b_platform_manager_hw_test_come_3.1.3.txt)
4. sensor_service correctly resolved versioned configs:
    - Resolved to `versionedPmSensors` (v3.1.1 / v3.1.2 / v3.1.3) for NETLAKE20 at `/SCM_SLOT@0/COMESE_SLOT@0`
[w800b_sensor_service_come_3.1.1.txt](https://github.com/user-attachments/files/32047832/w800b_sensor_service_come_3.1.1.txt)
[w800b_sensor_service_come_3.1.2.txt](https://github.com/user-attachments/files/32047833/w800b_sensor_service_come_3.1.2.txt)
[w800b_sensor_service_come_3.1.3.txt](https://github.com/user-attachments/files/32047834/w800b_sensor_service_come_3.1.3.txt)
5. sensor_service_hw_test — All test cases passed.
[w800b_sensor_service_hw_test_come_3.1.1.txt](https://github.com/user-attachments/files/32047835/w800b_sensor_service_hw_test_come_3.1.1.txt)
[w800b_sensor_service_hw_test_come_3.1.2.txt](https://github.com/user-attachments/files/32047836/w800b_sensor_service_hw_test_come_3.1.2.txt)
[w800b_sensor_service_hw_test_come_3.1.3.txt](https://github.com/user-attachments/files/32047837/w800b_sensor_service_hw_test_come_3.1.3.txt)
6. sensor_service_client — All test cases passed.
[w800b_sensor_service_client_come_3.1.1.txt](https://github.com/user-attachments/files/32047829/w800b_sensor_service_client_come_3.1.1.txt)
[w800b_sensor_service_client_come_3.1.2.txt](https://github.com/user-attachments/files/32047830/w800b_sensor_service_client_come_3.1.2.txt)
[w800b_sensor_service_client_come_3.1.3.txt](https://github.com/user-attachments/files/32047831/w800b_sensor_service_client_come_3.1.3.txt)
