### PR TITLE
[Cisco] Fix fboss2 interface traffic hangs and missing rates

### DIFF
--- a/common/stats/MonotonicCounter.h
+++ b/common/stats/MonotonicCounter.h
@@ -15,6 +15,8 @@
 #include <fb303/ServiceData.h>
 #include <folly/Range.h>
 
+#include <utility>
+
 namespace facebook {
 namespace stats {
 
@@ -22,11 +24,15 @@ class MonotonicCounter {
  public:
   MonotonicCounter(
       folly::StringPiece name,
-      fb303::ExportType,
-      fb303::ExportType) {
+      fb303::ExportType exportType1,
+      fb303::ExportType exportType2) {
     auto statMap = facebook::fb303::fbData->getStatMap();
     stat_ = statMap->getLockableStatNoExport(name);
     name_ = name;
+    statMap->exportStat(name, exportType1);
+    if (exportType2 != exportType1) {
+      statMap->exportStat(name, exportType2);
+    }
   }
   void updateValue(std::chrono::seconds now, int64_t value) {
     auto guard = stat_.lock();
@@ -43,7 +49,14 @@ class MonotonicCounter {
     prevValue_ = value;
     stat_.addValueLocked(guard, fb303::ExportedStat::TimePoint(now), delta_);
   }
-  void swap(MonotonicCounter& counter) {}
+  void swap(MonotonicCounter& counter) noexcept {
+    using std::swap;
+    swap(init_, counter.init_);
+    swap(prevValue_, counter.prevValue_);
+    swap(delta_, counter.delta_);
+    swap(name_, counter.name_);
+    stat_.swap(counter.stat_);
+  }
   int64_t get() const {
     return delta_;
   }

--- a/fboss/agent/hw/test/HwPortFb303StatsTests.cpp
+++ b/fboss/agent/hw/test/HwPortFb303StatsTests.cpp
@@ -631,10 +631,14 @@ TEST(HwPortFb303StatsTest, ReInit) {
       true /* inCongestionDiscardSeenSupported */);
   stats.portNameChanged(kNewPortName);
   for (const auto& sName : stats.kPortMonotonicCounterStatKeys()) {
-    EXPECT_TRUE(fbData->getStatMap()->contains(
-        HwPortFb303Stats::statName(sName, kNewPortName)));
-    EXPECT_FALSE(fbData->getStatMap()->contains(
-        HwPortFb303Stats::statName(sName, kPortName)));
+    const auto newStatName = HwPortFb303Stats::statName(sName, kNewPortName);
+    const auto oldStatName = HwPortFb303Stats::statName(sName, kPortName);
+    EXPECT_TRUE(fbData->getStatMap()->contains(newStatName));
+    EXPECT_FALSE(fbData->getStatMap()->contains(oldStatName));
+    EXPECT_TRUE(
+        fbData->getCounterIfExists(newStatName + ".rate.60").has_value());
+    EXPECT_FALSE(
+        fbData->getCounterIfExists(oldStatName + ".rate.60").has_value());
   }
   for (auto statKey : stats.kPortFb303CounterStatKeys()) {
     EXPECT_FALSE(
@@ -706,6 +710,21 @@ TEST(HwPortFb303StatsTest, ReInit) {
   // kPriorityGroupCounterStatKeys() are not initialized on construction or
   // reinit. They will be initialized only on the first set (via setPgCounter).
   // Hence, we don't check for their existence in this test.
+}
+
+TEST(HwPortFb303StatsTest, MonotonicCountersExportRate) {
+  const std::string portName = "eth1/1/7";
+  const auto statName = HwPortFb303Stats::statName(kInBytes(), portName);
+  const auto rateName = statName + ".rate.60";
+
+  {
+    HwPortFb303Stats stats(portName);
+    facebook::tcData().publishStats();
+    EXPECT_TRUE(fbData->getCounterIfExists(rateName).has_value());
+  }
+
+  facebook::tcData().publishStats();
+  EXPECT_FALSE(fbData->getCounterIfExists(rateName).has_value());
 }
 
 TEST(HwPortFb303Stats, UpdateStats) {

--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
@@ -25,11 +25,8 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
   auto client =
       utils::createClient<apache::thrift::Client<FbossCtrl>>(hostInfo);
 
-  folly::IOThreadPoolExecutor executor(2);
-
-  // Gather port stats asynchrounously
-  auto portInfos =
-      client->semifuture_getAllPortInfo().via(executor.getEventBase());
+  std::map<int32_t, facebook::fboss::PortInfoThrift> portInfos;
+  client->sync_getAllPortInfo(portInfos);
 
   std::map<std::string, int64_t> counters;
   if (utils::isMultiSwitchEnabled(hostInfo)) {
@@ -54,15 +51,10 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
         };
     utils::runOnAllHwAgents(hostInfo, hwAgentQueryFn);
   } else {
-    auto entries =
-        client->semifuture_getCounters().via(executor.getEventBase());
-    entries.wait();
-    counters = entries.value();
+    client->sync_getCounters(counters);
   }
 
-  portInfos.wait();
-
-  return createModel(portInfos.value(), counters, queriedIfs);
+  return createModel(portInfos, counters, queriedIfs);
 }
 
 CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::createModel(

--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.cpp
@@ -17,6 +17,30 @@
 #include <fmt/color.h>
 #include <re2/re2.h>
 
+#include <stdexcept>
+
+namespace {
+
+constexpr auto kTrafficCounterRegex =
+    ".*\\.(in_bytes|in_unicast_pkts|in_multicast_pkts|in_broadcast_pkts|"
+    "out_bytes|out_unicast_pkts|out_multicast_pkts|out_broadcast_pkts)"
+    "\\.rate\\.60$";
+
+int64_t getTrafficCounter(
+    const std::map<std::string, int64_t>& counters,
+    const std::string& portName,
+    const std::string& suffix) {
+  const auto counterName = portName + suffix;
+  const auto counter = counters.find(counterName);
+  if (counter == counters.end()) {
+    throw std::runtime_error(
+        "Required HW-agent traffic counter is unavailable: " + counterName);
+  }
+  return counter->second;
+}
+
+} // namespace
+
 namespace facebook::fboss {
 
 CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
@@ -37,7 +61,8 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
 #ifndef IS_OSS
           apache::thrift::Client<facebook::thrift::Monitor> monitoringClient{
               client.getChannelShared()};
-          monitoringClient.sync_getCounters(hwAgentCounters);
+          monitoringClient.sync_getRegexCounters(
+              hwAgentCounters, kTrafficCounterRegex);
 #else
           // FbossHwCtrl does not extend FacebookService; the OSS HwAgent
           // multiplex serves fb303 methods via a FacebookBase2 handler, so
@@ -45,13 +70,14 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
           // getCounters) to fetch HwAgent counters.
           apache::thrift::Client<facebook::fboss::FbossCtrl> fb303Client{
               client.getChannelShared()};
-          fb303Client.sync_getCounters(hwAgentCounters);
+          fb303Client.sync_getRegexCounters(
+              hwAgentCounters, kTrafficCounterRegex);
 #endif
           counters.merge(hwAgentCounters);
         };
     utils::runOnAllHwAgents(hostInfo, hwAgentQueryFn);
   } else {
-    client->sync_getCounters(counters);
+    client->sync_getRegexCounters(counters, kTrafficCounterRegex);
   }
 
   return createModel(portInfos, counters, queriedIfs);
@@ -59,7 +85,7 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::queryClient(
 
 CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::createModel(
     const std::map<int32_t, facebook::fboss::PortInfoThrift>& portCounters,
-    std::map<std::string, int64_t> intCounters,
+    const std::map<std::string, int64_t>& intCounters,
     const std::vector<std::string>& queriedIfs) {
   RetType ret;
 
@@ -99,27 +125,39 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::createModel(
       errorCounters.giantErrors() = 0;
       errorCounters.txErrors() = outputErrors;
 
+      if (isNonZeroErrors(errorCounters)) {
+        ret.error_counters()->push_back(errorCounters);
+      }
+
+      // Down ports cannot have current traffic and may not have HwAgent rate
+      // counters. Do not turn an unsupported counter into a false zero.
+      if (operState != facebook::fboss::PortOperState::UP) {
+        continue;
+      }
+
       cli::TrafficCounters trafficCounters;
       // Getting various counters and converting to Mbps
       int64_t portSpeed = folly::copy(portInfo.speedMbps().value());
 
-      long inSpeedBps = intCounters[pname + ".in_bytes.rate.60"] * 8;
-
-      double inSpeedMbps = (double)inSpeedBps / 1000000;
-
-      // Unicast + multicast + broadcast = PPS
-      int64_t inPPS = intCounters[pname + ".in_unicast_pkts.rate.60"] +
-          intCounters[pname + ".in_multicast_pkts.rate.60"] +
-          intCounters[pname + ".in_broadcast_pkts.rate.60"];
-
-      long outSpeedBps = intCounters[pname + ".out_bytes.rate.60"] * 8;
-
-      double outSpeedMbps = (double)outSpeedBps / 1000000;
+      const double inSpeedMbps =
+          getTrafficCounter(intCounters, pname, ".in_bytes.rate.60") * 8.0 /
+          1000000.0;
 
       // Unicast + multicast + broadcast = PPS
-      int64_t outPPS = intCounters[pname + ".out_unicast_pkts.rate.60"] +
-          intCounters[pname + ".out_multicast_pkts.rate.60"] +
-          intCounters[pname + ".out_broadcast_pkts.rate.60"];
+      const int64_t inPPS =
+          getTrafficCounter(intCounters, pname, ".in_unicast_pkts.rate.60") +
+          getTrafficCounter(intCounters, pname, ".in_multicast_pkts.rate.60") +
+          getTrafficCounter(intCounters, pname, ".in_broadcast_pkts.rate.60");
+
+      const double outSpeedMbps =
+          getTrafficCounter(intCounters, pname, ".out_bytes.rate.60") * 8.0 /
+          1000000.0;
+
+      // Unicast + multicast + broadcast = PPS
+      const int64_t outPPS =
+          getTrafficCounter(intCounters, pname, ".out_unicast_pkts.rate.60") +
+          getTrafficCounter(intCounters, pname, ".out_multicast_pkts.rate.60") +
+          getTrafficCounter(intCounters, pname, ".out_broadcast_pkts.rate.60");
 
       trafficCounters.interfaceName() = pname;
       trafficCounters.peerIf() =
@@ -127,20 +165,16 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::createModel(
       trafficCounters.inMbps() = inSpeedMbps;
       trafficCounters.inPct() =
           calculateUtilizationPercent(inSpeedMbps, portSpeed);
-      trafficCounters.inKpps() = inPPS / 1000;
+      trafficCounters.inKpps() = static_cast<double>(inPPS) / 1000.0;
       trafficCounters.outMbps() = outSpeedMbps;
       trafficCounters.outPct() =
           calculateUtilizationPercent(outSpeedMbps, portSpeed);
-      trafficCounters.outKpps() = outPPS / 1000;
+      trafficCounters.outKpps() = static_cast<double>(outPPS) / 1000.0;
       trafficCounters.portSpeed() = portSpeed;
 
       // The original in fb_toolkit has an option for "show zero".  Since we
       // can't accept arbitrarily deep parameters right now we will default to
       // show non-zero and revisit as an option down the road
-      if (isNonZeroErrors(errorCounters)) {
-        ret.error_counters()->push_back(errorCounters);
-      }
-
       if (isInterestingTraffic(trafficCounters)) {
         ret.traffic_counters()->push_back(trafficCounters);
       }
@@ -165,6 +199,9 @@ CmdShowInterfaceTraffic::RetType CmdShowInterfaceTraffic::createModel(
 double CmdShowInterfaceTraffic::calculateUtilizationPercent(
     double speedMbps,
     int bandwidth) {
+  if (bandwidth <= 0) {
+    return 0.0;
+  }
   return (speedMbps / bandwidth) * 100;
 }
 

--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.h
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.h
@@ -52,7 +52,7 @@ class CmdShowInterfaceTraffic : public CmdHandler<
       const std::vector<std::string>& queriedIfs);
   RetType createModel(
       const std::map<int32_t, facebook::fboss::PortInfoThrift>& portCounters,
-      std::map<std::string, int64_t> intCounters,
+      const std::map<std::string, int64_t>& intCounters,
       const std::vector<std::string>& queriedIfs);
   double calculateUtilizationPercent(double speedMbps, int bandwidth);
   std::string extractExpectedPort(const std::string& portDescription);

--- a/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.h
+++ b/fboss/cli/fboss2/commands/show/interface/traffic/CmdShowInterfaceTraffic.h
@@ -21,7 +21,6 @@
 #include "fboss/cli/fboss2/commands/show/interface/traffic/gen-cpp2/model_types.h"
 #include "fboss/cli/fboss2/utils/CmdUtils.h"
 #include "fboss/cli/fboss2/utils/Table.h"
-#include "folly/executors/IOThreadPoolExecutor.h"
 
 namespace facebook::fboss {
 

--- a/fboss/cli/fboss2/test/CmdShowInterfaceTrafficTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowInterfaceTrafficTest.cpp
@@ -3,7 +3,9 @@
 #include <boost/algorithm/string.hpp>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "fboss/agent/AddressUtil.h"
@@ -161,6 +163,69 @@ TEST_F(CmdShowInterfaceTrafficTestFixture, createModel) {
   EXPECT_NEAR(trafficCounters[2].outPct().value(), 19.7531, 0.0001);
 }
 
+TEST_F(CmdShowInterfaceTrafficTestFixture, queryClient) {
+  setupMockedAgentServer();
+
+  EXPECT_CALL(getMockAgent(), getAllPortInfo(_))
+      .WillOnce(Invoke([&](auto& entries) { entries = portInfo; }));
+
+  MultiSwitchRunState runState;
+  runState.multiSwitchEnabled() = false;
+  EXPECT_CALL(getMockAgent(), getMultiSwitchRunState(_))
+      .WillOnce(Invoke([&](auto& response) { response = runState; }));
+
+  auto response = intCounters;
+  EXPECT_CALL(getMockAgent(), async_eb_getRegexCounters(_, _))
+      .WillOnce(Invoke([&response](auto callback, auto regex) {
+        EXPECT_THAT(*regex, HasSuffix("\\.rate\\.60$"));
+        callback->result(std::move(response));
+      }));
+
+  auto model = CmdShowInterfaceTraffic().queryClient(localhost(), queriedIfs);
+  EXPECT_EQ(model.traffic_counters()->size(), 3);
+}
+
+TEST_F(CmdShowInterfaceTrafficTestFixture, missingRateCounterFails) {
+  intCounters.erase("eth1/1/1.in_bytes.rate.60");
+
+  auto cmd = CmdShowInterfaceTraffic();
+  EXPECT_THAT(
+      [&]() { cmd.createModel(portInfo, intCounters, queriedIfs); },
+      ThrowsMessage<std::runtime_error>(HasSubstr(
+          "Required HW-agent traffic counter is unavailable: "
+          "eth1/1/1.in_bytes.rate.60")));
+}
+
+TEST_F(CmdShowInterfaceTrafficTestFixture, downPortDoesNotRequireRateCounters) {
+  portInfo.at(1).operState() = facebook::fboss::PortOperState::DOWN;
+  for (auto counter = intCounters.begin(); counter != intCounters.end();) {
+    if (counter->first.rfind("eth1/1/1.", 0) == 0) {
+      counter = intCounters.erase(counter);
+    } else {
+      ++counter;
+    }
+  }
+
+  auto cmd = CmdShowInterfaceTraffic();
+  EXPECT_NO_THROW(cmd.createModel(portInfo, intCounters, queriedIfs));
+}
+
+TEST_F(CmdShowInterfaceTrafficTestFixture, preservesFractionalKpps) {
+  intCounters["eth1/1/1.in_unicast_pkts.rate.60"] = 100;
+  intCounters["eth1/1/1.in_multicast_pkts.rate.60"] = 200;
+  intCounters["eth1/1/1.in_broadcast_pkts.rate.60"] = 300;
+
+  auto cmd = CmdShowInterfaceTraffic();
+  auto model = cmd.createModel(portInfo, intCounters, queriedIfs);
+
+  EXPECT_DOUBLE_EQ(model.traffic_counters()->at(0).inKpps().value(), 0.6);
+}
+
+TEST_F(CmdShowInterfaceTrafficTestFixture, zeroBandwidthHasZeroUtilization) {
+  auto cmd = CmdShowInterfaceTraffic();
+  EXPECT_DOUBLE_EQ(cmd.calculateUtilizationPercent(100.0, 0), 0.0);
+}
+
 TEST_F(CmdShowInterfaceTrafficTestFixture, printOutput) {
   auto cmd = CmdShowInterfaceTraffic();
   auto model = cmd.createModel(portInfo, intCounters, queriedIfs);
@@ -189,6 +254,10 @@ TEST_F(CmdShowInterfaceTrafficTestFixture, printOutput) {
 // every rate counter, so isInterestingTraffic() filters out every row and the
 // Total is computed over an empty set. Totals must read 0.00%.
 TEST_F(CmdShowInterfaceTrafficTestFixture, printOutputNoInterestingTraffic) {
+  for (auto& [_, port] : portInfo) {
+    port.operState() = facebook::fboss::PortOperState::DOWN;
+  }
+
   auto cmd = CmdShowInterfaceTraffic();
   auto model = cmd.createModel(portInfo, {} /* intCounters */, queriedIfs);
 


### PR DESCRIPTION
# Summary

Fix `fboss2 show interface traffic` on OSS multi-switch systems where the command can hang indefinitely or return an empty/zero table while ports are carrying traffic.

This change:

- uses deterministic synchronous RPCs for the command's sequential data collection;
- exports the `SUM` and `RATE` types requested by `MonotonicCounter` callers, making port `.rate.60` counters available from the HW agent;
- fetches only the traffic-rate counter families needed by this command;
- skips down ports, which may legitimately have no HW-agent rate counters;
- reports a missing counter on an up port instead of silently converting it to zero; and
- preserves fractional Kpps values and guards per-port zero bandwidth.

The aggregate zero-bandwidth fix from #1560 is already present on `main` and remains unchanged.

# Root cause

There were three contributing problems:

1. `CmdShowInterfaceTraffic::queryClient()` mixed future-based RPCs attached to a short-lived local `IOThreadPoolExecutor` with blocking HW-agent fanout, followed by an unconditional `wait()`. If the future did not reach a terminal state on a cold/multi-switch path, the command had no forward progress and remained blocked. The operation is sequential at the point the model is created, so the local executor did not provide useful concurrency.
2. The OSS `MonotonicCounter` implementation created its backing stat with `getLockableStatNoExport()` and ignored both requested export types. Port counters were updated internally, but `.rate.60` was therefore absent from FB303 output.
3. The CLI read rate counters with `std::map::operator[]`. Missing counters were inserted as zero, making unavailable telemetry indistinguishable from a real zero traffic rate. It also attempted to read current rate counters for down ports.

# Fix details and compatibility

- The Thrift APIs and output schema are unchanged.
- Both monolithic and multi-switch paths remain supported.
- `MonotonicCounter` now honors its existing constructor contract. Its `swap()` implementation also transfers the state, name, and lockable stat so clear/rename operations retain the correct counter lifecycle.
- The FB303 regex is anchored to exact `.rate.60` suffixes, reducing the counter payload compared with fetching every agent counter.
- Down ports are excluded before rate lookup. An up port without required telemetry fails explicitly instead of displaying misleading zeros.
- Existing error-counter reporting is preserved for both up and down ports.

# Unit-test coverage

- synchronous query path and exact `.rate.60` regex;
- missing rate counter on an up port;
- down port without rate counters;
- fractional Kpps conversion;
- zero-bandwidth utilization;
- monotonic counter rate export, removal, and port-name reinitialization; and
- existing empty-traffic aggregate output coverage from #1560.

# Test Plan

- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed, including clang-format and repository checks.
- Built a full C8501 FBOSS image carrying the equivalent backport: `fboss-gr2-stable-20260903-fbc276b.1-1-ge405635`.
- Validated on a Cisco C8501 / Morgan800CC lab switch:
  - enabled all 128 physical ports; two connected ports came up;
  - verified all 1,024 expected physical-port traffic `.rate.60` counters (128 ports × 8 counters) were exported;
  - ran 70 no-traffic/below-threshold invocations and 30 active-traffic invocations: 100/100 returned successfully, with zero hangs or timeouts;
  - observed command latency between 32 ms and 64 ms;
  - generated a controlled traffic burst on `eth1/1/1` and observed:

```text
hwagent0  eth1/1/1.out_bytes.rate.60  52195

Interface Name  Peer  Intvl  InMbps  InPct  InKpps  OutMbps  OutPct  OutKpps
eth1/1/1        --    0:60   0.00    0.00%  0.00    0.42     0.00%   0.04
Total           --    --     0.00    0.00%  0.00    0.42     0.00%   0.04
```

- Confirmed `fboss_sw_agent`, `fboss_hw_agent@0`, and `qsfp_service` remained active after validation.
