### PR TITLE
[Nexthop][wedge800bnhp] Serialize deleteAllProbedData() with sync() under mutex_

### DIFF
--- a/fboss/agent/TunManager.cpp
+++ b/fboss/agent/TunManager.cpp
@@ -977,7 +977,9 @@ void TunManager::addressProcessor(struct nl_object* obj, void* data) {
       rtnl_addr_get_ifindex(addr), ipaddr, nl_addr_get_prefixlen(localaddr));
 }
 
-void TunManager::performInitialCleanup(std::shared_ptr<SwitchState> state) {
+void TunManager::performInitialCleanup(
+    std::lock_guard<std::mutex>& lock,
+    std::shared_ptr<SwitchState> state) {
   // Build a map of interface ID to table ID from state interfaces
   auto ifIdToTableId = this->buildIfIdToTableIdMap(state);
 
@@ -986,7 +988,7 @@ void TunManager::performInitialCleanup(std::shared_ptr<SwitchState> state) {
 
   // Only delete probed data if there's a difference between the maps
   if (requiresProbedDataCleanup(ifIdToTableId, probedIfIdToTableId)) {
-    deleteAllProbedData();
+    deleteAllProbedDataLocked(lock);
     probedStateCleanedUp_ = true;
     sw_->stats()->probedStateCleanedUp();
   }
@@ -1061,6 +1063,12 @@ void TunManager::doProbe(std::lock_guard<std::mutex>& /* lock */) {
  * tunnel interfaces.
  */
 void TunManager::deleteAllProbedData() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  deleteAllProbedDataLocked(lock);
+}
+
+void TunManager::deleteAllProbedDataLocked(
+    std::lock_guard<std::mutex>& /* lock */) {
   XLOG(INFO) << "Starting to delete all probed data from kernel";
 
   // Build a map of interface index to table ID from probed data
@@ -1196,7 +1204,7 @@ void TunManager::sync(std::shared_ptr<SwitchState> state) {
   }
   if (FLAGS_cleanup_probed_kernel_data) {
     if (!initialCleanupDone_) {
-      performInitialCleanup(state);
+      performInitialCleanup(lock, state);
     } else {
       XLOG(DBG2) << "Initial cleanup already completed, skipping cleanup";
     }

--- a/fboss/agent/TunManager.h
+++ b/fboss/agent/TunManager.h
@@ -104,9 +104,13 @@ class TunManager : public StateObserver {
   virtual void probe();
 
   /*
-   * Perform initial cleanup of probed data if required
+   * Perform initial cleanup of probed data if required. Caller must hold
+   * mutex_ (passed in as `lock`) since this function mutates probed state
+   * shared with sync()/probe().
    */
-  void performInitialCleanup(std::shared_ptr<SwitchState> state);
+  void performInitialCleanup(
+      std::lock_guard<std::mutex>& lock,
+      std::shared_ptr<SwitchState> state);
 
   void stopProcessing();
 
@@ -422,6 +426,13 @@ class TunManager : public StateObserver {
    * tunnel interfaces.
    */
   void deleteAllProbedData();
+
+  /**
+   * Same as deleteAllProbedData() but the caller must already be holding
+   * mutex_. Used by callers that need to perform additional work under the
+   * same critical section (e.g. performInitialCleanup invoked from sync()).
+   */
+  void deleteAllProbedDataLocked(std::lock_guard<std::mutex>& lock);
 
   /**
    * Get MTU of switch interface


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

**Pre-submission checklist**
- [x] I've ran the linters locally and fixed lint errors related to the files I modified in this PR. You can install the linters by running `pip install -r requirements-dev.txt && pre-commit install`
- [x] `pre-commit run`

# Summary

Fix a data race in `TunManager` that caused the `HwTunManagerProbeAndCleanup` benchmark to occasionally crash with `SIGSEGV` on Wedge800BACT.

## Root Cause

The benchmark drives `TunManager::probe()` and `TunManager::deleteAllProbedData()` directly from the benchmark thread while `TunManager` is still registered as a `StateObserver`. `TunManager::stateUpdated()` posts `sync()` onto `TunManager`'s event base (`SwSwitch::packetTxEventBase_`), and any late `SwitchState` delta (e.g. from `LinkStateToggler` bringing physical ports up asynchronously on real hardware) schedules a `sync()` that races with the benchmark's cleanup.

Two things made the race exploitable:

- `deleteAllProbedData()` mutated `intfs_`/`probedRoutes_`/`probedRules_` without holding `mutex_`, while `sync()` iterates `intfs_` and dereferences `unique_ptr<TunIntfBase>` entries under `mutex_`. Any interleaving of `intfs_.clear()` with `sync()`'s iteration is a data race on `boost::container::flat_map`, so the behavior is undefined in general. The specific observed failure is consistent with the most likely realization: `flat_map` is a sorted vector, so `clear()` destroys the `unique_ptr` elements in place without releasing the buffer, and a concurrent `sync()` reads a destroyed entry as null and dereferences `0x0` — matching the stack captured inside `TunManager::sync` dispatched from `stateUpdated`.
- The benchmark's `waitForBackgroundThread(sw)` drains `SwSwitch`'s background evb, but `TunManager` runs on `packetTxEventBase_`, so it never drained the queue that actually holds pending `sync()` tasks.

## Changes (`TunManager.{h,cpp}`) 

- Split `deleteAllProbedData()` into a locking entry point that acquires `mutex_` and a `deleteAllProbedDataLocked(std::lock_guard<std::mutex>&)` doing the work, mirroring the existing `probe()`/`doProbe(lock&)` pattern. Both are private; the benchmark and `AgentTunnelMgrTests` call the entry point via the existing friend macros, so no caller outside `TunManager` changes.
- Update `performInitialCleanup()` (only called from `sync()`, under `mutex_`) to take the `lock_guard&` and call the locked variant to avoid deadlocking on the non-recursive mutex.

# Test Plan

To verify these changes, the `HwTunManagerProbeAndCleanup` benchmark was run 100 times on a Wedge800BACT unit. The benchmark was run using the following command:

```
./run_test.py benchmark \
--config ./hw_bench_configs/wedge800bact.agent.materialized_JSON \
--skip-known-bad-tests brcm/13.3.0.0_odp/tomahawk5 \
--filter=HwTunManagerProbeAndCleanup
```

The benchmark passed 100 out of 100 times.