### PR TITLE
[Accton][oss] Forward BASE_OUTPUT_DIR into test agent systemd units

### DIFF
--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/services/service_utils.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/services/service_utils.py
@@ -135,6 +135,20 @@ def build_unit_file_content(
     tsan_options: str = "die_after_fork=0",
 ) -> str:
     library_path = os.environ.get("LD_LIBRARY_PATH") or "/opt/fboss/lib"
+
+    # Forward BASE_OUTPUT_DIR from the harness process into the unit.
+    # systemd services do NOT inherit the launching shell's environment, so a
+    # var the SDK needs to locate its resources must be declared in the unit.
+    # BASE_OUTPUT_DIR points some ASIC SDKs (e.g. Silicon One G2) at their
+    # resource tree (res/...); without it the SDK cannot find its mapping files
+    # and aborts hw_agent init. Emitted only when set, so this is a no-op for
+    # SDKs/platforms that don't use it (no regression). Mirrors the existing
+    # LD_LIBRARY_PATH forwarding above.
+    base_output_dir = os.environ.get("BASE_OUTPUT_DIR")
+    base_output_dir_line = (
+        f"Environment=BASE_OUTPUT_DIR={base_output_dir}\n" if base_output_dir else ""
+    )
+
     return f"""
 [Unit]
 Description={description}
@@ -147,7 +161,7 @@ MemorySwapMax=0
 
 Environment=TSAN_OPTIONS={tsan_options}
 Environment=LD_LIBRARY_PATH={library_path}
-ExecStart={exec_start_cmd}
+{base_output_dir_line}ExecStart={exec_start_cmd}
 SyslogIdentifier={syslog_identifier}
 Restart=no
 

--- a/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_agent_service.py
+++ b/fboss/oss/scripts/run_scripts/fboss_test_runner/unittests/test_agent_service.py
@@ -39,6 +39,26 @@ class TestServiceUnitEnvironment:
 
         assert "Environment=LD_LIBRARY_PATH=/opt/fboss/lib" in unit
 
+    def test_base_output_dir_forwarded_into_unit(self, monkeypatch):
+        # systemd does not inherit the shell env; the SDK-locating BASE_OUTPUT_DIR
+        # must be declared in the unit or SDK resource resolution fails (hw_agent
+        # aborts on e.g. g202_slices_mappings.json).
+        sdk_dir = "/opt/fboss/cisco/mklib.G202X.dc-25.11.4210.7"
+        monkeypatch.setenv("BASE_OUTPUT_DIR", sdk_dir)
+
+        unit = service_utils.build_unit_file_content("test", "true", "test")
+
+        assert f"Environment=BASE_OUTPUT_DIR={sdk_dir}" in unit
+
+    def test_base_output_dir_absent_when_unset(self, monkeypatch):
+        # No regression for SDKs/platforms that don't use BASE_OUTPUT_DIR:
+        # the line must be omitted entirely when the var is unset.
+        monkeypatch.delenv("BASE_OUTPUT_DIR", raising=False)
+
+        unit = service_utils.build_unit_file_content("test", "true", "test")
+
+        assert "BASE_OUTPUT_DIR" not in unit
+
 
 class TestCleanupHwAgentService:
     def test_stops_all_three_service_variants_and_pkills(self):


### PR DESCRIPTION
# Summary

`run_test.py sai_agent` in multi_switch mode fails to start the hardware agent on Silicon One G2 platforms. The harness launches the hw_agent as a systemd service (`fboss_hw_agent_oss@N`), but the generated unit does not carry `BASE_OUTPUT_DIR`. Because systemd services do **not** inherit the launching shell's environment, the hw_agent process starts without `BASE_OUTPUT_DIR` even when it is exported in the shell that runs `run_test.py`.

Without `BASE_OUTPUT_DIR`, the Silicon One SDK cannot locate its resource tree (e.g. `res/g2ll/g202_slices_mappings.json`) and aborts during device init:

# Changes

Forward `BASE_OUTPUT_DIR` from the harness process environment into the generated unit file, in `build_unit_file_content()` - the single place unit `Environment=` lines are emitted. This mirrors the existing `LD_LIBRARY_PATH` forwarding.

- Emitted **only when the variable is set**, so it is a no-op for SDKs and platforms that don't use it (no regression for Broadcom, etc.).
- Applies to both hw_agent and sw_agent units (both use `build_unit_file_content`).
- Vendor-neutral; nothing platform-specific is hardcoded.

# Test Plan

Unit tests (added to `TestServiceUnitEnvironment` in `test_agent_service.py`):
- `test_base_output_dir_forwarded_into_unit` - when `BASE_OUTPUT_DIR` is set, the `Environment=BASE_OUTPUT_DIR=...` line appears in the unit.
- `test_base_output_dir_absent_when_unset` - when unset, no line is emitted (no regression).
- Run `run_test.py` with the Agent run mode, `multi_switch` on **DUT** without aborts.

**Pre-submission checklist**
- [x ] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x ] `pre-commit run`
