### PR TITLE
[Cisco] Handle fboss2 interface phymap without XPHY

### DIFF
--- a/cmake/CliFboss2Test.cmake
+++ b/cmake/CliFboss2Test.cmake
@@ -77,6 +77,7 @@ add_executable(fboss2_cmd_test
   fboss/cli/fboss2/test/CmdShowInterfaceErrorsTest.cpp
   # fboss/cli/fboss2/test/CmdShowInterfaceFlapsTest.cpp - excluded (depends on hardware model not built in CMake)
   fboss/cli/fboss2/test/CmdShowInterfacePhyTest.cpp
+  fboss/cli/fboss2/test/CmdShowInterfacePhymapTest.cpp
   fboss/cli/fboss2/test/CmdShowInterfacePrbsTest.cpp
   fboss/cli/fboss2/test/CmdShowMacDetailsTest.cpp
   fboss/cli/fboss2/test/CmdShowMirrorTest.cpp

--- a/fboss/cli/fboss2/commands/show/interface/phymap/CmdShowInterfacePhymap.cpp
+++ b/fboss/cli/fboss2/commands/show/interface/phymap/CmdShowInterfacePhymap.cpp
@@ -31,9 +31,13 @@ CmdShowInterfacePhymapTraits::RetType CmdShowInterfacePhymap::queryClient(
   auto client =
       utils::createClient<apache::thrift::Client<QsfpService>>(hostInfo);
 
-  facebook::fboss::mka::MacsecPortPhyMap portsPhyMap;
+  std::vector<int32_t> macsecCapablePorts;
+  client->sync_getMacsecCapablePorts(macsecCapablePorts);
 
-  client->sync_macsecGetPhyPortInfo(portsPhyMap, queriedIfs);
+  facebook::fboss::mka::MacsecPortPhyMap portsPhyMap;
+  if (!macsecCapablePorts.empty()) {
+    client->sync_macsecGetPhyPortInfo(portsPhyMap, queriedIfs);
+  }
 
   return createModel(portsPhyMap);
 }

--- a/fboss/cli/fboss2/test/BUCK
+++ b/fboss/cli/fboss2/test/BUCK
@@ -187,6 +187,7 @@ cpp_unittest(
         "CmdShowInterfaceErrorsTest.cpp",
         "CmdShowInterfaceFlapsTest.cpp",
         "CmdShowInterfacePhyTest.cpp",
+        "CmdShowInterfacePhymapTest.cpp",
         "CmdShowInterfacePrbsTest.cpp",
         "CmdShowInterfaceStatusTest.cpp",
         "CmdShowInterfaceTest.cpp",

--- a/fboss/cli/fboss2/test/CmdShowInterfacePhymapTest.cpp
+++ b/fboss/cli/fboss2/test/CmdShowInterfacePhymapTest.cpp
@@ -1,0 +1,30 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "fboss/cli/fboss2/commands/show/interface/phymap/CmdShowInterfacePhymap.h"
+#include "fboss/cli/fboss2/test/CmdHandlerTestBase.h"
+
+using namespace ::testing;
+
+namespace facebook::fboss {
+
+class CmdShowInterfacePhymapTestFixture : public CmdHandlerTestBase {};
+
+TEST_F(CmdShowInterfacePhymapTestFixture, noXphyPlatform) {
+  setupMockedAgentServer();
+  EXPECT_CALL(getQsfpService(), getMacsecCapablePorts(_))
+      .WillOnce(Invoke([](auto& ports) { ports.clear(); }));
+
+  auto model = CmdShowInterfacePhymap().queryClient(localhost(), {});
+  EXPECT_FALSE(model.portsPhyMap().value().macsecPortPhyMap().has_value());
+
+  std::stringstream output;
+  CmdShowInterfacePhymap().printOutput(model, output);
+  EXPECT_EQ("No Phy port map for this platform\n", output.str());
+}
+
+} // namespace facebook::fboss

--- a/fboss/cli/fboss2/test/MockClients.h
+++ b/fboss/cli/fboss2/test/MockClients.h
@@ -190,6 +190,7 @@ class MockFbossQsfpService
   MOCK_METHOD2(
       getAllPortSupportedProfiles,
       void(std::map<std::string, std::vector<cfg::PortProfileID>>&, bool));
+  MOCK_METHOD(void, getMacsecCapablePorts, (std::vector<int32_t>&));
   MOCK_METHOD2(
       getSymbolErrorHistogram,
       void(CdbDatapathSymErrHistogram&, std::unique_ptr<std::string>));


### PR DESCRIPTION
# Summary

Make `fboss2 show interface phymap` handle platforms without an external PHY (XPHY) or MACsec-capable PHY ports as a supported empty result.

The command now checks the QsfpService MACsec-capable port list before requesting the MACsec PHY map. When the list is empty, it returns the existing user-facing result:

```text
No Phy port map for this platform
```

# Root cause

`CmdShowInterfacePhymap::queryClient()` unconditionally called `macsecGetPhyPortInfo()`. QsfpService protects that RPC with `validateHandler()`, which throws `FbossError("Macsec handler not initialized")` when the platform did not create a MACsec handler.

That is expected on platforms such as Cisco C8501 / Morgan800CC, which do not have an XPHY. The CLI treated a supported platform capability difference as a command failure.

# Fix details and compatibility

- Query `getMacsecCapablePorts()` first. This API returns an empty list when there is no PHY manager or no PHY port advertising the MACsec feature.
- Call `macsecGetPhyPortInfo()` only when at least one MACsec-capable port exists.
- Reuse the existing empty-model output instead of matching exception strings.
- No Thrift API or server behavior changes are required.
- Platforms with MACsec-capable XPHY ports continue through the existing PHY-map RPC and rendering path.

# Unit-test coverage

- Added `CmdShowInterfacePhymapTest.noXphyPlatform` with a mocked empty MACsec-capable port list.
- The test verifies that query execution succeeds, the returned model has no PHY map, and output is exactly `No Phy port map for this platform`.
- Added the test to both BUCK and CMake FBOSS CLI test targets.

# Test Plan

- `pre-commit run --from-ref upstream/main --to-ref HEAD` — passed, including clang-format and repository checks.
- Built a full C8501 FBOSS image carrying the equivalent backport: `fboss-gr2-stable-20260903-fbc276b.1-1-ge405635`.
- Validated on a Cisco C8501 / Morgan800CC lab switch.

Before:

```text
$ fboss2 show interface phymap
Thrift call failed: 'Macsec handler not initialized'
```

After:

```text
$ fboss2 show interface phymap
No Phy port map for this platform
```

- The fixed command exited with status 0 in 32 ms.
- Confirmed `fboss_sw_agent`, `fboss_hw_agent@0`, and `qsfp_service` remained active after validation.
